### PR TITLE
swim(post-migration): correct stale path/in-flight refs in migrated factory

### DIFF
--- a/SWIM/FORMAL-SWIM-RUNBOOK.md
+++ b/SWIM/FORMAL-SWIM-RUNBOOK.md
@@ -1,6 +1,6 @@
 # FORMAL SWIM RUNBOOK
 
-This is the authoritative swim starter for continuation verification on `openclaw-bootstrap`.
+This is the authoritative swim starter for continuation verification.
 
 It is a synthesis of:
 - `openclaw-bootstrap#427` (Swim 29 formal matrix shape)

--- a/SWIM/PR-UPDATE-VALIDATION-WALKTHROUGH.md
+++ b/SWIM/PR-UPDATE-VALIDATION-WALKTHROUGH.md
@@ -23,7 +23,7 @@ Before reading further, confirm:
 - you have read access to `SWIM/cases/CATALOG.md` (the canonical case registry)
 - `swims/` directory exists in `karmaterminal/karmaterminal-openclaw-docs` for instance landing
 
-If any of those are missing, fix that before continuing — this walkthrough does not work without the substrate stack landed (PR #938 already merged at `1efd7cf4c3935d951ceaa3872feb5483c013d5b5`; PRs #908 + #929 still in flight at filing time but should land first for the walkthrough to satisfy its own preconditions on first read).
+If any of those are missing, fix that before continuing — this walkthrough does not work without the substrate stack landed (all of PR #908, #929-as-#944, #938, #941, #943 merged 2026-05-06; SWIM/ factory migrated from openclaw-bootstrap to karmaterminal-openclaw-docs via PR #9 + bootstrap #945 same day).
 
 ---
 

--- a/SWIM/cases/REGISTRY-LIFECYCLE-WALKTHROUGH.md
+++ b/SWIM/cases/REGISTRY-LIFECYCLE-WALKTHROUGH.md
@@ -232,7 +232,7 @@ This is the tombstone shape. A `lost` case carries a confidence tag and a proven
 
 ## 6. Version-bump worked example
 
-A registry version bump captures one or more lifecycle transitions. It is its own PR against `karmaterminal-openclaw-docs/SWIM/cases/` (or `karmaterminal/openclaw-bootstrap/SWIM/cases/` until migration #939 lands).
+A registry version bump captures one or more lifecycle transitions. It is its own PR against `karmaterminal-openclaw-docs/SWIM/cases/`.
 
 **Worked example: bumping v1 → v2 to capture the transitions in §1 + §3**:
 


### PR DESCRIPTION
Per figs's directive 2026-05-06 (msg `1501715116...`): 'get the migration done; then correct the content'. Migration landed via PR #9 + openclaw-bootstrap#945 (squash 22f2a3b8778d3f22ad2840e688a1bf2a44396845 + db1f4dbb217631b6cc6d440251f712c65e4eebae respectively).

This is the content-correction follow-up: fixes 3 stale references that became inaccurate post-migration.

## Fixes

- **SWIM/FORMAL-SWIM-RUNBOOK.md** line 3: 'authoritative swim starter for continuation verification on `openclaw-bootstrap`' → 'authoritative swim starter for continuation verification' (location no longer bootstrap-specific)
- **SWIM/PR-UPDATE-VALIDATION-WALKTHROUGH.md §0** prereq: substrate stack status updated from 'PRs #908 + #929 still in flight at filing time' to 'all of PR #908, #929-as-#944, #938, #941, #943 merged 2026-05-06; SWIM/ factory migrated from openclaw-bootstrap to karmaterminal-openclaw-docs via PR #9 + bootstrap #945 same day'
- **SWIM/cases/REGISTRY-LIFECYCLE-WALKTHROUGH.md §6**: removed 'or `karmaterminal/openclaw-bootstrap/SWIM/cases/` until migration #939 lands' parenthetical (migration landed)

## Not changed

- All issue-number references (e.g. `karmaterminal/openclaw-bootstrap#933`, `#412`, `#427`, `#399`) intentionally preserved — these are issue citations not path references; they continue to point at bootstrap issue tracker correctly.
- README.md intentionally retains references to bootstrap-private archive (`SWIM/lessons/`, `SWIM/history/`) since those genuinely stay in bootstrap per the converged scope split.

## Acceptance

- [x] no remaining stale `openclaw-bootstrap/SWIM/` path references
- [x] no remaining 'in flight' / 'until migration lands' parentheticals
- [x] issue citations preserved

Per figs's directive: admin-merge expected, plumbing only.