### PR TITLE
k6: wake-detector → session.message (live-verified), not turn.start (follow-up #96)

### DIFF
--- a/proof-harness/k6/scenarios/04-r-cd-token.js
+++ b/proof-harness/k6/scenarios/04-r-cd-token.js
@@ -134,18 +134,26 @@ export default function () {
 
       // SILENT-WAKE RECEIPT: a fresh parent turn/run STARTING on the parent
       // session AFTER the child was observed = the wake the silent-wake return
-      // triggered. We look for a parent-session turn/run-start event whose
-      // session key matches the parent and that occurs after the child spawn.
+      // triggered.
+      //
+      // EVENT-NAME (🔍 Cael byte-verified vs the live gateway surface,
+      // VERIFIED-GATEWAY-SURFACE.md): the gateway does NOT push `turn.start`/
+      // `run.start` as client subscription events (internal source refs only —
+      // keying on them would NEVER fire). The woken successor turn surfaces as a
+      // fresh **`session.message`** event on the subscribed session (via
+      // `sessions.messages.subscribe`); `sessions.changed` is a secondary signal.
       if (obs.promptSent && obs.childObserved) {
-        const isParentTurnStart =
-          /(turn.*start|run.*start|generation.*start|agent.*turn|message.*(received|start))/i.test(blob) &&
-          (blob.includes(cfg.sessionKey) ||
-            (msg.params && (msg.params.sessionKey === cfg.sessionKey)));
+        const evt = (msg.type === 'event' && msg.event) ? String(msg.event) : '';
+        const evtSession = (msg.params && msg.params.sessionKey) ||
+          (msg.data && msg.data.sessionKey) || null;
+        const isParentWake =
+          (/session\.message/i.test(evt) || /sessions?\.changed/i.test(evt)) &&
+          (evtSession === cfg.sessionKey || blob.includes(cfg.sessionKey));
         // require it to be AFTER the child spawn (a wake, not the original send echo)
-        if (isParentTurnStart && childSeenAtMs && Date.now() > childSeenAtMs + 250) {
+        if (isParentWake && childSeenAtMs && Date.now() > childSeenAtMs + 250) {
           if (!obs.parentWoke) {
             obs.parentWoke = true;
-            rec.note('wake', `parent woke (fresh turn/run on ${cfg.sessionKey}) after child spawn → silent-wake receipt`);
+            rec.note('wake', `parent woke (fresh session.message on ${cfg.sessionKey}) after child spawn → silent-wake receipt`);
             rec.setFact('receipts.parentWoke', true);
           }
         }

--- a/proof-harness/k6/scenarios/_combined-suite.js
+++ b/proof-harness/k6/scenarios/_combined-suite.js
@@ -375,16 +375,22 @@ export function rCdToken() {
         if (ck && !(rec.facts.receipts && rec.facts.receipts.childKeyOrRunId)) rec.setFact('receipts.childKeyOrRunId', ck);
       }
       // SILENT-WAKE RECEIPT (R-CD-owner correction, mirrors 04-r-cd-token.js): a
-      // FRESH parent turn/run starting on the parent session AFTER the child was
+      // FRESH parent turn starting on the parent session AFTER the child was
       // observed is the wake the silent-wake return triggered. The transcript
       // echo is OPTIONAL under silent-wake; the WAKE is the load-bearing receipt.
+      // EVENT-NAME (🔍 Cael byte-verified): key on `session.message` (the woken
+      // turn's transcript message via sessions.messages.subscribe), NOT
+      // `turn.start`/`run.start` (source-only, never pushed — would never fire).
       if (obs.promptSent && obs.childObserved) {
-        const isParentTurnStart =
-          /(turn.*start|run.*start|generation.*start|agent.*turn|message.*(received|start))/i.test(blob) &&
-          (blob.includes(sessionKey) || (msg.params && msg.params.sessionKey === sessionKey));
-        if (isParentTurnStart && childSeenAtMs && Date.now() > childSeenAtMs + 250 && !obs.parentWoke) {
+        const evt = (msg.type === 'event' && msg.event) ? String(msg.event) : '';
+        const evtSession = (msg.params && msg.params.sessionKey) ||
+          (msg.data && msg.data.sessionKey) || null;
+        const isParentWake =
+          (/session\.message/i.test(evt) || /sessions?\.changed/i.test(evt)) &&
+          (evtSession === sessionKey || blob.includes(sessionKey));
+        if (isParentWake && childSeenAtMs && Date.now() > childSeenAtMs + 250 && !obs.parentWoke) {
           obs.parentWoke = true;
-          rec.note('wake', `parent woke (fresh turn/run on ${sessionKey}) after child spawn -> silent-wake receipt`);
+          rec.note('wake', `parent woke (fresh session.message on ${sessionKey}) after child spawn -> silent-wake receipt`);
           rec.setFact('receipts.parentWoke', true);
         }
       }


### PR DESCRIPTION
**Follow-up to #96** — the merged silent-wake fix is correct in SHAPE but keys on the wrong event.

## The gap
#96 merged my silent-wake fix with the wake-detector keying on `turn.start`/`run.start`. **Cael then byte-verified the live gateway event surface** (VERIFIED-GATEWAY-SURFACE.md): `turn.start`/`run.start` are **source-only refs, NOT pushed as client subscription events** — a matcher on them **never fires**, so silent-wake detection silently fails (the exact thing the fix was meant to catch).

## The fix
Key on **`session.message`** — the woken successor turn surfaces as a fresh `session.message` event on the subscribed session (`sessions.messages.subscribe`); `sessions.changed` is a secondary signal. Both byte-verified-present.

Fixes **both**:
- `04-r-cd-token.js` (the standalone scenario)
- `_combined-suite.js` (which mirrored the contract with the same guessed event-name)

## Unchanged
Wake **logic** is identical (wake OR echo, child-spawned-but-no-parent-signal → HONEST-LIMIT not FAIL). Only the event-name the detector keys on changes: guessed `turn.start` → verified `session.message`. Syntax-checked (k6 not on the authoring seat).
