### PR TITLE
docs(swims): slot historical swim-34 through swim-40 + index

### DIFF
--- a/swims/README.md
+++ b/swims/README.md
@@ -1,0 +1,47 @@
+# Swim index
+
+Public-facing evidence index for continuation-feature integration swims. Per figs's directive 2026-05-06 18:51Z, this index slots known historical swims so the cohort can arrange a comprehensive set for v2026.5.5 release-facing testing reconstruction.
+
+## Currently in this repo (public evidence surface)
+
+| Swim | Era | Status | Anchor |
+|---|---|---|---|
+| [Swim 9](swim-09/README.md) | early canary | retained historical | volitional-compaction, 5/5 PASS |
+| [Swim 10](swim-10/README.md) | full tool-parity canary | retained historical | 12 PASS / 1 DEFERRED, 13-row scorecard |
+| [Swim 41](swim-41/README.md) | v5.2 substrate verification | recent OV-row-driven | 3/4 OV closed; OV-4 in flight |
+| [Swim 42](swim-42/README.md) | v5.2 final-release integration | recent rows-era | Option B minimum-viable |
+
+## Known historical swims documented elsewhere (NOT yet in this repo)
+
+Per cohort archaeology 2026-05-06, evidence for these swims lives in [`karmaterminal/openclaw-bootstrap`](https://github.com/karmaterminal/openclaw-bootstrap) and/or in [`karmaterminal/openclaw`](https://github.com/karmaterminal/openclaw) frozen-branch RFC history:
+
+| Swim | Where to find evidence | Era / shape |
+|---|---|---|
+| Swim 5 | [`openclaw-bootstrap/SWIM/history/SWIM5-STATUS.md`](https://github.com/karmaterminal/openclaw-bootstrap/blob/main/SWIM/history/SWIM5-STATUS.md) | early — status doc |
+| Swim 6 | [`openclaw-bootstrap/SWIM/history/SWIM6-FINDINGS.md`](https://github.com/karmaterminal/openclaw-bootstrap/blob/main/SWIM/history/SWIM6-FINDINGS.md) + [`SWIM6-PROTOCOL.md`](https://github.com/karmaterminal/openclaw-bootstrap/blob/main/SWIM/history/SWIM6-PROTOCOL.md) | early — findings + protocol |
+| Swim 7 | [`openclaw-bootstrap/SWIM/history/SWIM7-RESULTS.md`](https://github.com/karmaterminal/openclaw-bootstrap/blob/main/SWIM/history/SWIM7-RESULTS.md) + [`silas-likes-to-watch/swim-logs/`](https://github.com/karmaterminal/silas-likes-to-watch/tree/main/swim-logs) | early — results + raw logs |
+| Swim 8 | RFC history on `feature/context-pressure-squashed` lineage in `karmaterminal/openclaw` | early; thin in current archives |
+| Swim 31 | [`openclaw-bootstrap/SWIM/history/SWIM31-EVIDENCE.md`](https://github.com/karmaterminal/openclaw-bootstrap/blob/main/SWIM/history/SWIM31-EVIDENCE.md) | mid — evidence doc |
+| [Swim 34](swim-34/README.md) | [`openclaw-bootstrap/swims/swim-34-formal-matrix/`](https://github.com/karmaterminal/openclaw-bootstrap/tree/main/swims/swim-34-formal-matrix) (largest matrix-era board) + [`swim-34-staleness/`](https://github.com/karmaterminal/openclaw-bootstrap/tree/main/swims/swim-34-staleness) | formal matrix era |
+| [Swim 35](swim-35/README.md) | [`openclaw-bootstrap/swims/swim-35-stabilization/`](https://github.com/karmaterminal/openclaw-bootstrap/tree/main/swims/swim-35-stabilization) | stabilization cycle |
+| [Swim 36](swim-36/README.md) | [`openclaw-bootstrap/swims/swim-36/`](https://github.com/karmaterminal/openclaw-bootstrap/tree/main/swims/swim-36) | mid cycle |
+| [Swim 37](swim-37/README.md) | [`openclaw-bootstrap/swims/swim-37/`](https://github.com/karmaterminal/openclaw-bootstrap/tree/main/swims/swim-37) + [`SWIM/lessons/swim-37-*`](https://github.com/karmaterminal/openclaw-bootstrap/tree/main/SWIM/lessons) | heartbeat-era + lessons |
+| [Swim 38](swim-38/README.md) | [`openclaw-bootstrap/swims/swim-38-slippy-hoodie/`](https://github.com/karmaterminal/openclaw-bootstrap/tree/main/swims/swim-38-slippy-hoodie) | slippy-hoodie cycle |
+| [Swim 39](swim-39/README.md) | [`openclaw-bootstrap/swims/swim-39-volatile-purge/`](https://github.com/karmaterminal/openclaw-bootstrap/tree/main/swims/swim-39-volatile-purge) | volatile-purge cycle |
+| [Swim 40](swim-40/README.md) | [`openclaw-bootstrap/swims/swim-40-v29-substrate-verification/`](https://github.com/karmaterminal/openclaw-bootstrap/tree/main/swims/swim-40-v29-substrate-verification) | v29 substrate verification |
+
+## Genuinely thin spots / gaps
+
+Swims **11–30** (except Swim 31), and **32–33** — these are not currently archived in either repo at a citable level. The earlier RFC inline summaries on `feature/context-pressure-squashed` lineage carry some bridge material but no dedicated swim-folders exist for these numbers.
+
+## Canonical anchors for full-suite reconstruction
+
+- [`openclaw-bootstrap#427`](https://github.com/karmaterminal/openclaw-bootstrap/issues/427) — Swim 29 formal test matrix (canonical row inventory)
+- [`openclaw-bootstrap#412`](https://github.com/karmaterminal/openclaw-bootstrap/issues/412) — continuation public-surface audit (tokens / tools / visibility / coexistence)
+- [`openclaw-bootstrap/SWIM/FORMAL-SWIM-RUNBOOK.md`](https://github.com/karmaterminal/openclaw-bootstrap/blob/main/SWIM/FORMAL-SWIM-RUNBOOK.md) — synthesized authoritative runbook
+
+## Provenance
+
+Swim slot-entries 34–40 in this PR are **slot stubs** authored 2026-05-06 by 🌿 frond-scribe pointing at the bootstrap source-of-truth. They do not yet replicate the full bootstrap evidence into the docs repo. That fuller migration is left to follow-on work (likely 🌻 Elliott per figs's "🌻 can arrange a nice set of 'all of the things'") so a single human can shape the public arrangement coherently.
+
+🌿 frond-scribe • 2026-05-06

--- a/swims/swim-34/README.md
+++ b/swims/swim-34/README.md
@@ -1,0 +1,21 @@
+# Swim 34 — formal matrix era
+
+**Era**: matrix-era full-walk (closest archived approximation of the historical 40–50-case full continuation suite)
+**Source-of-truth**: [`karmaterminal/openclaw-bootstrap/swims/swim-34-formal-matrix/`](https://github.com/karmaterminal/openclaw-bootstrap/tree/main/swims/swim-34-formal-matrix) + [`swim-34-staleness/`](https://github.com/karmaterminal/openclaw-bootstrap/tree/main/swims/swim-34-staleness)
+
+## Status
+
+Slot stub. The substantive evidence — `BRIEF-continuation-module.md`, `ROWS.md`, `archaeology/`, `comprehension/`, `coord-triage/`, `evidence/`, `rows/`, `scripts/` — lives on the openclaw-bootstrap repo at the path above. This entry exists so the public docs swim index can point at swim-34 without forcing a full content migration in the same PR.
+
+## Why this swim is load-bearing for full-walk reconstruction
+
+Per cohort archaeology 2026-05-06, swim-34's `formal-matrix/` directory carries the closest existing approximation of the historical full continuation walk that figs cited as "40–50 test cases over a number of categories" pre-decay. When v2026.5.5 reconstructs a FULL integration swim charter, swim-34's row inventory and category structure are the load-bearing primary source.
+
+## Cross-references
+
+- Cohort canonical anchors: [`openclaw-bootstrap#427`](https://github.com/karmaterminal/openclaw-bootstrap/issues/427) (formal matrix), [`#412`](https://github.com/karmaterminal/openclaw-bootstrap/issues/412) (continuation public-surface audit)
+- Lessons banked in [`openclaw-bootstrap/SWIM/lessons/swim-34-*.md`](https://github.com/karmaterminal/openclaw-bootstrap/tree/main/SWIM/lessons) (coord-continuation-brief, prereq-code-comprehension, procedural-uncurse, row-list-reconstruction)
+
+## Provenance
+
+Slot-stub authored 2026-05-06 by 🌿 frond-scribe per figs's directive 18:51:58Z to slot known historical swims into this docs repo. Full content migration is follow-on work for 🌻 to arrange.

--- a/swims/swim-35/README.md
+++ b/swims/swim-35/README.md
@@ -1,0 +1,12 @@
+# Swim 35 — stabilization
+
+**Era**: stabilization cycle following swim-34's formal-matrix run
+**Source-of-truth**: [`karmaterminal/openclaw-bootstrap/swims/swim-35-stabilization/`](https://github.com/karmaterminal/openclaw-bootstrap/tree/main/swims/swim-35-stabilization)
+
+## Status
+
+Slot stub. Substantive cycle materials live on openclaw-bootstrap at the path above.
+
+## Provenance
+
+Slot-stub authored 2026-05-06 by 🌿 frond-scribe per figs's directive 18:51:58Z. Full content migration is follow-on work for 🌻 to arrange.

--- a/swims/swim-36/README.md
+++ b/swims/swim-36/README.md
@@ -1,0 +1,12 @@
+# Swim 36
+
+**Era**: mid-cycle
+**Source-of-truth**: [`karmaterminal/openclaw-bootstrap/swims/swim-36/`](https://github.com/karmaterminal/openclaw-bootstrap/tree/main/swims/swim-36)
+
+## Status
+
+Slot stub. Substantive cycle materials live on openclaw-bootstrap at the path above.
+
+## Provenance
+
+Slot-stub authored 2026-05-06 by 🌿 frond-scribe per figs's directive 18:51:58Z. Full content migration is follow-on work for 🌻 to arrange.

--- a/swims/swim-37/README.md
+++ b/swims/swim-37/README.md
@@ -1,0 +1,13 @@
+# Swim 37 — heartbeat era
+
+**Era**: heartbeat-cycle (harness, memo, wire)
+**Source-of-truth**: [`karmaterminal/openclaw-bootstrap/swims/swim-37/`](https://github.com/karmaterminal/openclaw-bootstrap/tree/main/swims/swim-37) + branch artifacts (`elliott/swim-37-heartbeat-harness-nits`, `elliott/swim-37-heartbeat-memo`, `elliott/swim-37-heartbeat-wire`, `cael/swim-37-trap-classes`, `ronan/swim-36-c1-rfc-4.1`)
+**Lessons**: [`openclaw-bootstrap/SWIM/lessons/swim-37-pre-write-middleware-and-recovery-hierarchy.md`](https://github.com/karmaterminal/openclaw-bootstrap/blob/main/SWIM/lessons/swim-37-pre-write-middleware-and-recovery-hierarchy.md)
+
+## Status
+
+Slot stub. Substantive cycle materials live on openclaw-bootstrap at the path above.
+
+## Provenance
+
+Slot-stub authored 2026-05-06 by 🌿 frond-scribe per figs's directive 18:51:58Z. Full content migration is follow-on work for 🌻 to arrange.

--- a/swims/swim-38/README.md
+++ b/swims/swim-38/README.md
@@ -1,0 +1,12 @@
+# Swim 38 — slippy-hoodie
+
+**Era**: slippy-hoodie cycle
+**Source-of-truth**: [`karmaterminal/openclaw-bootstrap/swims/swim-38-slippy-hoodie/`](https://github.com/karmaterminal/openclaw-bootstrap/tree/main/swims/swim-38-slippy-hoodie) + branch `swim-38/candidate-cfa-plus-469`
+
+## Status
+
+Slot stub. Substantive cycle materials live on openclaw-bootstrap at the path above.
+
+## Provenance
+
+Slot-stub authored 2026-05-06 by 🌿 frond-scribe per figs's directive 18:51:58Z. Full content migration is follow-on work for 🌻 to arrange.

--- a/swims/swim-39/README.md
+++ b/swims/swim-39/README.md
@@ -1,0 +1,14 @@
+# Swim 39 — volatile-purge
+
+**Era**: volatile-purge cycle
+**Source-of-truth**: [`karmaterminal/openclaw-bootstrap/swims/swim-39-volatile-purge/`](https://github.com/karmaterminal/openclaw-bootstrap/tree/main/swims/swim-39-volatile-purge)
+**Workorder**: [`openclaw-bootstrap/WORKORDER-swim39-rows.md`](https://github.com/karmaterminal/openclaw-bootstrap/blob/main/WORKORDER-swim39-rows.md)
+**Branches**: `cael/swim39-474-cooldown-success-only`, `cael/swim39-477-taskflowdelegates-purge`, `frond-scribe/swim39-fixes-20260501`, `archived/frond-scribe-swim39-825-compaction-event-joint-attribution`
+
+## Status
+
+Slot stub. Substantive cycle materials live on openclaw-bootstrap at the path above.
+
+## Provenance
+
+Slot-stub authored 2026-05-06 by 🌿 frond-scribe per figs's directive 18:51:58Z. Full content migration is follow-on work for 🌻 to arrange.

--- a/swims/swim-40/README.md
+++ b/swims/swim-40/README.md
@@ -1,0 +1,17 @@
+# Swim 40 — v29 substrate verification
+
+**Era**: v29-substrate-verification (predecessor of v5.2 substrate verification cycle in swim-41)
+**Source-of-truth**: [`karmaterminal/openclaw-bootstrap/swims/swim-40-v29-substrate-verification/`](https://github.com/karmaterminal/openclaw-bootstrap/tree/main/swims/swim-40-v29-substrate-verification)
+**Workorder**: [`openclaw-bootstrap/WORKORDER-swim-40-board-prep.md`](https://github.com/karmaterminal/openclaw-bootstrap/blob/main/WORKORDER-swim-40-board-prep.md)
+
+## Status
+
+Slot stub. Substantive cycle materials live on openclaw-bootstrap at the path above.
+
+## Predecessor relationship
+
+Swim 40 is the v29 (= v2026.4.29) substrate verification cycle that precedes [Swim 41](../swim-41/README.md)'s v5.2 substrate verification. The OV-row-driven shape that Swim 41 uses was developed in Swim 40's board-prep workorder.
+
+## Provenance
+
+Slot-stub authored 2026-05-06 by 🌿 frond-scribe per figs's directive 18:51:58Z. Full content migration is follow-on work for 🌻 to arrange.


### PR DESCRIPTION
Per figs's directive 2026-05-06 18:51:58Z (msg `1501657799669842131`):

> *"you find swims? slot them into karmaterminal/karmaterminal-openclaw-docs --> PR so 🌻 can arrange a nice set of 'all of the things'. this will aid you in reconstruct of rigor in integration testing"*

## What this PR does

1. Adds **`swims/README.md`** — comprehensive swim index pointing at all known evidence locations (this repo + openclaw-bootstrap + silas-likes-to-watch), with explicit gap-naming (swims 11-30 except 31, and 32-33).

2. Adds **slot stubs for swims 34, 35, 36, 37, 38, 39, 40** — each minimal `README.md` pointing at bootstrap source-of-truth. No content migration; just public-evidence-repo slots so the index has anchors to point at.

## Why slot-stubs (not full migration)

Per figs's framing — "🌻 can arrange a nice set of 'all of the things'" — the comprehensive arrangement is a single-author shaping job for Elliott. This PR provides slot anchors so the public docs swim index has somewhere to point, without me unilaterally baking layout choices into the migration. Elliott can flesh each stub out into the right shape (matching swim-09/10 narrative form, swim-41 OV-table form, or some new shape) coherently.

## Cohort archaeology references

- 🌫 Silas's surgical archaeology pass: msg `1501657455732592660`
- 🌿 frond-scribe's bootstrap-side location-walk: msg `1501656469786067016`

## What this PR does NOT do

- Does NOT migrate evidence content from bootstrap to docs-repo (that's Elliott's arrangement job per figs's framing)
- Does NOT touch swims 11-30 (except 31) or 32-33 (genuine gaps; need fresh content)
- Does NOT propose what a v2026.5.5 FULL-swim-charter should be (that's the cohort's parallel design discussion 🌊+🩸+🌫 are converging on now)

## Files changed

- `swims/README.md` — new (index)
- `swims/swim-34/README.md` — new (formal-matrix slot, largest source)
- `swims/swim-35/README.md` — new (stabilization slot)
- `swims/swim-36/README.md` — new (mid-cycle slot)
- `swims/swim-37/README.md` — new (heartbeat-era slot)
- `swims/swim-38/README.md` — new (slippy-hoodie slot)
- `swims/swim-39/README.md` — new (volatile-purge slot)
- `swims/swim-40/README.md` — new (v29-substrate-verification slot)

🌿 frond-scribe • 2026-05-06
