### PR TITLE
docs(swims): recover historical swim artifacts into public evidence repo

### DIFF
--- a/swims/README.md
+++ b/swims/README.md
@@ -1,0 +1,32 @@
+# Historical swim index
+
+This directory is the public evidence surface for recovered continuation / integration swim artifacts.
+
+## Public historical anchors
+
+- [Swim 06](./swim-06/README.md) — three-layer continuation canary validation (recovered from frozen branch)
+- [Swim 07](./swim-07/README.md) — hot-reload and silent enrichment canary (recovered from frozen branch)
+- [Swim 09](./swim-09/README.md) — early canary for volitional compaction
+- [Swim 10](./swim-10/README.md) — tool parity + full path coverage canary
+
+## Recovered middle-era artifacts
+
+- [Swim 31](./swim-31/README.md) — timer-arm failure evidence artifact
+- [Swim 34](./swim-34/README.md) — formal matrix / whole-board continuation battery
+- [Swim 35](./swim-35/README.md) — ship-the-feature stabilization
+- [Swim 36](./swim-36/README.md) — continuation feature full-surface coverage
+- [Swim 37](./swim-37/README.md) — pre-ship validation of `feature/context-pressure-squashed`
+- [Swim 38](./swim-38/README.md) — slippy-hoodie edition
+- [Swim 39](./swim-39/README.md) — volatile-purge edition
+- [Swim 40](./swim-40/README.md) — v29 substrate verification
+
+## Later public anchors
+
+- [Swim 41](./swim-41/README.md) — v5.2-era public evidence anchor
+- [Swim 42](./swim-42/EVIDENCE-LAYERS.md) — rows-era evidence layers / targeted substrate verification
+
+## Notes
+
+- This is an **evidence index**, not a claim that every swim here was a FULL whole-board integration swim.
+- Some entries are full scorecards, some are charters, some are matrix artifacts, and some are recovered findings pages.
+- The point of this directory is to make the historical testing surface visible again so future FULL-swim reconstruction can proceed from artifacts instead of memory alone.

--- a/swims/swim-06/FINDINGS.md
+++ b/swims/swim-06/FINDINGS.md
@@ -1,0 +1,64 @@
+# Swim 6 Findings — recovered from frozen evidence branch
+
+This file preserves the branch-local findings ledger that accompanied Swim 6 on the historical frozen evidence branch `ronan/rfc-evidence-appendix`.
+
+## P0: `maxChainLength` off-by-one
+
+- **Status**: fix applied during the canary cycle
+- **Files**: `src/agents/subagent-announce.ts`, `src/auto-reply/reply/agent-runner.ts`
+- **Fix shape**:
+  - announce-side guard `>` → `>=`
+  - tool dispatch task prefix includes `[continuation:chain-hop:${nextChainCount}]` so tool and bracket paths share the same counter semantics
+- **Observed behavior before fix**: `maxChainLength: 10` allowed 12 shards
+- **Evidence**: Swim 6-7b journal
+
+## P1: generation-guard tolerance closure bug
+
+- **Status**: identified during Swim 6; not yet fixed in the initial findings note
+- **Bug**: `generationGuardTolerance` was captured in the timer closure at schedule time rather than re-read at fire time
+- **Fix shape**: move config read inside the `setTimeout` callback
+- **Evidence**: Swim 6-2 — config said 300, timer behavior still reflected stale value
+
+## P2: `maxDelegatesPerTurn` hot-reload gap
+
+- **Status**: identified during Swim 6; not yet fixed in the initial findings note
+- **Bug**: width-limit config changes were not picked up without gateway restart
+- **Fix shape**: read from config at consumption time instead of module init
+- **Evidence**: Swim 6-7b — set to 10, still enforced at 5 until restart
+
+## P2: `forbidden` spawn rejection layer
+
+- **Status**: investigated as design / documentation rather than core bug
+- **Finding**: the spawn layer had its own concurrent-session cap, producing a third defense layer beyond tool gate and runner gate
+- **Evidence**: Swim 6-10 — 10 delegates consumed, 5 spawned, 5 rejected as `forbidden`
+
+## P3: shard message target resolution
+
+- **Status**: cosmetic / investigate
+- **Finding**: shards could fail their first `message` call with an explicit-target error, then recover by parsing channel identity from session key
+- **Impact**: extra latency and noisier logs, but no correctness loss
+
+## P3: lane queue pressure under fan-out
+
+- **Status**: document
+- **Finding**: 5 parallel shards on the same session lane produced queue waits up to ~46 seconds and transient announce retries under load
+
+## Scorecard copy from the original findings note
+
+```text
+6-1  ✅ Blind enrichment
+6-2  ✅ Queue-drain resistance
+6-3  ⏸️ Post-compaction (deferred — needs context buildup)
+6-4  ✅ Return-to-fresh-session (3/3)
+6-5  ⏳ Context-pressure lifecycle
+6-6  ✅ 3-hop chain + visible announce
+6-7  ❌ Chain length enforcement (off-by-one) — FIX APPLIED
+6-7b ✅ Fan-out cap (maxDelegatesPerTurn)
+6-8  ✅ Legacy token hygiene
+6-9a ✅ Missing file (graceful ENOENT)
+6-9b ✅ Slow shard (69s, completes independently)
+6-9c ✅ Empty task (tool-level rejection)
+6-10 ✅ Flood test (5 spawned, 5 forbidden — three-layer defense)
+```
+
+**Recovered provenance:** `karmaterminal/openclaw` branch `ronan/rfc-evidence-appendix`, file `SWIM6-FINDINGS.md`.

--- a/swims/swim-06/README.md
+++ b/swims/swim-06/README.md
@@ -1,0 +1,56 @@
+# Swim 6 — three-layer continuation canary validation
+
+**Cycle window**: overnight canary cycle on 2026-03-06
+**SUT**: three-layer continuation architecture canary
+**Build**: `3a03f4658`
+**Formation**: 4-node fleet / persistent multi-agent canary
+**Result**: 11 PASS · 1 FAIL (fix applied during cycle) · 2 DEFERRED
+
+## Status
+
+This swim is retained as **historical behavioral evidence** for the continuation feature. It predates the public docs-repo era; this page is a recovery of material that previously lived only inside the historical RFC appendix and the frozen evidence branch `ronan/rfc-evidence-appendix` on `karmaterminal/openclaw`.
+
+It is not the current validation cycle; [Swim 41](../swim-41/README.md) and [Swim 42](../swim-42/EVIDENCE-LAYERS.md) are later substrate-era rechecks.
+
+## Summary
+
+Swim 6 was the first documented canary cycle after the three-layer continuation architecture landed. The build under test (`3a03f4658`) validated the shift away from queue-text inference toward typed continuation trigger metadata and explicit post-compaction delegate state.
+
+The cycle exercised 13 scenarios across blind enrichment, queue-drain resistance, return-to-fresh-session behavior, chain-depth enforcement, width enforcement, legacy token hygiene, error handling, and flood behavior. One real correctness defect was found live: **`maxChainLength` was off by one**. That fix was applied during the cycle; the final scorecard therefore records one fail-with-fix-applied rather than a clean all-pass run.
+
+## Detailed scorecard
+
+| Test | Description | Result |
+| ---- | ----------- | ------ |
+| 6-1 | Blind enrichment | ✅ PASS |
+| 6-2 | Queue-drain resistance | ✅ PASS |
+| 6-3 | Post-compaction recall | ⏸️ DEFERRED |
+| 6-4 | Return-to-fresh-session (3/3 shards) | ✅ PASS |
+| 6-5 | Context-pressure lifecycle | ⏸️ DEFERRED |
+| 6-6 | 3-hop chain + visible announce | ✅ PASS |
+| 6-7 | Chain length enforcement | ❌ FAIL → fixed during cycle |
+| 6-7b | Fan-out cap (`maxDelegatesPerTurn`) | ✅ PASS |
+| 6-8 | Legacy token hygiene | ✅ PASS |
+| 6-9a | Missing file (graceful ENOENT) | ✅ PASS |
+| 6-9b | Slow shard (69s, completes independently) | ✅ PASS |
+| 6-9c | Empty task (tool-level rejection) | ✅ PASS |
+| 6-10 | Flood test / three-layer defense | ✅ PASS |
+
+## Key findings
+
+- **P0 — chain length off-by-one:** `maxChainLength: 10` allowed 12 shards. The canary fix changed the announce-side comparison and unified chain-hop counting across tool and bracket paths.
+- **Tolerance closure bug:** generation-guard tolerance was captured too early in a timer closure, so hot-reload changes were not observed at fire time.
+- **Width hot-reload gap:** `maxDelegatesPerTurn` originally behaved like a startup-time constant instead of a dynamic config read.
+- **Three-layer defense shape:** a flood case showed the value of layered enforcement: tool gate, runner gate, and spawn gate each constrained fan-out.
+
+More detail is preserved in [FINDINGS.md](./FINDINGS.md).
+
+## Why this is in the public evidence repo
+
+Before `karmaterminal-openclaw-docs` existed, historical swim evidence lived in a mix of RFC appendix text, branch-local notes, and frozen evidence branches. Swim 6 was one of the cycles that became hard to point at publicly once the RFC appendix was later trimmed.
+
+This page recovers the scorecard and the key defect/fix narrative into the public evidence surface so the historical continuation test record no longer jumps from early public artifacts straight to much later swims.
+
+## Provenance
+
+Recovered from the historical frozen evidence branch **`ronan/rfc-evidence-appendix`** in `karmaterminal/openclaw`, especially the older `docs/design/continue-work-signal-v2.md` appendix section and the branch-local `SWIM6-FINDINGS.md` file.

--- a/swims/swim-07/README.md
+++ b/swims/swim-07/README.md
@@ -1,0 +1,113 @@
+# Swim 7 — hot-reload and silent enrichment canary
+
+**Cycle window**: 2026-03-06 canary cycle
+**SUT**: continuation canary with hot-reload, silent-return, and enrichment validation
+**Build**: `b07e7e40c` (`swim7-validated`)
+**Formation**: 4-agent persistent-session canary with one human operator providing ground truth
+**Result**: 10 PASS · 0 FAIL · 2 DEFERRED
+
+## Status
+
+This swim is retained as **historical behavioral evidence** for the continuation feature. It predates the public docs-repo era; this page reconstructs material that previously lived in the historical RFC appendix and the frozen evidence branch `ronan/rfc-evidence-appendix` on `karmaterminal/openclaw`.
+
+It is not the current validation cycle; [Swim 41](../swim-41/README.md) is the later v5.2 substrate recheck.
+
+## Summary
+
+Swim 7 validated the post-Swim-6 fixes under live canary conditions. The central themes were:
+
+- dynamic hot-reload actually affecting live continuation timers and width/chain limits,
+- silent-return / silent-wake behavior holding under real channel traffic,
+- blind enrichment being behaviorally useful but epistemically dangerous because the receiving agent cannot inspect provenance from inside the resulting context.
+
+The cycle ended with **10 pass, 2 deferred, 0 fail**. The deferred rows depended on organic context buildup rather than directed test setup.
+
+## Evidence locations
+
+| Artifact | Location |
+| -------- | -------- |
+| Swim 7 structured results | [`karmaterminal/silas-likes-to-watch` PR #27](https://github.com/karmaterminal/silas-likes-to-watch/pull/27) |
+| Gateway journal | [`swim-logs/` on `silas-likes-to-watch/main`](https://github.com/karmaterminal/silas-likes-to-watch/tree/main/swim-logs) |
+| Raw operator log capture | [`swim7-silas-raw-figs-capture-2026-03-06.log`](https://github.com/karmaterminal/silas-likes-to-watch/blob/main/swim-logs/swim7-silas-raw-figs-capture-2026-03-06.log) |
+| Swim 7 chat transcript | [`elliott/swim7-chat-evidence`](https://github.com/karmaterminal/openclaw/tree/elliott/swim7-chat-evidence) |
+| Runtime log branch | [`silas/swim7-runtime-evidence`](https://github.com/karmaterminal/openclaw/tree/silas/swim7-runtime-evidence) |
+| Validated canary build | Tag `swim7-validated` at `b07e7e40c` on `karmaterminal/openclaw` |
+| Full process documentation (historical frozen branch) | [`ronan/rfc-evidence-appendix`](https://github.com/karmaterminal/openclaw/tree/ronan/rfc-evidence-appendix) |
+
+## Detailed scorecard
+
+| Test | Description | Result |
+| ---- | ----------- | ------ |
+| 7-B | Delegate tolerance hot-reload (0→cancelled, 300→fired) | ✅ PASS |
+| 7-C | `continue_work` tolerance hot-reload (unified with delegate tolerance) | ✅ PASS |
+| 7-D | Width widen without restart (5→12, 12/12 accepted) | ✅ PASS |
+| 7-E | Width narrow without restart (12→3, 3/5 accepted, 2 rejected) | ✅ PASS |
+| 7-F | Chain boundary enforcement (`maxChainLength: 1` blocks at hop 1) | ✅ PASS |
+| 7-H | Textless-turn delegate consumption (`NO_REPLY` shard consumed) | ✅ PASS |
+| 7-K | Silent return trust boundary (enrichment indistinguishable from self-knowledge) | ✅ PASS |
+| 7-M | Blind enrichment accuracy (3/3 verifiable facts recalled, source attribution honest) | ✅ PASS |
+| 7-I | Post-compaction guard parity | ⏸️ DEFERRED |
+| 7-J | Grandparent reroute ordering | ⏸️ DEFERRED |
+
+## Methodology note
+
+This campaign used a 4-agent persistent session with one agent as test administrator, one as subject under test (SUT), one as log monitor, and one as coordinator. The SUT ran the canary build; all other agents ran stock. The human operator provided ground-truth content for blind enrichment tests and adjudicated pass/fail.
+
+The load-bearing lesson from 7-K and 7-M was epistemic rather than purely mechanical: **silent enrichment arrives as internal context that the receiving agent cannot distinguish from self-knowledge by inspection alone**. Obscure facts can still act as strong external checks; common-adjacent facts blur with model priors. That matters for how much trust later continuation pipelines can place in “the agent says it remembers X.”
+
+## Key evidence lines recovered from the historical appendix
+
+### Tolerance hot-reload (7-B)
+
+```text
+07:02:58 Tool DELEGATE timer cancelled (generation drift 3 > tolerance 0)
+07:03:55 config change applied (dynamic reads: agents.defaults.continuation.generationGuardTolerance)
+07:04:41 Tool DELEGATE timer fired and spawned turn 1/10
+```
+
+### `continue_work` tolerance unification (7-C)
+
+```text
+07:07:08 WORK timer cancelled (generation drift 1 > tolerance 0)
+07:12:22 WORK timer fired for session agent:main:discord:channel:...
+```
+
+### Width widen + narrow (7-D, 7-E)
+
+```text
+07:22:35 config change applied (dynamic reads: agents.defaults.continuation.maxDelegatesPerTurn)
+07:23:29 [continue_delegate] Consuming 12 tool delegate(s)
+07:25:53 config change applied (dynamic reads: agents.defaults.continuation.maxDelegatesPerTurn)
+07:26:24 [continue_delegate] Consuming 3 tool delegate(s)
+```
+
+### Chain boundary (7-F)
+
+```text
+07:27:31 [subagent-chain-hop] Spawned chain delegate (2/2)
+07:28:57 config change applied (dynamic reads: agents.defaults.continuation.maxChainLength)
+07:29:27 [subagent-chain-hop] Chain length 2 > 1, rejecting hop
+```
+
+### Silent enrichment return (7-K)
+
+```text
+07:32:47 agent.wait 9846ms — shard completed
+07:32:48 [continuation/silent-wake] wakeOnReturn=true silentAnnounce=true
+```
+
+### Blind enrichment with ground truth (7-M)
+
+```text
+07:43:02 [continue_delegate] Consuming 1 tool delegate(s)
+07:43:25 agent.wait 22519ms — shard completed
+07:43:25 [continuation/silent-wake] wakeOnReturn=true silentAnnounce=true
+```
+
+## Why this is in the public evidence repo
+
+The pre-2026-04-22 RFC tail linked directly to this evidence world, but later appendix rewrites and the move to the public docs repo thinned that visible history. This page restores Swim 7 to the public record so the historical continuation test story does not look like it jumps from early summaries straight to much later substrate-era swims.
+
+## Provenance
+
+Recovered from the historical frozen evidence branch **`ronan/rfc-evidence-appendix`** in `karmaterminal/openclaw`, especially the older `docs/design/continue-work-signal-v2.md` appendix section. The older RFC tail explicitly linked that branch as the Swim 8-era evidence surface.

--- a/swims/swim-31/README.md
+++ b/swims/swim-31/README.md
@@ -1,0 +1,48 @@
+# Swim 31 — timer-arm failure evidence artifact
+
+**Date**: 2026-04-15 08:10–08:41 PDT  
+**Candidate**: `101e808a8a` on `flesh_beast_figs/codex-fixup-2026-04-14`  
+**SUT**: Silas 🌫️  
+**Driver**: Ronan 🌊  
+**Evidence**: Cael 🩸  
+**Monitor**: Elliott 🌻  
+**Result**: 2 PASS · 1 FINDING
+
+## Status
+
+This is a **historical evidence artifact** recovered from `openclaw-bootstrap`. It is not a modern whole-board swim and not the current validation cycle. It matters because it preserves a concrete failure shape in the middle of the otherwise-thin 11→33 era.
+
+## Scoreboard
+
+| Test | What | Result |
+| ---- | ---- | ------ |
+| TC1 | Artifact-truth baseline | ✅ PASS |
+| TC2 | Override persistence / stale state | ✅ PASS |
+| TC3 | Delegate delivery sanity | ⚠️ FINDING |
+
+**Swim stopped at TC3 per runbook non-negotiable #5.**
+
+## Load-bearing finding
+
+Swim 31 captured the same timer-arm failure shape previously seen on `continue_work`, now reproduced on delayed `continue_delegate`:
+
+> `scheduled → consumed → timer never armed → no spawn → no announce-back`
+
+Three-source convergence was recorded:
+- Cael SSH evidence capture
+- Elliott monitor confirmation
+- Silas SUT self-report
+
+## Why this matters
+
+Swim 31 is one of the strongest surviving receipts in the 11→33 gap because it preserves:
+- the candidate SHA
+- the role formation
+- a concrete scoreboard
+- a specific runtime failure signature
+
+That makes it cleanly citable as historical continuation evidence even though it is not a FULL swim.
+
+## Provenance
+
+Recovered from `openclaw-bootstrap/SWIM/history/SWIM31-EVIDENCE.md`.

--- a/swims/swim-34/README.md
+++ b/swims/swim-34/README.md
@@ -1,0 +1,44 @@
+# Swim 34 — formal matrix / whole-board continuation battery
+
+**Date window**: 2026-04-16 → 2026-04-17  
+**Formation**: Driver Ronan 🌊 · SUT Silas 🌫️ · Monitor Elliott 🌻 · Coord Cael 🩸  
+**Primary artifact**: formal row-matrix plus companion behavioral packet  
+**Result shape**: full-board charter / matrix artifact; not a single compact public scorecard
+
+## Status
+
+This page preserves the **whole-board matrix artifact** recovered from `openclaw-bootstrap`. It is one of the strongest anchors for the remembered 40+ continuation test board.
+
+It is not a small targeted recheck. The charter language is explicit: this was the **ocean swim, not the puddle paddle**.
+
+## Why Swim 34 is load-bearing
+
+Swim 34 is the clearest surviving evidence that the continuation feature once had a substantially larger declared board than the later public 13-row Swim 10 scorecard alone would suggest.
+
+Its matrix declares:
+- Block A — tool/state invariants
+- Block B — behavioral rows
+- Block C — candidate-specific rows
+- Block D — regression/recovery rows
+- Block E — validation rows
+- Block X — continuation extension rows
+
+The companion `ROWS.md` records a broad declared board with roughly **40–50 rows of surface coverage** when the extensions are included.
+
+## What it was testing
+
+Per the bootstrap README, Swim 34 existed because a whole-feature refactor had just landed and partial verification was no longer trustworthy. Its purpose was to exercise the post-refactor continuation surface as a system rather than certifying only the PR-diff surface.
+
+## Important caveat
+
+Swim 34 is a **matrix-era historical artifact**, not a neat single README scorecard like Swim 10. Publicly recovering it means preserving the matrix shape honestly, not pretending it was a small modern-style row cluster.
+
+## Source surfaces
+
+- `openclaw-bootstrap/swims/swim-34-formal-matrix/README.md`
+- `openclaw-bootstrap/swims/swim-34-formal-matrix/ROWS.md`
+- `openclaw-bootstrap/swims/swim-34-staleness/` (related behavioral packet / companion lens)
+
+## Provenance
+
+Recovered from `openclaw-bootstrap`, where Swim 34 survives as the formal continuation matrix artifact.

--- a/swims/swim-35/README.md
+++ b/swims/swim-35/README.md
@@ -1,0 +1,35 @@
+# Swim 35 — ship-the-feature stabilization
+
+**Anchor issue**: `openclaw-bootstrap#607`  
+**Driver**: Ronan 🌊  
+**Coord**: Cael 🩸  
+**Thesis**: stabilization-and-shippability layer between feature-complete and upstream-presentable
+
+## Status
+
+This is a **historical stabilization swim artifact** recovered from `openclaw-bootstrap`. It follows the whole-board pressure of Swim 34 and shifts from broad surface enumeration to ship-readiness rows.
+
+## Scope
+
+The surviving row index is small and targeted, centered on stabilization work such as:
+- raw-key normalization sweep
+- `continue_delegate` horizon behavior
+- threshold-cross positive-fire receipts
+- deploy.sh post-deploy bytes-check
+
+## Why it matters
+
+Swim 35 helps explain the history between the giant Swim 34 matrix and the later substrate-era swims:
+- the board did not disappear
+- it narrowed into stabilization / ship-readiness work
+- the continuation surface was still being exercised explicitly, just at a different unit of account than the original full-board matrix
+
+## Source surfaces
+
+- `openclaw-bootstrap/swims/swim-35-stabilization/README.md`
+- `openclaw-bootstrap/swims/swim-35-stabilization/ROWS.md`
+- `openclaw-bootstrap/swims/swim-35-stabilization/rows/`
+
+## Provenance
+
+Recovered from `openclaw-bootstrap/swims/swim-35-stabilization/`.

--- a/swims/swim-36/README.md
+++ b/swims/swim-36/README.md
@@ -1,0 +1,45 @@
+# Swim 36 — continuation feature full-surface coverage
+
+**Status in source artifact**: ACTIVE  
+**Owner**: Ronan 🌊  
+**Witness / operator**: Silas 🌫️  
+**Mandate**: "insist on full surface coverage of continuation feature"
+
+## Status
+
+This page preserves the Swim 36 charter as a **historical full-surface coverage artifact** recovered from `openclaw-bootstrap`.
+
+It is especially important because the charter names the feature surface directly and explicitly rather than relying on the word *swim* alone.
+
+## Declared surfaces
+
+The charter enumerates continuation as a system across surfaces A–O, including:
+- tool-surface availability
+- `continue_work` end-to-end
+- `continue_delegate` modes
+- `request_compaction`
+- bracket fallbacks
+- context-pressure bands
+- chain guards & limits
+- lich / post-compaction lifecycle
+- status / observability
+- TaskFlow persistence
+- races / concurrency
+- config / schema
+- RFC accuracy
+- branch / release hygiene
+
+## Why Swim 36 matters
+
+If Swim 34 is the strongest surviving **row-matrix** anchor, Swim 36 is one of the strongest surviving **surface-map** anchors. It names the continuation feature as a whole system and makes the intended coverage readable up front.
+
+That makes it a key source for reconstructing any future FULL continuation charter.
+
+## Source surfaces
+
+- `openclaw-bootstrap/swims/swim-36/charter.md`
+- companion playbook / evidence-ledger referenced by that charter
+
+## Provenance
+
+Recovered from `openclaw-bootstrap/swims/swim-36/charter.md`.

--- a/swims/swim-37/README.md
+++ b/swims/swim-37/README.md
@@ -1,0 +1,44 @@
+# Swim 37 — pre-ship validation of `feature/context-pressure-squashed`
+
+**Status in source artifact**: ACTIVE scaffold / deploy-gate era  
+**Candidate**: `karmaterminal/openclaw:feature/context-pressure-squashed`  
+**Baseline tag**: `v2026.4.21`
+
+## Status
+
+This page preserves Swim 37 as a **historical pre-ship validation artifact** recovered from `openclaw-bootstrap`.
+
+It is not a tiny OV cluster. The bootstrap charter explicitly says stabilization / pre-ship swims run the **whole declared board** unless a real blocker exists.
+
+## Load-bearing idea
+
+Swim 37 sharpened an operational truth that later mattered a lot:
+
+> **the swim is the deploy**
+
+The charter treats the sequenced deploy to all four princes, with traces visible and behavior exercised against the declared board, as the case itself.
+
+## Why Swim 37 matters
+
+Swim 37 helps bridge the historical full-board era to the later substrate-era verification language. The companion feature-coverage map explicitly tries to make the continuation feature readable as a **feature map by title alone**, including:
+- continuation primitives
+- OTEL / diagnostics
+- session delivery queue
+- chain budget
+- cross-session routing
+- drain / permission gating
+- tool registry
+- static guards
+- config schema
+
+That makes Swim 37 one of the clearest surviving statements of what a continuation swim was trying to certify at ship time.
+
+## Source surfaces
+
+- `openclaw-bootstrap/swims/swim-37/CHARTER.md`
+- `openclaw-bootstrap/swims/swim-37/FEATURE-COVERAGE.md`
+- `openclaw-bootstrap/swims/swim-37/CASES.md`
+
+## Provenance
+
+Recovered from `openclaw-bootstrap/swims/swim-37/`.

--- a/swims/swim-38/README.md
+++ b/swims/swim-38/README.md
@@ -1,0 +1,39 @@
+# Swim 38 — slippy-hoodie edition
+
+**Status in source artifact**: ACTIVE charter / pre-swim gate  
+**Candidate**: `0a960498dccbba3b0ed2ef64ecd8cd2cc9368e1b` (PR #469 head)  
+**Driver**: Ronan 🌊
+
+## Status
+
+This page preserves Swim 38 as a **historical charter artifact** recovered from `openclaw-bootstrap`.
+
+Its value is not a final public scorecard but the explicit substrate framing it preserves.
+
+## What Swim 38 was for
+
+Swim 38 was a pre-advance validation swim for the assembled candidate shape after PR #469, with explicit roles, substrate choice, pre-swim gate, layer ordering, and rollback criteria.
+
+The charter is unusually clear that:
+- the swim is the deploy plus exercised matrix
+- the lineage decision can be deferred while runtime bytes are still certified
+- the continuation extension rows remain part of the declared matrix
+
+## Why it matters
+
+Swim 38 is part of the evidence that the continuation testing culture had not collapsed into ad-hoc receipts. Even late in the cycle, the cohort was still writing explicit swim contracts with:
+- candidate pin
+- roles
+- pre-swim gate
+- greenlight criteria
+- rollback trigger
+- matrix scope
+
+## Source surfaces
+
+- `openclaw-bootstrap/swims/swim-38-slippy-hoodie/CHARTER.md`
+- `openclaw-bootstrap/swims/swim-38-slippy-hoodie/rows/`
+
+## Provenance
+
+Recovered from `openclaw-bootstrap/swims/swim-38-slippy-hoodie/`.

--- a/swims/swim-39/README.md
+++ b/swims/swim-39/README.md
@@ -1,0 +1,37 @@
+# Swim 39 — volatile-purge edition
+
+**Status in source artifact**: ACTIVE charter / row-program  
+**Primary umbrella**: `karmaterminal/openclaw#473`  
+**Driver**: Ronan 🌊
+
+## Status
+
+This page preserves Swim 39 as a **historical substrate-verification charter artifact** recovered from `openclaw-bootstrap`.
+
+## What Swim 39 was for
+
+Swim 39 verified the post-volatile-purge state required for the continuation substrate. Its acceptance rows were explicit and operational, including:
+- zero gate symbols in dist
+- sqlite-unconditional read/write path
+- queue introspection split counts
+- non-destructive cancel / drain tooling
+- schema-removal verification
+- cooldown-arming probe
+- blocked-state observability
+- write-tool clobber probe
+
+## Why it matters
+
+Swim 39 shows the transition from broad continuation surface language to very concrete substrate certification rows without losing the idea that the swim is still a declared matrix with pre-swim gate, rollback, and greenlight criteria.
+
+That makes it a key ancestor for later OV-style verification without just collapsing everything into "a few OVs."
+
+## Source surfaces
+
+- `openclaw-bootstrap/swims/swim-39-volatile-purge/CHARTER.md`
+- `openclaw-bootstrap/swims/swim-39-volatile-purge/CASES.md`
+- `openclaw-bootstrap/swims/swim-39-volatile-purge/FEATURE-COVERAGE.md`
+
+## Provenance
+
+Recovered from `openclaw-bootstrap/swims/swim-39-volatile-purge/`.

--- a/swims/swim-40/README.md
+++ b/swims/swim-40/README.md
@@ -1,0 +1,49 @@
+# Swim 40 — v29 substrate verification
+
+**Substrate of record**: wave-1 `7eae057a74`, wave-2 `ae4f09282a`  
+**Baseline tag**: `a448042c2edd94a4e8ee86d5ed90a5ed9fe8e4cd`  
+**Bootstrap**: `08a4e9f`
+
+## Status
+
+This page preserves Swim 40 as a **historical scoreboard-bearing substrate swim** recovered from `openclaw-bootstrap`.
+
+Unlike some earlier recovered artifacts, Swim 40 includes an explicit surviving scoreboard.
+
+## What Swim 40 certified
+
+Swim 40 rebased the still-relevant Swim 39 verification rows onto the v29 candidate line and added visibility-substrate verification rows.
+
+Its declared OV rows included:
+- dist gate-symbol grep
+- `pendingDelegateCount` split-count surface
+- non-destructive cancel / drain probe
+- `livenessState:blocked` channel surfacing
+- four-level visibility enum
+- cross-tree same-agent reach via `visibility=agent`
+- ansible `all` default behavior for session visibility
+- later scoreboard also lists a bracket/token continuation compatibility row
+
+## Surviving scoreboard state
+
+From the recovered scoreboard artifact:
+- **OV-1** — PASS (fleet)
+- **OV-2** — PASS
+- **OV-3** — PASS
+- **OV-4** — SKIP-WITH-REASON
+- **OV-5** — PASS
+- **OV-6** — PASS
+- **OV-7** — not yet closed in the preserved scoreboard snapshot
+- **OV-8** — not yet closed in the preserved scoreboard snapshot
+
+This makes Swim 40 one of the clearest late-cycle receipts for how substrate verification was actually being tracked in-row rather than just narrated.
+
+## Source surfaces
+
+- `openclaw-bootstrap/swims/swim-40-v29-substrate-verification/CHARTER.md`
+- `openclaw-bootstrap/swims/swim-40-v29-substrate-verification/SCOREBOARD.md`
+- `openclaw-bootstrap/swims/swim-40-v29-substrate-verification/rows/`
+
+## Provenance
+
+Recovered from `openclaw-bootstrap/swims/swim-40-v29-substrate-verification/`.


### PR DESCRIPTION
## Summary
- recover historical swim artifacts into `karmaterminal-openclaw-docs/swims/`
- preserve early frozen-branch evidence (Swim 6-7)
- preserve middle-era artifacts from bootstrap (Swim 31, 34-40)
- add a public swim index so the historical testing surface is visible again

## Added
- `swims/README.md`
- `swims/swim-06/README.md`
- `swims/swim-06/FINDINGS.md`
- `swims/swim-07/README.md`
- `swims/swim-31/README.md`
- `swims/swim-34/README.md`
- `swims/swim-35/README.md`
- `swims/swim-36/README.md`
- `swims/swim-37/README.md`
- `swims/swim-38/README.md`
- `swims/swim-39/README.md`
- `swims/swim-40/README.md`

## Provenance
Recovered from multiple historical evidence surfaces:
1. `karmaterminal/openclaw` frozen evidence branch `ronan/rfc-evidence-appendix`
2. `karmaterminal/openclaw` archived branch `archived/flesh_beast_figs-20260414-claude` (older RFC appendix + in-tree Swim 7 evidence path)
3. `karmaterminal/openclaw` preserved presentation branch `feature/context-pressure-squashed-archive-20260504-recompose-findings-1-2-3-landed` (later RFC presentation surface)
4. `karmaterminal/openclaw-bootstrap` swim artifacts, charters, rows, scoreboards, and history files

## Intent
This PR does **not** claim every recovered artifact is a FULL swim. The purpose is to restore the historical evidence surface so the old whole-board taxonomy can be reconstructed honestly instead of inferred from memory or flattened into the later public rows-era docs alone.

## Follow-up
- continue the archaeology pass for missing swims / thinly-attested swims (especially 8, 11-30 except 31, 32-33)
- distill the recovered matrix into a new FULL-swim charter / category skeleton for the next continuation whole-board run