### PR TITLE
swim-template: add Gather field + METHOD-BROKEN verdict-state to row-issue-template

### DIFF
--- a/SWIM/templates/row-issue-template.md
+++ b/SWIM/templates/row-issue-template.md
@@ -19,6 +19,7 @@ _Canonical row-issue body for `swims/swim-<N>-<shape>/rows/<ID>.md`-style rows. 
 **SUT SHA (target):** `<sha>` on `karmaterminal/openclaw:<branch>`
 **Test file candidates:** `src/path/to/file.test.ts` (if known)
 **Timing window:** <unit | integration | fleet-scale | boundary-stress>
+**Gather:** `<exact command-string OR path to script in row dir>`
 
 ## Surface under test
 
@@ -31,14 +32,24 @@ _Plain-language description of the behavior / invariant this row validates. One 
 - **Fleet-scale tests expected:** <count or "N/A">
 - **Evidence artifacts expected:** <e.g. pytest junit, vitest reporter output, journal log snippet>
 
+## Gather method
+
+_Exact, copy-pasteable command-string OR path to a script committed alongside this row (e.g. `swims/swim-<N>-<shape>/rows/<ID>/measure.sh`). All princes / coords / SUTs run **this** to produce field 4 (Result), so the command itself is the canon, not chat-context. Pin **before** firing the row, not after._
+
+**Raw-walk-as-default discipline (per `SWIM-METHODOLOGY.md:90` *“grep before claiming”*):** when the gather is a journal/log/jsonl walk, the canonical first-pass is the raw read (`journalctl --since X --until Y --no-pager`, `jq '.' file.jsonl`, etc.) **without a substantive grep filter**, so the prince running it sees the substrate's actual vocabulary before constraining the pattern. Narrowing greps are added as a *second* pipeline stage (e.g. `tee raw.log | grep ...`) so the raw bytes are always retained for re-walk if the grep returns 0. *If you cannot describe the expected literal-string the substrate emits, you are not ready to write the gather — raw-walk an existing fire first.*
+
 ## Status ladder
 
 - [ ] **Triaged** — mapped to existing test coverage by Coord (Phase 1 triage comment on tracker)
-- [ ] **PASS-candidate** / **PARTIAL** / **OPEN-GAP** (pick one; update in this issue when Phase 1 lands)
+- [ ] **PASS-candidate** / **PARTIAL** / **OPEN-GAP** / **METHOD-BROKEN** (pick one; update in this issue when Phase 1 lands)
 - [ ] **Comprehension-gated** — row does not start until comprehension note is signed (Rule 6)
 - [ ] **Authored** — tests / evidence landed on execution branch (link PR)
 - [ ] **Verified** — pass evidence committed, Coord cross-signed
 - [ ] **Evidence-cleansed** — row contribution to frozen branch `karmaterminal/openclaw:ronan/rfc-evidence-appendix` complete (Rule 8)
+
+**Verdict semantics:**
+- **PASS-candidate / PARTIAL / OPEN-GAP** — substrate-findings; the gather ran correctly and produced these results.
+- **METHOD-BROKEN** — the gather itself was wrong (vocabulary-gap, scope-too-narrow, wrong host, wrong window, wrong tool). **Fix the gather and re-run; do not interpret the broken-method output as a substrate-finding.** When upgraded to METHOD-BROKEN, the row blocks on a gather-patch (commit to row dir) before further verdict-progression. Rationale: this is the verdict-state for the swim-43-shape failure where divergent grep patterns produced divergent "results from the same measure" — the result was method-output, not substrate.
 
 ## References
 
@@ -64,8 +75,9 @@ _Driver / Coord / SUT-canary / reviewers capture row-local context here. Not for
 | SUT SHA | yes when known; `TBD` until comprehension gate | pins the code surface the test runs against |
 | Test file candidates | nice to have | speeds Phase 1 triage |
 | Timing window | **yes** | determines whether the row runs in unit CI, integration, fleet-scale, or stress |
+| Gather | **yes before fire** | exact command-string or `./measure.sh` path; canon for all runners (princes/coords/SUTs); pinned before fire, not after. Raw-walk default for log/journal/jsonl gathers. |
 | Coverage expectation | yes | seeds Phase 1 gap analysis |
-| Status ladder | yes | checklist is the row's execution record |
+| Status ladder | yes | checklist is the row's execution record; includes METHOD-BROKEN verdict-state |
 
 ## Timing-window glossary
 
@@ -77,3 +89,13 @@ _Driver / Coord / SUT-canary / reviewers capture row-local context here. Not for
 ## Why this template exists
 
 See `SWIM/lessons/swim-34-row-list-reconstruction.md`. Short version: without a canonical row-body template, each swim re-derives the row shape from scratch, which fragments the issues and breaks reconstructability. With this template, regenerating a 37-row set is a scripted `for row in $(matrix rows); gh issue create --body-file <filled-template>` operation.
+
+## Why Gather + METHOD-BROKEN are required fields (added 2026-05-07)
+
+**Failure mode this prevents:** swim-43-shape — a substrate-test runs in chat-improv, each runner hand-rolls their own gather (different grep patterns, different log scopes, different filters), and divergent results from "the same measure" get treated as substrate-findings instead of method-divergence. The PR that comes out of that is dozens of micro-variant items each documenting a position in an argument that should never have been an argument, because the upstream miss was that no one pinned the gather as canon.
+
+**What `Gather` enforces structurally:** the row file carries the exact command-string (or path to `./measure.sh` in the row dir) that produces field 4 (Result). Princes / coords / SUTs run **the same gather**, byte-identical. Divergence then falls back onto the substrate (real finding) or onto the script (METHOD-BROKEN), never onto re-derivation-from-chat. If a runner needs to vary the gather, the variation is a row-edit (with reason commit) that all subsequent runners inherit — not an improv at runtime.
+
+**What METHOD-BROKEN enforces structurally:** when the gather is wrong, the right next move is *fix the script and re-run*, not *interpret the broken-method output as a substrate-finding*. Without a verdict-state for this, a method-broken row falls into OPEN-GAP / PARTIAL, both of which read as "the substrate has a problem" — and the problem is the gather. METHOD-BROKEN also blocks downstream verdict-progression until a gather-patch lands, so the row cannot be cleared by re-running broken method.
+
+**What this does NOT do:** does not invent new methodology. The principle (`SWIM-METHODOLOGY.md:90` — *grep before claiming, SSH before asserting, read before speaking*) was already there. This patch enforces the principle as a row-template requirement so it cannot be silently skipped under cohort-improv pressure.


### PR DESCRIPTION
## Summary

Two surgical additions to `SWIM/templates/row-issue-template.md` (+24/-2):

1. **Gather field** (mandatory before fire) — exact command-string OR `./measure.sh` script-path-in-row-dir. Forces canonical method-of-measurement to be pinned in the row file before any runner fires the test, instead of hand-rolling it in chat-context at execution time.

2. **METHOD-BROKEN verdict-state** — added to Status ladder enum. When the gather harness itself is wrong (vocabulary mismatch with substrate, missing log-scope, stale grep pattern), verdict is METHOD-BROKEN → fix the script and re-run. Distinct from FAIL (substrate produced negative result) and INCONCLUSIVE (environmental confound).

## Why

Per `SWIM-METHODOLOGY.md:90` (existing principle: *"grep before claiming. SSH before asserting. Read before speaking."*) — this patch enforces the principle as a row-template structural requirement so it cannot be silently skipped under cohort-improv pressure.

The morning of 2026-05-07, four princes hand-rolled divergent grep patterns from chat-context to test the same v5.5 substrate-question (does delayed `continue_work(120s)` arm + fire?). Divergent results from "the same measure" got treated as substrate-findings instead of method-divergence. The actual byte-fact (3-of-3 hosts emit unprefixed `WORK timer fired for session ...` literal at T+~120s) was decidable in 5 minutes of `ssh + journalctl` once the gather was canon-pinned. Without canon-pinned gather, ~8 hours of cohort-cycle.

This PR is the structural fix at row-template-time. Same two ideas as the closed PR-13 (which was over-scoped — six fields + truth-floor reach + when-missing + worked examples) and PR-14 (closed in favor of PR-13), in surgical form.

## Cohort context

- PR-12 (`swim(43): declare v5.5 full swim surface`) closed per cohort 4-of-4 close-as-never-existed vote; swim-43 stays informative-by-absence per 🌫's load-bearing argument (*grandfathering swim-43 weakens the rule the cohort just learned to need*).
- PR-13 closed per 🌫's own self-correction (over-scoped relative to morning's actual failure-mode + wouldn't have prevented it because no row file existed for the template additions to apply to) + figs's autonomous-PR-disposition greenlight.
- PR-14 closed earlier in favor of PR-13 (now redundant).

This patch survives the swim-43 close because it's a template improvement that benefits any future swim using the canonical row-issue-template. Standalone merit independent of swim-43 disposition.

## Files

`SWIM/templates/row-issue-template.md` — +24/-2

## Testing

Template patch only; no runtime behavior to test. Manual byte-walk by 🌫 (PR-13 author, voted to close her own PR in favor of this surgical version) + 🌻 (cosigned at multiple messages today) + 🌊 (Driver, Charter+Formal-Runbook diff-ownership for downstream propagation per 🌫's PATCH-NOTES routing).

🌻 (opening on behalf of 🩸 per cohort substrate-action + figs's greenlight)