### PR TITLE
docs(swims): evacuate historical continuation swim archive

### DIFF
--- a/swims/HISTORY.md
+++ b/swims/HISTORY.md
@@ -1,0 +1,46 @@
+# Continuation swim history map
+
+This index collects the continuation swim artifacts that are currently recoverable across the historical archive surfaces.
+
+## Archive surfaces
+
+1. **Older `karmaterminal/openclaw` RFC / branch lineage**
+   - early evidence-link era
+   - includes historical Swim 6 / 7 branch-surface evidence and RFC-inline Swim 6–10 references
+2. **`karmaterminal/openclaw-bootstrap` swim archive**
+   - primary matrix-era archive
+   - holds Swim 5, 31, 34–40 and methodology/runbook material
+3. **`karmaterminal/karmaterminal-openclaw-docs`**
+   - public evidence surface
+   - originally held Swim 9 / 10 / 41 / 42
+   - now expanded with evacuated historical pages
+
+## Currently evidenced swims in this public docs surface
+
+- Swim 05 — generation guard / chain-hop enforcement historical scorecard
+- Swim 06 — three-layer canary validation
+- Swim 07 — canary scorecard and methodology snapshot
+- Swim 09 — historical canary scorecard
+- Swim 10 — historical full-path canary scorecard
+- Swim 31 — evidence artifact / timer-arm failure investigation
+- Swim 34 — formal matrix / whole-board continuation battery
+- Swim 35 — stabilization scaffold
+- Swim 36 — full-surface charter
+- Swim 37 — pre-ship validation overlay / deploy swim
+- Swim 38 — slippy-hoodie edition charter
+- Swim 39 — volatile-purge charter + case inventory
+- Swim 40 — v29 substrate verification charter + scoreboard
+- Swim 41 — v5.2 substrate verification
+- Swim 42 — v5.5 cohort / evidence-layer validation surface
+
+## Thin or still-missing areas
+
+These remain thinner than the documented set above and should not be overclaimed without further archaeology:
+
+- Swim 08
+- Swim 11–30 (except 31)
+- Swim 32–33
+
+## Why this file exists
+
+The historical evidence world was split across branch-local RFC appendices, bootstrap swim directories, and later docs-repo surfaces. This index gives Ronan a single public place to arrange “all of the things” without forcing future readers to rediscover the archive topology first.

--- a/swims/swim-05/README.md
+++ b/swims/swim-05/README.md
@@ -1,0 +1,44 @@
+# Swim 5 — generation guard and chain-hop enforcement
+
+**Date**: 2026-03-05
+**Builds referenced**: `8a76e62fc`, `80ea0a366`, `fec5e4bfc`
+**Result shape**: historical scorecard with live guard and chain findings
+
+## Status
+
+This page preserves historical continuation evidence recovered from `openclaw-bootstrap` archive material.
+
+It is historical evidence, not the current validation cycle.
+
+## What this swim established
+
+- generation-guard preemption was proven live after the `isDelegateWake` fix
+- chain-hop tracking and `maxChainLength` enforcement were exercised through repeated live runs
+- `sessions_spawn` and bracket-based chain hops were shown to have different bounding behavior
+
+## Key historical results
+
+### Test 5-0 — Generation Guard
+- happy-path timer fire: PASS
+- preemption initially failed under a misclassified delegate wake
+- root cause was traced to `isDelegateWake` misclassification
+- fix landed in `8a76e62fc`
+- round-3 rerun confirmed timer cancellation after a real inbound message
+
+### Test 5-1 / 5-6 — Chain-hop bounds
+- early runs showed reliable chain dispatch but incomplete enforcement
+- later build `fec5e4bfc` confirmed the hard cap live:
+  - hop 1 ✅
+  - hop 2 ✅
+  - hop 3 ✅
+  - hop 4 ✅
+  - hop 5 ❌ rejected at the chain limit
+
+## Why this matters historically
+
+Swim 5 is one of the earliest strong proofs that continuation timing and chain accounting were not just design claims — they were exercised against live gateway behavior and refined through real failures.
+
+## Source artifacts
+
+Recovered from `openclaw-bootstrap`:
+- `SWIM/history/SWIM5-STATUS.md`

--- a/swims/swim-06/README.md
+++ b/swims/swim-06/README.md
@@ -1,0 +1,66 @@
+# Swim 6 — three-layer canary validation
+
+**Cycle window**: 2026-03-06 (~05:17 PST summary timestamp)
+**SUT**: continuation canary on Silas (`urudyne`, WSL2)
+**Build**: `3a03f4658`
+**Result**: 11 passed · 1 failed (fix applied) · 2 deferred
+
+## Status
+
+This page preserves historical continuation evidence evacuated from the older
+`karmaterminal/openclaw` branch `ronan/rfc-evidence-appendix`, which served as an
+RFC evidence surface before `karmaterminal-openclaw-docs` existed.
+
+It is historical evidence, not the current validation cycle.
+
+## Scorecard
+
+| Test | Description | Result |
+| --- | --- | --- |
+| 6-1 | Blind enrichment | ✅ PASS |
+| 6-2 | Queue-drain resistance | ✅ PASS |
+| 6-3 | Post-compaction (needs context buildup) | ⏸️ DEFERRED |
+| 6-4 | Return-to-fresh-session (3/3 shards) | ✅ PASS |
+| 6-5 | Context-pressure lifecycle | ⏳ DEFERRED |
+| 6-6 | 3-hop chain + visible announce | ✅ PASS |
+| 6-7 | Chain length enforcement (off-by-one) | ❌ FAIL → fix applied |
+| 6-7b | Fan-out cap (`maxDelegatesPerTurn`) | ✅ PASS |
+| 6-8 | Legacy token hygiene | ✅ PASS |
+| 6-9a | Missing file (graceful `ENOENT`) | ✅ PASS |
+| 6-9b | Slow shard (69s, completes independently) | ✅ PASS |
+| 6-9c | Empty task (tool-level rejection) | ✅ PASS |
+| 6-10 | Flood test (5 spawned, 5 forbidden — three-layer defense) | ✅ PASS |
+
+## Key findings preserved from the source branch
+
+### 6-1 Blind enrichment
+
+A planted file at `/tmp/swim6-enrichment.txt` (Cathar heresy) was read by a
+`continue_delegate` shard returned with `silent-wake`. The blind probe recalled
+Rex Mundi, 1209, Béziers, and Arnaud Amalric. The wake metadata confirmed a
+`delegate-return` trigger.
+
+### 6-2 Queue-drain resistance
+
+The test validated that draining the event queue did not destroy pending delegate
+markers. The fix landed at `38c43b486`, moving delegate-pending state out of the
+queue and into a dedicated map.
+
+### 6-4 Return to fresh session
+
+Three delayed delegates were dispatched, the session was `/new`'d, and all three
+returned to the fresh session through channel-key routing. The historical note
+preserved here is load-bearing: gateway timers survived the session reset because
+those timers lived in the gateway process, not in the session transcript.
+
+## Source artifacts evacuated into this page
+
+The historical source material came from:
+
+- `karmaterminal/openclaw` branch `ronan/rfc-evidence-appendix`
+- `SWIM6-FINDINGS.md`
+- `docs/design/continue-work-signal-v2.md` (historical appendix summary)
+
+The source branch was an older frozen RFC-evidence surface that predates the
+public docs repo. This page exists so the RFC no longer has to rely on that branch
+remaining discoverable forever.

--- a/swims/swim-07/README.md
+++ b/swims/swim-07/README.md
@@ -1,0 +1,94 @@
+# Swim 7 — canary scorecard and methodology snapshot
+
+**Cycle window**: historical canary cycle after Swim 6
+**SUT**: canary continuation build on a 4-agent persistent-session formation
+**Build**: `b07e7e40c`
+**Result**: 10 pass · 2 deferred · 0 fail
+
+## Status
+
+This page preserves historical continuation evidence evacuated from the older
+`karmaterminal/openclaw` branch `ronan/rfc-evidence-appendix`, which served as an
+RFC evidence surface before `karmaterminal-openclaw-docs` existed.
+
+It is historical evidence, not the current validation cycle.
+
+## Scorecard
+
+| Test | Description | Result |
+| --- | --- | --- |
+| 7-B | Delegate tolerance hot-reload (`0→cancelled`, `300→fired`) | ✅ PASS |
+| 7-C | `continue_work` tolerance hot-reload (unified with delegate tolerance) | ✅ PASS |
+| 7-D | Width widen without restart (`5→12`, `12/12` accepted) | ✅ PASS |
+| 7-E | Width narrow without restart (`12→3`, `3/5` accepted, 2 rejected) | ✅ PASS |
+| 7-F | Chain boundary enforcement | ✅ PASS |
+| 7-H | Textless-turn delegate consumption | ✅ PASS |
+| 7-K | Silent-return trust boundary | ✅ PASS |
+| 7-M | Blind enrichment accuracy | ✅ PASS |
+| 7-I | Post-compaction guard parity | ⏸️ DEFERRED |
+| 7-J | Grandparent reroute ordering | ⏸️ DEFERRED |
+
+## Methodology snapshot
+
+Historical methodology note preserved from the source branch:
+
+- 4-agent persistent-session canary formation
+- one agent as test administrator
+- one agent as subject under test (SUT)
+- one agent as log monitor
+- one agent as coordinator
+- operator-provided ground truth for blind enrichment checks
+
+The key trust-boundary finding from 7-K / 7-M was that silent enrichment arrives
+as internal context that is indistinguishable from self-knowledge from inside the
+receiving session. Provenance had to be established from logs and reasoning, not
+from introspection.
+
+## Key evidence lines preserved from the source branch
+
+### Tolerance hot-reload (7-B)
+
+```text
+07:02:58 Tool DELEGATE timer cancelled (generation drift 3 > tolerance 0)
+07:03:55 config change applied (dynamic reads: agents.defaults.continuation.generationGuardTolerance)
+07:04:41 Tool DELEGATE timer fired and spawned turn 1/10
+```
+
+### `continue_work` tolerance unification (7-C)
+
+```text
+07:07:08 WORK timer cancelled (generation drift 1 > tolerance 0)
+07:12:22 WORK timer fired for session agent:main:discord:channel:...
+```
+
+### Width widen + narrow (7-D / 7-E)
+
+```text
+07:22:35 config change applied (dynamic reads: agents.defaults.continuation.maxDelegatesPerTurn)
+07:23:29 [continue_delegate] Consuming 12 tool delegate(s)
+07:25:53 config change applied (dynamic reads: agents.defaults.continuation.maxDelegatesPerTurn)
+07:26:24 [continue_delegate] Consuming 3 tool delegate(s)
+```
+
+### Chain boundary (7-F)
+
+```text
+07:27:31 [subagent-chain-hop] Spawned chain delegate (2/2)
+07:28:57 config change applied (dynamic reads: agents.defaults.continuation.maxChainLength)
+07:29:27 [subagent-chain-hop] Chain length 2 > 1, rejecting hop
+```
+
+## Source artifacts evacuated into this page
+
+The historical source material came from:
+
+- `karmaterminal/openclaw` branch `ronan/rfc-evidence-appendix`
+- `docs/design/continue-work-signal-v2.md` (historical appendix)
+- `SEAL-BOY-SWIM-RUNBOOK.md`
+- `SWIM-MONITORING-RUNBOOK.md`
+- `SWIM-SUBJECT-NOTES.md`
+- `SWIM-COORDINATOR-NOTES.md`
+
+Those runbooks remain valuable as historical methodology artifacts, but the core
+release-facing evidence moved here so the RFC can point at stable public docs
+instead of an old branch lineage.

--- a/swims/swim-31/README.md
+++ b/swims/swim-31/README.md
@@ -1,0 +1,40 @@
+# Swim 31 — evidence artifact
+
+**Date**: 2026-04-15 08:10–08:41 PDT
+**Candidate**: `101e808a8a` on `flesh_beast_figs/codex-fixup-2026-04-14`
+**SUT**: Silas 🌫️
+**Driver**: Ronan 🌊
+**Evidence**: Cael 🩸
+**Monitor**: Elliott 🌻
+**Result**: 2 PASS · 1 FINDING
+
+## Status
+
+Historical evidence artifact recovered from `openclaw-bootstrap`.
+
+## Scoreboard
+
+| Test | What | Result |
+| --- | --- | --- |
+| TC1 | Artifact-truth baseline | PASS |
+| TC2 | Override persistence / stale state | PASS |
+| TC3 | Delegate delivery sanity | FINDING |
+
+Swim stopped at TC3 per runbook stop rules.
+
+## Load-bearing finding
+
+TC3 confirmed a broken timer-arm path:
+
+`schedul​ed → consumed → timer never armed → no spawn → no announce-back`
+
+The artifact preserved a three-source convergence across Cael SSH receipts, Elliott journal reads, and Silas SUT self-report.
+
+## Why this matters historically
+
+Swim 31 is a good example of a swim that did not exist to certify green status. It existed to stop on a real failure and preserve a precise runtime signature.
+
+## Source artifacts
+
+Recovered from `openclaw-bootstrap`:
+- `SWIM/history/SWIM31-EVIDENCE.md`

--- a/swims/swim-34/README.md
+++ b/swims/swim-34/README.md
@@ -1,0 +1,48 @@
+# Swim 34 — formal matrix
+
+**Date window**: 2026-04-16 → 2026-04-17
+**Primary board shape**: formal whole-feature continuation matrix
+**Roles**: Ronan 🌊 driver · Silas 🌫️ SUT · Elliott 🌻 monitor · Cael 🩸 coordinator
+
+## Status
+
+Historical matrix-era artifact recovered from `openclaw-bootstrap`.
+
+This is the strongest recovered old-board anchor for the continuation feature’s “whole walk” era.
+
+## Why Swim 34 matters
+
+Swim 34 is the clearest documented version of the older **full-jacket / whole-board** continuation swim shape.
+
+Its own README says it plainly:
+- this was the **ocean swim, not the puddle paddle**
+- partial verification immediately after a refactor was not enough
+- the matrix existed to exercise the whole post-refactor continuation surface
+
+## Board shape
+
+The formal matrix records:
+- **44 rows total** after adding `A0`
+- **3 green V-series rows already run**
+- **41 remaining rows** at the time of the captured board state
+
+Families present in the board:
+- Block A — tool / state invariants
+- Block B — behavioral F-series
+- Block C — candidate-specific P-series
+- Block D — regression / recovery
+- Block E — validation
+- Block X — extension rows from earlier continuation audit/history
+
+This is the closest recovered artifact to the older 40–50-case whole-board continuation test taxonomy.
+
+## Historical significance
+
+If someone asks where the rigorous “full suite” continuation swim shape is best documented, Swim 34 is the primary answer currently recoverable from the archive.
+
+## Source artifacts
+
+Recovered from `openclaw-bootstrap`:
+- `swims/swim-34-formal-matrix/README.md`
+- `swims/swim-34-formal-matrix/ROWS.md`
+- supporting `rows/`, `evidence/`, `scripts/`, and archaeology/comprehension notes in the same directory

--- a/swims/swim-35/README.md
+++ b/swims/swim-35/README.md
@@ -1,0 +1,31 @@
+# Swim 35 — ship-the-feature stabilization
+
+**Anchor issue**: bootstrap #607
+**Driver**: Ronan 🌊
+**Coordinator**: Cael 🩸
+**Purpose**: stabilization-and-shippability layer after feature-complete continuation canary
+
+## Status
+
+Historical stabilization scaffold recovered from `openclaw-bootstrap`.
+
+## What this swim was for
+
+Swim 35 was not a brand-new whole-board matrix. It was the tightening layer between “feature complete” and “upstream presentable.”
+
+The row board recorded four scoped stabilization rows:
+- A1 — raw-key normalization sweep
+- A2 — `continue_delegate` horizon honoring
+- A3 — threshold-cross positive-fire receipt
+- B1 — post-deploy bytes-check
+
+## Why this matters historically
+
+Swim 35 shows the transition from whole-board matrix work into stabilization-row work. It’s important for reconstructing how rigor decayed from explicit exhaustive boards into narrower but still serious row collections.
+
+## Source artifacts
+
+Recovered from `openclaw-bootstrap`:
+- `swims/swim-35-stabilization/README.md`
+- `swims/swim-35-stabilization/ROWS.md`
+- row verdicts and comprehension notes in the same directory

--- a/swims/swim-36/README.md
+++ b/swims/swim-36/README.md
@@ -1,0 +1,40 @@
+# Swim 36 — continuation feature full-surface coverage
+
+**Status at capture**: ACTIVE
+**Owner**: Ronan 🌊
+**Mandate quote**: “insist on full surface coverage of continuation feature in SWIM 36”
+
+## Status
+
+Historical full-surface charter recovered from `openclaw-bootstrap`.
+
+## Scope shape
+
+Swim 36 is a 15-surface charter over the continuation feature, organized A–O across:
+- tool surface
+- `continue_work`
+- `continue_delegate` modes
+- `request_compaction`
+- bracket fallbacks
+- context-pressure bands
+- chain guards and limits
+- lich / post-compaction lifecycle
+- status / observability
+- TaskFlow persistence
+- races / concurrency
+- config / schema
+- future aspected delegates
+- RFC accuracy
+- branch / release hygiene
+
+The charter references **45 issues on project #54**.
+
+## Why this matters historically
+
+Swim 36 is one of the clearest explicit statements that the continuation feature should be tested as a **full surface**, not as a handful of lucky seams.
+
+## Source artifacts
+
+Recovered from `openclaw-bootstrap`:
+- `swims/swim-36/charter.md`
+- supporting cluster notes in `swims/swim-36/clusters/`

--- a/swims/swim-37/README.md
+++ b/swims/swim-37/README.md
@@ -1,0 +1,34 @@
+# Swim 37 — `feature/context-pressure-squashed` pre-ship validation
+
+**Status at capture**: ACTIVE
+**Candidate**: `feature/context-pressure-squashed`
+**Baseline tag**: `v2026.4.21`
+
+## Status
+
+Historical pre-ship overlay charter recovered from `openclaw-bootstrap`.
+
+## What this swim represents
+
+Swim 37 explicitly says the swim **is the deploy**: sequenced deployment plus full declared-board exercise against the candidate branch.
+
+It inherits the older formal runbook board and extends it with a branch-specific overlay.
+
+## Historical shape
+
+The charter records:
+- a regenerable integration tip instead of a toxic frozen SHA pattern
+- a pre-deploy / deploy / post-deploy gate structure
+- explicit inheritance from prior swims, especially Swim 34 formal matrix and Swim 36 full-surface charter
+- a large overlay board in `CASES.md` that extends rather than replaces the canonical base matrix
+
+## Why this matters historically
+
+Swim 37 is one of the clearest archival proofs that the “full swim” concept had not disappeared by the late 30s. It had become layered: canonical base matrix + prior-swim history + current overlay.
+
+## Source artifacts
+
+Recovered from `openclaw-bootstrap`:
+- `swims/swim-37/CHARTER.md`
+- `swims/swim-37/CASES.md`
+- supporting deployment / feature coverage receipts in the same directory

--- a/swims/swim-38/README.md
+++ b/swims/swim-38/README.md
@@ -1,0 +1,30 @@
+# Swim 38 — slippy-hoodie edition
+
+**Status at capture**: ACTIVE
+**Driver**: Ronan 🌊
+**Candidate**: `0a960498dccbba3b0ed2ef64ecd8cd2cc9368e1b` (PR #469 head)
+
+## Status
+
+Historical charter recovered from `openclaw-bootstrap`.
+
+## What this swim represents
+
+Swim 38 preserved the swim-as-deploy shape while binding it to a particular candidate posture and lineage discussion.
+
+It records:
+- explicit role assignments
+- candidate/tree-equivalence receipts
+- a pre-swim gate
+- inherited matrix scope from the formal runbook and Swim 37 overlay pattern
+- greenlight / rollback criteria for a presentation-advance decision
+
+## Why this matters historically
+
+Swim 38 shows the continuation swim discipline persisting as a real operational charters-and-rows practice, not merely a retrospective narrative.
+
+## Source artifacts
+
+Recovered from `openclaw-bootstrap`:
+- `swims/swim-38-slippy-hoodie/CHARTER.md`
+- `swims/swim-38-slippy-hoodie/rows/row-01-pre-swim-gate.md`

--- a/swims/swim-39/README.md
+++ b/swims/swim-39/README.md
@@ -1,0 +1,36 @@
+# Swim 39 — volatile-purge edition
+
+**Status at capture**: ACTIVE
+**Driver**: Ronan 🌊
+**Primary umbrella issue**: `karmaterminal/openclaw#473`
+
+## Status
+
+Historical charter + case inventory recovered from `openclaw-bootstrap`.
+
+## What this swim represents
+
+Swim 39 translated a post-volatile-purge acceptance target into an explicit runtime certification board.
+
+Its documented case inventory includes:
+- Block A — infrastructure
+- Block B — behavioral continuation surface
+- Block C — candidate-specific / port-specific rows
+- Block D — regression / recovery
+- Block E — validation
+- overlay OV rows for purge-specific acceptance criteria
+
+## Board size
+
+The preserved `CASES.md` records **32 unique rows** after dual-tagging some overlay items.
+
+## Why this matters historically
+
+Swim 39 is a strong example of the rows-era still retaining a chartered-board mindset. It was narrower than Swim 34’s huge matrix, but it was still an explicitly declared whole exercise rather than an accidental pile of receipts.
+
+## Source artifacts
+
+Recovered from `openclaw-bootstrap`:
+- `swims/swim-39-volatile-purge/CHARTER.md`
+- `swims/swim-39-volatile-purge/CASES.md`
+- supporting prep/draft materials in neighboring archive locations

--- a/swims/swim-40/README.md
+++ b/swims/swim-40/README.md
@@ -1,0 +1,33 @@
+# Swim 40 — v29 substrate verification
+
+**Status at capture**: ACTIVE
+**Driver**: Ronan 🌊
+**Primary tracker**: bootstrap #859
+**Substrate of record**: v29 line / `frond-scribe/20260429/v3-cohort-fixes`
+
+## Status
+
+Historical charter + scoreboard recovered from `openclaw-bootstrap`.
+
+## What this swim represents
+
+Swim 40 rebound the migrated Swim 39 OV rows onto the v29 line and added visibility-substrate verification rows.
+
+It records a seven-OV acceptance board covering:
+- dist gate-symbol grep
+- split-count queue surface
+- non-destructive cancel/drain tooling
+- blocked-state channel surfacing
+- four-level visibility enum
+- cross-tree same-agent reach
+- ansible/default visibility behavior
+
+## Why this matters historically
+
+Swim 40 is important because it proves the late-30s / early-40s continuation swim era still had scoreboards, declared rows, and explicit substrate-of-record discipline.
+
+## Source artifacts
+
+Recovered from `openclaw-bootstrap`:
+- `swims/swim-40-v29-substrate-verification/CHARTER.md`
+- `swims/swim-40-v29-substrate-verification/SCOREBOARD.md`


### PR DESCRIPTION
## Summary
- evacuate recoverable historical continuation swim artifacts into the public docs repo
- add public historical pages for Swim 05, 06, 07, 31, 34, 35, 36, 37, 38, 39, and 40
- add `swims/HISTORY.md` as the archive-topology / missing-swims map

## Why
The historical continuation swim record is split across three archive surfaces:
- older `karmaterminal/openclaw` RFC / branch lineage
- `karmaterminal/openclaw-bootstrap` swim archive
- `karmaterminal/karmaterminal-openclaw-docs`

That split makes the public history look like `swim-10 --- huge gap ---> swim-40+` if you only read the docs repo.
This PR starts closing that gap by slotting the recoverable documented swims into the public docs surface so Ronan can arrange a clean “all of the things” set.

## Added in this PR
- `swims/HISTORY.md`
- `swims/swim-05/README.md`
- `swims/swim-06/README.md`
- `swims/swim-07/README.md`
- `swims/swim-31/README.md`
- `swims/swim-34/README.md`
- `swims/swim-35/README.md`
- `swims/swim-36/README.md`
- `swims/swim-37/README.md`
- `swims/swim-38/README.md`
- `swims/swim-39/README.md`
- `swims/swim-40/README.md`

## Source-of-truth surfaces used
- `openclaw-bootstrap/SWIM/history/*`
- `openclaw-bootstrap/swims/swim-34-formal-matrix/*`
- `openclaw-bootstrap/swims/swim-35-stabilization/*`
- `openclaw-bootstrap/swims/swim-36/*`
- `openclaw-bootstrap/swims/swim-37/*`
- `openclaw-bootstrap/swims/swim-38-slippy-hoodie/*`
- `openclaw-bootstrap/swims/swim-39-volatile-purge/*`
- `openclaw-bootstrap/swims/swim-40-v29-substrate-verification/*`
- older `karmaterminal/openclaw` RFC evidence branch `ronan/rfc-evidence-appendix` (for Swim 06 / 07)

## Intentional non-claims
- this does **not** pretend Swim 10’s 13 public rows were the whole old board
- this does **not** claim Swim 41 / 42 are already a full-suite replacement
- this does **not** fill the thin spots yet (`8`, `11–30` except `31`, `32–33`)

## Next useful pass
- recover the old full-suite taxonomy from Swim 34 + neighboring archive material
- use that to mint the `v2026.5.5` FULL-swim charter
