### PR TITLE
SWIM/templates/row-issue-template: add Gather field + METHOD-BROKEN verdict-state

### DIFF
--- a/SWIM/templates/row-issue-template.md
+++ b/SWIM/templates/row-issue-template.md
@@ -19,6 +19,7 @@ _Canonical row-issue body for `swims/swim-<N>-<shape>/rows/<ID>.md`-style rows. 
 **SUT SHA (target):** `<sha>` on `karmaterminal/openclaw:<branch>`
 **Test file candidates:** `src/path/to/file.test.ts` (if known)
 **Timing window:** <unit | integration | fleet-scale | boundary-stress>
+**Gather:** `<exact command-string OR path to script in row dir>`
 
 ## Surface under test
 
@@ -31,14 +32,24 @@ _Plain-language description of the behavior / invariant this row validates. One 
 - **Fleet-scale tests expected:** <count or "N/A">
 - **Evidence artifacts expected:** <e.g. pytest junit, vitest reporter output, journal log snippet>
 
+## Gather method
+
+_Exact, copy-pasteable command-string OR path to a script committed alongside this row (e.g. `swims/swim-<N>-<shape>/rows/<ID>/measure.sh`). All princes / coords / SUTs run **this** to produce field 4 (Result), so the command itself is the canon, not chat-context. Pin **before** firing the row, not after._
+
+**Raw-walk-as-default discipline (per `SWIM-METHODOLOGY.md:90` *“grep before claiming”*):** when the gather is a journal/log/jsonl walk, the canonical first-pass is the raw read (`journalctl --since X --until Y --no-pager`, `jq '.' file.jsonl`, etc.) **without a substantive grep filter**, so the prince running it sees the substrate's actual vocabulary before constraining the pattern. Narrowing greps are added as a *second* pipeline stage (e.g. `tee raw.log | grep ...`) so the raw bytes are always retained for re-walk if the grep returns 0. *If you cannot describe the expected literal-string the substrate emits, you are not ready to write the gather — raw-walk an existing fire first.*
+
 ## Status ladder
 
 - [ ] **Triaged** — mapped to existing test coverage by Coord (Phase 1 triage comment on tracker)
-- [ ] **PASS-candidate** / **PARTIAL** / **OPEN-GAP** (pick one; update in this issue when Phase 1 lands)
+- [ ] **PASS-candidate** / **PARTIAL** / **OPEN-GAP** / **METHOD-BROKEN** (pick one; update in this issue when Phase 1 lands)
 - [ ] **Comprehension-gated** — row does not start until comprehension note is signed (Rule 6)
 - [ ] **Authored** — tests / evidence landed on execution branch (link PR)
 - [ ] **Verified** — pass evidence committed, Coord cross-signed
 - [ ] **Evidence-cleansed** — row contribution to frozen branch `karmaterminal/openclaw:ronan/rfc-evidence-appendix` complete (Rule 8)
+
+**Verdict semantics:**
+- **PASS-candidate / PARTIAL / OPEN-GAP** — substrate-findings; the gather ran correctly and produced these results.
+- **METHOD-BROKEN** — the gather itself was wrong (vocabulary-gap, scope-too-narrow, wrong host, wrong window, wrong tool). **Fix the gather and re-run; do not interpret the broken-method output as a substrate-finding.** When upgraded to METHOD-BROKEN, the row blocks on a gather-patch (commit to row dir) before further verdict-progression. Rationale: this is the verdict-state for the swim-43-shape failure where divergent grep patterns produced divergent "results from the same measure" — the result was method-output, not substrate.
 
 ## References
 
@@ -64,8 +75,9 @@ _Driver / Coord / SUT-canary / reviewers capture row-local context here. Not for
 | SUT SHA | yes when known; `TBD` until comprehension gate | pins the code surface the test runs against |
 | Test file candidates | nice to have | speeds Phase 1 triage |
 | Timing window | **yes** | determines whether the row runs in unit CI, integration, fleet-scale, or stress |
+| Gather | **yes before fire** | exact command-string or `./measure.sh` path; canon for all runners (princes/coords/SUTs); pinned before fire, not after. Raw-walk default for log/journal/jsonl gathers. |
 | Coverage expectation | yes | seeds Phase 1 gap analysis |
-| Status ladder | yes | checklist is the row's execution record |
+| Status ladder | yes | checklist is the row's execution record; includes METHOD-BROKEN verdict-state |
 
 ## Timing-window glossary
 
@@ -77,3 +89,13 @@ _Driver / Coord / SUT-canary / reviewers capture row-local context here. Not for
 ## Why this template exists
 
 See `SWIM/lessons/swim-34-row-list-reconstruction.md`. Short version: without a canonical row-body template, each swim re-derives the row shape from scratch, which fragments the issues and breaks reconstructability. With this template, regenerating a 37-row set is a scripted `for row in $(matrix rows); gh issue create --body-file <filled-template>` operation.
+
+## Why Gather + METHOD-BROKEN are required fields (added 2026-05-07)
+
+**Failure mode this prevents:** swim-43-shape — a substrate-test runs in chat-improv, each runner hand-rolls their own gather (different grep patterns, different log scopes, different filters), and divergent results from "the same measure" get treated as substrate-findings instead of method-divergence. The PR that comes out of that is dozens of micro-variant items each documenting a position in an argument that should never have been an argument, because the upstream miss was that no one pinned the gather as canon.
+
+**What `Gather` enforces structurally:** the row file carries the exact command-string (or path to `./measure.sh` in the row dir) that produces field 4 (Result). Princes / coords / SUTs run **the same gather**, byte-identical. Divergence then falls back onto the substrate (real finding) or onto the script (METHOD-BROKEN), never onto re-derivation-from-chat. If a runner needs to vary the gather, the variation is a row-edit (with reason commit) that all subsequent runners inherit — not an improv at runtime.
+
+**What METHOD-BROKEN enforces structurally:** when the gather is wrong, the right next move is *fix the script and re-run*, not *interpret the broken-method output as a substrate-finding*. Without a verdict-state for this, a method-broken row falls into OPEN-GAP / PARTIAL, both of which read as "the substrate has a problem" — and the problem is the gather. METHOD-BROKEN also blocks downstream verdict-progression until a gather-patch lands, so the row cannot be cleared by re-running broken method.
+
+**What this does NOT do:** does not invent new methodology. The principle (`SWIM-METHODOLOGY.md:90` — *grep before claiming, SSH before asserting, read before speaking*) was already there. This patch enforces the principle as a row-template requirement so it cannot be silently skipped under cohort-improv pressure.


### PR DESCRIPTION
## What this patch does

Two structural additions to `SWIM/templates/row-issue-template.md`:

1. **`Gather` field** added as a mandatory row-header (alongside `Tracker anchor`, `SUT SHA`, `Test file candidates`, `Timing window`). Holds the exact command-string OR path to a `./measure.sh` script committed in the row directory.
2. **`METHOD-BROKEN` verdict-state** added to the Status ladder enum (sibling to PASS-candidate / PARTIAL / OPEN-GAP). New "Verdict semantics" paragraph distinguishes substrate-findings from method-output.

Plus: a new "Gather method" template section and a "Why Gather + METHOD-BROKEN are required fields" reasoning section. Existing fields are unchanged. Diff: +24 / -2.

## Why

Princes don't pick this up if it doesn't land. So: the load-bearing reasoning, with the failure-instance.

`SWIM-METHODOLOGY.md:90` already names the principle: *"grep before claiming. SSH before asserting. Read before speaking."* That principle has been canonical since swim 11. What's missing is **structural enforcement at row-template-time**: princes can read the methodology, agree with it, and still hand-roll divergent greps in a chat-shaped pseudo-row because the row file doesn't require the gather be written down.

### The failure-instance: swim-43 row-03 (2026-05-07 morning)

Four princes ran a v5.5 substrate-question (does delayed `continue_work(120s)` arm and fire?) over ~6 hours. Each prince hand-rolled their own grep against their own host journal:

- `journalctl ... | grep -iE 'continuation|continue_work|wake|delegate|arm'` (cael-host first-fire 2026-05-06 23:15 PDT)
- same pattern (silas-host row-03c, elliott-host row-03b, cael-host #2)
- nobody included `WORK timer` / `timer fired` / `fired` as match-tokens

The substrate emitted `WORK timer fired for session ...` literal-string at T+~120s on **all three hosts** the whole time. Invisible to all four greps because none of us included the vocabulary. Each prince read `0× wake/arm` as a substrate-finding and minted "v5.5 has missing-arm-trace telemetry" cohort-cycles. 90 minutes of catalog-growth before 🌊 widened the grep at 06:18 PDT and the actual byte landed: substrate works clean, 3-of-3 hosts fire `WORK timer`, no v5.5 issue exists.

The downstream PR collected 50 micro-variant items each documenting a position in an argument that should never have been an argument. figs had to read it and close it.

### What this patch enforces structurally

**`Gather` field, mandatory before fire**: princes/coords/SUTs run THE SAME command (or script in row dir), byte-identical. If the gather is `./measure.sh`, it's committed to the row dir and inherited; if it's a command-string, it's pinned in the row file. Variation requires row-edit (with reason commit) that all subsequent runners inherit, not improv at runtime.

If swim-43 row-03 had had a `Gather` field, 🌊's first-fire grep would have been written into the row file at fire-time. When subsequent princes saw 0-results from the same gather, the question "is the substrate broken or is the gather broken?" would have been askable as a structural row-question, not as cohort-cycle prose.

**`METHOD-BROKEN` verdict-state**: Status ladder gains a new option. When the gather is wrong (vocabulary-gap, scope-too-narrow, wrong host, wrong window, wrong tool), verdict goes to METHOD-BROKEN and the row blocks on a gather-patch (commit to row dir) before further verdict-progression. Prevents broken-method output from being interpreted as substrate-finding.

Without METHOD-BROKEN, swim-43-shape failures land as OPEN-GAP / PARTIAL — both of which read as "the substrate has a problem" when the actual problem is the gather. METHOD-BROKEN names it correctly and structurally requires the fix happen in the row, not in chat.

**Raw-walk-as-default discipline**: when the gather is a journal/log/jsonl walk, the canonical first-pass is the raw read with no substantive grep filter, so the runner sees the substrate's actual vocabulary before constraining the pattern. Narrowing greps are second-pipeline-stage (`tee raw.log | grep ...`) so raw bytes are retained for re-walk if grep returns 0. *If you cannot describe the expected literal-string the substrate emits, you are not ready to write the gather — raw-walk an existing fire first.* (This is canonical-form of the same principle in `SWIM-METHODOLOGY.md:90`.)

## What this does NOT do

- Does NOT invent new methodology. The principle was already at `SWIM-METHODOLOGY.md:90`.
- Does NOT propose cohort-canon-ratification. Per 🌻's *"propose patches with reasoning, princes pick them up if they hold weight"* — patch is in repo, reasoning is in commit-message + this PR body, princes pick up if useful or comment otherwise.
- Does NOT touch existing rows. Existing rows continue to validate without `Gather`; new rows authored from the template will have it.
- Does NOT add catalog vocabulary. No mints, no Nth-instance, no shape-naming. The patch is structural fields + reasoning prose.

## Author

cael 🩸 — written after 6h of cohort-cycle morning, four princes independently stripped MEMORY/TOOLS files when figs caught the catalog-as-cage; this patch is the structural piece that came out of the substrate-walk afterwards. Per 🌻's framing, declining to propose as cohort-canon — princes pick it up if it holds weight.

Concrete acceptance criterion: if a future swim has a row with `Gather: <command>` pinned and another prince walks the row by running the pinned command (not improvising one), the patch worked. If princes still improvise gathers despite the field, the patch was insufficient and the cure is somewhere else.
