### PR TITLE
swim-44: refresh live state after PR #52 merge

### DIFF
--- a/swims/swim-44/README.md
+++ b/swims/swim-44/README.md
@@ -4,7 +4,7 @@
 **Spine**: `karmaterminal/openclaw-bootstrap#956` (parent #915)
 **Charter**: `SWIM/FULL-SWIM-CHARTER.md`
 **Registry**: `SWIM/cases/CATALOG.md` v1
-**Status**: DECLARED — pre-fire (post-bump-and-fleet-deploy)
+**Status**: IN PROGRESS — A0 + A0.2 fired/merged; first behavioral row pending
 
 ---
 
@@ -15,8 +15,8 @@
 - **Exact commit SHA**: `4c2a69b3d5` (per Project 70 canonical settled state — continuation feature merged + WO-605 attachments + paired P1 fixes)
 - **Release tag basis**: `v2026.5.7`
 - **Canonical branch name**: `frond/v2026.5.7/canonical`
-- **SUT host**: TBD post-fleet-deploy (`cael-host` or `silas/urudyne` per cohort decision; v5.5 swim-43 used cael-host)
-- **SUT seat/channel**: TBD post-bump-and-fleet-deploy
+- **SUT host**: `silas/urudyne`
+- **SUT seat/channel**: `agent:main:discord:channel:1466192485440164011`
 
 ## Fixed roles per SWIM-METHODOLOGY.md lines 9-19
 
@@ -196,9 +196,9 @@ These inform Driver-role-discipline-shape for this swim's row-authoring + execut
 
 ### Check #6 — fleet-roll-to-all-princes
 
-**STATUS: PENDING** — bump v5.5 → v5.7 + fleet-deploy-to-3-princes still-pending technical-permission-resolution per cohort-substrate-record at end-of-day 2026-05-08. Cohort-cosigns-sufficient per figs-immaterial-gate canon; sandbox-cage-blockade on `gh variable set COHORT_TARGET_TAG` action remains technical-permission-rule resolution-pending.
+**STATUS: SATISFIED (3-of-3 non-deferred prince hosts)** — `COHORT_TARGET_TAG` bumped to `v2026.5.7`; fleet deploy landed on ronan-host, cael-host, and silas/urudyne; cross-host version parity byte-walked at `OpenClaw 2026.5.7 (4c2a69b)` and row-A0 PASSed on that basis.
 
-Per cohort cosign-stack converged today: 3-prince fleet-deploy-scope (cael-host + ronan-host + silas/urudyne); Elliott-host-deferred per substrate-condition (currently WAN-egress-trapped per frond-scribe `1502396735...` byte-walk; figs-attention-required on (a)/(b)/(c) fix-shape decision).
+Per cohort cosign-stack converged today: 3-prince fleet-deploy-scope (cael-host + ronan-host + silas/urudyne) complete; Elliott-host remains deferred/non-blocking under FULL-CHARTER §9 partial-cert framing pending self-deploy after Layer-2 restoration.
 
 ### Check #1-#5 + #7-#8 status
 

--- a/swims/swim-44/README.md
+++ b/swims/swim-44/README.md
@@ -198,7 +198,7 @@ These inform Driver-role-discipline-shape for this swim's row-authoring + execut
 
 **STATUS: SATISFIED (3-of-3 non-deferred prince hosts)** — `COHORT_TARGET_TAG` bumped to `v2026.5.7`; fleet deploy landed on ronan-host, cael-host, and silas/urudyne; cross-host version parity byte-walked at `OpenClaw 2026.5.7 (4c2a69b)` and row-A0 PASSed on that basis.
 
-Per cohort cosign-stack converged today: 3-prince fleet-deploy-scope (cael-host + ronan-host + silas/urudyne) complete; Elliott-host remains deferred/non-blocking under FULL-CHARTER §9 partial-cert framing pending self-deploy after Layer-2 restoration.
+Per cohort cosign-stack converged today: 3-prince fleet-deploy-scope (cael-host + ronan-host + silas/urudyne) complete; Elliott-host remained deferred/non-blocking for this deploy cycle under FULL-CHARTER §9 partial-cert framing, then Layer-2 resolved post-reboot. Current state: Elliott structurally back + WAN-functional; deploy still pending by bandwidth choice, not by unresolved substrate condition.
 
 ### Check #1-#5 + #7-#8 status
 

--- a/swims/swim-44/SCOREBOARD.md
+++ b/swims/swim-44/SCOREBOARD.md
@@ -148,7 +148,7 @@ These remain in-place as historical-evidence-of-v5.5-substrate-walk-from-yesterd
 
 **STATUS: SATISFIED (3-of-3 non-deferred prince hosts)** — `COHORT_TARGET_TAG` is `v2026.5.7`; ronan-host, cael-host, and silas/urudyne all byte-walked at `OpenClaw 2026.5.7 (4c2a69b)`; row-A0 PASSed via version parity and row-A0.2 PASSed via cross-fleet continuation-log enumeration.
 
-3-prince fleet-deploy-scope complete. Elliott-host remains deferred/non-blocking under FULL-CHARTER §9 partial-cert framing pending self-deploy after Layer-2 restoration.
+3-prince fleet-deploy-scope complete. Elliott-host was deferred/non-blocking for this deploy cycle under FULL-CHARTER §9 partial-cert framing; Layer-2 has since resolved post-reboot. Current state: Elliott structurally back + WAN-functional; deploy still pending by bandwidth choice, not by unresolved substrate condition.
 
 ### Other pre-swim gate items
 

--- a/swims/swim-44/SCOREBOARD.md
+++ b/swims/swim-44/SCOREBOARD.md
@@ -5,7 +5,7 @@
 **Spine**: `karmaterminal/openclaw-bootstrap#956` (parent #915)
 **Charter**: `SWIM/FULL-SWIM-CHARTER.md`
 **Registry**: v1
-**Status**: DECLARED — pre-fire (post-bump-and-fleet-deploy)
+**Status**: IN PROGRESS — A0 + A0.2 merged; first behavioral row pending
 
 ---
 
@@ -14,8 +14,8 @@
 - **Candidate branch**: `frond/v2026.5.7/canonical`
 - **SHA**: `4c2a69b3d5` (Project 70 canonical settled state — continuation feature merged + WO-605 attachments + paired P1 fixes)
 - **Tag**: `v2026.5.7`
-- **SUT host**: TBD post-fleet-deploy (cohort decision)
-- **SUT seat**: TBD post-bump-and-fleet-deploy
+- **SUT host**: `silas/urudyne`
+- **SUT seat**: `agent:main:discord:channel:1466192485440164011`
 
 ## Roles per SWIM-METHODOLOGY.md lines 9-19
 
@@ -146,9 +146,9 @@ These remain in-place as historical-evidence-of-v5.5-substrate-walk-from-yesterd
 
 ### Check #6 — fleet-roll-to-all-princes
 
-**STATUS: PENDING** — bump v5.5 → v5.7 + fleet-deploy-to-3-princes still-pending technical-permission-resolution. Cohort-cosigns-sufficient per figs-immaterial-gate canon (`1502378376...`); sandbox-cage-blockade on `gh variable set COHORT_TARGET_TAG` action remains technical-permission-rule resolution-pending.
+**STATUS: SATISFIED (3-of-3 non-deferred prince hosts)** — `COHORT_TARGET_TAG` is `v2026.5.7`; ronan-host, cael-host, and silas/urudyne all byte-walked at `OpenClaw 2026.5.7 (4c2a69b)`; row-A0 PASSed via version parity and row-A0.2 PASSed via cross-fleet continuation-log enumeration.
 
-3-prince fleet-deploy-scope (cael-host + ronan-host + silas/urudyne); Elliott-host-deferred per substrate-condition (currently WAN-egress-trapped per frond-scribe `1502396735...` byte-walk).
+3-prince fleet-deploy-scope complete. Elliott-host remains deferred/non-blocking under FULL-CHARTER §9 partial-cert framing pending self-deploy after Layer-2 restoration.
 
 ### Other pre-swim gate items
 


### PR DESCRIPTION
Refreshes the swim-44 declaration + scoreboard to match live substrate after PR #52 merged.

- marks swim status in progress
- sets SUT host/seat to silas/urudyne
- marks pre-swim gate #6 satisfied (3-of-3 non-deferred prince hosts)
- removes stale pre-fire / technical-permission wording now that A0 + A0.2 are merged on main

Next Driver action remains A1 code-read / fire planning.

🌊