### PR TITLE
PROOFS/0831fb5e80: counter-shape note (chain-hop vs subagent-tree depth)

### DIFF
--- a/PROOFS/0831fb5e80/README.md
+++ b/PROOFS/0831fb5e80/README.md
@@ -128,6 +128,24 @@ This is the "single addendum-citable bundle" surface: the chat-card row is back,
 it cleanly, the chain numbers cross-walk to internal proof rows, and the compaction lifecycle is
 visible from the outside.
 
+## Counter-shape note (chain-hop vs subagent-tree depth)
+
+The `R-CD-CHAINED-DEPTH2` chains track two distinct counters and they measure different things:
+
+- **`chain-hop`** is the logical `continue_delegate` chain counter. Each `continue_delegate`
+  fire (root → outer, outer → inner) advances the chain. In our chains the inner-leaf
+  reports `chain hop: 1` because each `continue_delegate` opens a fresh top-level subagent
+  rather than nesting inside the dispatcher's existing subagent tree.
+- **subagent-tree depth `N/5`** is the runtime depth banner of the subagent the leaf is
+  running inside. The inner leaf reports `2/5` because, from the gateway's runtime view,
+  it is two hops below the human-bound root session.
+
+These counters are deliberately decoupled. The depth-2 banner on every inner-leaf receipt
+is the subagent-tree counter; the strict "delegate spawned a sub-delegate" claim is the
+chain-counter shape (each chain has both an outer-link `continue_delegate` schedule receipt
+and an inner-leaf return). Both counters appear in every chain receipt so the maintainer
+can read either.
+
 ## Visual evidence — Chain 3 echo arm landing in `#heartbeat`
 
 The cross-channel side-effect arm of `R-CD-CHAINED-DEPTH2 / Chain 3` is the depth-2 inner leaf


### PR DESCRIPTION
Small README-only follow-on to the merged proof corpus.

Cael surfaced the substrate distinction at byte: `chain-hop` (the logical `continue_delegate` chain counter) and the subagent depth banner `N/5` measure different things. Each `continue_delegate` opens a fresh top-level subagent rather than nesting inside the dispatcher's subagent tree, so the two counters are decoupled.

This PR adds a "Counter-shape note (chain-hop vs subagent-tree depth)" section to `PROOFS/0831fb5e80/README.md` so a reader of the `R-CD-CHAINED-DEPTH2` chain receipts doesn't conflate `inner depth 2/5` with `chain-hop = 2`. Both counters are already present in every receipt; this section just names what each one is measuring.

No new evidence files. README-only. One commit on top of latest `main` (post-`#64` and `#66`).

Co-authored-by: Cael
