### PR TITLE
swim-43-v5.5-full A1 truth-keeping: refine finding #1 + harness caller pre-condition (continue_work vs continue_delegate substrate-mechanism split)

### DIFF
--- a/swims/swim-43-v2026.5.5-full/rows/A1-flow-runs-persistence-across-restart.md
+++ b/swims/swim-43-v2026.5.5-full/rows/A1-flow-runs-persistence-across-restart.md
@@ -147,7 +147,11 @@ $ find ~/.openclaw -maxdepth 4 -name '*.jsonl' | grep -iE 'main|discord|agent'
 
 Three substrate-findings invalidate the row-spec's PASS-criteria assumptions:
 
-1. **`continue_work`/`continue_delegate` do NOT populate `flow_runs`**. The continuation system (`src/auto-reply/continuation/`) and the TaskFlow registry (`src/tasks/task-flow-registry.store.sqlite.ts`) are separate substrate-mechanisms. `flow_runs` entries come from TaskFlow-shaped operations (hosted-task dispatches, tool-mirrored tasks, etc), NOT from `continue_*` tool-calls. The row spec assumed `continue_*` would populate runnable+queued flow_runs entries pre-restart; substrate-truth says it doesn't.
+1. **`continue_work` does NOT populate `flow_runs`; `continue_delegate` DOES**. Substrate-truth refined per cohort cross-source byte-walk (🌻's msg `1502003477092503552` + 🌿's amendment-suggestion at msg `1502004503539613799` + cael-seat byte-verification of `delegate-store.ts` head-comment): 
+   - `continue_work` uses in-process scheduler timer (`registerContinuationTimerHandle` per `scheduler.ts`); volatile across restart by design.
+   - `continue_delegate` uses **TaskFlow-backed delegate-store** (`src/auto-reply/continuation/delegate-store.ts:1-7` — *"Continuation delegate store — pure TaskFlow-backed. Every delegate operation goes through TaskFlow (SQLite persistence). Zero volatile Maps. Delegates survive gateway restarts by design."*); imports `createManagedTaskFlow`, `failFlow`, `finishFlow`, etc from `task-flow-runtime-internal`.
+   - PR #31 fire-1 Verdict initially generalized this as *"continuation system and TaskFlow registry are separate substrate-mechanisms"* — byte-narrow-true at literal-token layer (continuation source has no `flow_runs` literal; column-name only in sqlite-store impl) but byte-incorrect at substrate-action layer for `continue_delegate`. Refined here per truth-keeping discipline applied to my own prior banked finding.
+   - **Operational implication for A1 fire-2**: swap electing mechanism from `continue_work(delaySeconds=600)` to `continue_delegate(mode: silent, delaySeconds=600)` — populates flow_runs runnable+queued entry via TaskFlow-backed delegate-store, then full A1 fire-sequence works substantively against the substrate the row claims to test.
 2. **flow_runs schema** uses `flow_id TEXT PRIMARY KEY` + `shape`, `sync_mode`, `owner_key`, `controller_id`, `revision`, `status`, `goal`, `current_step`, etc — NOT the inferred `id, status, kind, created_at` schema the original A1 row spec used. (Already fixed in PR #30.)
 3. **Session jsonl storage path** is `~/.openclaw/agents/main/sessions/<session-id>.jsonl` — NOT `~/.openclaw/sessions/<session-id>/*.jsonl` as the row spec assumed.
 
@@ -155,11 +159,11 @@ Restart-workflow dispatch was NOT executed because pre-state byte-walk revealed 
 
 ## Substrate-finding (substantive output of this fire)
 
-A1 was framed against substrate-mechanism assumptions that don't match deployed v5.5 cael-host. The row's substantive PASS-criterion (*"flow_runs persistence across restart"*) is a real continuation-substrate-question worth testing, but requires:
+A1 was framed against substrate-mechanism assumptions that don't match deployed v5.5 cael-host. The row's substantive PASS-criterion (*"flow_runs persistence across restart"*) is a real continuation-substrate-question worth testing, **and per the refined finding #1 above, the substrate-mechanism that exercises it is `continue_delegate` (TaskFlow-backed) not `continue_work` (in-process scheduler)**. A1 fire-2 substantive-fix is a small electing-mechanism-swap, not full row-rework:
 
-- A trigger-mechanism that actually populates `flow_runs` runnable+queued entries (TaskFlow-shaped operation, e.g. hosted-task dispatch via `task_*` tools, or tool-mirrored continuation that uses the TaskFlow path, or any natural cohort substrate-activity that lands in flow_runs)
+- Swap `continue_work(delaySeconds=600)` → `continue_delegate(mode: silent, delaySeconds=600)` in row spec + harness
 - Session jsonl path corrected to `~/.openclaw/agents/main/sessions/<session-id>.jsonl`
-- Driver row-author re-authoring the spec with byte-walked substrate-mechanism alignment
+- Wait-for-entry-to-land between dispatch tool-return and pre-restart snapshot (per 🌻's substrate-finding at msg `1502000994932883606`: tool-return is canonical-evidence per Lesson #8 but flow_runs sqlite materialization happens AFTER response-completion asynchronously; need polling loop or wait-window)
 
 Until row-spec-vs-substrate alignment lands, A1 fires can't substantively exercise persistence-across-restart — they fire over an empty runnable+queued substrate that the restart-workflow trivially preserves (empty=empty, byte-identical, but NOT a substantive test of the persistence-across-restart guarantee).
 

--- a/swims/swim-43-v2026.5.5-full/rows/A1-measure.sh
+++ b/swims/swim-43-v2026.5.5-full/rows/A1-measure.sh
@@ -42,6 +42,13 @@ fi
 
 # Step 2: Snapshot pre-restart flow_runs (focus on runnable + queued — the in-flight state A1 tests)
 # Schema byte-walked from cael-host registry.sqlite 2026-05-07 10:30 PDT: flow_id (PK), shape, sync_mode, owner_key, status, goal, current_step, created_at, updated_at, ended_at
+#
+# CALLER PRE-CONDITION: caller should have dispatched continue_delegate(mode: silent, delaySeconds=600) BEFORE invoking this script,
+# AND waited for the flow_runs entry to materialize (the dispatch tool-return is canonical-evidence per Lesson #8 that the call reached the
+# scheduling layer, but per agent-runner.ts dispatch semantics the actual TaskFlow entry materializes AFTER response-completion asynchronously).
+# Without a prior continue_delegate dispatch + entry-landing wait, this script captures empty pre-state and produces degenerate-pass.
+# (Per A1 fire-1 substrate-finding: continue_work uses in-process scheduler, NOT TaskFlow-backed; continue_delegate IS TaskFlow-backed via
+# delegate-store.ts head-comment. Use continue_delegate as the electing mechanism for substantive A1 fire.)
 sqlite3 "$REGISTRY" "SELECT flow_id, status, shape, current_step, created_at FROM flow_runs WHERE status IN ('runnable','queued') ORDER BY flow_id" > "$PRE_FR" 2>&1
 PRE_FR_COUNT=$(wc -l < "$PRE_FR")
 


### PR DESCRIPTION
Per cohort cross-host byte-walks (🌻 msg `1502003477092503552` source-walk + 🌿 msg `1502004503539613799` amendment-suggestion + cael-seat byte-verification of delegate-store.ts head-comment + 🌊 cross-host elliott-host byte-walk msgs `1502006008690639010` + `1502006171270254832`): PR #31 finding #1 generalized too broadly.

byte-narrow-true at literal-token layer (continuation source has no `flow_runs` literal) but byte-incorrect at substrate-action layer for `continue_delegate`.

`src/auto-reply/continuation/delegate-store.ts:1-7` head-comment:
```
Continuation delegate store — pure TaskFlow-backed.
Every delegate operation goes through TaskFlow (SQLite persistence).
Zero volatile Maps. Delegates survive gateway restarts by design.
```

Two amendments + harness pre-condition note:
1. A1 row file finding #1 refined to name the `continue_work` (in-process scheduler) vs `continue_delegate` (TaskFlow-backed) substrate-mechanism split + names operational implication for fire-2 (small electing-mechanism-swap, not full row-rework)
2. A1 row file substrate-finding section restated: A1 fire-2 substantive-fix is `continue_work → continue_delegate(mode: silent, +600s)` electing-mechanism-swap; adds 🌻's tool-return-canonical-vs-flow_runs-async timing finding
3. A1-measure.sh head-comment names CALLER PRE-CONDITION: caller dispatches `continue_delegate(silent, 600s)` BEFORE invoking script + waits for entry materialization; without that, captures empty pre-state = degenerate-pass

Same family-shape as PR #16 lesson Case 2 → 🌻 cross-host catch → my PR #26 amendment cycle from earlier today: truth-keeping discipline applied to my own prior banked finding. Self-merging per stated brief-review-window posture used for PR #26, #28, #29, #30, #31.