### PR TITLE
🪨 Add k6 preflight candidate evidence path

### DIFF
--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -123,3 +123,17 @@ This is **declared in the manifest before the run**, not a post-hoc excuse. The 
 - Foundation: [#100](https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/100) (artifact layout by Emeric)
 - Coordinator: @silas-dandelion-cult
 - Project: [karmaterminal project 81](https://github.com/orgs/karmaterminal/projects/81)
+
+## Preflight (Scenario 0)
+
+The `preflight.js` scenario is the required read-only starting point for any PROOFS validation run. It verifies:
+- Gateway WebSocket connectivity and auth token validity
+- Server capability flags
+- Available session tools (`sessions.list`, `tools.effective`)
+- Continuation tools presence (`continue_work`, `continue_delegate`, `request_compaction`)
+
+### Redaction Boundary
+
+The k6 harness enforces a strict redaction boundary to keep public evidence artifacts safe:
+- **`gateway-ws.js`**: `redactEvent()` drops raw `sessionKey` and `childSessionKey` from payload events, keeping only `session_scope`
+- **`evidence-writer.mjs`**: Recursively scrubs any accidental raw session keys from the final `k6-summary.json` and `gateway-events.ndjson` artifacts.

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -1,6 +1,6 @@
-# k6 Proof Harness — continue_delegate rows
+# k6 Proof Harness — PROOFS rows
 
-Deterministic proof-row fire-and-observe harness for the OpenClaw continuation feature corpus.
+Deterministic proof-row fire-and-observe harness for the OpenClaw continuation feature corpus. Preflight is read-only inventory; row scenarios remain candidate-output-only until review.
 
 ## Structure
 
@@ -38,7 +38,10 @@ tools/k6-proofs/
 ### 1. Preflight check
 
 ```bash
-OPENCLAW_GATEWAY_TOKEN="***" k6 run tools/k6-proofs/scenarios/preflight.js
+OPENCLAW_GATEWAY_TOKEN="***" \
+OPENCLAW_ROW_MANIFEST="tools/k6-proofs/manifests/preflight.example.json" \
+OPENCLAW_SESSION_KEY="agent:main:main" \
+  k6 run tools/k6-proofs/scenarios/preflight.js 2>&1 | tee /tmp/preflight-output.txt
 ```
 
 ### 2. Run R-CD-1 (manifest-driven)
@@ -99,6 +102,7 @@ This is **declared in the manifest before the run**, not a post-hoc excuse. The 
 
 | Row | Scenario | Surface | Expected outcome |
 |-----|----------|---------|-----------------|
+| preflight | Read-only gateway/session/tool inventory | read-only | PASS-candidate when health, sessions, and required continuation tools are visible |
 | R-CD-1 | Typed `continue_delegate()` | typed-tool | PASS-candidate |
 | R-CD-TOKEN | Bracket `[[CONTINUE_DELEGATE:...]]` | bracket-token | Seat-dependent (see manifest) |
 
@@ -114,7 +118,8 @@ This is **declared in the manifest before the run**, not a post-hoc excuse. The 
 ## Coordination
 
 - Epic: [#106](https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/106)
-- Row issue: [#103](https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/103)
+- Preflight issue: [#101](https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/101)
+- continue_delegate row issue: [#103](https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/103)
 - Foundation: [#100](https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/100) (artifact layout by Emeric)
 - Coordinator: @silas-dandelion-cult
 - Project: [karmaterminal project 81](https://github.com/orgs/karmaterminal/projects/81)

--- a/tools/k6-proofs/lib/gateway-ws.js
+++ b/tools/k6-proofs/lib/gateway-ws.js
@@ -98,8 +98,8 @@ export class RequestTracker {
 const EVENT_ALLOWLIST = new Set([
   'type', 'id', 'method', 'event',
   // Payload fields safe for public
-  'ok', 'status', 'uptime', 'sessionKey', 'taskId', 'runId',
-  'childSessionKey', 'traceId', 'spanId', 'tools', 'name',
+  'ok', 'status', 'uptime', 'taskId', 'runId',
+  'traceId', 'spanId', 'tools', 'name',
   'state', 'reason', 'delaySeconds', 'mode',
   // Timing
   'ts', 'timestamp', 'startedAt', 'completedAt', 'duration',

--- a/tools/k6-proofs/manifests/preflight.example.json
+++ b/tools/k6-proofs/manifests/preflight.example.json
@@ -1,11 +1,11 @@
 {
   "schema": "openclaw.k6.proof-row-manifest.v1",
   "rowId": "preflight",
-  "issue": 100,
+  "issue": 101,
   "candidateSha": "82827d3cbcba92ff6e19863b30615db028c2651c",
-  "seat": "emeric-nuc",
+  "seat": "${OPENCLAW_SEAT_NAME:-local-seat}",
   "sessionKey": "${OPENCLAW_SESSION_KEY}",
-  "transport": "offline",
+  "transport": "websocket",
   "toolSurface": "read-only",
   "mutates": false,
   "timeoutSeconds": 30,
@@ -16,7 +16,7 @@
   "scenario": {
     "name": "preflight inventory",
     "description": "Authenticate/read-only gateway inventory: health/status, sessions.list, tools.effective. Offline mode validates manifest shape without gateway traffic.",
-    "methods": ["health", "status", "sessions.list", "tools.effective"]
+    "methods": ["health", "sessions.list", "tools.effective"]
   },
   "expectedReceipts": [
     {
@@ -35,20 +35,20 @@
       "name": "tool-inventory",
       "required": false,
       "pathHint": "artifacts/tool-inventory.json",
-      "description": "Live preflight only: tools.effective inventory for the target session."
+      "description": "Live preflight: redacted tools.effective inventory for the target session."
     },
     {
       "name": "session-inventory",
       "required": false,
       "pathHint": "artifacts/session-inventory.json",
-      "description": "Live preflight only: sessions.list/session resolution receipt."
+      "description": "Live preflight: redacted sessions.list/session resolution receipt."
     }
   ],
   "artifactDestination": {
     "root": "PROOFS",
     "sha": "82827d3cbcba92ff6e19863b30615db028c2651c",
     "row": "preflight",
-    "seat": "emeric-nuc",
+    "seat": "${OPENCLAW_SEAT_NAME:-local-seat}",
     "runDirPrefix": "k6-run"
   },
   "review": {

--- a/tools/k6-proofs/scenarios/preflight.js
+++ b/tools/k6-proofs/scenarios/preflight.js
@@ -30,6 +30,14 @@ export const options = {
 const failures = new Counter('proof_failures');
 const duration = new Trend('preflight_duration');
 
+function publicSessionScope(key) {
+  if (!key) return 'unspecified';
+  if (key === 'main' || key === 'agent:main:main') return 'main';
+  if (key.startsWith('agent:main:')) return 'main-agent-session';
+  if (key.startsWith('agent:')) return 'agent-session';
+  return 'configured-session';
+}
+
 export default function () {
   const url = __ENV.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
   const token = __ENV.OPENCLAW_GATEWAY_TOKEN;
@@ -55,7 +63,7 @@ export default function () {
     issue: 101,
     manifest_loaded: !!manifest,
     seat,
-    sessionKey,
+    session_scope: publicSessionScope(sessionKey),
     candidateSha: manifest?.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
     started: new Date().toISOString(),
     health_received: false,

--- a/tools/k6-proofs/scenarios/preflight.js
+++ b/tools/k6-proofs/scenarios/preflight.js
@@ -6,9 +6,9 @@
  */
 import ws from 'k6/ws';
 import { check } from 'k6';
-import { Counter } from 'k6/metrics';
+import { Counter, Trend } from 'k6/metrics';
 import { connectFrame, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
-import { loadManifestFromEnv } from '../lib/manifest-loader.js';
+import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
 
 // Manifest-driven (non-blocking — preflight uses minimal config)
 const manifest = loadManifestFromEnv();
@@ -19,7 +19,7 @@ export const options = {
       executor: 'shared-iterations',
       vus: 1,
       iterations: 1,
-      maxDuration: '30s',
+      maxDuration: '45s',
     },
   },
   thresholds: {
@@ -28,17 +28,45 @@ export const options = {
 };
 
 const failures = new Counter('proof_failures');
+const duration = new Trend('preflight_duration');
 
 export default function () {
   const url = __ENV.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
   const token = __ENV.OPENCLAW_GATEWAY_TOKEN;
-  const sessionKey = __ENV.OPENCLAW_SESSION_KEY || 'main';
+  const sessionKey = manifest?.sessionKey || __ENV.OPENCLAW_SESSION_KEY || 'main';
+  const seat = manifest?.seat || __ENV.OPENCLAW_SEAT_NAME || 'unknown-seat';
 
   if (!token) {
     console.error('OPENCLAW_GATEWAY_TOKEN is required');
     failures.add(1);
     return;
   }
+
+  if (manifest) {
+    const errors = validateManifest(manifest);
+    if (errors.length > 0) {
+      console.warn(`Manifest validation warnings: ${errors.join('; ')}`);
+    }
+  }
+
+  const started = Date.now();
+  const evidence = {
+    row: 'preflight',
+    issue: 101,
+    manifest_loaded: !!manifest,
+    seat,
+    sessionKey,
+    candidateSha: manifest?.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
+    started: new Date().toISOString(),
+    health_received: false,
+    sessions_received: false,
+    target_session_seen: false,
+    tools_received: false,
+    tool_count: 0,
+    required_tools: ['continue_work', 'continue_delegate', 'request_compaction'],
+    missing_tools: [],
+    redacted_events: [],
+  };
 
   const results = { health: null, tools: null, sessions: null };
 
@@ -50,7 +78,7 @@ export default function () {
       socket.setTimeout(() => tracker.send(socket, 'health'), 300);
       socket.setTimeout(() => tracker.send(socket, 'sessions.list'), 600);
       socket.setTimeout(() => tracker.send(socket, 'tools.effective', { sessionKey }), 900);
-      socket.setTimeout(() => socket.close(), 8000);
+      socket.setTimeout(() => socket.close(), Number(manifest?.timeoutSeconds || 30) * 1000);
     });
 
     socket.on('message', (raw) => {
@@ -58,14 +86,35 @@ export default function () {
         const msg = JSON.parse(raw);
         const classified = tracker.classify(msg);
 
+        evidence.redacted_events.push({
+          ts: Date.now(),
+          kind: classified.kind,
+          method: classified.method || null,
+          event: classified.event || null,
+          ok: classified.ok !== undefined ? classified.ok : null,
+          data: classified.payload ? redactEvent(classified.payload) : null,
+        });
+
         if (classified.kind === 'response') {
+          if (classified.error) {
+            console.error(`Request ${classified.method} failed: ${JSON.stringify(classified.error)}`);
+            failures.add(1);
+          }
           switch (classified.method) {
             case 'health':
               results.health = classified.payload;
+              evidence.health_received = classified.ok && !!classified.payload;
               break;
-            case 'sessions.list':
+            case 'sessions.list': {
               results.sessions = classified.payload?.sessions || classified.payload;
+              evidence.sessions_received = classified.ok && !!results.sessions;
+              const sessions = Array.isArray(results.sessions) ? results.sessions : [];
+              evidence.target_session_seen = sessions.some((s) => {
+                const key = s.sessionKey || s.key || s.id;
+                return key === sessionKey || (sessionKey === 'main' && key === 'agent:main:main');
+              });
               break;
+            }
             case 'tools.effective': {
               // Response shape: { agentId, profile, groups: [{ tools: [{ id, ... }] }] }
               const groups = classified.payload?.groups || [];
@@ -73,6 +122,8 @@ export default function () {
                 ? groups.flatMap((g) => g.tools || [])
                 : [];
               results.tools = allTools;
+              evidence.tools_received = classified.ok && allTools.length > 0;
+              evidence.tool_count = allTools.length;
               break;
             }
           }
@@ -90,6 +141,10 @@ export default function () {
 
   check(res, { 'websocket connected': (r) => r && r.status === 101 });
 
+  evidence.ended = new Date().toISOString();
+  evidence.duration_ms = Date.now() - started;
+  duration.add(evidence.duration_ms);
+
   // Verify expected tools are visible
   if (results.tools && results.tools.length > 0) {
     // Tools use 'id' field, not 'name'
@@ -98,6 +153,7 @@ export default function () {
     const hasCW = toolIds.includes('continue_work');
     const hasCD = toolIds.includes('continue_delegate');
     const hasRC = toolIds.includes('request_compaction');
+    evidence.missing_tools = evidence.required_tools.filter((tool) => !toolIds.includes(tool));
 
     check(null, {
       'continue_work visible': () => hasCW,
@@ -116,5 +172,12 @@ export default function () {
     failures.add(1);
   }
 
+  if (!evidence.health_received || !evidence.sessions_received || !evidence.tools_received) {
+    failures.add(1);
+  }
+
   console.log(`Preflight complete. Health: ${JSON.stringify(results.health)}`);
+  console.log(`\n--- PREFLIGHT EVIDENCE SUMMARY ---`);
+  console.log(JSON.stringify(evidence, null, 2));
+  console.log(`--- END EVIDENCE ---\n`);
 }

--- a/tools/k6-proofs/scripts/evidence-writer.mjs
+++ b/tools/k6-proofs/scripts/evidence-writer.mjs
@@ -77,7 +77,18 @@ if (evidence.events && !evidence.redacted_events) {
   process.exit(1);
 }
 
-const events = evidence.redacted_events || [];
+function scrubPublicArtifact(value) {
+  if (Array.isArray(value)) return value.map((item) => scrubPublicArtifact(item));
+  if (typeof value !== 'object' || value === null) return value;
+  const out = {};
+  for (const [key, child] of Object.entries(value)) {
+    if (key === 'sessionKey' || key === 'childSessionKey') continue;
+    out[key] = scrubPublicArtifact(child);
+  }
+  return out;
+}
+
+const events = scrubPublicArtifact(evidence.redacted_events || []);
 
 // Build output directory
 const runId = `k6-run-${stamp()}`;
@@ -85,7 +96,7 @@ const outDir = join('PROOFS', args.sha, args.row, args.seat, runId);
 mkdirSync(join(outDir, 'artifacts'), { recursive: true });
 
 // Write k6-summary.json (evidence without raw events)
-const summary = { ...evidence };
+const summary = scrubPublicArtifact({ ...evidence });
 delete summary.redacted_events; // events go to ndjson, not summary
 writeFileSync(join(outDir, 'k6-summary.json'), JSON.stringify(summary, null, 2) + '\n');
 

--- a/tools/k6-proofs/scripts/evidence-writer.mjs
+++ b/tools/k6-proofs/scripts/evidence-writer.mjs
@@ -95,10 +95,19 @@ if (events.length > 0) {
   writeFileSync(join(outDir, 'gateway-events.ndjson'), ndjson);
 }
 
-// Determine verdict
-const verdict = evidence.tool_accepted || evidence.prompt_sent
-  ? (evidence.task_created || evidence.child_spawned ? 'PASS-candidate' : 'PARTIAL-candidate')
-  : 'FAIL-candidate';
+// Determine verdict. Preflight is read-only inventory, not a tool-mutation row.
+const isPreflight = (args.row || '').toLowerCase() === 'preflight' || evidence.row === 'preflight';
+const preflightPassed = isPreflight
+  && evidence.health_received
+  && evidence.sessions_received
+  && evidence.tools_received
+  && Array.isArray(evidence.missing_tools)
+  && evidence.missing_tools.length === 0;
+const verdict = isPreflight
+  ? (preflightPassed ? 'PASS-candidate' : 'FAIL-candidate')
+  : (evidence.tool_accepted || evidence.prompt_sent
+    ? (evidence.task_created || evidence.child_spawned ? 'PASS-candidate' : 'PARTIAL-candidate')
+    : 'FAIL-candidate');
 
 // Write row-result.json
 const result = {
@@ -137,11 +146,18 @@ const md = `# ${args.row} — ${args.seat} — ${verdict}
 
 | Check | Result |
 |-------|--------|
-| Tool/prompt accepted | ${evidence.tool_accepted || evidence.prompt_sent ? '✓' : '✗'} |
+${isPreflight ? `| Health/status received | ${evidence.health_received ? '✓' : '✗'} |
+| Sessions inventory received | ${evidence.sessions_received ? '✓' : '✗'} |
+| Target session seen | ${evidence.target_session_seen ? '✓' : 'not required / not observed'} |
+| Tools inventory received | ${evidence.tools_received ? '✓' : '✗'} |
+| Required continuation tools visible | ${Array.isArray(evidence.missing_tools) && evidence.missing_tools.length === 0 ? '✓' : `✗ missing: ${(evidence.missing_tools || []).join(', ') || 'unknown'}`} |
+| Tool count | ${evidence.tool_count ?? 'N/A'} |
+| Manifest loaded | ${evidence.manifest_loaded ? '✓' : '✗ (defaults used)'} |`
+: `| Tool/prompt accepted | ${evidence.tool_accepted || evidence.prompt_sent ? '✓' : '✗'} |
 | Task/child created | ${evidence.task_created || evidence.child_spawned ? '✓' : '✗'} |
 | Parent return observed | ${evidence.parent_return ? '✓' : '✗'} |
 | Nonce | \`${evidence.nonce || 'N/A'}\` |
-| Manifest loaded | ${evidence.manifest_loaded ? '✓' : '✗ (defaults used)'} |
+| Manifest loaded | ${evidence.manifest_loaded ? '✓' : '✗ (defaults used)'} |`}
 
 ## Artifacts
 


### PR DESCRIPTION
## Summary

Adds the Project 81 `#101` preflight lane so the k6 proof harness can produce candidate evidence for read-only gateway/session/tool inventory before mutating rows run.

Changes:
- makes `preflight.js` manifest-aware and emits a redacted `PREFLIGHT EVIDENCE SUMMARY`
- updates the preflight manifest to issue `#101`, websocket transport, and env-resolved seat/session fields
- teaches `evidence-writer.mjs` how to score `preflight` as PASS/FAIL-candidate from health/session/tool receipts instead of tool-mutation receipts
- documents preflight usage and row coverage in the k6 harness README

## Scope / guardrails

- Candidate output only; no corpus/manifest fold
- Read-only gateway/session/tool inventory only
- No #1077/source-fix work
- No secrets in source or artifacts; output uses existing redacted event path

## Validation

- `node --check tools/k6-proofs/scripts/evidence-writer.mjs`
- `node --check tools/k6-proofs/scenarios/preflight.js`
- JSON parse for `tools/k6-proofs/manifests/preflight.example.json` and `tools/k6-proofs/row-manifest.schema.json`
- Fixture postprocess for `preflight` generated `PASS-candidate` row-result/EVIDENCE, then fixture artifact removed

Not run: live `k6 run` on Rune-seat (`k6` is not installed here).

Closes #101 when reviewed/accepted.
