### PR TITLE
swim(post-migration): receive factory-shape artifacts (ARCHAEOLOGY-INVENTORY + FULL-SWIM-CROSSWALK) into SWIM/

### DIFF
--- a/SWIM/ARCHAEOLOGY-INVENTORY-8-40.md
+++ b/SWIM/ARCHAEOLOGY-INVENTORY-8-40.md
@@ -1,0 +1,130 @@
+# Archaeology inventory — Swim 8 through Swim 40
+
+Purpose: separate historical continuation evidence into the honest migration buckets needed for FULL-swim reconstruction.
+
+## 1. Branch-backed / RFC-history-backed
+
+These have citable evidence on old `karmaterminal/openclaw` RFC / frozen-branch surfaces.
+
+### Swim 8
+- `origin/ronan/rfc-tool-parity:docs/design/continue-work-signal-v2.md`
+  - `D.4 Swim 8 detailed results`
+  - points at `ronan/rfc-evidence-appendix`
+- `origin/archived/flesh_beast_figs-20260414-claude:docs/design/continue-work-signal-v2.md`
+  - Appendix D.2 / D.3 names Swim 8 as archived evidence on `ronan/rfc-evidence-appendix`
+- `origin/archived/feature-context-pressure-squashed:docs/design/continue-work-signal-v2.md`
+  - same Appendix D stratum, still points Swim 8 to `ronan/rfc-evidence-appendix`
+
+### Swim 9
+- `origin/ronan/rfc-tool-parity:docs/design/continue-work-signal-v2.md`
+  - `D.5 Swim 9 and Swim 10 detailed results`
+  - evidence table points Swim 9 issue/results at `openclaw-bootstrap#375`
+- `origin/archived/flesh_beast_figs-20260414-claude:docs/design/continue-work-signal-v2.md`
+  - D.3 treats Swim 9 as one of the most-recent full-coverage canary sessions
+- `origin/archived/feature-context-pressure-squashed:docs/design/continue-work-signal-v2.md`
+  - same later Appendix D.3 framing
+- `origin/feature/context-pressure-squashed-recompose-20260504-findings-1-2-3-savegame-pre-strip:docs/design/continue-work-signal-v2.md`
+  - public-docs bridge already links `swims/swim-09/README.md`
+
+### Swim 10
+- `origin/ronan/rfc-tool-parity:docs/design/continue-work-signal-v2.md`
+  - D.5 detailed scorecard
+  - evidence table points Swim 10 issue/results at `openclaw-bootstrap#377`
+- `origin/archived/flesh_beast_figs-20260414-claude:docs/design/continue-work-signal-v2.md`
+  - D.3 full scorecard and retained notes
+- `origin/archived/feature-context-pressure-squashed:docs/design/continue-work-signal-v2.md`
+  - same later Appendix D.3 framing
+- `origin/feature/context-pressure-squashed-recompose-20260504-findings-1-2-3-savegame-pre-strip:docs/design/continue-work-signal-v2.md`
+  - public-docs bridge already links `swims/swim-10/README.md`
+
+### Swim 41
+- `origin/feature/context-pressure-squashed-recompose-20260504-findings-1-2-3-savegame-pre-strip:docs/design/continue-work-signal-v2.md`
+  - `D.4 Current validation cycle: Swim 41 v5.2 substrate verification`
+  - links public evidence at `karmaterminal-openclaw-docs/swims/swim-41/`
+- `origin/feature/context-pressure-squashed-archive-20260504-recompose-findings-1-2-3-landed:docs/design/continue-work-signal-v2.md`
+  - later D.4 v5.2 substrate verification stratum (less explicit naming than savegame-pre-strip)
+
+## 2. Bootstrap-only / bootstrap-primary
+
+These do not currently have strong branch-backed evidence and should be treated as bootstrap-primary archaeology.
+
+### Swim 31
+- `openclaw-bootstrap/SWIM/history/SWIM31-EVIDENCE.md`
+- public summary may exist in docs repo, but source-of-truth is bootstrap history
+
+### Swim 34
+- `openclaw-bootstrap/swims/swim-34-formal-matrix/ROWS.md`
+- `openclaw-bootstrap/swims/swim-34-formal-matrix/README.md`
+- strongest old-board anchor; explicit A0–A5, B1–B8, C1–C7, D1–D5, E1–E3, X1–X15 inventory
+
+### Swim 35
+- `openclaw-bootstrap/swims/swim-35-stabilization/ROWS.md`
+- `openclaw-bootstrap/swims/swim-35-stabilization/README.md`
+- `openclaw-bootstrap/swims/swim-35-stabilization/BRIEF.md`
+
+### Swim 36
+- `openclaw-bootstrap/swims/swim-36/charter.md`
+- 15-surface coverage expansion
+
+### Swim 37
+- `openclaw-bootstrap/swims/swim-37/FEATURE-COVERAGE.md`
+- `openclaw-bootstrap/swims/swim-37/CASES.md`
+- `openclaw-bootstrap/swims/swim-37/OVERLAY.md`
+- `openclaw-bootstrap/swims/swim-37/CHARTER.md`
+- explicit inherited-board framing over Swim 34 / 35 / 36
+
+### Swim 38
+- `openclaw-bootstrap/swims/swim-38-slippy-hoodie/CHARTER.md`
+
+### Swim 39
+- `openclaw-bootstrap/swims/swim-39-volatile-purge/CHARTER.md`
+- `.../CASES.md`
+- `.../FEATURE-COVERAGE.md`
+- `.../OVERLAY.md`
+- explicit reuse of the formal runbook block taxonomy in a real cycle
+
+### Swim 40
+- `openclaw-bootstrap/swims/swim-40-v29-substrate-verification/CHARTER.md`
+- `openclaw-bootstrap/swims/swim-40-v29-substrate-verification/SCOREBOARD.md`
+
+## 3. Appendix-can-surface-now vs needs fresh docs migration
+
+### Appendix-can-surface-now
+- Swim 8 — via old RFC appendix surfaces (`ronan/rfc-tool-parity`, archived RFC branches) pointing to `ronan/rfc-evidence-appendix`
+- Swim 9 — via old RFC appendix surfaces + public docs bridge
+- Swim 10 — via old RFC appendix surfaces + public docs bridge
+- Swim 41 — via later RFC appendix surfaces + public docs bridge
+
+### Needs fresh docs migration / explicit public evacuation
+- Swim 31
+- Swim 34
+- Swim 35
+- Swim 36
+- Swim 37
+- Swim 38
+- Swim 39
+- Swim 40
+
+These may already have partial slotting or summaries in docs-repo PR lanes, but their primary evidence body still lives in bootstrap and should not be described as already fully public.
+
+## 4. Too thin to cite cleanly
+
+Within the 8→40 range, the thinnest surfaces are:
+- any attempt to treat Swim 32 or Swim 33 as evidenced boards (outside this range request, but adjacent gap remains real)
+- any attempt to treat Swim 41 / Swim 42 as replacing the old whole-board taxonomy
+- any attempt to treat branch-era Appendix D summaries as sufficient proof for the bootstrap-era 34→40 whole-board structure
+
+## 5. Load-bearing reconstruction anchors
+
+- Old whole-board taxonomy: `openclaw-bootstrap/swims/swim-34-formal-matrix/ROWS.md`
+- Carried-forward matrix / delta framing: `openclaw-bootstrap/swims/swim-35-stabilization/ROWS.md`, `openclaw-bootstrap/swims/swim-36/charter.md`, `openclaw-bootstrap/swims/swim-37/FEATURE-COVERAGE.md`
+- Early branch-backed evidence-link lineage: `origin/ronan/rfc-tool-parity:docs/design/continue-work-signal-v2.md`
+- Later docs-bridge lineage: `origin/feature/context-pressure-squashed-recompose-20260504-findings-1-2-3-savegame-pre-strip:docs/design/continue-work-signal-v2.md`
+
+## 6. Honest reading
+
+The archive is not a void and not one branch.
+It is a layered three-surface history:
+1. early branch-backed RFC evidence
+2. middle bootstrap swim archive
+3. later public docs distillate

--- a/SWIM/FULL-SWIM-CROSSWALK.md
+++ b/SWIM/FULL-SWIM-CROSSWALK.md
@@ -1,0 +1,134 @@
+# FULL swim crosswalk
+
+Purpose: map the historical whole-board taxonomy onto the cleaner modern FULL-swim families without flattening the archive.
+
+## Crosswalk
+
+| Historical block / surface | Modern FULL family | Status | Notes |
+| --- | --- | --- | --- |
+| **A — Infrastructure** (`TC1–TC4`) | **Turns** + **Guards** + **Observability** | adapt | Old infra rows mix turn-election prerequisites, persistence truth, and status/queue truth. Should be split across modern families instead of carried forward as one bucket. |
+| **B — Behavioral F-series** (`F1–F8`) | **Delegates** + **Turns** | keep | This is the clearest historical delegate/behavior core: clean/noisy `continue_work`, `continue_delegate`, silent-wake, back-to-back scheduling, ghost/stale-wake, post-compaction delegate behavior. |
+| **C — Port / candidate-specific** (`P1–P7`) | **Routes** + **Observability** + **Guards** | adapt | Historically mixed candidate seams, routing truth, pending-flag lifecycle, timer disposal, memoization, queue/telemetry add-ons. Keep the seams, rename by what contract they actually test. |
+| **D — Regression / recovery** (`R1–R5`) | **Recovery** + **Rollout** | keep | Boot-time stall, memory growth, compaction recovery, gateway restart recovery, multi-prince simultaneous activity are still load-bearing and map cleanly to live recovery truth. |
+| **E — Validation suite** (`V1–V3`) | **Rollout** + closure discipline | adapt | Build/check/vitest do not by themselves make FULL, but they remain part of the declared board as supporting release-facing confidence. Modern charter should keep them distinct from live behavioral proof. |
+| **X — Extension rows** (`X1–X15`, from `#412`) | **Guards** + **Observability** + **Routes** + public-surface claims | keep | This is where the public continuation surface claims were attached back onto the board. Load-bearing for reconstructing "what the feature promised" rather than only how it behaved in one cycle. |
+
+## Family-level reconstruction
+
+### 1. Turns
+Inherited from:
+- A infrastructure prerequisites around session/state truth
+- B behavioral rows for `continue_work`
+- parts of X/public-surface coverage where fallback or visibility changes turn-election behavior
+
+Keep:
+- immediate and delayed `continue_work`
+- noisy-channel / inbound-message edge behavior
+- turn-state truth vs narrated success
+
+### 2. Delegates
+Inherited from:
+- core of B behavioral F-series
+- post-compaction delegate behavior from B/D boundary
+
+Keep:
+- normal / silent / silent-wake / post-compaction
+- delayed delegate fire
+- staggered multi-delegate behavior
+- delegate behavior under live queue timing
+
+### 3. Guards
+Inherited from:
+- A infrastructure guard prerequisites
+- C candidate-specific caps / state boundaries
+- X extension rows from `#412`
+
+Keep:
+- chain-depth cap
+- width / fanout cap
+- deny / unavailable-tool behavior
+- malformed fallback/token behavior where still promised
+- clean failure truthfulness
+
+### 4. Routes
+Inherited from:
+- C candidate-specific routing seams
+- X public-surface / topology coverage
+
+Keep:
+- same-session return
+- targeted cross-session return
+- multi-recipient return
+- fanout semantics
+- completion-envelope routing vs task-body routing distinction
+
+### 5. Recovery
+Inherited from:
+- D regression/recovery
+- B post-compaction behavior
+- parts of A persistence truth
+
+Keep:
+- context-pressure event / response
+- `request_compaction()` success and failure
+- post-compaction successor truth
+- restart before fire / after fire / during return path
+- staged delegate residue / janitor behavior
+
+### 6. Rollout
+Inherited from:
+- D multi-prince / restart reality
+- E validation suite
+- later Swim 37/39/40 deploy-ledger evolution
+
+Keep:
+- real-host canary proof
+- cross-seat / cross-host attestation
+- deploy-byte proof before row fire
+- hot-reload vs restart-required behavior
+- canonical drift acknowledgment during live swim
+
+### 7. Observability
+Newly named, historically distributed across A/C/E/X
+
+Status: **new explicit family, old distributed responsibility**
+
+This family should be explicit in the modern charter even though the old board scattered it across multiple blocks.
+
+Keep / add:
+- `/status` truth vs decorative surfaces
+- queue/diagnostic counters match substrate truth
+- trace/provenance survives return path where claimed
+- narrated-tool-use false-positive defense
+- scoreboard truthfulness against actual row receipts
+
+## Keep / adapt / new / gap summary
+
+### Keep
+- B as the behavioral heart
+- D as the recovery truth heart
+- X as the public-surface / extension discipline
+
+### Adapt
+- A infra rows into Turns / Guards / Observability
+- C candidate-specific rows into Routes / Observability / Guards
+- E validation rows into Rollout-supporting, not FULL-defining by themselves
+
+### New explicit modern family
+- **Observability** — historically present, but not cleanly named as its own family
+
+### Gaps to fill explicitly in the modern charter
+- cross-session targeting truth under recreated sessions
+- failed-compaction residue truth
+- hot-reload honesty vs restart-required behavior
+- live-host disagreement / cross-seat attestation
+- contamination / invalidation rules as first-class board content
+
+## Source anchors
+
+Primary reconstruction anchors:
+- `openclaw-bootstrap#412` — public continuation surface claims
+- `openclaw-bootstrap#427` — whole-board behavioral suite shape
+- `openclaw-bootstrap/swims/swim-34-formal-matrix/ROWS.md` — strongest surviving old-board matrix
+- `openclaw-bootstrap/swims/swim-36/charter.md` — full-surface expansion
+- `openclaw-bootstrap/swims/swim-37/FEATURE-COVERAGE.md` — carried-forward board + surface-map evolution


### PR DESCRIPTION
Per silas's #913 ledger framing (msg `1501716374...`): 'move swims/ARCHAEOLOGY-INVENTORY-8-40.md + swims/FULL-SWIM-CROSSWALK.md from swims/ to SWIM/ since they describe catalog/relationship layer'.

Bootstrap-side companion: openclaw-bootstrap removal PR.

## Why this exists

These two files describe catalog/relationship layer (factory-shape), not single-cycle instance evidence. I filed them in bootstrap/swims/ by mistake when shipping PR #908 (should have been bootstrap/SWIM/ from the start). The migration to docs-repo (#9 + #945) moved the publishable factory but left these two misfiled in bootstrap/swims/ since they were in the wrong directory there.

## What this lands

`SWIM/ARCHAEOLOGY-INVENTORY-8-40.md` (130 lines) — three-column substrate map for branch/RFC-history-backed vs bootstrap-primary vs appendix-surfaceable-now-vs-needs-fresh-docs-migration. Used by FULL-charter and appendix-restoration lanes.

`SWIM/FULL-SWIM-CROSSWALK.md` (134 lines) — historical block-taxonomy → modern 8-family charter mapping with keep / adapt / new / gap discipline. Used to bridge swim-34/35/36/37 historical board to the modern FULL contract.

Bytes-identical to bootstrap originals (no content changes; just relocation). Per figs's directive: drive past plumbing, admin-merge expected.