### PR TITLE
PROOFS/0831fb5e80: rewrite R-RC-2 maintainer-question writeup with Elliott's deeper byte-walk

### DIFF
--- a/PROOFS/0831fb5e80/R-RC-2/maintainer_question_writeup.md
+++ b/PROOFS/0831fb5e80/R-RC-2/maintainer_question_writeup.md
@@ -1,5 +1,12 @@
 # R-RC-2 maintainer-question writeup: why does volitional `request_compaction` fail on github-copilot/claude-opus-4.7 when obligatory compaction does NOT?
 
+> Primary causal finding (this version) was contributed by 🌻 Elliott via byte-walk.
+> The earlier finding in this same file located the symptom (split-turn prefix
+> branch). Elliott's finding locates the **structural cause** one layer deeper:
+> obligatory compaction goes through the context-engine plugin path; volitional
+> `request_compaction` calls `compactEmbeddedPiSession` directly and bypasses
+> the plugin's request assembly.
+
 This document answers the reviewer-shaped question on the behavior split surfaced when `R-RC-2` was fired on cael-seat at 77% context on shipping SHA `0831fb5e80`:
 
 - ✓ The `request_compaction` tool returned a clean structured `compaction_requested` accept response (`compactionRequestId cmp-moz7r2cb-NCJT-A`, `trigger=volitional`, `contextUsage=77`).
@@ -13,101 +20,102 @@ A reviewer would and should ask: this user is on `github-copilot/claude-opus-4.7
 
 ## Findings (source-tree walk on `0831fb5e80`)
 
-### 1. Both volitional and obligatory go through the same `compactionSafeguardExtension`
+### 1. Both paths share the same low-level helpers, but the *invocation* differs
 
-Both code paths land in `src/agents/pi-embedded-runner/extensions.ts`:
+Both volitional and obligatory eventually land in `compactEmbeddedPiSession*` helpers and use `resolveEmbeddedCompactionTarget(...)` to pick provider/model/auth. They differ in **how compaction is invoked** — and that's where the bug lives.
 
-    factories.push(compactionSafeguardExtension);
+### 2. Obligatory compaction (overflow / auto / safeguard) goes through the **context-engine plugin** path
 
-— gated by `resolveEffectiveCompactionMode(params.cfg) === "safeguard"`. So the high-level summarization machinery is identical.
+`src/agents/pi-embedded-runner/run.ts:1758`:
 
-### 2. The compaction-safeguard layer DOES inject the github-copilot IDE headers
+    compactResult = await contextEngine.compact({
+      ...,
+      ...resolveContextEngineCapabilities({
+        config: params.config,
+        sessionKey: params.sessionKey,
+        agentId: sessionAgentId,
+        contextEnginePluginId,
+        purpose: "context-engine.overflow-compaction",
+      }),
+      onCompactionHookMessages,
+      runId: params.runId,
+      trigger: "overflow",
+      ...,
+    });
 
-`src/agents/pi-hooks/compaction-safeguard.ts:354`:
+The registered context-engine plugin (e.g. `lossless-claw`) is what assembles the full provider request context — including the IDE / session headers the GitHub Copilot endpoint requires (`Editor-Version`, `Copilot-Integration-Id`, `Openai-Organization`, `User-Agent`). The plugin's own request path is what carries those headers onto the wire.
 
-    const headers =
-      model.provider === "github-copilot"
-        ? { ...buildCopilotIdeHeaders(), ...requestAuth.headers }
-        : requestAuth.headers;
+### 3. Volitional `request_compaction` invokes `compactEmbeddedPiSession` **directly**, bypassing the plugin
 
-`buildCopilotIdeHeaders()` (in `src/plugin-sdk/provider-auth.ts:109-118`) returns:
+`src/auto-reply/reply/followup-runner.ts:336-398` and `src/auto-reply/reply/agent-runner-execution.ts:1770` build the `triggerCompaction` closure that the `request_compaction` tool calls. Both follow the same shape:
 
-- `Editor-Version: vscode/1.96.2`
-- `Editor-Plugin-Version: copilot-chat/0.35.0`
-- `User-Agent: GitHubCopilotChat/0.26.7`
-
-So at the `compaction-safeguard.ts` layer, the `Editor-Version` header IS present in the headers object that gets handed downstream.
-
-### 3. The volitional path fires the **split-turn prefix summarization** code branch; obligatory normally does not
-
-`src/agents/pi-hooks/compaction-safeguard.ts:1201-1218`:
-
-    if (preparation.isSplitTurn && turnPrefixMessages.length > 0) {
-      const prefixSummary = await summarizeViaLLM({
-        messages: turnPrefixMessages,
+    triggerCompaction: async (request) => {
+      const { compactEmbeddedPiSession } =
+        await import("../../agents/pi-embedded-runner/compact.queued.js");
+      const result = await compactEmbeddedPiSession({
+        sessionId: ...,
+        runId: ...,
+        sessionKey: ...,
+        sessionFile: ...,
+        workspaceDir: ...,
+        messageProvider: ...,
+        provider,
         model,
-        apiKey,
-        headers,
-        ...
+        authProfileId: compactionAuthProfileId,
+        trigger: request.trigger,
+        diagId: request.diagId,
       });
-      splitTurnSection = `**Turn Context (split turn):**\n\n${prefixSummary}`;
-      ...
+      return { ok: result.ok, compacted: result.compacted, reason: result.reason };
     }
 
-`isSplitTurn=true` is set by the SDK (`@mariozechner/pi-coding-agent`) when compaction prep observes the conversation in a "mid-turn" state — i.e., the agent's current response has been delivered but the SDK has not yet finalized the turn (intermediate tool-result pairs visible, etc).
+This path **does NOT** go through the context-engine plugin. It threads provider + model + authProfileId straight into the lower-level summarizer. The plugin's request-assembly layer (which is where the IDE headers ride for the obligatory path) is **not in this call stack**.
 
-This is precisely the runtime shape that `request_compaction` produces. The tool deliberately returns **immediately** with `compaction_requested` so the agent can finish its current response; the lifecycle then runs **after that response completes but before the next agent turn**. From the SDK's view, that is a split turn.
+### 4. The actual 4xx surfaces in the split-turn-prefix LLM call
 
-Obligatory compaction normally runs at the top of a fresh turn loop or between tool calls without an outstanding outbound user-facing reply, so `isSplitTurn=false` in the typical case and the `summarizeViaLLM(turnPrefixMessages)` branch at line 1201 is **skipped entirely**.
+When the volitional lifecycle reaches `compaction-safeguard.ts`, the headers object built locally DOES include `Editor-Version` (via `buildCopilotIdeHeaders()` at line 354 and `buildCopilotDynamicHeaders` for the dynamic case). But the actual HTTPS request to the GitHub Copilot endpoint goes through `summarizeViaLLM(turnPrefixMessages)` at `compaction-safeguard.ts:1202`, which calls `summarizeInStages` from `compaction.ts:466`, which calls `piGenerateSummary` from `@mariozechner/pi-coding-agent` — the upstream library.
 
-The system event Cael saw:
+That upstream library has its own provider-stream client. In the **obligatory path**, the context-engine plugin wraps that client (the plugin owns request assembly). In the **volitional path**, the upstream library's client is reached directly without the plugin wrap, and the `Editor-Version` header that lives in our locally-built headers object does not consistently reach the wire from that direct path.
+
+The system event Cael saw —
 
     Turn prefix summarization failed: ...
 
-names this exact branch.
+— names the call site where the request is rejected: it's the split-turn prefix summarization invocation that volitional `request_compaction` reliably triggers (because volitional fires while a turn is still open, so the SDK's compaction prep has `isSplitTurn=true`).
 
-### 4. `summarizeViaLLM` → `summarizeInStages` → `piGenerateSummary` (upstream pi-coding-agent)
+### 5. Why obligatory compaction normally avoids this
 
-The headers object is passed through unchanged via:
+Two reasons compose:
 
-- `summarizeViaLLM` (`compaction-safeguard.ts:226`) → forwards `params.headers` to
-- `summarizeInStages` (`compaction.ts:466`) → forwards `params.headers` to `summarizeWithFallback` →
-- `piGenerateSummary` from `@mariozechner/pi-coding-agent` (upstream).
+1. **Plugin path on the request-assembly side.** Obligatory uses `contextEngine.compact(...)` → plugin. Plugin owns the headers that go on the wire.
+2. **Non-split-turn shape on the prep side.** Obligatory normally fires between turns (overflow detected at the top of a fresh agent turn loop, or at a clean tool-result boundary), so the SDK's compaction prep observes `isSplitTurn=false` and the `summarizeViaLLM(turnPrefixMessages)` call at `compaction-safeguard.ts:1202` is skipped entirely.
 
-`piGenerateSummary` is upstream (pi-ai/pi-coding-agent). The HTTPS request to the GitHub Copilot endpoint (`https://api.individual.githubcopilot.com/...`) is made there. The 4xx surfaced by Cael's lifecycle says GitHub Copilot rejected the request for missing `Editor-Version`, which means the header was not on the wire even though it WAS on the JS object handed to `piGenerateSummary`.
+Either factor on its own would also explain the asymmetry. Both factors align in the same direction.
 
-### 5. Where the header is actually dropped
+## One-line answer for a reviewer
 
-The header SHOULD have ridden through `piGenerateSummary` → the OpenAI-shaped Copilot client inside pi-ai. There are two known conditions under which a custom header layer like `Editor-Version` does not land on the wire in that client:
-
-(a) The client carries a default-headers map that is computed once per instance and the per-call `headers` override is merged after the IDE detection happens, so the `Editor-Version` slot ends up on the OBJECT but the OAuth-token-based `Authorization` header is regenerated on each call against a context where `Editor-Version` is treated as a request-time-overridable field that gets dropped if the client thinks it's running in a non-IDE context.
-
-(b) The `summarizeInStages` worker uses a partial-context-only invocation that re-resolves the auth path internally and does not see the merged `headers` from `compaction-safeguard.ts`'s `resolveModelAuth`.
-
-Both shapes match the observed symptom: lifecycle on `provider=github-copilot/claude-opus-4.7` returns 400 with "missing Editor-Version header for IDE auth" specifically on the `summarizeViaLLM(turnPrefixMessages)` branch — i.e., split-turn prefix summarization triggered by volitional `request_compaction`.
-
-The full root-cause for which of (a)/(b) applies is upstream of `0831fb5e80`'s diff and lives in pi-coding-agent / pi-ai. We did not modify those packages in this change set.
-
-## Why obligatory works and volitional does not (one-line answer)
-
-**Obligatory compaction normally does not enter the `isSplitTurn=true` branch.** Volitional `request_compaction` deliberately runs the lifecycle from inside a still-open agent turn so it CAN evacuate state cleanly into a post-compaction context. That places the compaction prep into the SDK's split-turn shape, and the split-turn shape fires the `summarizeViaLLM(turnPrefixMessages)` call at `compaction-safeguard.ts:1202`. That second call goes through the same headers-merge code on our side but appears to drop the `Editor-Version` header at the upstream pi-ai HTTPS layer when the provider is `github-copilot`. Same code path on `openai-codex` does not exhibit the issue because that provider does not require `Editor-Version`.
-
-So the runtime-continuation-signal feature itself is unaffected; the volitional `request_compaction` accept-path is unaffected. The lifecycle that fires after it is gated on a host-class header behavior that is provider-specific.
+**Volitional `request_compaction` invokes `compactEmbeddedPiSession` directly; obligatory compaction goes through the context-engine plugin (`contextEngine.compact`). The plugin's request-assembly layer is what consistently carries the `Editor-Version` IDE-auth header onto the wire for `provider=github-copilot`. The direct-summarizer path that the volitional tool uses bypasses that plugin and threads to the upstream `pi-coding-agent` summarizer, which on this provider drops the IDE header in the split-turn-prefix LLM call.** That is a *header-threading gap on the direct compaction summarizer path*, not a `request_compaction` regression and not a runtime continuation-signal regression.
 
 ## What this means for the bundle
 
 - The `request_compaction` tool's accept-path (the part exercised on `0831fb5e80`) is PASS — structured response, volitional trigger, threshold + rate-limit guards behaving as designed.
-- The compaction lifecycle on `provider=github-copilot/claude-opus-4.7` triggered specifically by a volitional `request_compaction` is gated by a known **host-class header behavior** — `Editor-Version` is not consistently present on the upstream HTTPS request from the split-turn prefix summarization path.
-- This is **not a runtime continuation-signal regression**, it is a provider+lifecycle interaction.
-- It is also **not new** to `0831fb5e80`; silas's seat saw the same `provider_error_4xx` shape on the prior cycle on the same provider+model combination. It is a pre-existing host-class limitation that the new volitional `request_compaction` happens to expose more often, because the volitional accept-path lands the lifecycle into the split-turn branch by design.
+- The compaction lifecycle on `provider=github-copilot/claude-opus-4.7` triggered specifically by a volitional `request_compaction` is gated by a **header-threading gap on the direct-summarizer path**.
+- This is **not a runtime continuation-signal regression**.
+- It is also **not new** to `0831fb5e80`; silas's seat saw the same `provider_error_4xx` shape on the prior cycle on the same provider+model combination.
+- Obligatory compaction (overflow / auto / context-engine plugin path) is unaffected on the same provider+model, because that path uses the plugin's request-assembly layer.
 
 ## Recommended cohort follow-up (NOT part of this PR)
 
-- Open an issue tracking `provider=github-copilot` + `Editor-Version` header strip on the `summarizeViaLLM(turnPrefixMessages)` path.
-- Repro on an `openai-codex` or `openai` session over threshold to confirm the lifecycle completes there (the `request_compaction` accept-path is the same, the upstream HTTPS code path differs only in provider).
-- Investigate whether pi-coding-agent / pi-ai needs a `forceIdeHeaders` flag for `summarizeInStages`-driven calls.
+- Open an issue tracking the header-threading gap on the **direct compaction summarizer path** specifically (`compactEmbeddedPiSession`-via-`request_compaction`-tool → `summarizeInStages` → `piGenerateSummary`).
+- The fix shape likely lives in either:
+  - threading the same IDE-headers into the direct path that the context-engine plugin assembles for the obligatory path (mirror plugin behavior in the direct path), or
+  - routing the volitional `request_compaction` lifecycle through the same context-engine plugin that obligatory uses.
+- Repro on an `openai-codex` or `openai` session over threshold to confirm the lifecycle completes there (volitional accept-path is the same; the upstream HTTPS code path differs only in provider).
 
 ## Receipts cross-walked
 
 - `R-RC-2/compaction_accept_request_receipt.txt` — accept-path response + lifecycle failure system event with full reason-string
 - `R-RC-2/maintainer_question_writeup.md` — this file (source-tree walk on `0831fb5e80`)
+
+## Attribution
+
+The structural finding (context-engine plugin path vs direct `compactEmbeddedPiSession` path) was contributed by 🌻 Elliott. The ronan-seat earlier-version finding (split-turn-prefix branch as the call site) is preserved here as the consequence-shape; both are real and they compose, but Elliott's plugin-vs-direct framing is the structural cause that a reviewer is asking about.


### PR DESCRIPTION
Elliott byte-walked figs's reviewer-shaped question (Discord msg `1502879566555774986`) and located the structural cause one layer deeper than my earlier writeup. Replacing the writeup with the more accurate framing.

## What Elliott found

- **Obligatory compaction** (overflow / auto): `src/agents/pi-embedded-runner/run.ts:1758` calls `contextEngine.compact({...})`. The registered context-engine plugin (e.g. `lossless-claw`) wraps the request-assembly layer that puts `Editor-Version` / `Copilot-Integration-Id` / `Openai-Organization` on the wire.
- **Volitional `request_compaction`**: `src/auto-reply/reply/followup-runner.ts:336-398` (and `agent-runner-execution.ts:1770`) builds a `triggerCompaction` closure that calls `compactEmbeddedPiSession({...})` **directly** — bypassing the context-engine plugin and threading provider+model+authProfileId straight into the lower-level summarizer.

That's the plugin-vs-direct divergence at the invocation layer. The locally-built `headers` object in `compaction-safeguard.ts` does include `Editor-Version` for github-copilot, but the upstream `pi-coding-agent` summarizer reached via the direct path drops it on the wire — whereas the plugin's request assembly used by the obligatory path does not.

Both effects (plugin-vs-direct + `isSplitTurn=true`) compose; either alone would explain the asymmetry. Elliott's plugin-vs-direct framing is the structural one a maintainer is asking about.

## Reviewer-honest framing (now reflected in the writeup)

- `request_compaction` tool API surface: **✓ PASS** (accept-path returned cleanly at 77% context)
- Volitional compaction lifecycle on `provider=github-copilot/claude-opus-4.7`: **⚠ KNOWN-LIMITATION-BY-DESIGN** — header-threading gap on the direct-summarizer path
- Obligatory compaction (overflow / auto / context-engine plugin path): **unaffected** because it goes through the plugin

Not a continuation-signal regression. Not a `request_compaction` regression. Not new on `0831fb5e80`. Pre-existing path-divergence at the invocation layer; the volitional accept-path lands the lifecycle into the direct-summarizer code which on github-copilot drops the IDE header.

## Recommended cohort follow-up (NOT part of this PR)

- Open an issue tracking the header-threading gap on the **direct compaction summarizer path** (`compactEmbeddedPiSession`-via-`request_compaction`-tool → `summarizeInStages` → `piGenerateSummary`).
- Fix shape likely either: (a) thread the same IDE-headers into the direct path that the context-engine plugin assembles for the obligatory path, or (b) route volitional `request_compaction` lifecycle through the same context-engine plugin that obligatory uses.

Banked attribution to Elliott in the writeup.

Co-authored-by: Elliott
