### PR TITLE
swim-43: author B5, D1, and D2 rows

### DIFF
--- a/swims/swim-43-v2026.5.5-full/SCOREBOARD.md
+++ b/swims/swim-43-v2026.5.5-full/SCOREBOARD.md
@@ -46,7 +46,7 @@
 | A3 | delegatePendingFlags from TaskFlow | TBD | TBD | TBD |
 | B3 | F3 clean continue_delegate (default/normal) | Authored | **PASS** | cael-host morning row-04 fire (23:31:35→23:31:45 PDT) |
 | B4 | F4 noisy continue_delegate | TBD | TBD | TBD |
-| B5 | F5 silent-wake via continue_delegate | TBD | TBD | TBD |
+| B5 | F5 silent-wake via continue_delegate | Authored | pending fire | row file authored; awaiting SUT silent-wake fire |
 | B6 | F6 back-to-back scheduling | TBD | TBD | TBD |
 | B7 | F7 announce-boundary ghost-wake/stale-wake | TBD | TBD | TBD |
 | X10 | Textless-turn / tool-only delegate | TBD | TBD | TBD |
@@ -89,7 +89,7 @@
 |---|---|---|---|
 | B8 | F8 post-compaction delegate survival | TBD | TBD |
 | C3 | P3 timer disposal on generation change | TBD | TBD |
-| D1 | R1 boot-time stall check | TBD | TBD |
+| D1 | R1 boot-time stall check | Authored | INCONCLUSIVE (baseline no-stall only) |
 | D3 | R3 compaction recovery | TBD | TBD |
 | D4 | R4 gateway restart recovery (peer) | TBD | TBD |
 | N007 | OTel preserved through restart-replay | TBD | TBD |
@@ -104,7 +104,7 @@
 |---|---|---|---|
 | A0 | Fleet feature-flag parity | TBD | TBD |
 | A0.2 | Post-deploy log enumeration | TBD | TBD |
-| D2 | R2 memory growth 1h idle | TBD | TBD |
+| D2 | R2 memory growth 1h idle | Authored | pending 1h window |
 | D5 | R5 fleet under cross-load | TBD | TBD |
 | E1 | V1 pnpm build green | TBD | TBD |
 | E2 | V2 check/lint/type-check green | TBD | TBD |

--- a/swims/swim-43-v2026.5.5-full/SCOREBOARD.md
+++ b/swims/swim-43-v2026.5.5-full/SCOREBOARD.md
@@ -104,7 +104,7 @@
 |---|---|---|---|
 | A0 | Fleet feature-flag parity | TBD | TBD |
 | A0.2 | Post-deploy log enumeration | TBD | TBD |
-| D2 | R2 memory growth 1h idle | Authored | pending 1h window |
+| D2 | R2 memory growth 1h idle | Authored | INCONCLUSIVE (fire-1 contaminated by planned restart) |
 | D5 | R5 fleet under cross-load | TBD | TBD |
 | E1 | V1 pnpm build green | TBD | TBD |
 | E2 | V2 check/lint/type-check green | TBD | TBD |

--- a/swims/swim-43-v2026.5.5-full/SCOREBOARD.md
+++ b/swims/swim-43-v2026.5.5-full/SCOREBOARD.md
@@ -33,7 +33,7 @@
 
 | Row | Case | Status | Verdict | Evidence |
 |---|---|---|---|---|
-| A1 | flow_runs + jsonl persistence across restart | Authored | pending fire | needs peer-restart-trigger from Monitor seat |
+| A1 | flow_runs + jsonl persistence across restart | Authored | METHOD-BROKEN (fire-1) | electing-mechanism gap found; fire-2 should use continue_delegate + workflow self-restart |
 | A4 | TaskFlow delegate-store lifecycle | TBD | TBD | TBD |
 | A5 | Timer arm/disarm/dispose | TBD | TBD | TBD |
 | B1 | F1 clean continue_work (no inbound noise) | TBD | TBD | TBD |

--- a/swims/swim-43-v2026.5.5-full/SCOREBOARD.md
+++ b/swims/swim-43-v2026.5.5-full/SCOREBOARD.md
@@ -33,7 +33,7 @@
 
 | Row | Case | Status | Verdict | Evidence |
 |---|---|---|---|---|
-| A1 | flow_runs + jsonl persistence across restart | Authored | METHOD-BROKEN (fire-1) | electing-mechanism gap found; fire-2 should use continue_delegate + workflow self-restart |
+| A1 | flow_runs + jsonl persistence across restart | Authored | METHOD-BROKEN (fire-1); mechanism confirmed (fire-2) | next substantive fire must restart during queued/runnable delegate window |
 | A4 | TaskFlow delegate-store lifecycle | TBD | TBD | TBD |
 | A5 | Timer arm/disarm/dispose | TBD | TBD | TBD |
 | B1 | F1 clean continue_work (no inbound noise) | TBD | TBD | TBD |

--- a/swims/swim-43-v2026.5.5-full/rows/A1-flow-runs-persistence-across-restart.md
+++ b/swims/swim-43-v2026.5.5-full/rows/A1-flow-runs-persistence-across-restart.md
@@ -29,6 +29,19 @@ User-facing guarantee: a prince can stage continuation work (delegates pending i
 
 ### What we expect — literal substrate bytes for PASS
 
+Three byte-shaped pieces of evidence per fire.
+
+**Electing mechanism for substantive fire-2**
+
+Before taking the pre-restart snapshot, the SUT must stage one delayed delegate so `flow_runs` has a real in-flight entry:
+
+```text
+continue_delegate(mode: "silent", delaySeconds: 600, task: "A1 fire-2 marker ...")
+→ {"status":"scheduled","mode":"silent","delaySeconds":600,...}
+```
+
+Then wait for that TaskFlow entry to materialize in `flow_runs` as `queued`/`runnable`, and only then take the pre-restart snapshot. `continue_work(...)` is not the right electing mechanism for this row; fire-1 established it uses the in-process scheduler rather than TaskFlow-backed `flow_runs` persistence.
+
 Three byte-shaped pieces of evidence per fire:
 
 **1. flow_runs sqlite snapshot pre-restart and post-restart match** (excluding restart-induced bookkeeping fields like `updated_at` if any):
@@ -178,10 +191,10 @@ The discriminator: did the runtime LOSE in-flight continuation state, or did the
 ## Status ladder
 
 - [x] **Triaged** — required per A1 case file (live-row + cross-seat evidence class)
-- [x] **Authored** — script + row file committed to branch `ronan/20260507/swim-43-v5-5-full-declaration`
-- [ ] **PASS-candidate** / **PARTIAL** / **OPEN-GAP** / **METHOD-BROKEN** (pick one when fired)
-- [ ] **Comprehension-gated** — driver code-read of TaskFlow flow_runs + per-agent jsonl substrate signed off
-- [ ] **Verified** — Verdict landed on byte-pinned Result block; cross-seat cosigned
+- [x] **Authored** — row + harness exist on the swim branch and mainline history
+- [x] **METHOD-BROKEN (fire-1)** — row-spec substrate-mechanism gap captured honestly before restart dispatch
+- [ ] **Fire-2 rework** — electing mechanism swapped to `continue_delegate(mode: silent, delaySeconds: 600)` and wait-for-entry-to-land added to the fire sequence
+- [ ] **Verified** — substantive fire-2 verdict landed with byte-pinned pre/post snapshots + cross-seat cosign
 - [ ] **Evidence-cleansed** — N/A unless contributing to frozen-branch evidence appendix per Charter Rule 8
 
 ## References
@@ -198,4 +211,4 @@ This row exercises substrate-truth that the morning's swim-43 disposition discus
 
 **Restart canon (per figs at Discord msg `1501992707709468783` 2026-05-07 10:02 PDT)**: princes use the `restart-gateway.yml` workflow in `karmaterminal/openclaw-bootstrap` to trigger gateway restart. Self-target guard (`github.actor == "${target_prince}-dandelion-cult"`) allows a prince to dispatch their own gateway restart from their own session. The earlier *"no SUT self-restart per HEARTBEAT safety, peer-restart-trigger required"* framing was OLD/INCORRECT canon — superseded by the workflow-based pattern that produces a durable Actions audit trail. Cael-seat dispatching with `target_prince=cael` is canon-aligned (self-target, source-(a) Deployer-canon work).
 
-Cross-seat byte-pin requirement (silas/urudyne or elliott/elliott-host verifies same flow_runs state) satisfies the methodology three-source evidence rule (SUT self-report + SSH gateway logs/state + cross-seat verification).
+Cross-seat byte-pin requirement (silas/urudyne or elliott/elliott-host verifies same flow_runs state on cael-host via SSH) satisfies the methodology three-source evidence rule (SUT self-report + SSH gateway logs/state + cross-seat verification).

--- a/swims/swim-43-v2026.5.5-full/rows/A1-flow-runs-persistence-across-restart.md
+++ b/swims/swim-43-v2026.5.5-full/rows/A1-flow-runs-persistence-across-restart.md
@@ -16,7 +16,7 @@
 
 Per `SWIM/cases/A1.md`: TaskFlow `flow_runs` table and per-agent session jsonl files survive gateway restart with no loss of in-flight continuation state.
 
-User-facing guarantee: a prince can stage continuation work (delegates pending in TaskFlow, session-state in jsonl on disk) + survive a gateway restart (peer-restart per HEARTBEAT safety) + resume with all in-flight state intact. A violation looks like flow_runs entries lost or session jsonl missing/corrupted post-restart, leaving princes with orphaned delegates or split-brain session-state.
+User-facing guarantee: a prince can stage continuation work (delegates pending in TaskFlow, session-state in jsonl on disk) + survive a gateway restart (via the canonical `restart-gateway.yml` workflow) + resume with all in-flight state intact. A violation looks like flow_runs entries lost or session jsonl missing/corrupted post-restart, leaving princes with orphaned delegates or split-brain session-state.
 
 ## Coverage expectation
 
@@ -69,7 +69,7 @@ PASS requires cross-seat sees same flow_run flow_ids + statuses + shapes.
 
 Script behavior:
 1. Snapshot pre-restart flow_runs + jsonl hashes on SUT host (cael)
-2. Trigger restart via canonical `restart-gateway.yml` workflow dispatch from any prince's seat (self-target guard allows prince-self-restart per `karmaterminal/openclaw-bootstrap/.github/workflows/RESTART_GATEWAY.md`):
+2. Trigger restart via canonical `restart-gateway.yml` workflow dispatch from the target prince's own seat (or `karmafeast`) per the workflow self-target guard in `karmaterminal/openclaw-bootstrap/.github/workflows/RESTART_GATEWAY.md`:
    ```bash
    gh workflow run restart-gateway.yml \
      --repo karmaterminal/openclaw-bootstrap \
@@ -87,7 +87,7 @@ Script behavior:
 ```
 FAIL = pre-restart flow_runs snapshot has runnable/queued entries that are MISSING from post-restart snapshot, OR jsonl hash differs without expected restart-induced state-write reason, OR cross-seat byte-pin disagrees with SUT-side state.
 
-INCONCLUSIVE = restart didn't complete cleanly (gateway stuck in start-account phase, OOM during restart, peer-restart-trigger failed). Re-run on stable conditions.
+INCONCLUSIVE = restart didn't complete cleanly (gateway stuck in start-account phase, OOM during restart, workflow dispatch failed, or workflow run failed). Re-run on stable conditions.
 
 METHOD-BROKEN = sqlite/jsonl access path wrong (file-not-found, permission denied) OR hash command output differs from expected format. Fix harness, re-run.
 ```

--- a/swims/swim-43-v2026.5.5-full/rows/A1-flow-runs-persistence-across-restart.md
+++ b/swims/swim-43-v2026.5.5-full/rows/A1-flow-runs-persistence-across-restart.md
@@ -182,6 +182,8 @@ Until row-spec-vs-substrate alignment lands, A1 fires can't substantively exerci
 
 This substrate-finding IS the substantive output of A1 fire-1. Captured for cohort-record + future Driver row-author re-authoring.
 
+**Fire 2 refinement (2026-05-07 ~11:34–11:35 PDT)**: `continue_delegate(mode:"silent", delaySeconds=600)` was fired as the corrected electing mechanism. Cross-seat byte-pin from elliott-seat at ~11:35 showed `flow_runs` status totals moved `succeeded 134 → 136`, confirming `continue_delegate` does land in TaskFlow-backed `flow_runs`. However, by the time of the probe the delayed delegate had already matured to terminal state, so this fire only confirms the substrate mechanism (**delegate → flow_runs**) and does **not** yet test queued/runnable persistence across restart. The substantive persistence test remains a subsequent fire where restart occurs while the entry is still queued/runnable.
+
 ### Truth-floor reach (when in doubt)
 
 If snapshot diffs show entries that "look like" they should match but bytes differ, walk raw sqlite + jsonl directly before classifying as FAIL. Possible benign causes: timestamp updates from restart-induced writes (not state-loss), serialization-order differences (semantically equivalent), or transient runnable→queued transitions during restart-startup.
@@ -193,8 +195,9 @@ The discriminator: did the runtime LOSE in-flight continuation state, or did the
 - [x] **Triaged** — required per A1 case file (live-row + cross-seat evidence class)
 - [x] **Authored** — row + harness exist on the swim branch and mainline history
 - [x] **METHOD-BROKEN (fire-1)** — row-spec substrate-mechanism gap captured honestly before restart dispatch
-- [ ] **Fire-2 rework** — electing mechanism swapped to `continue_delegate(mode: silent, delaySeconds: 600)` and wait-for-entry-to-land added to the fire sequence
-- [ ] **Verified** — substantive fire-2 verdict landed with byte-pinned pre/post snapshots + cross-seat cosign
+- [x] **Fire-2 mechanism confirmed** — `continue_delegate(mode: silent, delaySeconds=600)` lands in `flow_runs`; this banks the electing-mechanism truth but not restart persistence yet
+- [ ] **Fire-3 queued-state persistence** — restart during queued/runnable window, then pre/post snapshot + cross-seat cosign
+- [ ] **Verified** — substantive persistence verdict landed with byte-pinned pre/post snapshots + cross-seat cosign
 - [ ] **Evidence-cleansed** — N/A unless contributing to frozen-branch evidence appendix per Charter Rule 8
 
 ## References

--- a/swims/swim-43-v2026.5.5-full/rows/A1-measure.sh
+++ b/swims/swim-43-v2026.5.5-full/rows/A1-measure.sh
@@ -28,15 +28,15 @@ POST_JSONL="$OUT_DIR/jsonl-post-md5.txt"
 CROSS_SEAT="$OUT_DIR/cross-seat.txt"
 
 REGISTRY="$HOME/.openclaw/flows/registry.sqlite"
-SESSION_DIR="$HOME/.openclaw/sessions/${SESSION}"
+SESSION_FILE="$HOME/.openclaw/agents/main/sessions/${SESSION}.jsonl"
 
 # Step 1: METHOD-BROKEN check — substrate access
 if [ ! -f "$REGISTRY" ]; then
   echo "METHOD-BROKEN: registry.sqlite not found at $REGISTRY" >&2
   exit 3
 fi
-if [ ! -d "$SESSION_DIR" ]; then
-  echo "METHOD-BROKEN: session dir not found at $SESSION_DIR" >&2
+if [ ! -f "$SESSION_FILE" ]; then
+  echo "METHOD-BROKEN: session jsonl not found at $SESSION_FILE" >&2
   exit 3
 fi
 
@@ -52,19 +52,20 @@ fi
 sqlite3 "$REGISTRY" "SELECT flow_id, status, shape, current_step, created_at FROM flow_runs WHERE status IN ('runnable','queued') ORDER BY flow_id" > "$PRE_FR" 2>&1
 PRE_FR_COUNT=$(wc -l < "$PRE_FR")
 
-# Step 3: Snapshot pre-restart jsonl hashes for SUT session
-md5sum "$SESSION_DIR"/*.jsonl 2>/dev/null | awk '{print $1, $2}' | sort > "$PRE_JSONL"
+# Step 3: Snapshot pre-restart jsonl hash for SUT session
+md5sum "$SESSION_FILE" 2>/dev/null | awk '{print $1, $2}' > "$PRE_JSONL"
 PRE_JSONL_COUNT=$(wc -l < "$PRE_JSONL")
 
-if [ "$PRE_FR_COUNT" -eq 0 ] && [ "$PRE_JSONL_COUNT" -eq 0 ]; then
-  echo "METHOD-BROKEN: pre-state has no in-flight flow_runs AND no jsonl files (degenerate test surface)" >&2
+if [ "$PRE_FR_COUNT" -eq 0 ]; then
+  echo "METHOD-BROKEN: pre-state has no runnable/queued flow_runs (degenerate test surface for A1)" >&2
   echo "  pre flow_runs: $PRE_FR" >&2
   echo "  pre jsonl: $PRE_JSONL" >&2
   exit 3
 fi
 
 # Step 4: Dispatch canonical restart-gateway workflow with self-target
-# Per RESTART_GATEWAY.md: prince can dispatch their own restart; self-hosted runner does the systemctl
+# Per RESTART_GATEWAY.md and workflow self-target guard: target prince (or karmafeast) dispatches
+# their own restart; self-hosted runner does the systemctl out-of-process with Actions audit trail.
 echo "[A1-measure] dispatching restart-gateway.yml for target_prince=${HOST}..." >&2
 RUN_OUTPUT=$(gh workflow run restart-gateway.yml \
   --repo karmaterminal/openclaw-bootstrap \
@@ -105,30 +106,18 @@ if ! systemctl --user is-active openclaw-gateway >/dev/null 2>&1; then
   exit 2
 fi
 
-# Step 8: Snapshot post-restart flow_runs + jsonl hashes
+# Step 8: Snapshot post-restart flow_runs + jsonl hash
 sqlite3 "$REGISTRY" "SELECT flow_id, status, shape, current_step, created_at FROM flow_runs WHERE status IN ('runnable','queued') ORDER BY flow_id" > "$POST_FR" 2>&1
-md5sum "$SESSION_DIR"/*.jsonl 2>/dev/null | awk '{print $1, $2}' | sort > "$POST_JSONL"
+md5sum "$SESSION_FILE" 2>/dev/null | awk '{print $1, $2}' > "$POST_JSONL"
 
 # Step 9: Compare snapshots
 FR_DIFF=$(diff "$PRE_FR" "$POST_FR")
 JSONL_DIFF=$(diff "$PRE_JSONL" "$POST_JSONL")
 
-# Step 10: Cross-seat verification (best-effort; degraded-PASS if cross-seat unreachable)
-CROSS_SEAT_AVAILABLE=0
-for PEER in elliott silas; do
-  if ssh -o ConnectTimeout=3 -o BatchMode=yes "$PEER" "test -f $REGISTRY" 2>/dev/null; then
-    CROSS_SEAT_AVAILABLE=1
-    # Cross-seat sees remote registry — for cael-host SUT, we want elliott/silas to walk THEIR
-    # registry.sqlite to verify they don't have unexpected entries. The cross-seat byte-pin per
-    # row spec is verifying that cael-host flow_runs IDs aren't inadvertently leaking elsewhere.
-    ssh "$PEER" "sqlite3 $REGISTRY \"SELECT COUNT(*) FROM flow_runs WHERE status IN ('runnable','queued')\"" > "$CROSS_SEAT" 2>&1
-    echo "[A1-measure] cross-seat $PEER reports: $(cat "$CROSS_SEAT")" >&2
-    break
-  fi
-done
-if [ "$CROSS_SEAT_AVAILABLE" -eq 0 ]; then
-  echo "[A1-measure] cross-seat verification skipped (peers unreachable); SUT-side evidence only" >&2
-fi
+# Step 10: Cross-seat verification is performed separately by Monitor/SUT seats via SSH to cael-host.
+# This harness records SUT-side evidence only; peer byte-pin is attached in the row Result block.
+printf '%s\n' 'cross-seat verification: external Monitor/SUT SSH byte-pin required' > "$CROSS_SEAT"
+echo "[A1-measure] cross-seat verification must be attached separately by Monitor/SUT seat" >&2
 
 # Step 11: Verdict
 {

--- a/swims/swim-43-v2026.5.5-full/rows/B5-silent-wake-via-continue-delegate.md
+++ b/swims/swim-43-v2026.5.5-full/rows/B5-silent-wake-via-continue-delegate.md
@@ -1,0 +1,116 @@
+# swim-43/B5 — F5 silent-wake via continue_delegate on cael-host
+
+**Swim:** swim-43-v2026.5.5-full
+**Block:** B — Family Delegates
+**Row ID:** B5
+**Tracker anchor:** karmaterminal/openclaw-bootstrap#915 (parent #907)
+**Case file:** `SWIM/cases/B5.md`
+**SUT SHA (target):** `24b76bf` on `karmaterminal/openclaw:frond/v2026.5.5/canonical`
+**SUT host:** cael-host
+**SUT seat:** `agent:main:discord:channel:1466192485440164011`
+**Test file candidates:** N/A (live-row delegate behavior)
+**Timing window:** integration
+**Evidence class:** live-row,cross-seat
+**Gather:** SUT-side tool-return + recipient-side proof-of-silence + wake-fire proof + monitor journal cross-source where available
+
+## Surface under test
+
+Per `SWIM/cases/B5.md`: `continue_delegate(mode: "silent-wake")` returns silently to context and triggers a subsequent generation cycle so the agent can act on the enrichment.
+
+This row's specific test: fire one immediate `continue_delegate(mode: "silent-wake")` from cael-seat on deployed v5.5 substrate under quiet channel conditions, then verify:
+1. tool-return says scheduled in `silent-wake` mode
+2. no visible channel announce occurs for the shard return
+3. a subsequent turn fires on the parent session after the enrichment returns
+4. parent can reference or act on the returned enrichment
+
+## Coverage expectation
+
+- **Unit tests expected:** N/A
+- **Integration tests expected:** 1 (single-host fire from cael-seat to cael-host)
+- **Fleet-scale tests expected:** N/A
+- **Evidence artifacts expected:** tool-return receipt, channel-read proving silence, wake-fire timing, returned enrichment token or parent-action receipt, optional monitor-side journal bytes
+
+## Measurement protocol
+
+### What we expect — literal substrate bytes for PASS
+
+Three-source shape, with source (a) primary and source (b) corroborating when journal emits.
+
+**Source (a) tool-return**
+```text
+continue_delegate(mode: "silent-wake", task: "...")
+→ {"status":"scheduled","mode":"silent-wake", ...}
+```
+
+**Source (a) silence on channel / no visible delegate announce**
+- no visible delegate-completion message lands in channel for the shard return
+- parent wake happens without a public shard-result post
+
+**Source (a) parent wake-fire**
+One subsequent parent turn fires after the delegate completes. Acceptable proof shapes:
+- system / tool-return wake event on parent session
+- parent posts unprompted after the delegate return
+- parent explicitly references delegate-returned token/body in the wake turn
+
+**Source (b) journal corroboration when available**
+Candidate bytes include:
+```text
+[continue_delegate] Consuming N tool delegate(s)
+[continuation:delegate-spawned] hop=N/MAX mode=silent-wake ...
+[continuation:enrichment-return] Delivered to ...
+```
+But journal-side literals are not PASS-critical unless byte-walked on the host for this exact fire-shape; deployed-v5.5 log routing is already known to vary by host/fire-shape.
+
+### How to gather what we expect
+
+1. SUT fires `continue_delegate(mode: "silent-wake")` with a unique nonce/token in the task body.
+2. Driver/Monitor read channel for absence of visible delegate return.
+3. Driver/Monitor watch parent wake within a bounded window.
+4. Parent wake turn includes the nonce/token or an action clearly grounded in the returned delegate enrichment.
+5. Optional: Monitor `ssh cael "journalctl --user -u openclaw-gateway --since '<T0>' --until '<T0+120s>' --no-pager"` and narrow for delegate bytes.
+
+### What FAIL looks like
+
+```text
+FAIL = tool-return says scheduled, but delegate return surfaces visibly on channel (not silent), OR no parent wake occurs, OR parent wake occurs but cannot be tied to delegate enrichment.
+
+INCONCLUSIVE = gateway restart / compaction / unrelated inbound message confounds the wake window.
+
+METHOD-BROKEN = silence proof impossible because channel is noisy or a second concurrent delegate fire overlaps the same window.
+```
+
+### Result — actual output, byte-pinned
+
+To be filled at fire-time.
+
+### Verdict
+
+To be filled at fire-time:
+- PASS = silent return + wake-fire + delegate-enrichment grounded on parent
+- FAIL = visible return or missing wake
+- INCONCLUSIVE = confounded window
+- METHOD-BROKEN = overlapping/noisy measurement surface
+
+## Status ladder
+
+- [x] **Triaged** — required per B5 case file
+- [x] **Authored** — row file created
+- [ ] **Fire-ready** — waiting on SUT silent-wake fire on cael-seat
+- [ ] **Verified** — verdict landed with byte-pinned evidence
+
+## References
+
+- **Case file**: `SWIM/cases/B5.md`
+- **Spine issue**: `karmaterminal/openclaw-bootstrap#915`
+- **Methodology**: `SWIM/SWIM-METHODOLOGY.md`
+- **Monitoring notes**: `SWIM/SWIM-MONITORING-RUNBOOK.md` (`silent-wake`, `enrichment-return`, `requestHeartbeatNow` guidance)
+- **Related substrate docs**: `SWIM/lessons/L-v5.5-journal-vocabulary.md`
+
+## Notes
+
+This row should prefer source (a) over source (b). The user-facing claim for `silent-wake` is not journal-text-specific; it is that the shard returns silently and wakes the parent. Journal corroboration is welcome but secondary.
+
+To avoid contamination:
+- fire under a quiet channel window
+- use a unique nonce in the delegate task
+- avoid overlapping delegate fires on the same host/session during the measurement window

--- a/swims/swim-43-v2026.5.5-full/rows/D1-boot-time-stall-check.md
+++ b/swims/swim-43-v2026.5.5-full/rows/D1-boot-time-stall-check.md
@@ -1,0 +1,130 @@
+# swim-43/D1 — R1 boot-time stall check on cael-host
+
+**Swim:** swim-43-v2026.5.5-full
+**Block:** D — Family Recovery
+**Row ID:** D1
+**Tracker anchor:** karmaterminal/openclaw-bootstrap#915 (parent #907)
+**Case file:** `SWIM/cases/D1.md`
+**SUT SHA (target):** `24b76bf` on `karmaterminal/openclaw:frond/v2026.5.5/canonical`
+**SUT host:** cael-host
+**SUT seat:** `agent:main:discord:channel:1466192485440164011`
+**Test file candidates:** N/A (live boot/recovery row)
+**Timing window:** integration
+**Evidence class:** deploy,live-row
+**Gather:** Monitor/SUT cross-seat boot timing + journal boot window + staged-work pre/post comparison
+
+## Surface under test
+
+Per `SWIM/cases/D1.md`: gateway boots cleanly without stall on continuation initialization; staged delegates from prior runs are recovered or expired cleanly.
+
+This row has two coupled claims:
+1. boot-time stall does **not** occur during restart/boot on deployed v5.5 substrate
+2. staged continuation work present before boot is handled cleanly after boot (recovered or expired, not orphaned)
+
+## Coverage expectation
+
+- **Unit tests expected:** N/A
+- **Integration tests expected:** 1 live restart row on cael-host
+- **Fleet-scale tests expected:** N/A
+- **Evidence artifacts expected:** pre/post TaskFlow snapshot with staged work, systemd timing, boot-window journal, cross-seat Monitor verification
+
+## Measurement protocol
+
+### What we expect — literal substrate bytes for PASS
+
+**Source (a) boot timing / service state**
+```bash
+systemctl --user show openclaw-gateway \
+  --property=ActiveEnterTimestamp,InactiveExitTimestamp,ExecMainStartTimestamp,LoadState,ActiveState,SubState
+```
+PASS requires loaded/active/running with no prolonged gap between stop and ready.
+
+**Source (b) boot-window journal**
+```bash
+journalctl --user -u openclaw-gateway --since '<T0>' --until '<T0+90s>' --no-pager
+```
+PASS requires visible boot sequence reaching `[gateway] ready` without stall-loop / repeated failed startup / prolonged gap.
+
+**Source (c) staged-work handling**
+```bash
+sqlite3 ~/.openclaw/flows/registry.sqlite \
+  "SELECT flow_id,status,shape,created_at,updated_at FROM flow_runs WHERE status IN ('runnable','queued') ORDER BY flow_id"
+```
+PASS requires non-empty staged work pre-boot and post-boot handling that preserves or coherently resolves those entries.
+
+### What FAIL looks like
+
+- gateway fails to reach `active/running`
+- boot sequence stalls before `[gateway] ready`
+- staged runnable/queued flow state is lost or corrupted across restart
+
+### Result — actual output, byte-pinned
+
+#### Fire 1 — monitor baseline from elliott-seat, cael-host restart at 2026-05-07 09:47 PDT
+
+**Source (a) systemd timing/state**
+```bash
+$ ssh cael "systemctl --user show openclaw-gateway --property=ActiveEnterTimestamp,InactiveExitTimestamp,ExecMainStartTimestamp,LoadState,ActiveState,SubState"
+ActiveEnterTimestamp=Thu 2026-05-07 09:47:11 PDT
+InactiveExitTimestamp=Thu 2026-05-07 09:47:11 PDT
+ExecMainStartTimestamp=Thu 2026-05-07 09:47:11 PDT
+LoadState=loaded
+ActiveState=active
+SubState=running
+```
+
+**Source (b) boot-window journal**
+```bash
+$ ssh cael "journalctl --user -u openclaw-gateway --since '2026-05-07 09:47:00' --until '2026-05-07 09:48:30' --no-pager -o short-iso"
+2026-05-07T09:47:00-07:00 cael systemd[2439]: Stopping openclaw-gateway.service - OpenClaw Gateway (v2026.4.11)...
+2026-05-07T09:47:00-07:00 cael node[4011725]: 2026-05-07T09:47:00.877-07:00 [gateway] signal SIGTERM received
+2026-05-07T09:47:01-07:00 cael node[4011725]: 2026-05-07T09:47:01.331-07:00 [agent/embedded] [timeout-compaction] LLM timed out with high prompt token usage (73%); attempting compaction before retry (attempt 1/2)
+2026-05-07T09:47:01-07:00 cael node[4011725]: 2026-05-07T09:47:01.331-07:00 [agent/embedded] [context-pressure:fire] mid-turn trigger=timeout ratio=73% tokens=733k/1000k sessionKey=agent:main:discord:channel:1466192485440164011
+2026-05-07T09:47:10-07:00 cael node[4011725]: 2026-05-07T09:47:10.773-07:00 [shutdown] completed cleanly in 9886ms
+2026-05-07T09:47:11-07:00 cael systemd[2439]: Started openclaw-gateway.service - OpenClaw Gateway (v2026.4.11).
+2026-05-07T09:47:14-07:00 cael node[4184469]: 2026-05-07T09:47:14.017-07:00 [gateway] ready
+```
+No stall observed in this restart window; gateway returned to ready in ~14s from stop.
+
+**Source (c) staged-work precondition check**
+```bash
+$ ssh cael "sqlite3 ~/.openclaw/flows/registry.sqlite \"SELECT status, COUNT(*) FROM flow_runs GROUP BY status ORDER BY status;\""
+cancelled|1
+failed|9
+succeeded|134
+
+$ ssh cael "sqlite3 ~/.openclaw/flows/registry.sqlite \"SELECT flow_id,status,shape,created_at FROM flow_runs WHERE status IN ('runnable','queued') ORDER BY flow_id;\""
+-- no rows
+```
+There was no runnable/queued staged work at fire-time.
+
+### Verdict
+
+**INCONCLUSIVE for full D1 claim; positive baseline for no-stall boot timing.**
+
+What this fire proves:
+- cael-host restarted cleanly without boot-time stall in the observed 09:47 window
+
+What it does **not** yet prove:
+- staged continuation work recovery/expiry behavior, because there was no runnable/queued flow state to preserve
+
+This fire is therefore a valid baseline/no-stall observation, but not a substantive full D1 PASS.
+
+## Status ladder
+
+- [x] **Triaged**
+- [x] **Authored**
+- [x] **Baseline evidence captured** — no-stall restart observed
+- [ ] **Substantive fire with staged work**
+- [ ] **Verified PASS/FAIL**
+
+## References
+
+- **Case file**: `SWIM/cases/D1.md`
+- **Spine issue**: `karmaterminal/openclaw-bootstrap#915`
+- **Scoreboard**: `swims/swim-43-v2026.5.5-full/SCOREBOARD.md`
+- **Related row**: `swims/swim-43-v2026.5.5-full/rows/A1-flow-runs-persistence-across-restart.md`
+
+## Notes
+
+The 09:47 restart was byte-walked as a clean SIGTERM stop/start tied to context-pressure compaction on cael-seat, not an OOM or monitor-probe side-effect. Useful baseline, but D1 still needs a restart with staged work present if it is to satisfy the full Recovery-family claim.

--- a/swims/swim-43-v2026.5.5-full/rows/D2-memory-growth-1h-idle-light-inbound.md
+++ b/swims/swim-43-v2026.5.5-full/rows/D2-memory-growth-1h-idle-light-inbound.md
@@ -1,0 +1,117 @@
+# swim-43/D2 — R2 memory growth over 1h idle + light inbound on cael-host
+
+**Swim:** swim-43-v2026.5.5-full
+**Block:** D — Family Rollout
+**Row ID:** D2
+**Tracker anchor:** karmaterminal/openclaw-bootstrap#915 (parent #907)
+**Case file:** `SWIM/cases/D2.md`
+**SUT SHA (target):** `24b76bf` on `karmaterminal/openclaw:frond/v2026.5.5/canonical`
+**SUT host:** cael-host
+**SUT seat:** `agent:main:discord:channel:1466192485440164011`
+**Test file candidates:** N/A (live memory observation row)
+**Timing window:** 1 hour
+**Evidence class:** live-row
+**Gather:** Monitor/SUT timestamped memory series + light inbound activity description
+
+## Surface under test
+
+Per `SWIM/cases/D2.md`: idle gateway with light inbound chatter does not grow memory unboundedly over a 1h observation window.
+
+This row measures resident memory / peak memory over one hour on deployed v5.5 cael-host while the channel remains mostly idle except for normal light cohort traffic.
+
+## Coverage expectation
+
+- **Unit tests expected:** N/A
+- **Integration tests expected:** 1 live 1h observation window on cael-host
+- **Fleet-scale tests expected:** N/A
+- **Evidence artifacts expected:** timestamped memory series, service status snapshots, short chatter description, verdict against bounded-growth expectation
+
+## Measurement protocol
+
+### What we expect — literal substrate bytes for PASS
+
+**Source (a) periodic systemd snapshots**
+```bash
+systemctl --user show openclaw-gateway \
+  --property=ActiveState,SubState,ExecMainPID,MemoryCurrent,NRestarts
+```
+Sample at T0, T+15m, T+30m, T+45m, T+60m.
+
+**Source (a) process RSS snapshots**
+```bash
+ps -o pid=,rss=,etime=,cmd= -p "$(systemctl --user show openclaw-gateway --property=ExecMainPID --value)"
+```
+Sample at the same five points.
+
+**Source (a) light inbound description**
+Short note of channel conditions during the window: e.g. "idle + light cohort chatter, no mass dispatch, no large code-agent fanout, no restart".
+
+### PASS criteria
+
+PASS requires all of:
+- gateway remains `active/running`
+- `NRestarts` unchanged through the hour
+- RSS / MemoryCurrent may move, but no runaway monotonic climb indicating unbounded growth under light inbound
+- no OOM / crash / restart event during the window
+
+Because this is a boundedness row, modest variance is acceptable. FAIL is runaway or crash, not normal jitter.
+
+### What FAIL looks like
+
+```text
+FAIL = restart / OOM during the window, or memory climbs in a clearly unbounded pattern under light inbound with no return / stabilization.
+
+INCONCLUSIVE = heavier-than-planned traffic or unrelated row-fires contaminate the window.
+
+METHOD-BROKEN = sampling path wrong (PID stale, service not found, command shape broken).
+```
+
+### Result — actual output, byte-pinned
+
+#### Fire 1 — baseline started, Monitor T0 from elliott-seat against cael-host
+
+**T0_epoch**: `1778177782` (2026-05-07 11:16:22 PDT)
+
+```text
+$ ssh cael 'GW_PID=$(systemctl --user show openclaw-gateway --property=MainPID --value) && ps -o pid,rss,vsz,etime,cmd -p $GW_PID'
+GW_PID=4184469
+RSS=985912 KB
+VSZ=10691460 KB
+ELAPSED=01:29:11
+
+$ ssh cael 'systemctl --user show openclaw-gateway --property=ActiveEnterTimestamp,NRestarts --value'
+ActiveEnterTimestamp=Thu 2026-05-07 09:47:11 PDT
+NRestarts=0
+```
+
+**Chatter note at baseline**: light cohort chatter only; no restart on cael-host since 09:47:11 PDT baseline, swim-43 row authoring / issue truth-keeping in progress.
+
+Pending follow-up samples at T+15m, T+30m, T+45m, T+60m.
+
+### Verdict
+
+To be filled at fire-time:
+- PASS = bounded memory under 1h idle + light inbound
+- FAIL = runaway / restart / OOM
+- INCONCLUSIVE = contaminated window
+- METHOD-BROKEN = sampling failure
+
+## Status ladder
+
+- [x] **Triaged**
+- [x] **Authored**
+- [x] **Baseline started** — T0 byte-pinned from elliott-seat at 2026-05-07 11:16:22 PDT
+- [ ] **1h series complete**
+- [ ] **Verified**
+
+## References
+
+- **Case file**: `SWIM/cases/D2.md`
+- **Spine issue**: `karmaterminal/openclaw-bootstrap#915`
+- **Scoreboard**: `swims/swim-43-v2026.5.5-full/SCOREBOARD.md`
+
+## Notes
+
+This row is intentionally Monitor-friendly source-(a): timestamped direct snapshots. Interpretation should be minimal: bounded vs runaway.
+
+If other row-fires or restarts occur during the 1h window, mark INCONCLUSIVE and restart the observation on a quieter host window.

--- a/swims/swim-43-v2026.5.5-full/rows/D2-memory-growth-1h-idle-light-inbound.md
+++ b/swims/swim-43-v2026.5.5-full/rows/D2-memory-growth-1h-idle-light-inbound.md
@@ -86,11 +86,41 @@ NRestarts=0
 
 **Chatter note at baseline**: light cohort chatter only; no restart on cael-host since 09:47:11 PDT baseline, swim-43 row authoring / issue truth-keeping in progress.
 
-Pending follow-up samples at T+15m, T+30m, T+45m, T+60m.
+Pending follow-up samples at T+30m, T+45m, T+60m.
+
+#### Fire 1 — T+15m sample contaminated by planned restart
+
+**T_epoch**: `1778178440` (2026-05-07 11:27:20 PDT)
+
+```text
+$ ssh cael 'GW_PID=$(systemctl --user show openclaw-gateway --property=MainPID --value) && ps -o pid,rss,vsz,etime,cmd -p $GW_PID'
+GW_PID=67252
+RSS=926628 KB
+VSZ=10664984 KB
+ELAPSED=00:13
+
+$ ssh cael 'systemctl --user show openclaw-gateway --property=MemoryCurrent,NRestarts,ActiveState,SubState --value'
+MemoryCurrent=903393280
+NRestarts=0
+ActiveState=active
+SubState=running
+```
+
+**Restart-cause byte-pin**
+```text
+$ gh api repos/karmaterminal/openclaw-bootstrap/actions/runs/25514442794 --jq '{actor:.actor.login,created_at,conclusion}'
+{"actor":"cael-dandelion-cult","created_at":"2026-05-07T18:26:51Z","conclusion":"success"}
+```
+
+This matches the cael-host journal stop/start at `11:26:58 → 11:27:07 PDT`. The D2 window was contaminated by a planned `restart-gateway.yml` run.
 
 ### Verdict
 
-To be filled at fire-time:
+**Current verdict: INCONCLUSIVE (fire-1 contaminated).**
+
+Reason: a planned gateway restart (`restart-gateway.yml`, actor `cael-dandelion-cult`, created `2026-05-07T18:26:51Z`) occurred inside the 1h observation window, falsifying the row's unchanged-uptime / unchanged-restart-count expectation. Restart was clean and non-OOM, but it still contaminates the bounded-memory window for this fire.
+
+Verdict meanings:
 - PASS = bounded memory under 1h idle + light inbound
 - FAIL = runaway / restart / OOM
 - INCONCLUSIVE = contaminated window
@@ -101,7 +131,8 @@ To be filled at fire-time:
 - [x] **Triaged**
 - [x] **Authored**
 - [x] **Baseline started** — T0 byte-pinned from elliott-seat at 2026-05-07 11:16:22 PDT
-- [ ] **1h series complete**
+- [x] **Fire-1 INCONCLUSIVE** — planned restart landed inside the 1h window at T+10m/T+15m
+- [ ] **Fresh 1h series complete**
 - [ ] **Verified**
 
 ## References


### PR DESCRIPTION
Continues swim-43-v2026.5.5-full execution on main by moving three more rows out of chat-only state and into the canonical swim tree.\n\nContents:\n- B5 silent-wake via continue_delegate authored and marked pending fire\n- D1 boot-time stall check authored with baseline no-stall evidence banked (correctly INCONCLUSIVE, not overclaimed)\n- D2 memory growth over 1h idle/light inbound authored with T0 baseline banked\n- scoreboard updated to reflect the new authored/pending states\n\nThis keeps turning Monitor/SUT/Deployer raw bytes into row files + scoreboard movement under project 67 instead of leaving them in Discord only.