### PR TITLE
docs(swim): provenance-class tagging pass on merged public shelf (#916/D)

### DIFF
--- a/swims/HISTORY.md
+++ b/swims/HISTORY.md
@@ -17,21 +17,25 @@ This index collects the continuation swim artifacts that are currently recoverab
 
 ## Currently evidenced swims in this public docs surface
 
-- Swim 05 — generation guard / chain-hop enforcement historical scorecard
-- Swim 06 — three-layer canary validation
-- Swim 07 — canary scorecard and methodology snapshot
-- Swim 09 — historical canary scorecard
-- Swim 10 — historical full-path canary scorecard
-- Swim 31 — evidence artifact / timer-arm failure investigation
-- Swim 34 — formal matrix / whole-board continuation battery
-- Swim 35 — stabilization scaffold
-- Swim 36 — full-surface charter
-- Swim 37 — pre-ship validation overlay / deploy swim
-- Swim 38 — slippy-hoodie edition charter
-- Swim 39 — volatile-purge charter + case inventory
-- Swim 40 — v29 substrate verification charter + scoreboard
-- Swim 41 — v5.2 substrate verification
-- Swim 42 — v5.5 cohort / evidence-layer validation surface
+Each swim below is tagged with its provenance class per `swims/README.md` (see also the appendix-discipline ledger at `karmaterminal/openclaw-bootstrap` PR #912 / `swims/MISSING-SWIMS-LEDGER.md`):
+
+- Swim 05 — generation guard / chain-hop enforcement historical scorecard — `appendix/branch-native`
+- Swim 06 — three-layer canary validation — `appendix/branch-native`
+- Swim 07 — canary scorecard and methodology snapshot — `appendix/branch-native`
+- Swim 09 — historical canary scorecard — `appendix/branch-native`
+- Swim 10 — historical full-path canary scorecard — `appendix/branch-native`
+- Swim 31 — evidence artifact / timer-arm failure investigation — `bootstrap-pointer`
+- Swim 34 — formal matrix / whole-board continuation battery — `bootstrap-pointer`
+- Swim 35 — stabilization scaffold — `bootstrap-pointer`
+- Swim 36 — full-surface charter — `bootstrap-pointer`
+- Swim 37 — pre-ship validation overlay / deploy swim — `bootstrap-pointer`
+- Swim 38 — slippy-hoodie edition charter — `bootstrap-pointer`
+- Swim 39 — volatile-purge charter + case inventory — `bootstrap-pointer`
+- Swim 40 — v29 substrate verification charter + scoreboard — `bootstrap-pointer`
+- Swim 41 — v5.2 substrate verification — `appendix/branch-native`
+- Swim 42 — v5.5 cohort / evidence-layer validation surface — `bootstrap-pointer`
+
+Provenance grammar: `appendix/branch-native` = backed by surviving in-tree or RFC-history evidence on `karmaterminal/openclaw`; `bootstrap-pointer` = bootstrap remains the source-of-truth body and the public page is a pointer; `adjacent branch-era` / `inferred from neighboring evidence, not directly preserved` = reserved for future evacuations (no swim sits here yet).
 
 ## Thin or still-missing areas
 

--- a/swims/README.md
+++ b/swims/README.md
@@ -2,31 +2,52 @@
 
 This directory is the public evidence surface for recovered continuation / integration swim artifacts.
 
+## Provenance classes
+
+Every linked swim below is tagged with one of three provenance classes, surfaced both here and in-file at the top of each per-swim README:
+
+- **`appendix/branch-native`** — backed by surviving in-tree or RFC-history evidence on the `karmaterminal/openclaw` fork, or recovered from the `ronan/rfc-evidence-appendix` frozen branch. The public page can stand on first-party byte evidence.
+- **`bootstrap-pointer`** — public surface evacuated from `karmaterminal/openclaw-bootstrap` (e.g. `swims/swim-NN-…/`, `SWIM/history/`); bootstrap remains the source-of-truth body. The public page is a pointer to the bootstrap body, not a substitute for it.
+- **`adjacent branch-era` / `inferred from neighboring evidence, not directly preserved`** — reserved for future evacuations where the evidence is from neighboring branches or inferred rather than directly preserved. No swim in this index currently sits here; the appendix-discipline ledger at `karmaterminal/openclaw-bootstrap` PR #912 (`swims/MISSING-SWIMS-LEDGER.md`) tracks what would land here when migrated.
+
+The provenance grammar follows `karmaterminal/openclaw-bootstrap` PR #908 + #912 + `swims/MISSING-SWIMS-LEDGER.md`. Anti-flattening rule: a `bootstrap-pointer` page is **not** appendix-native proof, and silent promotion across classes is a discipline failure.
+
 ## Public historical anchors
 
-- [Swim 06](./swim-06/README.md) — three-layer continuation canary validation (recovered from frozen branch)
-- [Swim 07](./swim-07/README.md) — hot-reload and silent enrichment canary (recovered from frozen branch)
-- [Swim 09](./swim-09/README.md) — early canary for volitional compaction
-- [Swim 10](./swim-10/README.md) — tool parity + full path coverage canary
+- [Swim 06](./swim-06/README.md) — three-layer continuation canary validation (recovered from frozen branch) — `appendix/branch-native`
+- [Swim 07](./swim-07/README.md) — hot-reload and silent enrichment canary (recovered from frozen branch) — `appendix/branch-native`
+- [Swim 09](./swim-09/README.md) — early canary for volitional compaction — `appendix/branch-native`
+- [Swim 10](./swim-10/README.md) — tool parity + full path coverage canary — `appendix/branch-native`
 
 ## Recovered middle-era artifacts
 
-- [Swim 31](./swim-31/README.md) — timer-arm failure evidence artifact
-- [Swim 34](./swim-34/README.md) — formal matrix / whole-board continuation battery
-- [Swim 35](./swim-35/README.md) — ship-the-feature stabilization
-- [Swim 36](./swim-36/README.md) — continuation feature full-surface coverage
-- [Swim 37](./swim-37/README.md) — pre-ship validation of `feature/context-pressure-squashed`
-- [Swim 38](./swim-38/README.md) — slippy-hoodie edition
-- [Swim 39](./swim-39/README.md) — volatile-purge edition
-- [Swim 40](./swim-40/README.md) — v29 substrate verification
+- [Swim 31](./swim-31/README.md) — timer-arm failure evidence artifact — `bootstrap-pointer`
+- [Swim 34](./swim-34/README.md) — formal matrix / whole-board continuation battery — `bootstrap-pointer`
+- [Swim 35](./swim-35/README.md) — ship-the-feature stabilization — `bootstrap-pointer`
+- [Swim 36](./swim-36/README.md) — continuation feature full-surface coverage — `bootstrap-pointer`
+- [Swim 37](./swim-37/README.md) — pre-ship validation of `feature/context-pressure-squashed` — `bootstrap-pointer`
+- [Swim 38](./swim-38/README.md) — slippy-hoodie edition — `bootstrap-pointer`
+- [Swim 39](./swim-39/README.md) — volatile-purge edition — `bootstrap-pointer`
+- [Swim 40](./swim-40/README.md) — v29 substrate verification — `bootstrap-pointer`
 
 ## Later public anchors
 
-- [Swim 41](./swim-41/README.md) — v5.2-era public evidence anchor
-- [Swim 42](./swim-42/EVIDENCE-LAYERS.md) — rows-era evidence layers / targeted substrate verification
+- [Swim 41](./swim-41/README.md) — v5.2-era public evidence anchor — `appendix/branch-native`
+- [Swim 42](./swim-42/README.md) — v5.5 / final-release-integration charter — `bootstrap-pointer`
+- [Swim 42 evidence layers](./swim-42/EVIDENCE-LAYERS.md) — rows-era evidence layers / targeted substrate verification
+
+## Anti-flattening note (what is and isn't migrated)
+
+The `swims/HISTORY.md` companion index lists all currently-evidenced swims and explicitly names thin / still-missing areas:
+
+- **Migrated and surfaced here**: 05, 06, 07, 09, 10, 31, 34, 35, 36, 37, 38, 39, 40, 41, 42
+- **Thin or still-missing (do NOT treat absence as completeness)**: 08, 11–30 except 31, 32, 33
+
+Per `karmaterminal/openclaw-bootstrap#912` (`swims/MISSING-SWIMS-LEDGER.md`), swims 11–30 (except 31) plus 32–33 are tracked at the appendix-discipline level as `pointer-only acceptable` (22 / 25 / 27 / 28), bootstrap-primary pointer entries (26 / 29 / 32 / 33), or `needs-migration before any appendix entry` (the rest). They do not have public pages here precisely because they lack the surviving-artifact density to honestly carry one yet.
 
 ## Notes
 
 - This is an **evidence index**, not a claim that every swim here was a FULL whole-board integration swim.
 - Some entries are full scorecards, some are charters, some are matrix artifacts, and some are recovered findings pages.
 - The point of this directory is to make the historical testing surface visible again so future FULL-swim reconstruction can proceed from artifacts instead of memory alone.
+- For the FULL-swim charter contract these recovered artifacts feed into, see `karmaterminal/openclaw-bootstrap` `SWIM/FULL-SWIM-CHARTER.md` (PR #908) and `SWIM/CASE-REGISTRY-RULES.md` (PR #929). For the case registry that elects against this surface, see `SWIM/cases/` (PR #938).

--- a/swims/swim-05/README.md
+++ b/swims/swim-05/README.md
@@ -3,6 +3,8 @@
 **Date**: 2026-03-05
 **Builds referenced**: `8a76e62fc`, `80ea0a366`, `fec5e4bfc`
 **Result shape**: historical scorecard with live guard and chain findings
+**Provenance class**: `appendix/branch-native` — backed by surviving in-tree or RFC-history evidence on the openclaw fork (or recovered from the `ronan/rfc-evidence-appendix` frozen branch). See `swims/README.md` for the full provenance-class definitions and `swims/HISTORY.md` for the archive-surface map.
+
 
 ## Status
 

--- a/swims/swim-06/README.md
+++ b/swims/swim-06/README.md
@@ -5,6 +5,8 @@
 **Build**: `3a03f4658`
 **Formation**: 4-node fleet / persistent multi-agent canary
 **Result**: 11 PASS · 1 FAIL (fix applied during cycle) · 2 DEFERRED
+**Provenance class**: `appendix/branch-native` — backed by surviving in-tree or RFC-history evidence on the openclaw fork (or recovered from the `ronan/rfc-evidence-appendix` frozen branch). See `swims/README.md` for the full provenance-class definitions and `swims/HISTORY.md` for the archive-surface map.
+
 
 ## Status
 

--- a/swims/swim-07/README.md
+++ b/swims/swim-07/README.md
@@ -5,6 +5,8 @@
 **Build**: `b07e7e40c` (`swim7-validated`)
 **Formation**: 4-agent persistent-session canary with one human operator providing ground truth
 **Result**: 10 PASS · 0 FAIL · 2 DEFERRED
+**Provenance class**: `appendix/branch-native` — backed by surviving in-tree or RFC-history evidence on the openclaw fork (or recovered from the `ronan/rfc-evidence-appendix` frozen branch). See `swims/README.md` for the full provenance-class definitions and `swims/HISTORY.md` for the archive-surface map.
+
 
 ## Status
 

--- a/swims/swim-09/README.md
+++ b/swims/swim-09/README.md
@@ -5,6 +5,8 @@
 **Build**: `b2322f5`
 **Duration**: approximately 2 hours, Phase 1 low-context testing
 **Result**: 5/5 PASS after fixing a missing forwarding of `requestCompactionOpts` from `run.ts` to `attempt.ts`
+**Provenance class**: `appendix/branch-native` — backed by surviving in-tree or RFC-history evidence on the openclaw fork (or recovered from the `ronan/rfc-evidence-appendix` frozen branch). See `swims/README.md` for the full provenance-class definitions and `swims/HISTORY.md` for the archive-surface map.
+
 
 ## Status
 

--- a/swims/swim-10/README.md
+++ b/swims/swim-10/README.md
@@ -6,6 +6,8 @@
 **Duration**: approximately 5 hours
 **Formation**: driver, log monitor, SUT, coordinator, human user (5-role canary)
 **Result**: 12 PASS · 0 FAIL · 1 DEFERRED
+**Provenance class**: `appendix/branch-native` — backed by surviving in-tree or RFC-history evidence on the openclaw fork (or recovered from the `ronan/rfc-evidence-appendix` frozen branch). See `swims/README.md` for the full provenance-class definitions and `swims/HISTORY.md` for the archive-surface map.
+
 
 ## Status
 

--- a/swims/swim-31/README.md
+++ b/swims/swim-31/README.md
@@ -7,6 +7,8 @@
 **Evidence**: Cael 🩸  
 **Monitor**: Elliott 🌻  
 **Result**: 2 PASS · 1 FINDING
+**Provenance class**: `bootstrap-pointer` — public surface evacuated from `karmaterminal/openclaw-bootstrap` (e.g. `swims/swim-NN-…/`, `SWIM/history/`); bootstrap remains the source-of-truth body for this swim. See `swims/README.md` for the full provenance-class definitions and `swims/HISTORY.md` for the archive-surface map.
+
 
 ## Status
 

--- a/swims/swim-34/README.md
+++ b/swims/swim-34/README.md
@@ -4,6 +4,8 @@
 **Formation**: Driver Ronan 🌊 · SUT Silas 🌫️ · Monitor Elliott 🌻 · Coord Cael 🩸  
 **Primary artifact**: formal row-matrix plus companion behavioral packet  
 **Result shape**: full-board charter / matrix artifact; not a single compact public scorecard
+**Provenance class**: `bootstrap-pointer` — public surface evacuated from `karmaterminal/openclaw-bootstrap` (e.g. `swims/swim-NN-…/`, `SWIM/history/`); bootstrap remains the source-of-truth body for this swim. See `swims/README.md` for the full provenance-class definitions and `swims/HISTORY.md` for the archive-surface map.
+
 
 ## Status
 

--- a/swims/swim-35/README.md
+++ b/swims/swim-35/README.md
@@ -4,6 +4,8 @@
 **Driver**: Ronan 🌊  
 **Coord**: Cael 🩸  
 **Thesis**: stabilization-and-shippability layer between feature-complete and upstream-presentable
+**Provenance class**: `bootstrap-pointer` — public surface evacuated from `karmaterminal/openclaw-bootstrap` (e.g. `swims/swim-NN-…/`, `SWIM/history/`); bootstrap remains the source-of-truth body for this swim. See `swims/README.md` for the full provenance-class definitions and `swims/HISTORY.md` for the archive-surface map.
+
 
 ## Status
 

--- a/swims/swim-36/README.md
+++ b/swims/swim-36/README.md
@@ -4,6 +4,8 @@
 **Owner**: Ronan 🌊  
 **Witness / operator**: Silas 🌫️  
 **Mandate**: "insist on full surface coverage of continuation feature"
+**Provenance class**: `bootstrap-pointer` — public surface evacuated from `karmaterminal/openclaw-bootstrap` (e.g. `swims/swim-NN-…/`, `SWIM/history/`); bootstrap remains the source-of-truth body for this swim. See `swims/README.md` for the full provenance-class definitions and `swims/HISTORY.md` for the archive-surface map.
+
 
 ## Status
 

--- a/swims/swim-37/README.md
+++ b/swims/swim-37/README.md
@@ -3,6 +3,8 @@
 **Status in source artifact**: ACTIVE scaffold / deploy-gate era  
 **Candidate**: `karmaterminal/openclaw:feature/context-pressure-squashed`  
 **Baseline tag**: `v2026.4.21`
+**Provenance class**: `bootstrap-pointer` — public surface evacuated from `karmaterminal/openclaw-bootstrap` (e.g. `swims/swim-NN-…/`, `SWIM/history/`); bootstrap remains the source-of-truth body for this swim. See `swims/README.md` for the full provenance-class definitions and `swims/HISTORY.md` for the archive-surface map.
+
 
 ## Status
 

--- a/swims/swim-38/README.md
+++ b/swims/swim-38/README.md
@@ -3,6 +3,8 @@
 **Status in source artifact**: ACTIVE charter / pre-swim gate  
 **Candidate**: `0a960498dccbba3b0ed2ef64ecd8cd2cc9368e1b` (PR #469 head)  
 **Driver**: Ronan 🌊
+**Provenance class**: `bootstrap-pointer` — public surface evacuated from `karmaterminal/openclaw-bootstrap` (e.g. `swims/swim-NN-…/`, `SWIM/history/`); bootstrap remains the source-of-truth body for this swim. See `swims/README.md` for the full provenance-class definitions and `swims/HISTORY.md` for the archive-surface map.
+
 
 ## Status
 

--- a/swims/swim-39/README.md
+++ b/swims/swim-39/README.md
@@ -3,6 +3,8 @@
 **Status in source artifact**: ACTIVE charter / row-program  
 **Primary umbrella**: `karmaterminal/openclaw#473`  
 **Driver**: Ronan 🌊
+**Provenance class**: `bootstrap-pointer` — public surface evacuated from `karmaterminal/openclaw-bootstrap` (e.g. `swims/swim-NN-…/`, `SWIM/history/`); bootstrap remains the source-of-truth body for this swim. See `swims/README.md` for the full provenance-class definitions and `swims/HISTORY.md` for the archive-surface map.
+
 
 ## Status
 

--- a/swims/swim-40/README.md
+++ b/swims/swim-40/README.md
@@ -3,6 +3,8 @@
 **Substrate of record**: wave-1 `7eae057a74`, wave-2 `ae4f09282a`  
 **Baseline tag**: `a448042c2edd94a4e8ee86d5ed90a5ed9fe8e4cd`  
 **Bootstrap**: `08a4e9f`
+**Provenance class**: `bootstrap-pointer` — public surface evacuated from `karmaterminal/openclaw-bootstrap` (e.g. `swims/swim-NN-…/`, `SWIM/history/`); bootstrap remains the source-of-truth body for this swim. See `swims/README.md` for the full provenance-class definitions and `swims/HISTORY.md` for the archive-surface map.
+
 
 ## Status
 

--- a/swims/swim-41/README.md
+++ b/swims/swim-41/README.md
@@ -5,6 +5,8 @@
 **Driver**: 🌊 Ronan (4th prince)
 **Tracker**: [`karmaterminal/openclaw-bootstrap#892`](https://github.com/karmaterminal/openclaw-bootstrap/issues/892) (private; cohort-internal)
 **Driver-stamp**: opened at [issuecomment-4365486568](https://github.com/karmaterminal/openclaw-bootstrap/issues/892#issuecomment-4365486568) on 2026-05-03
+**Provenance class**: `appendix/branch-native` — backed by surviving in-tree or RFC-history evidence on the openclaw fork (or recovered from the `ronan/rfc-evidence-appendix` frozen branch). See `swims/README.md` for the full provenance-class definitions and `swims/HISTORY.md` for the archive-surface map.
+
 
 ## Purpose
 

--- a/swims/swim-42/README.md
+++ b/swims/swim-42/README.md
@@ -3,6 +3,8 @@
 **Status at charter time:** OPEN / scaffolded, later exercised as live row clusters in this docs directory
 **Substrate target at swim-wake:** `frond/v2026.5.2/canonical @ f39b8c9751...`
 **Meaning:** final-release integration charter for the v5.2 line, with the public row receipts in this directory as its evidence surface
+**Provenance class**: `bootstrap-pointer` — public surface evacuated from `karmaterminal/openclaw-bootstrap` (e.g. `swims/swim-NN-…/`, `SWIM/history/`); bootstrap remains the source-of-truth body for this swim. See `swims/README.md` for the full provenance-class definitions and `swims/HISTORY.md` for the archive-surface map.
+
 
 ## Why this page exists
 


### PR DESCRIPTION
Lane: `karmaterminal/openclaw-bootstrap#927` (`#916/D`).

Follow-up to the docs-arrangement chain (`#916/A` → `#916/B` → `#916/C` landed via PR #4, PR #7, PR #6).

## What this does

Adds explicit **provenance-class tagging** to every recovered swim README on the public shelf, plus surfaces the class at the index level so the chunk-level provenance is visible without opening per-swim files.

### Per-swim README tagging (15 files)

A single-line `**Provenance class**:` field added to each `swim-NN/README.md` immediately after the metadata block, naming the class and pointing at the index for the full grammar.

Provenance class assignment per `karmaterminal/openclaw-bootstrap#912` (`swims/MISSING-SWIMS-LEDGER.md`) appendix-discipline ledger:

- `appendix/branch-native` (6 swims): **05 / 06 / 07 / 09 / 10 / 41**
- `bootstrap-pointer` (9 swims): **31 / 34 / 35 / 36 / 37 / 38 / 39 / 40 / 42**
- `adjacent branch-era` / `inferred from neighboring evidence, not directly preserved` (0 swims): reserved for future evacuations

### Index-level surfacing

- `swims/README.md` — adds a **Provenance classes** section defining the three-class grammar, surfaces the class on every link, and adds an explicit anti-flattening note naming exactly which swims are migrated (05/06/07/09/10/31/34/35/36/37/38/39/40/41/42) and which are thin/still-missing per the appendix-discipline ledger (08, 11–30 except 31, 32, 33). Cross-references the FULL-swim charter contract (PR #908), case-registry-rules (PR #929), and case registry (PR #938) so readers can follow the discipline chain from the public shelf back to the contract substrate.
- `swims/HISTORY.md` — provenance class added inline next to every currently-evidenced swim entry. Provenance grammar restated at the section level so the page stays standalone-readable.

## Anti-flattening rule preserved

A `bootstrap-pointer` page is NOT appendix-native proof. Silent promotion across classes is a discipline failure. The appendix-discipline ledger at `karmaterminal/openclaw-bootstrap#912` remains the authoritative tombstone for swim-level evidence-class survivability.

## What this does NOT change

- No content/wording changes to per-swim README bodies (only the `**Provenance class**:` line is inserted)
- No re-classification of any swim against the ledger; the assignments mirror what `MISSING-SWIMS-LEDGER.md` cosigned
- No change to `swim-42/EVIDENCE-LAYERS.md` (already an evidence-layer document, not a swim README)

## Closes

- `karmaterminal/openclaw-bootstrap#927` (`#916/D`) — provenance-class tagging pass on the merged public shelf

Last remaining `#916` sub-task. Cosign byte-walk welcome from any non-author seat.