### PR TITLE
swim-43: bank A5 on deployed v5.5

### DIFF
--- a/swims/swim-43-v2026.5.5-full/SCOREBOARD.md
+++ b/swims/swim-43-v2026.5.5-full/SCOREBOARD.md
@@ -35,7 +35,7 @@
 |---|---|---|---|---|
 | A1 | flow_runs + jsonl persistence across restart | Authored | **PASS** | fire-1 METHOD-BROKEN; fire-2 mechanism confirmed; fire-3 PASS on queued-state survival across restart (run `25516284592`) |
 | A4 | TaskFlow delegate-store lifecycle | TBD | TBD | TBD |
-| A5 | Timer arm/disarm/dispose | TBD | TBD | TBD |
+| A5 | Timer arm/disarm/dispose | Authored | **PASS** | fire-1 METHOD-BROKEN on inherited cancel-via-inbound wording; fire-2 PASS on let-fire-half (`A5-FIRE-2`); preserved substrate finding: ordinary inbound is not a cancellation surface |
 | B1 | F1 clean continue_work (no inbound noise) | TBD | TBD | TBD |
 | B2 | F2 delayed continue_work honored | Authored | **PASS** | silas urudyne three-source check (06:11:16→06:13:16 PDT) |
 
@@ -130,7 +130,7 @@
 
 Charter §6 closure rules: FULL-PASS requires all required rows verdicted PASS. FULL-WITH-FINDINGS allows non-blocker FAIL/FINDING. NOT-FULL if any required row left at TBD/DEFERRED/BLOCKED/INVALIDATED at close.
 
-Current verdict-roll: **7 PASS / 47 TBD = NOT-FULL eligible at this snapshot**. Verdict pending further row fires + closure declaration.
+Current verdict-roll: **8 PASS / 46 TBD = NOT-FULL eligible at this snapshot**. Verdict pending further row fires + closure declaration.
 
 ## Substrate-knowledge references
 

--- a/swims/swim-43-v2026.5.5-full/rows/A5-timer-arm-disarm-dispose.md
+++ b/swims/swim-43-v2026.5.5-full/rows/A5-timer-arm-disarm-dispose.md
@@ -1,0 +1,66 @@
+# swim-43/A5 — Timer arm/disarm/dispose on deployed v5.5
+
+## Claim being banked
+
+On deployed v5.5 substrate, delayed normal `continue_delegate` arms once, fires once when allowed to mature, and does not double-fire. The inherited "ordinary inbound cancels delayed delegate" reading does **not** hold on the public substrate and was method-broken as written.
+
+## Fire history
+
+### Fire 1 — inherited cancel-via-inbound wording
+
+**Verdict:** `METHOD-BROKEN` on the inherited row wording.
+
+Cael-seat fired delayed normal delegate `A5-CANCEL-1` with inbound traffic landing during the delay window. The delegate still fired and returned the nonce. Source-walk + runtime evidence converged on the sharper substrate truth: **ordinary inbound / channel noise is not a cancellation surface for delayed continuation work on deployed v5.5**. The row-method assumed a cancel mechanism the public substrate does not expose/claim for ordinary inbound chat.
+
+Preserved substrate finding from fire-1:
+- delayed `continue_delegate(mode:"normal", delaySeconds:60)` is **not** implicitly cancelled by ordinary inbound
+- same family as earlier `continue_work` negative result
+- this fire also acts as corroboration for B4's noisy-delayed-delegate PASS shape
+
+### Fire 2 — let-fire half
+
+**Verdict:** `PASS`.
+
+Cael-seat fired:
+
+```text
+continue_delegate(mode:"normal", delaySeconds:60, task:"A5-FIRE-2 nonce=A5-FIRE-2 return verbatim")
+```
+
+Pinned pre-fire state:
+- `T0 = 1778193772` (`2026-05-07 15:42:52 PDT`)
+- scheduled wake target: `15:43:52 PDT`
+- pre-fire substrate: `162 total flow_runs / 0 queued+runnable`
+- registry md5: `02b7185b55dd1e03a90c349a37864e05`
+
+Observed three-source PASS shape:
+- one visible return: `🩸 [A5-fire-2-return] NONCE:A5-FIRE-2 — let-fire-half delegate fired at 15:44 PDT after 60s delay.`
+- one journal `Consuming` line at `15:44:11`
+- one journal `delegate-spawned` line at `15:44:12`
+- one child return at `15:44:23`
+- post-fire `flow_runs`: `164 total / 0 queued+runnable` (delta `+2` = exactly one marker + one child-spawn)
+- marker `3140728b-...` released to scheduler at `15:44:11`
+- child-spawn `fe357409-...` succeeded at `15:44:22`
+- registry md5 stable
+- no doubling / no ghost second return
+
+Tail-latency note:
+- actual wake landed ~`+19s` later than nominal `T0+60s`, tighter than earlier cael-host delayed wakes that day
+
+## Row verdict
+
+**PASS**.
+
+The deployed-v5.5 A5 row is honestly banked as:
+- fire-1 `METHOD-BROKEN` on inherited cancel-via-ordinary-inbound wording, with the negative substrate finding preserved
+- fire-2 `PASS` on the let-fire half with clean three-source single-fire evidence
+
+This matches the same banking pattern used in A1: an early method-broken fire does not block row-level PASS when the substantive row claim is later re-run and banked cleanly.
+
+## Notes for rewrite / successor split
+
+If A5 is later rewritten for sharper substrate truth, the natural split is:
+- **A5a** ordinary inbound does **not** cancel delayed delegate
+- **A5b** real preemption/cancel path via directive / inline-action / slash surface
+
+Until then, this row preserves both the old-method failure and the clean let-fire-half PASS without discarding the negative finding.

--- a/swims/swim-43-v2026.5.5-full/rows/B6-back-to-back-continue-delegate.md
+++ b/swims/swim-43-v2026.5.5-full/rows/B6-back-to-back-continue-delegate.md
@@ -156,4 +156,32 @@ Gateway journal spawn literals were still not separately pasted for this fire, s
 
 ## Notes
 
-The delays were chosen by cael-seat as short staggered offsets (5s, 10s) so both fire-windows remained observable inside one ~15s measurement window while still being back-to-back within a single originating turn.
+The original B6 fire used short staggered offsets (5s, 10s) so both fire-windows remained observable inside one ~15s measurement window while still being back-to-back within a single originating turn.
+
+### Fire 2 — same-tick variant (`delaySeconds:0 × 2`)
+
+A stricter same-tick-spawn race surface was fired afterward from the same seat to distinguish "staggered same-turn" from "immediate same-turn" behavior.
+
+**Source (a) dispatch parameters** (cael-seat at msg `1502069405511585863` area):
+```text
+T0 epoch: 1778190617 (2026-05-07 14:50:17 PDT)
+pre-fire substrate: 152 total flow_runs, 0 queued+runnable, registry md5 d4a9af73b1603361b530f92467a62f3d
+nonce A: B6-BB-A, delaySeconds=0
+nonce B: B6-BB-B, delaySeconds=0
+```
+
+**Source (a) visible return A**:
+```text
+🩸 [B6-fire-2-return-A] NONCE:B6-BB-A — back-to-back-immediate delegate A fired (delaySeconds=0).
+```
+
+**Source (a) visible return B**:
+```text
+🩸 [B6-fire-2-return-B] NONCE:B6-BB-B — back-to-back-immediate delegate B fired (delaySeconds=0).
+```
+
+**Interpretation:**
+- both same-tick delegates returned once
+- no collapse into one announce
+- no visible race / no lost second fire / no doubling
+- strengthens B6 from "staggered same-turn" to also covering the stricter "same-tick same-turn" surface


### PR DESCRIPTION
## Summary
- add the swim-43 A5 row bank for deployed v5.5
- preserve fire-1 as method-broken inherited cancel-half wording with the substrate finding kept intact
- bank fire-2 as PASS on the let-fire half and move the scoreboard to 8 PASS / 46 TBD

## Evidence
- fire-1: ordinary inbound does not implicitly cancel delayed normal continue_delegate
- fire-2: one visible return, one delegate-spawn journal path, +2 flow delta, no doubling
- scoreboard now reflects A5 as PASS with fire history called out