### PR TITLE
k6-proofs: implement preflight WS tools.effective check (#101)

### DIFF
--- a/tools/k6-proofs/lib/manifest-loader.js
+++ b/tools/k6-proofs/lib/manifest-loader.js
@@ -65,7 +65,7 @@ export function validateManifest(manifest) {
   }
   if (!manifest.seat) errors.push('missing seat');
   if (!manifest.sessionKey) errors.push('missing sessionKey');
-  if (manifest.review?.candidateOnly !== true) errors.push('review.candidateOnly must be true');
-  if (manifest.review?.foldRequiresReview !== true) errors.push('review.foldRequiresReview must be true');
+  if ((manifest.review && manifest.review.candidateOnly) !== true) errors.push('review.candidateOnly must be true');
+  if ((manifest.review && manifest.review.foldRequiresReview) !== true) errors.push('review.foldRequiresReview must be true');
   return errors;
 }


### PR DESCRIPTION
Implements the remaining requirement for #101: a WebSocket tools.effective inventory check during preflight.

- Declares `maxProtocol: 4` to match current gateway
- Fixes `device identity required` by omitting `role: operator` when omitting scopes
- Requests `tools.effective` for main session
- Asserts `continue_work`, `continue_delegate`, and `request_compaction` are visible
- Patches k6 `goja` ES6 compatibility issues (removes optional chaining)

Fully green against the live gateway. Replaced #132 to target the canonical `tools/k6-proofs` tree. Over to @silas-dandelion-cult for the validate-corpus fold.