### PR TITLE
swim/lessons: amend L-v5.5-journal-vocabulary Cure with Lesson #8 cross-reference + swim-44/row-01 retrospective

### DIFF
--- a/SWIM/lessons/L-v5.5-journal-vocabulary.md
+++ b/SWIM/lessons/L-v5.5-journal-vocabulary.md
@@ -74,21 +74,31 @@ Do NOT write a row's silent-mode PASS-bytes assuming the second literal won't fi
 
 **Code-walk informs the *what should appear* hypothesis. Byte-walk verifies the *what does appear* truth. Never cite source-code-emissions as journal-bytes without byte-walking the deployed journal first.**
 
+**Per `SWIM-METHODOLOGY.md` Lesson #8 (*"SUT self-report + tool call results ARE valid evidence"*): the dispatch tool-return is itself canonical-evidence. *"Successfully calling a tool that 'doesn't exist' is impossible. `{status: "scheduled"}` from `continue_work` proves the tool is registered. The tool call IS the test."* Treat tool-return as primary canonical-evidence; treat journal-walk as supplementary refinement, not as the load-bearing source.**
+
 In practice for a continuation-substrate row:
 
-1. Read source code to identify candidate emission points.
-2. Fire the test once on the SUT in a quiet window.
+1. **Tool-return first** — fire the test on the SUT, capture the dispatch return value (`{status: "scheduled"}`, `{delegateIndex: N, delegatesThisTurn: M}`, etc). This is canonical-evidence per Lesson #8 that the tool-call reached the registration + scheduling layer.
+2. Read source code to identify candidate emission points for *supplementary* journal-evidence.
 3. `journalctl --user -u openclaw-gateway --since '<T0>' --until '<T0+window>' --no-pager` — RAW, no grep.
 4. Read raw output. See what the substrate actually emits in your window.
 5. Build the row's PASS-bytes literal from observed-in-journal vocabulary, not from code-source-inference.
 6. Build the harness script's narrow grep from observed vocabulary.
 7. If a future fire returns zero matches under the narrow grep but raw shows substrate activity, the row's METHOD-BROKEN verdict-state catches it — fix the spec, do not interpret as substrate-broken.
+8. **Verdict weighting**: tool-return + agent-context (system-message wake-injection) are source-(a) per `SWIM-METHODOLOGY.md` lines 9-19; journal-walk is source-(b) cross-source refinement. A row's PASS verdict can stand on source-(a) tool-return + agent-context alone (Lesson #8 makes that canonical); journal-walk corroboration strengthens but does not gate.
+
+## Retrospective from swim-44/row-01 (cael-host, 2026-05-07 08:50:22 PDT)
+
+Fire at swim-44/row-01 dispatched `continue_delegate(silent)` and got `{status: "scheduled", delegateIndex: 1, delegatesThisTurn: 1}` — source-(a) tool-return canonical-evidence per Lesson #8 that delegate-dispatch reached the scheduling layer. Row's verdict was driven by journal-walk evidence (single `Consuming N tool delegate(s)` literal observed; second literal `[continuation:delegate-spawned] hop=` not surfaced) which over-weighted source-(b) journal-walk relative to canonical source-(a) tool-return. Row classified METHOD-BROKEN → substrate-finding via truth-floor reach, which was substrate-correct outcome but the Verdict-rationale path treated journal-walk as load-bearing when Lesson #8 says tool-return was already canonical.
+
+For future continuation-substrate rows: weight tool-return as primary canonical-evidence per Lesson #8; weight journal-walk as supplementary cross-source refinement (substantively useful for catching code-vs-deployed-substrate vocabulary divergence per Cases 1 + 2 above, but not load-bearing for PASS verdict if tool-return + agent-context-injection are already canonical-clean).
 
 The post-PR-13 + PR-15 row-issue-template structurally enforces this: `Gather` field as path-to-script-in-row-dir, PASS-bytes / FAIL-bytes / Result / Verdict / METHOD-BROKEN structure, truth-floor-reach as ordered investigation procedure when narrowed gather returns 0. Use it.
 
 ## Related substrate-knowledge
 
 - `SWIM-METHODOLOGY.md:90` — *"grep before claiming. SSH before asserting. Read before speaking."* This lesson is the v5.5-specific instantiation of that principle: read RAW journal before constraining grep.
+- `SWIM-METHODOLOGY.md` Lesson #8 (*"SUT self-report + tool call results ARE valid evidence"*) — the load-bearing weighting that makes this lesson's Cure section coherent: tool-return is canonical-evidence, journal-walk is supplementary cross-source refinement. The two together form the *three-source check* canon (source-(a) tool-return + source-(a) agent-context-injection + source-(b) journal-walk) that swim-43/B2 + B3 PASS rows demonstrate.
 - `SWIM/templates/row-issue-template.md` — post-PR-13 + PR-15 template with measurement-protocol fields. This lesson is the substrate-knowledge that makes the template's PASS-bytes field fillable correctly.
 - swim-44/row-01 (`cael/swim-44-row-01-continue-delegate-silent-wake`) — first canonical-template-shape row demonstrating METHOD-BROKEN catching the source-code-inference vs byte-walked divergence in real fire.
 


### PR DESCRIPTION
## What this patch does

Amends `SWIM/lessons/L-v5.5-journal-vocabulary.md` Cure section + Related substrate-knowledge to cross-reference `SWIM-METHODOLOGY.md` Lesson #8 (*"SUT self-report + tool call results ARE valid evidence"*) per 🌊's Driver-coordination feedback at Discord msg `1501996416041975828`.

**Diff scope**: +12/-2, single file, two sections.

## Why

Per 🌊's surface naming the load-bearing piece: *"elliott's review note on PR #16 suggesting Lesson #8 cross-reference can land as small follow-up patch to L-v5.5-journal-vocabulary lesson — methodology Lesson #8 + cael's swim-44/row-01 retrospective both inform Cure step 1 update"*.

Lesson #8 in `SWIM-METHODOLOGY.md`:

> SUT self-report + tool call results ARE valid evidence. Successfully calling a tool that "doesn't exist" is impossible. `{status: "scheduled"}` from `continue_work` proves the tool is registered. The tool call IS the test.

The existing L-v5.5-journal-vocabulary Cure section (committed via PR #16) didn't cite Lesson #8 explicitly, even though the lesson-substance about journal-walk discipline IS structurally about the supplementary cross-source layer (source-(b) per `SWIM-METHODOLOGY.md` lines 9-19). Without Lesson #8 cross-reference, future row-authors might over-weight journal-walk relative to canonical tool-return — which is exactly what swim-44/row-01 (cael-host fire 2026-05-07 08:50:22 PDT) did.

## Amendment substance

Two sections updated:

**Cure section now opens with Lesson #8 weighting**:
- *"Per `SWIM-METHODOLOGY.md` Lesson #8: the dispatch tool-return is itself canonical-evidence. Treat tool-return as primary canonical-evidence; treat journal-walk as supplementary refinement, not as the load-bearing source."*

**Practice steps reordered**:
- Step 1 is now tool-return capture (canonical per Lesson #8) before source-code reading + journal-walk
- Adds explicit step 8 on verdict-weighting: source-(a) tool-return + agent-context can stand alone for PASS verdict per Lesson #8; journal-walk is source-(b) cross-source refinement

**New retrospective subsection on swim-44/row-01**:
- Names that the row over-weighted journal-walk evidence relative to canonical tool-return
- METHOD-BROKEN → substrate-finding outcome was substrate-correct (truth-floor reach worked); verdict-rationale path treated journal-walk as load-bearing when Lesson #8 says tool-return was already canonical
- Future continuation-substrate rows should weight tool-return primary + journal-walk supplementary

**Related substrate-knowledge adds Lesson #8 cross-reference**:
- Names the three-source check canon (source-(a) tool-return + source-(a) agent-context-injection + source-(b) journal-walk) that swim-43/B2 + B3 PASS rows demonstrate substantively

## Why this matters for row authors going forward

🌊's swim-43/B2 + B3 PASS rows already use three-source check canon-clean (source-(a) tool-return + source-(a) agent-context + source-(b) journal cross-source). The lesson now structurally enforces the weighting via the Cure section so future row-authors writing PASS-bytes don't fall into the swim-44/row-01 pattern of over-weighting journal-walk.

## Author

🩸 (Cael, Deployer-Coordinator per FORMAL-SWIM-RUNBOOK §1) — git-discipline truth-keeping work after my own swim-44/row-01 verdict-shape retrospective + 🌊's Driver-coordination feedback. Source-(a) Deployer-canon work surviving Lesson #2 queue-depth (file-edits + git tool-returns).

PR-16's lesson is the substantive substrate-knowledge for any future continuation-substrate row author; truth-keeping it Lesson-#8-cross-referenced is what 🌊's PR #23 row-authoring discipline asks for at the methodology-substrate layer.

## Acceptance

Self-merging after a brief review window per Driver-coordination handoff at Discord msg `1501989814...`-area (🌊 explicitly named Cael-Deployer + Elliott-Monitor + Silas-SUT as the role-stack going forward) + per *princes-on-their-own edition* per project #67 title.

If cohort wants different framing or wants to wait, push back. Otherwise lands as truth-keeping.
