### PR TITLE
fix(k6): R-CW hop-2 matchers → session.message (kill the dead turn.start guess)

### DIFF
--- a/proof-harness/k6/scenarios/02-r-cw-token.js
+++ b/proof-harness/k6/scenarios/02-r-cw-token.js
@@ -117,13 +117,20 @@ export default function () {
         rec.note('hop2', `hop-2 detected carrying nonce: "${hop2Needle}"`);
       }
 
-      // Weaker signal: a turn/run-start event after our send (hop-2 may fire even
-      // if the model phrased the echo differently). Count turns to disambiguate.
-      if (obs.promptSent && /turn[_-]?start|run[_-]?start|continuation/i.test(blob) && blob.includes(cfg.sessionKey)) {
+      // Weaker signal: a successor turn after our send (hop-2 may fire even if the
+      // model phrased the echo differently). The live successor-turn surfaces as a
+      // `session.message` event (VERIFIED-GATEWAY-SURFACE.md: turn.start/run.start
+      // are NOT in the live 25-event surface — they're source-internal, never
+      // pushed as client events, so a matcher on them never fires). Key on
+      // session.message (the woken turn's transcript message); `continuation` span
+      // text is a secondary signal. Count turns to disambiguate.
+      const isSuccessorEvt = (msg.type === 'event' && /session\.message/i.test(blob)) ||
+        /"event"\s*:\s*"session\.message"|continuation\.work/i.test(blob);
+      if (obs.promptSent && isSuccessorEvt && blob.includes(cfg.sessionKey)) {
         turnsAfterSend += 1;
         if (turnsAfterSend >= 2 && !obs.hop2Observed) {
-          obs.hop2Observed = true; // a second turn began ⇒ a hop-2 occurred
-          rec.note('hop2', 'a second turn began after send (hop-2 likely) — nonce not yet matched');
+          obs.hop2Observed = true; // a second session.message turn began ⇒ a hop-2 occurred
+          rec.note('hop2', 'a second turn began after send (hop-2 likely, via session.message) — nonce not yet matched');
         }
       }
 

--- a/proof-harness/k6/scenarios/_combined-suite.js
+++ b/proof-harness/k6/scenarios/_combined-suite.js
@@ -215,7 +215,11 @@ export function rCw1() {
         if (tid) { obs.traceId = tid; rec.setFact('receipts.traceId', tid); }
       }
       const blob = JSON.stringify(msg);
-      if (obs.accepted && /turn[_-]?start|run[_-]?start|continuation/i.test(blob) && blob.includes(cfg.sessionKey)) {
+      // Live successor-turn = `session.message` event (turn.start/run.start are NOT
+      // live-pushed — VERIFIED-GATEWAY-SURFACE.md). Key on session.message.
+      const isSuccessorEvt = (msg.type === 'event' && /session\.message/i.test(blob)) ||
+        /"event"\s*:\s*"session\.message"|continuation\.work/i.test(blob);
+      if (obs.accepted && isSuccessorEvt && blob.includes(cfg.sessionKey)) {
         turnsAfterFire += 1;
         obs.successorTurnObserved = true;
         if (blob.includes(nonce) || /chain|parent|continuation/i.test(blob)) obs.chainCorrelated = true;
@@ -269,11 +273,11 @@ export function rCwToken() {
         obs.hop2Observed = true; obs.nonceEchoedInHop2 = true;
         rec.note('hop2', `hop-2 detected carrying nonce: "${hop2Needle}"`);
       }
-      if (obs.promptSent && /turn[_-]?start|run[_-]?start|continuation/i.test(blob) && blob.includes(sessionKey)) {
+      if (obs.promptSent && /"event"\s*:\s*"session\.message"|continuation\.work/i.test(blob) && blob.includes(sessionKey)) {
         turnsAfterSend += 1;
         if (turnsAfterSend >= 2 && !obs.hop2Observed) {
           obs.hop2Observed = true;
-          rec.note('hop2', 'a second turn began after send (hop-2 likely) -- nonce not yet matched');
+          rec.note('hop2', 'a second turn began after send (hop-2 likely, via session.message) -- nonce not yet matched');
         }
       }
       const tid = deepFindTraceId(msg);


### PR DESCRIPTION
Elliotts fix-sub-agent flagged it (in-scope: silent-wake matcher only): the **R-CW-1 + R-CW-TOKEN hop-2/successor-turn matchers still keyed on `turn.start`/`run.start`** (`02:122`, `_combined-suite:218`+`:272`, live code). Per my `VERIFIED-GATEWAY-SURFACE.md` those are NOT in the live 25-event surface → the matcher never fires live → R-CW hop-2 detection would silently miss.

**Fix:** re-pointed all 3 sites to **`session.message`** (the live woken-turn event), same fix the silent-wake matcher already got. The strong nonce-echo signal is unchanged (that was already robust); only the weaker turn-count signal — which keyed on the dead event names — is corrected. `node --check` clean on both files.

Closes the R-CW-matcher surface-confirm blocker. Combined with the already-verified Tempo span-names (`90358ec` on my feeder), that is the last two guesses killed → **all harness matches verified-byte, milestone-1 surface-confirmed.**

My rows (R-CW), my fix — the verify caught it in my own scenarios, both directions.