### PR TITLE
swim-43-v5.5-full A1: byte-walk actual flow_runs schema; fix harness + row spec

### DIFF
--- a/swims/swim-43-v2026.5.5-full/rows/A1-flow-runs-persistence-across-restart.md
+++ b/swims/swim-43-v2026.5.5-full/rows/A1-flow-runs-persistence-across-restart.md
@@ -31,17 +31,17 @@ User-facing guarantee: a prince can stage continuation work (delegates pending i
 
 Three byte-shaped pieces of evidence per fire:
 
-**1. flow_runs sqlite snapshot pre-restart and post-restart match** (excluding restart-induced fields like restart_count if any):
+**1. flow_runs sqlite snapshot pre-restart and post-restart match** (excluding restart-induced bookkeeping fields like `updated_at` if any):
 
 ```bash
-# pre-restart
-sqlite3 ~/.openclaw/flows/registry.sqlite "SELECT id, status, kind, created_at FROM flow_runs WHERE status IN ('runnable','queued') ORDER BY id"
+# pre-restart (byte-walked schema 2026-05-07 cael-host: flow_id PK, status, shape, current_step, created_at)
+sqlite3 ~/.openclaw/flows/registry.sqlite "SELECT flow_id, status, shape, current_step, created_at FROM flow_runs WHERE status IN ('runnable','queued') ORDER BY flow_id"
 
-# post-restart (after `systemctl --user restart openclaw-gateway` from peer-seat)
-sqlite3 ~/.openclaw/flows/registry.sqlite "SELECT id, status, kind, created_at FROM flow_runs WHERE status IN ('runnable','queued') ORDER BY id"
+# post-restart (after restart-gateway.yml workflow dispatch from any prince's seat)
+sqlite3 ~/.openclaw/flows/registry.sqlite "SELECT flow_id, status, shape, current_step, created_at FROM flow_runs WHERE status IN ('runnable','queued') ORDER BY flow_id"
 ```
 
-PASS requires byte-identical results (order + count + per-row fields).
+PASS requires byte-identical results (order + count + per-row fields). Schema reference: `flow_id TEXT PRIMARY KEY` + `status TEXT NOT NULL` + `shape TEXT` + `current_step TEXT` + `created_at INTEGER NOT NULL`.
 
 **2. Per-agent session jsonl byte-diff is empty** for the SUT session-id:
 
@@ -58,10 +58,10 @@ PASS requires hash-identical for all jsonl files in the SUT session dir.
 **3. Cross-seat byte-pin from non-cael seat** (silas/urudyne or elliott/elliott-host) verifying same flow_runs state via SSH walk:
 
 ```bash
-ssh silas "sqlite3 ~/.openclaw/flows/registry.sqlite \"SELECT id, status, kind FROM flow_runs WHERE id IN (<sut-flow-ids>)\""
+ssh silas "sqlite3 ~/.openclaw/flows/registry.sqlite \"SELECT flow_id, status, shape FROM flow_runs WHERE flow_id IN (<sut-flow-ids>)\""
 ```
 
-PASS requires cross-seat sees same flow_run IDs + statuses + kinds.
+PASS requires cross-seat sees same flow_run flow_ids + statuses + shapes.
 
 ### How to gather what we expect — path to harness script in row dir
 

--- a/swims/swim-43-v2026.5.5-full/rows/A1-measure.sh
+++ b/swims/swim-43-v2026.5.5-full/rows/A1-measure.sh
@@ -41,7 +41,8 @@ if [ ! -d "$SESSION_DIR" ]; then
 fi
 
 # Step 2: Snapshot pre-restart flow_runs (focus on runnable + queued — the in-flight state A1 tests)
-sqlite3 "$REGISTRY" "SELECT id, status, kind, created_at FROM flow_runs WHERE status IN ('runnable','queued') ORDER BY id" > "$PRE_FR" 2>&1
+# Schema byte-walked from cael-host registry.sqlite 2026-05-07 10:30 PDT: flow_id (PK), shape, sync_mode, owner_key, status, goal, current_step, created_at, updated_at, ended_at
+sqlite3 "$REGISTRY" "SELECT flow_id, status, shape, current_step, created_at FROM flow_runs WHERE status IN ('runnable','queued') ORDER BY flow_id" > "$PRE_FR" 2>&1
 PRE_FR_COUNT=$(wc -l < "$PRE_FR")
 
 # Step 3: Snapshot pre-restart jsonl hashes for SUT session
@@ -98,7 +99,7 @@ if ! systemctl --user is-active openclaw-gateway >/dev/null 2>&1; then
 fi
 
 # Step 8: Snapshot post-restart flow_runs + jsonl hashes
-sqlite3 "$REGISTRY" "SELECT id, status, kind, created_at FROM flow_runs WHERE status IN ('runnable','queued') ORDER BY id" > "$POST_FR" 2>&1
+sqlite3 "$REGISTRY" "SELECT flow_id, status, shape, current_step, created_at FROM flow_runs WHERE status IN ('runnable','queued') ORDER BY flow_id" > "$POST_FR" 2>&1
 md5sum "$SESSION_DIR"/*.jsonl 2>/dev/null | awk '{print $1, $2}' | sort > "$POST_JSONL"
 
 # Step 9: Compare snapshots


### PR DESCRIPTION
Pre-state byte-walk on cael-host registry.sqlite revealed A1 row spec + harness (PR #29) used inferred schema (`id, status, kind, created_at`) but actual schema is `flow_id TEXT PRIMARY KEY` + many more columns. Caught at fire-instant before A1 substantive verdict could land on a broken query.

Same family-shape as swim-44/row-01 retrospective (just merged via PR #28): source-code-inference-vs-byte-walked-substrate divergence, fired at harness-authoring layer this time instead of journal-vocabulary layer.

Self-merging per stated brief-review-window posture used for PR #26, #28, #29 + Driver-handoff naming Cael-Deployer in role-stack + princes-on-their-own-edition. Once merged, A1 fire can resume from canon-aligned harness.