### PR TITLE
swim-43: bank D1 staged-work restart PASS

### DIFF
--- a/swims/swim-43-v2026.5.5-full/SCOREBOARD.md
+++ b/swims/swim-43-v2026.5.5-full/SCOREBOARD.md
@@ -89,7 +89,7 @@
 |---|---|---|---|
 | B8 | F8 post-compaction delegate survival | TBD | TBD |
 | C3 | P3 timer disposal on generation change | TBD | TBD |
-| D1 | R1 boot-time stall check | Authored | INCONCLUSIVE (baseline no-stall only) |
+| D1 | R1 boot-time stall check | Authored | **PASS** | fire-1 no-stall baseline; fire-2 PASS with staged queued row surviving restart (`25516284592`) |
 | D3 | R3 compaction recovery | TBD | TBD |
 | D4 | R4 gateway restart recovery (peer) | TBD | TBD |
 | N007 | OTel preserved through restart-replay | TBD | TBD |
@@ -130,7 +130,7 @@
 
 Charter §6 closure rules: FULL-PASS requires all required rows verdicted PASS. FULL-WITH-FINDINGS allows non-blocker FAIL/FINDING. NOT-FULL if any required row left at TBD/DEFERRED/BLOCKED/INVALIDATED at close.
 
-Current verdict-roll: **3 PASS / 52 TBD = NOT-FULL eligible at this snapshot**. Verdict pending row authoring + fires + closure declaration.
+Current verdict-roll: **4 PASS / 51 TBD = NOT-FULL eligible at this snapshot**. Verdict pending row authoring + fires + closure declaration.
 
 ## Substrate-knowledge references
 

--- a/swims/swim-43-v2026.5.5-full/SCOREBOARD.md
+++ b/swims/swim-43-v2026.5.5-full/SCOREBOARD.md
@@ -33,7 +33,7 @@
 
 | Row | Case | Status | Verdict | Evidence |
 |---|---|---|---|---|
-| A1 | flow_runs + jsonl persistence across restart | Authored | METHOD-BROKEN (fire-1); mechanism confirmed (fire-2) | next substantive fire must restart during queued/runnable delegate window |
+| A1 | flow_runs + jsonl persistence across restart | Authored | **PASS** | fire-1 METHOD-BROKEN; fire-2 mechanism confirmed; fire-3 PASS on queued-state survival across restart (run `25516284592`) |
 | A4 | TaskFlow delegate-store lifecycle | TBD | TBD | TBD |
 | A5 | Timer arm/disarm/dispose | TBD | TBD | TBD |
 | B1 | F1 clean continue_work (no inbound noise) | TBD | TBD | TBD |
@@ -130,7 +130,7 @@
 
 Charter §6 closure rules: FULL-PASS requires all required rows verdicted PASS. FULL-WITH-FINDINGS allows non-blocker FAIL/FINDING. NOT-FULL if any required row left at TBD/DEFERRED/BLOCKED/INVALIDATED at close.
 
-Current verdict-roll: **2 PASS / 53 TBD = NOT-FULL eligible at this snapshot**. Verdict pending row authoring + fires + closure declaration.
+Current verdict-roll: **3 PASS / 52 TBD = NOT-FULL eligible at this snapshot**. Verdict pending row authoring + fires + closure declaration.
 
 ## Substrate-knowledge references
 

--- a/swims/swim-43-v2026.5.5-full/rows/A1-flow-runs-persistence-across-restart.md
+++ b/swims/swim-43-v2026.5.5-full/rows/A1-flow-runs-persistence-across-restart.md
@@ -156,19 +156,15 @@ $ find ~/.openclaw -maxdepth 4 -name '*.jsonl' | grep -iE 'main|discord|agent'
 
 ### Verdict
 
-**Verdict: METHOD-BROKEN → row-spec substrate-mechanism gap (NOT substrate-broken)**
+**Current verdict: PASS.**
 
-Three substrate-findings invalidate the row-spec's PASS-criteria assumptions:
+A1's real question is now answered on deployed v5.5 cael-host with two-seat evidence: a delayed silent `continue_delegate` entry remained present and coherent across a canonical `restart-gateway.yml` restart. The historical split still matters:
 
-1. **`continue_work` does NOT populate `flow_runs`; `continue_delegate` DOES**. Substrate-truth refined per cohort cross-source byte-walk (🌻's msg `1502003477092503552` + 🌿's amendment-suggestion at msg `1502004503539613799` + cael-seat byte-verification of `delegate-store.ts` head-comment): 
-   - `continue_work` uses in-process scheduler timer (`registerContinuationTimerHandle` per `scheduler.ts`); volatile across restart by design.
-   - `continue_delegate` uses **TaskFlow-backed delegate-store** (`src/auto-reply/continuation/delegate-store.ts:1-7` — *"Continuation delegate store — pure TaskFlow-backed. Every delegate operation goes through TaskFlow (SQLite persistence). Zero volatile Maps. Delegates survive gateway restarts by design."*); imports `createManagedTaskFlow`, `failFlow`, `finishFlow`, etc from `task-flow-runtime-internal`.
-   - PR #31 fire-1 Verdict initially generalized this as *"continuation system and TaskFlow registry are separate substrate-mechanisms"* — byte-narrow-true at literal-token layer (continuation source has no `flow_runs` literal; column-name only in sqlite-store impl) but byte-incorrect at substrate-action layer for `continue_delegate`. Refined here per truth-keeping discipline applied to my own prior banked finding.
-   - **Operational implication for A1 fire-2**: swap electing mechanism from `continue_work(delaySeconds=600)` to `continue_delegate(mode: silent, delaySeconds=600)` — populates flow_runs runnable+queued entry via TaskFlow-backed delegate-store, then full A1 fire-sequence works substantively against the substrate the row claims to test.
-2. **flow_runs schema** uses `flow_id TEXT PRIMARY KEY` + `shape`, `sync_mode`, `owner_key`, `controller_id`, `revision`, `status`, `goal`, `current_step`, etc — NOT the inferred `id, status, kind, created_at` schema the original A1 row spec used. (Already fixed in PR #30.)
-3. **Session jsonl storage path** is `~/.openclaw/agents/main/sessions/<session-id>.jsonl` — NOT `~/.openclaw/sessions/<session-id>/*.jsonl` as the row spec assumed.
+1. **Fire 1 = METHOD-BROKEN.** The original row used the wrong electing mechanism (`continue_work`) and wrong storage assumptions (session path + flow_runs schema), so it taught the substrate-mechanism lesson but did not exercise restart persistence.
+2. **Fire 2 = mechanism confirmed.** `continue_delegate(mode: "silent", delaySeconds: 600)` was shown to land in TaskFlow-backed `flow_runs`, but the probe caught the row after it had already terminalized, so persistence across restart was still untested.
+3. **Fire 3 = PASS.** The delayed delegate row survived restart still queued, with the same `flow_id`, `owner_key`, `notify_policy`, `created_at`, and `updated_at`, and the restart boundary itself was byte-pinned by the successful workflow run plus post-restart gateway timestamps.
 
-Restart-workflow dispatch was NOT executed because pre-state byte-walk revealed substrate-mechanism gaps that would produce degenerate-pass at best. Per Truth-floor reach: **fix the row-spec substrate-mechanism alignment + re-fire**, do NOT classify as substrate-FAIL.
+So the row verdict is now substantive PASS, while fire-1 / fire-2 remain preserved as the path by which the room learned the correct substrate shape.
 
 ## Substrate-finding (substantive output of this fire)
 
@@ -184,6 +180,30 @@ This substrate-finding IS the substantive output of A1 fire-1. Captured for coho
 
 **Fire 2 refinement (2026-05-07 ~11:34–11:35 PDT)**: `continue_delegate(mode:"silent", delaySeconds=600)` was fired as the corrected electing mechanism. Cross-seat byte-pin from elliott-seat at ~11:35 showed `flow_runs` status totals moved `succeeded 134 → 136`, confirming `continue_delegate` does land in TaskFlow-backed `flow_runs`. However, by the time of the probe the delayed delegate had already matured to terminal state, so this fire only confirms the substrate mechanism (**delegate → flow_runs**) and does **not** yet test queued/runnable persistence across restart. The substantive persistence test remains a subsequent fire where restart occurs while the entry is still queued/runnable.
 
+**Fire 3 substantive PASS (2026-05-07 12:04–12:10 PDT)**: cael-seat staged `continue_delegate(mode:"silent", delaySeconds:600)` and took the pre-restart snapshot at `12:04:41 PDT`, then dispatched canonical workflow run `25516284592` (`restart-gateway.yml`, conclusion `success`). Post-restart source-(a) on cael-seat and cross-seat byte-pin from elliott-seat both showed the same queued marker row persisted across restart:
+
+```text
+flow_id=e9a87f45-4806-4a69-9f58-629ed629b3bf
+status=queued
+current_step=Queued for continuation dispatch
+owner_key=agent:main:discord:channel:1466192485440164011
+notify_policy=silent
+created_at=1778180670729
+updated_at=1778180670729
+```
+
+Restart receipt:
+
+```text
+workflow run 25516284592 = success
+ActiveEnterTimestamp=Thu 2026-05-07 12:05:06 PDT
+MainPID=100312
+NRestarts=0
+registry.sqlite md5=a5deeb6f0f315b7522b09c134b590313
+```
+
+Elliott's cross-seat pin at `T_post_restart_epoch=1778181007` matched the same `flow_id`, `status=queued`, `owner_key`, and timestamps from elliott-seat against cael-host, closing the row with independent two-seat confirmation.
+
 ### Truth-floor reach (when in doubt)
 
 If snapshot diffs show entries that "look like" they should match but bytes differ, walk raw sqlite + jsonl directly before classifying as FAIL. Possible benign causes: timestamp updates from restart-induced writes (not state-loss), serialization-order differences (semantically equivalent), or transient runnable→queued transitions during restart-startup.
@@ -195,9 +215,9 @@ The discriminator: did the runtime LOSE in-flight continuation state, or did the
 - [x] **Triaged** — required per A1 case file (live-row + cross-seat evidence class)
 - [x] **Authored** — row + harness exist on the swim branch and mainline history
 - [x] **METHOD-BROKEN (fire-1)** — row-spec substrate-mechanism gap captured honestly before restart dispatch
-- [x] **Fire-2 mechanism confirmed** — `continue_delegate(mode: silent, delaySeconds=600)` lands in `flow_runs`; this banks the electing-mechanism truth but not restart persistence yet
-- [ ] **Fire-3 queued-state persistence** — restart during queued/runnable window, then pre/post snapshot + cross-seat cosign
-- [ ] **Verified** — substantive persistence verdict landed with byte-pinned pre/post snapshots + cross-seat cosign
+- [x] **Fire-2 mechanism confirmed** — `continue_delegate(mode: silent, delaySeconds=600)` lands in `flow_runs`; this banked the electing-mechanism truth
+- [x] **Fire-3 queued-state persistence** — same queued marker row survived canonical restart on cael-host
+- [x] **Verified** — substantive persistence verdict landed with byte-pinned pre/post snapshots + cross-seat cosign
 - [ ] **Evidence-cleansed** — N/A unless contributing to frozen-branch evidence appendix per Charter Rule 8
 
 ## References

--- a/swims/swim-43-v2026.5.5-full/rows/D1-boot-time-stall-check.md
+++ b/swims/swim-43-v2026.5.5-full/rows/D1-boot-time-stall-check.md
@@ -100,23 +100,55 @@ There was no runnable/queued staged work at fire-time.
 
 ### Verdict
 
-**INCONCLUSIVE for full D1 claim; positive baseline for no-stall boot timing.**
+**Current verdict: PASS.**
 
-What this fire proves:
-- cael-host restarted cleanly without boot-time stall in the observed 09:47 window
+Historical split:
+- **Fire 1** gave a clean no-stall baseline but was INCONCLUSIVE for the full row because there was no staged work to preserve.
+- **Fire 2** completed the missing half using the same canonical restart window that closed A1: boot remained clean and staged queued continuation work survived the restart coherently.
 
-What it does **not** yet prove:
-- staged continuation work recovery/expiry behavior, because there was no runnable/queued flow state to preserve
+#### Fire 2 — substantive staged-work restart using A1 fire-3 window (2026-05-07 12:04–12:10 PDT)
 
-This fire is therefore a valid baseline/no-stall observation, but not a substantive full D1 PASS.
+**Source (a) staged-work pre-restart**
+```text
+flow_id=e9a87f45-4806-4a69-9f58-629ed629b3bf
+status=queued
+current_step=Queued for continuation dispatch
+owner_key=agent:main:discord:channel:1466192485440164011
+notify_policy=silent
+created_at=1778180670729
+updated_at=1778180670729
+```
+
+**Source (a) restart receipt / boot timing**
+```text
+workflow run 25516284592 = success
+ActiveEnterTimestamp=Thu 2026-05-07 12:05:06 PDT
+MainPID=100312
+NRestarts=0
+```
+
+**Source (b) staged-work post-restart / cross-seat corroboration**
+```text
+T_post_restart_epoch=1778181007
+flow_id|status|shape|current_step|owner_key|notify_policy|created_at|updated_at
+e9a87f45-4806-4a69-9f58-629ed629b3bf|queued||Queued for continuation dispatch|agent:main:discord:channel:1466192485440164011|silent|1778180670729|1778180670729
+```
+
+What this now proves:
+- cael-host reaches `active/running` cleanly without boot stall in the observed restart windows
+- staged queued continuation work present before restart remains coherent after boot, not orphaned or lost
+
+So D1 now satisfies both coupled claims in the case file:
+1. no boot-time stall on deployed v5.5 cael-host
+2. staged continuation work survives the boot path without being orphaned
 
 ## Status ladder
 
 - [x] **Triaged**
 - [x] **Authored**
 - [x] **Baseline evidence captured** — no-stall restart observed
-- [ ] **Substantive fire with staged work**
-- [ ] **Verified PASS/FAIL**
+- [x] **Substantive fire with staged work** — queued TaskFlow row survived canonical restart
+- [x] **Verified PASS**
 
 ## References
 
@@ -127,4 +159,4 @@ This fire is therefore a valid baseline/no-stall observation, but not a substant
 
 ## Notes
 
-The 09:47 restart was byte-walked as a clean SIGTERM stop/start tied to context-pressure compaction on cael-seat, not an OOM or monitor-probe side-effect. Useful baseline, but D1 still needs a restart with staged work present if it is to satisfy the full Recovery-family claim.
+The 09:47 restart remains the useful no-stall baseline. The later 12:04–12:10 PDT restart window (workflow run `25516284592`) completed the row by adding the missing staged-work preservation proof. A1 and D1 now share the same restart receipts from different angles: A1 answers TaskFlow row persistence directly; D1 answers boot/recovery cleanliness with staged work present.


### PR DESCRIPTION
## Summary
- bank D1's substantive staged-work restart pass using the same canonical restart window that closed A1
- preserve fire-1 as the useful no-stall baseline and add fire-2 as the missing staged-work proof
- update the swim-43 scoreboard to `D1 = PASS` and roll counts to `4 PASS / 51 TBD`

## Grounding
- workflow run `25516284592` completed successfully
- staged queued continuation row `e9a87f45-4806-4a69-9f58-629ed629b3bf` was present before restart and still queued after restart
- cross-seat pin from elliott-seat matched the same row post-restart
- boot timing stayed clean: `ActiveEnterTimestamp=Thu 2026-05-07 12:05:06 PDT`

## Notes
- this reuses the same restart receipts from A1, but from the recovery/boot-cleanliness angle rather than the TaskFlow-row-persistence angle
