### PR TITLE
feat(k6-proofs): integration workflow validator + contribution checklist (#105)

### DIFF
--- a/tools/k6-proofs/CONTRIBUTING-ROWS.md
+++ b/tools/k6-proofs/CONTRIBUTING-ROWS.md
@@ -1,0 +1,110 @@
+# Contributing a row PR — k6 proofs
+
+Checklist for a prince opening a row PR against `karmaterminal-openclaw-docs`.
+
+The goal: **running a k6 proof is very little work beyond kickoff**. This page is the
+short version of what each row PR must include so the coordinator can fold it
+into `PROOFS/<sha>/` without back-and-forth.
+
+## Before you start
+
+1. **Claim the labelled issue on [Project 81](https://github.com/orgs/karmaterminal/projects/81)
+   BEFORE doing row work.** Assign yourself. If you don't see it on the board, ping the
+   coordinator — don't shadow-run.
+2. Confirm the **deployed SHA** you will fire against. Get the 40-char hex from the
+   gateway (`/version` / build banner) on the seat you will run from. The SHA is the
+   identity of your proof; do not invent or trim it.
+3. Confirm secrets are in env, not on disk. `OPENCLAW_GATEWAY_TOKEN` and friends come
+   from the seat's environment or GH Actions repo secrets — **zero secrets in source,
+   manifests, evidence, or PR body**. If the token leaks into a log, rotate before
+   pushing.
+
+## Running the row
+
+Use the harness as documented in [`README.md`](README.md):
+
+1. Optional preflight: `k6 run tools/k6-proofs/scenarios/preflight.js`.
+2. Run the row scenario with the manifest pointed via `OPENCLAW_ROW_MANIFEST` and the
+   deployed SHA in `OPENCLAW_CANDIDATE_SHA`. Tee the output to a local file.
+3. Post-process into proof artifacts with `evidence-writer.mjs` (or
+   `postprocess-k6-summary.mjs` for the summary-driven path):
+
+   ```bash
+   node tools/k6-proofs/scripts/evidence-writer.mjs \
+     --input /tmp/<row>-output.txt \
+     --row <ROW-ID> \
+     --seat <seat> \
+     --sha <40-char-sha>
+   ```
+
+   The script writes into `PROOFS/<sha>/<row>/<seat>/k6-run-<timestamp>/`.
+
+## Required artifacts per row dir
+
+Every `PROOFS/<sha>/<row>/<seat>/k6-run-<ts>/` directory must contain:
+
+- `EVIDENCE.md` — candidate evidence document. Captures the run context, the
+  candidate outcome, receipts table, and the review checklist (`evidence-writer.mjs`
+  emits the right shape; do not hand-edit the schema).
+- `k6-summary.json` — the structured k6 summary / evidence block (post-processor
+  output; no raw unredacted events).
+- `gateway-events.ndjson` — redacted gateway events, one JSON object per line. Skip
+  only if the row genuinely captured no frames; note the absence in EVIDENCE.md.
+- `row-result.json` — normalised outcome (`PASS-candidate` / `PARTIAL-candidate` /
+  `HONEST-LIMIT-candidate` / `FAIL-candidate`).
+- Trace JSON (e.g. Tempo dump) under `artifacts/` if the row produced one. Trace
+  evidence is required before a continuation row can be folded as `pass`.
+
+## EVIDENCE.md must record
+
+- Row id, deployed SHA, session, provider, seat, run id, generated timestamp.
+- Candidate outcome and the reason for it (which checks did/did not fire).
+- Receipt table (tool/prompt accepted, task/child spawned, parent return, nonce,
+  manifest loaded).
+- A "no secrets" line — explicit statement that the captured artifacts contain no
+  tokens, no prompt bodies, no user content.
+- For HONEST-LIMIT outcomes: the declared seat-class expectation that explains
+  why it is honest-limit and not a fail (e.g. message-body seat killed the bracket
+  scanner — must be declared in the manifest before the run, not retro-justified).
+
+## PR contract
+
+- **PR body** includes:
+  - the row issue link (Project 81 card),
+  - the row id(s) covered,
+  - the seat,
+  - the deployed 40-char SHA (not abbreviated).
+- **Run the validator and paste the output:**
+
+  ```bash
+  node tools/k6-proofs/scripts/validate-corpus.mjs --sha <40-char-sha>
+  ```
+
+  The PR is only review-ready when the validator exits 0 against the SHA you fired
+  on. If the SHA is not yet folded into INDEX/manifests, fold-style integration
+  PRs run `--sha` after the fold; row-only PRs that only add a row dir + EVIDENCE
+  still paste the validator output for whichever SHA the artifacts target.
+
+- **Zero secrets** anywhere in the diff. Grep your PR yourself for `OPENCLAW_GATEWAY_TOKEN`,
+  bearer fragments, session keys, etc. If found, rotate the secret and remove from
+  history before pushing.
+
+- **Do not edit `PROOFS/INDEX.json` or `PROOFS/<sha>/proofs-manifest.json` from a row PR.**
+  The coordinator (Silas) folds rows + regenerates INDEX/manifest in one integration
+  PR after evidence review. Row PRs only **add** files under your row directory.
+
+## What the coordinator does next
+
+1. Reviews EVIDENCE.md + receipts against the manifest's declared expectation.
+2. Folds the row into the corpus, regenerates INDEX/manifest, and runs
+   `node tools/k6-proofs/scripts/validate-corpus.mjs --index` — green is mandatory
+   before merge.
+3. Any row that fires `pending_push`, `upload-blame`, `TODO-UPLOAD`, or similar
+   "promise-of-artifact" wording is bounced back. Either the artifact exists or
+   the row is not folded.
+
+## See also
+
+- [README.md](README.md) — harness usage, design principles, redaction boundary.
+- [`validate-corpus.mjs`](scripts/validate-corpus.mjs) — invariants enforced at fold time.
+- [Project 81](https://github.com/orgs/karmaterminal/projects/81) — row backlog.

--- a/tools/k6-proofs/CONTRIBUTING-ROWS.md
+++ b/tools/k6-proofs/CONTRIBUTING-ROWS.md
@@ -11,9 +11,23 @@ into `PROOFS/<sha>/` without back-and-forth.
 1. **Claim the labelled issue on [Project 81](https://github.com/orgs/karmaterminal/projects/81)
    BEFORE doing row work.** Assign yourself. If you don't see it on the board, ping the
    coordinator — don't shadow-run.
-2. Confirm the **deployed SHA** you will fire against. Get the 40-char hex from the
-   gateway (`/version` / build banner) on the seat you will run from. The SHA is the
-   identity of your proof; do not invent or trim it.
+2. **Verify the gateway you fire against is actually deployed to the corpus-pin SHA.**
+   This is a PRE-FIRE gate the validator CANNOT do for you: `validate-corpus.mjs`
+   checks that your *artifacts* are consistent with a SHA, but it cannot verify your
+   running *gateway* is on that SHA. Confirm both, on the seat you will run from:
+   ```bash
+   # (a) what SHA is this seat's gateway actually running?
+   openclaw --version            # or: git -C ~/flesh_beast_tmp/openclaw rev-parse HEAD
+   # (b) does that SHA carry the feature under test? (example: continuation parser)
+   gh api repos/karmaterminal/openclaw/contents/src/auto-reply/tokens.ts?ref=<that-sha> \
+     --jq '.content' | base64 -d | grep -c CONTINUE_WORK   # want > 0
+   ```
+   The SHA is the identity of your proof; do not invent or trim it. If the gateway is
+   on a different line than the corpus pin (e.g. `main` / an upstream-mirror SHA that
+   lacks the feature), **deploy the seat first** — firing against a feature-less
+   gateway produces rows that fail at the gateway-lacks-feature layer, not the harness
+   layer, and the failure is easy to misread. The fleet can run mixed SHAs; check
+   *your* seat, not someone else's.
 3. Confirm secrets are in env, not on disk. `OPENCLAW_GATEWAY_TOKEN` and friends come
    from the seat's environment or GH Actions repo secrets — **zero secrets in source,
    manifests, evidence, or PR body**. If the token leaks into a log, rotate before

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -111,6 +111,37 @@ This is **declared in the manifest before the run**, not a post-hoc excuse. The 
 - Post-processor refuses unredacted event data.
 - No manifest fold without review (per #100 foundation contract).
 
+## Integration & validation
+
+Row PRs go through a contribution checklist + a fold-time validator. See
+[`CONTRIBUTING-ROWS.md`](CONTRIBUTING-ROWS.md) for the prince-facing checklist
+(claim the issue, run the row, post-process, paste validator output in the PR
+body, zero secrets).
+
+The corpus invariants enforced at fold time live in
+[`scripts/validate-corpus.mjs`](scripts/validate-corpus.mjs):
+
+```bash
+# Validate a single corpus dir (manifest + rollup tally + evidence + dirs)
+node tools/k6-proofs/scripts/validate-corpus.mjs --sha <40-char-sha>
+
+# Validate every PROOFS/<sha>/ that has a manifest; legacy short-SHA dirs are skipped
+node tools/k6-proofs/scripts/validate-corpus.mjs --all
+
+# Validate PROOFS/INDEX.json consistency vs the manifest it points to
+node tools/k6-proofs/scripts/validate-corpus.mjs --index
+
+# Machine-readable
+node tools/k6-proofs/scripts/validate-corpus.mjs --index --json
+```
+
+Checks: JSON parse, schema sanity (`openclaw.proofs.index.v1` /
+`openclaw.proofs.manifest.v1`), every declared `evidence_doc` and `rows[].dir`
+exists, no orphan row dirs, INDEX `rollup` tallies match the manifest `rows[].state`
+counts, manifest `capture_sha` matches its directory name, and no stale
+`pending_push` / `upload-blame` / `TODO-UPLOAD` wording. Exit code is non-zero
+on any failure; the script never mutates corpus data.
+
 ## Coordination
 
 - Epic: [#106](https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/106)

--- a/tools/k6-proofs/scripts/validate-corpus.mjs
+++ b/tools/k6-proofs/scripts/validate-corpus.mjs
@@ -1,0 +1,440 @@
+#!/usr/bin/env node
+/**
+ * validate-corpus.mjs — k6 PROOFS corpus integration validator.
+ *
+ * Validates the integration invariants enforced when row PRs are folded into
+ * PROOFS/<sha>/. Node built-ins only; ESM. Sibling to evidence-writer.mjs and
+ * postprocess-k6-summary.mjs.
+ *
+ * Usage:
+ *   node tools/k6-proofs/scripts/validate-corpus.mjs --sha <40-char-sha>
+ *   node tools/k6-proofs/scripts/validate-corpus.mjs --all
+ *   node tools/k6-proofs/scripts/validate-corpus.mjs --index
+ *   node tools/k6-proofs/scripts/validate-corpus.mjs --index --json
+ *
+ * Optional:
+ *   --root <path>   PROOFS parent (defaults to CWD, matching sibling scripts).
+ *   --json          Emit a machine-readable JSON result on stdout.
+ *
+ * Exit code is non-zero on any check failure; 0 on clean validation.
+ */
+
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const STALE_TOKENS = [
+  'pending_push',
+  'pending push',
+  'upload-blame',
+  'TODO-UPLOAD',
+  'pending_upload',
+];
+
+const ROLLUP_KEYS = ['total_rows', 'pass', 'partial', 'thin', 'fail', 'honest_limit', 'missing'];
+const STATE_KEYS = ['pass', 'partial', 'thin', 'fail', 'honest_limit', 'missing'];
+
+function parseArgs(argv) {
+  const out = { _: [] };
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (!arg.startsWith('--')) {
+      out._.push(arg);
+      continue;
+    }
+    const key = arg.slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith('--')) {
+      out[key] = true;
+    } else {
+      out[key] = next;
+      i += 1;
+    }
+  }
+  return out;
+}
+
+function usage() {
+  console.error(
+    `Usage:\n` +
+      `  node tools/k6-proofs/scripts/validate-corpus.mjs --sha <40-char-sha>\n` +
+      `  node tools/k6-proofs/scripts/validate-corpus.mjs --all\n` +
+      `  node tools/k6-proofs/scripts/validate-corpus.mjs --index\n` +
+      `Options: --root <path>  --json`,
+  );
+}
+
+function tryParseJson(filePath) {
+  let raw;
+  try {
+    raw = readFileSync(filePath, 'utf8');
+  } catch (err) {
+    return { ok: false, error: `read failed: ${err.message}` };
+  }
+  try {
+    return { ok: true, value: JSON.parse(raw), raw };
+  } catch (err) {
+    return { ok: false, error: `JSON parse failed: ${err.message}` };
+  }
+}
+
+function listSubdirs(dirPath) {
+  try {
+    return readdirSync(dirPath, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+  } catch (err) {
+    return null;
+  }
+}
+
+function walkFiles(dirPath) {
+  const out = [];
+  const stack = [dirPath];
+  while (stack.length) {
+    const cur = stack.pop();
+    let entries;
+    try {
+      entries = readdirSync(cur, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const ent of entries) {
+      const full = join(cur, ent.name);
+      if (ent.isDirectory()) stack.push(full);
+      else if (ent.isFile()) out.push(full);
+    }
+  }
+  return out;
+}
+
+function findStaleTokenHits(rootDir) {
+  const hits = [];
+  if (!existsSync(rootDir)) return hits;
+  for (const file of walkFiles(rootDir)) {
+    if (!/\.(md|json|ndjson|txt)$/i.test(file)) continue;
+    let raw;
+    try {
+      raw = readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+    for (const tok of STALE_TOKENS) {
+      if (raw.includes(tok)) hits.push({ file, token: tok });
+    }
+  }
+  return hits;
+}
+
+function pushCheck(report, name, ok, detail) {
+  report.checks.push({ name, ok, detail: detail || null });
+  if (!ok) report.failed += 1;
+  else report.passed += 1;
+}
+
+function validateSha(root, sha, { manifestRequired = true } = {}) {
+  const report = { sha, checks: [], passed: 0, failed: 0, skipped: false };
+  const shaDir = join(root, 'PROOFS', sha);
+  const manifestPath = join(shaDir, 'proofs-manifest.json');
+
+  if (!existsSync(shaDir)) {
+    pushCheck(report, 'sha-dir-exists', false, `PROOFS/${sha}/ not found`);
+    return report;
+  }
+  if (!existsSync(manifestPath)) {
+    if (manifestRequired) {
+      pushCheck(report, 'manifest-present', false, `no proofs-manifest.json in PROOFS/${sha}/`);
+      return report;
+    }
+    report.skipped = true;
+    report.reason = 'no manifest';
+    return report;
+  }
+
+  const parsed = tryParseJson(manifestPath);
+  pushCheck(report, 'json-parse-manifest', parsed.ok, parsed.ok ? manifestPath : parsed.error);
+  if (!parsed.ok) return report;
+  const manifest = parsed.value;
+
+  const schemaOk = manifest.schema === 'openclaw.proofs.manifest.v1';
+  pushCheck(
+    report,
+    'schema-manifest',
+    schemaOk,
+    schemaOk ? 'openclaw.proofs.manifest.v1' : `expected openclaw.proofs.manifest.v1, got ${JSON.stringify(manifest.schema)}`,
+  );
+
+  const hasCaptureSha = typeof manifest.capture_sha === 'string' && manifest.capture_sha.length > 0;
+  pushCheck(
+    report,
+    'schema-manifest-capture-sha',
+    hasCaptureSha,
+    hasCaptureSha ? manifest.capture_sha : 'missing capture_sha',
+  );
+
+  const hasRows = Array.isArray(manifest.rows);
+  pushCheck(
+    report,
+    'schema-manifest-rows',
+    hasRows,
+    hasRows ? `${manifest.rows.length} rows` : 'rows[] missing or not an array',
+  );
+  if (!hasRows) return report;
+
+  const captureMatches = manifest.capture_sha === sha;
+  pushCheck(
+    report,
+    'capture-sha-agreement',
+    captureMatches,
+    captureMatches
+      ? `capture_sha == dir name (${sha})`
+      : `capture_sha=${manifest.capture_sha} != dir ${sha}`,
+  );
+
+  const evidenceMisses = [];
+  for (const row of manifest.rows) {
+    if (!row.evidence_doc) {
+      evidenceMisses.push({ row: row.row, evidence_doc: '(none declared)' });
+      continue;
+    }
+    const evPath = join(root, row.evidence_doc);
+    if (!existsSync(evPath)) {
+      evidenceMisses.push({ row: row.row, evidence_doc: row.evidence_doc });
+    }
+  }
+  pushCheck(
+    report,
+    'evidence-doc-exists',
+    evidenceMisses.length === 0,
+    evidenceMisses.length === 0
+      ? `${manifest.rows.length}/${manifest.rows.length} evidence_doc paths exist`
+      : `${evidenceMisses.length} missing: ${evidenceMisses.map((m) => `${m.row}→${m.evidence_doc}`).join('; ')}`,
+  );
+
+  const declaredDirs = new Set();
+  const dirMisses = [];
+  for (const row of manifest.rows) {
+    if (!row.dir) {
+      dirMisses.push({ row: row.row, dir: '(none declared)' });
+      continue;
+    }
+    const dirNoSlash = row.dir.replace(/\/+$/, '');
+    declaredDirs.add(dirNoSlash);
+    const fullDir = join(root, row.dir);
+    if (!existsSync(fullDir) || !statSync(fullDir).isDirectory()) {
+      dirMisses.push({ row: row.row, dir: row.dir });
+    }
+  }
+  pushCheck(
+    report,
+    'row-dirs-exist',
+    dirMisses.length === 0,
+    dirMisses.length === 0
+      ? `${manifest.rows.length}/${manifest.rows.length} row dirs exist`
+      : `${dirMisses.length} missing: ${dirMisses.map((m) => `${m.row}→${m.dir}`).join('; ')}`,
+  );
+
+  const onDiskRowDirs = listSubdirs(shaDir) || [];
+  const orphanDirs = [];
+  for (const sub of onDiskRowDirs) {
+    const candidate = join('PROOFS', sha, sub);
+    if (!declaredDirs.has(candidate)) {
+      orphanDirs.push(`PROOFS/${sha}/${sub}/`);
+    }
+  }
+  pushCheck(
+    report,
+    'no-orphan-row-dirs',
+    orphanDirs.length === 0,
+    orphanDirs.length === 0
+      ? `${onDiskRowDirs.length} on-disk row dirs all referenced`
+      : `orphans: ${orphanDirs.join(', ')}`,
+  );
+
+  const tallied = { pass: 0, partial: 0, thin: 0, fail: 0, honest_limit: 0, missing: 0 };
+  const unknownStates = [];
+  for (const row of manifest.rows) {
+    if (Object.prototype.hasOwnProperty.call(tallied, row.state)) tallied[row.state] += 1;
+    else unknownStates.push({ row: row.row, state: row.state });
+  }
+  tallied.total_rows = manifest.rows.length;
+  pushCheck(
+    report,
+    'state-values-known',
+    unknownStates.length === 0,
+    unknownStates.length === 0
+      ? 'all states ∈ {pass,partial,thin,fail,honest_limit,missing}'
+      : unknownStates.map((u) => `${u.row}→${JSON.stringify(u.state)}`).join('; '),
+  );
+  report.talliedRollup = tallied;
+
+  const stale = findStaleTokenHits(shaDir);
+  pushCheck(
+    report,
+    'no-stale-pending-tokens',
+    stale.length === 0,
+    stale.length === 0
+      ? `no occurrences of ${STALE_TOKENS.map((t) => `\`${t}\``).join(', ')}`
+      : stale.map((h) => `${relative(root, h.file)}:${h.token}`).join('; '),
+  );
+
+  return report;
+}
+
+function validateIndex(root) {
+  const indexPath = join(root, 'PROOFS', 'INDEX.json');
+  const report = { kind: 'index', checks: [], passed: 0, failed: 0, indexPath };
+
+  const parsed = tryParseJson(indexPath);
+  pushCheck(report, 'json-parse-index', parsed.ok, parsed.ok ? indexPath : parsed.error);
+  if (!parsed.ok) return report;
+  const index = parsed.value;
+
+  const schemaOk = index.schema === 'openclaw.proofs.index.v1';
+  pushCheck(
+    report,
+    'schema-index',
+    schemaOk,
+    schemaOk ? 'openclaw.proofs.index.v1' : `expected openclaw.proofs.index.v1, got ${JSON.stringify(index.schema)}`,
+  );
+
+  const requiredKeys = ['current_sha', 'corpus_path', 'manifest_path', 'rollup'];
+  const missingKeys = requiredKeys.filter((k) => !(k in index));
+  pushCheck(
+    report,
+    'schema-index-keys',
+    missingKeys.length === 0,
+    missingKeys.length === 0 ? requiredKeys.join(', ') : `missing keys: ${missingKeys.join(', ')}`,
+  );
+
+  if (!index.current_sha) return report;
+
+  report.shaReport = validateSha(root, index.current_sha, { manifestRequired: true });
+
+  if (index.rollup && report.shaReport.talliedRollup) {
+    const tallied = report.shaReport.talliedRollup;
+    const diffs = [];
+    for (const k of ROLLUP_KEYS) {
+      const got = index.rollup[k];
+      const expect = tallied[k];
+      if (got !== expect) diffs.push(`${k}: index=${got} tallied=${expect}`);
+    }
+    pushCheck(
+      report,
+      'rollup-matches-manifest',
+      diffs.length === 0,
+      diffs.length === 0
+        ? `INDEX rollup matches manifest tally (${ROLLUP_KEYS.map((k) => `${k}=${tallied[k]}`).join(', ')})`
+        : diffs.join('; '),
+    );
+  } else if (!index.rollup) {
+    pushCheck(report, 'rollup-matches-manifest', false, 'INDEX.rollup missing');
+  }
+
+  return report;
+}
+
+function validateAll(root) {
+  const proofsDir = join(root, 'PROOFS');
+  const subs = listSubdirs(proofsDir) || [];
+  const reports = [];
+  for (const sub of subs) {
+    const manifestPath = join(proofsDir, sub, 'proofs-manifest.json');
+    if (!existsSync(manifestPath)) {
+      reports.push({ sha: sub, skipped: true, reason: 'no manifest', checks: [], passed: 0, failed: 0 });
+      continue;
+    }
+    reports.push(validateSha(root, sub, { manifestRequired: true }));
+  }
+  return reports;
+}
+
+function renderReport(report, opts) {
+  const lines = [];
+  if (report.kind === 'index') {
+    lines.push(`INDEX: ${report.indexPath}`);
+  } else if (report.skipped) {
+    lines.push(`SHA ${report.sha}: skipped (${report.reason})`);
+    return lines.join('\n');
+  } else {
+    lines.push(`SHA: ${report.sha}`);
+  }
+  for (const c of report.checks) {
+    lines.push(`  ${c.ok ? '✓' : '✗'} ${c.name}${c.detail ? ` — ${c.detail}` : ''}`);
+  }
+  if (report.shaReport) {
+    lines.push('  -- current_sha manifest --');
+    if (report.shaReport.skipped) {
+      lines.push(`  · SHA ${report.shaReport.sha}: skipped (${report.shaReport.reason})`);
+    } else {
+      for (const c of report.shaReport.checks) {
+        lines.push(`  · ${c.ok ? '✓' : '✗'} ${c.name}${c.detail ? ` — ${c.detail}` : ''}`);
+      }
+    }
+  }
+  lines.push(`  ${report.failed === 0 ? 'OK' : 'FAIL'}: ${report.passed} passed, ${report.failed} failed`);
+  return lines.join('\n');
+}
+
+function reportFailed(report) {
+  if (report.failed > 0) return true;
+  if (report.shaReport && report.shaReport.failed > 0) return true;
+  return false;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const root = args.root || process.cwd();
+  const wantJson = Boolean(args.json);
+
+  let modeCount = 0;
+  if (args.sha) modeCount += 1;
+  if (args.all) modeCount += 1;
+  if (args.index) modeCount += 1;
+  if (modeCount !== 1) {
+    usage();
+    process.exitCode = 2;
+    return;
+  }
+
+  let payload;
+  let failed = false;
+  let skipped = 0;
+
+  if (args.sha) {
+    if (typeof args.sha !== 'string' || !/^[0-9a-f]{40}$/.test(args.sha)) {
+      console.error(`ERROR: --sha must be a 40-character hex string (got: ${JSON.stringify(args.sha)})`);
+      process.exitCode = 2;
+      return;
+    }
+    const report = validateSha(root, args.sha, { manifestRequired: true });
+    failed = reportFailed(report);
+    payload = { mode: 'sha', root, reports: [report] };
+    if (!wantJson) console.log(renderReport(report));
+  } else if (args.all) {
+    const reports = validateAll(root);
+    for (const r of reports) {
+      if (r.skipped) skipped += 1;
+      if (reportFailed(r)) failed = true;
+      if (!wantJson) console.log(renderReport(r));
+    }
+    if (!wantJson) {
+      const validated = reports.length - skipped;
+      const okCount = reports.filter((r) => !r.skipped && !reportFailed(r)).length;
+      console.log(`\n--all summary: ${validated} validated (${okCount} OK), ${skipped} skipped (no manifest)`);
+    }
+    payload = { mode: 'all', root, reports };
+  } else {
+    const report = validateIndex(root);
+    failed = reportFailed(report);
+    payload = { mode: 'index', root, reports: [report] };
+    if (!wantJson) console.log(renderReport(report));
+  }
+
+  if (wantJson) {
+    payload.failed = failed;
+    process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+  }
+  process.exitCode = failed ? 1 : 0;
+}
+
+main();


### PR DESCRIPTION
## #105 — the fold/validation side of the k6 PROOFS pipeline

Makes prince row-PRs fold into the corpus on a **checklist, not by eyeball** — half of figs's "very little work from a prince beyond kickoff" (the kickoff half is #127, the GH Actions workflow).

### Deliverables (purely additive — no PROOFS/INDEX/manifest byte touched)
- **`tools/k6-proofs/scripts/validate-corpus.mjs`** (Node built-ins, ESM, no deps). Modes: `--sha <sha>` / `--all` / `--index`, plus `--json` and `--root`. Checks:
  - JSON parse (INDEX + every manifest)
  - schema sanity (`openclaw.proofs.index.v1`, `openclaw.proofs.manifest.v1`)
  - every declared `evidence_doc` exists on disk
  - no orphan / missing row dirs
  - INDEX `rollup` ↔ manifest `rows[].state` tally match
  - `capture_sha` == dir name
  - no stale `pending_push` / `upload-blame` / `TODO-UPLOAD` tokens
- **`tools/k6-proofs/CONTRIBUTING-ROWS.md`** — prince row-PR checklist: claim issue → run → artifacts to `PROOFS/<sha>/<row>/<seat>/` → `validate-corpus.mjs --sha` → paste ✓ in PR body. Secrets via GH Actions repo secrets, **zero in source**.
- **README** — `## Integration & validation` section.

### Verification (byte-checked by me, not just agent-reported)
- `--index` on current corpus (`82827d3`): **exit 0**, 24/24 evidence_docs + row dirs exist, rollup matches (`total_rows=24 pass=22 honest_limit=2`), no stale tokens.
- Negative test (broken rollup + missing evidence_doc + stale `pending_push`): validator catches all 4 classes, **exit 1**.
- `node --check` clean.

### Surfaced for coordinator review (NOT auto-fixed — out of #105 scope)
`--all` flagged genuine drift in **legacy/carried** manifests (current corpus is clean):
- `53c30255` / `b248f2fd` / `d04ab6c5`: `capture_sha=749f95b9...` ≠ dir name + `honest-limit` (hyphen) vs canonical `honest_limit`.
- `8cafdcd2` / `c8149791`: pre-schema manifests (no `schema:`/`capture_sha:`), seat-grouped layout, some missing row dirs.

Recommend a one-shot normalization pass (separate issue) or a `carried_from` exception — coordinator review, not this PR.

### Follow-up (noted, not in this PR)
Add a **same-session co-fire check** (per Elliott's lock-cascade byte on #104): flag R-RC-* compaction rows sharing a session target with a non-serialized row — makes the SAFETY-MANIFEST (#104/#125) serialization machine-enforced.

Closes #105.