### PR TITLE
fix(k6-proofs skill): repoint to tools/k6-proofs + address codex P2 review findings (redirect of openclaw#1078)

### DIFF
--- a/.agents/skills/k6-proofs/SKILL.md
+++ b/.agents/skills/k6-proofs/SKILL.md
@@ -11,14 +11,14 @@ prince's gateway, capture OTel/Prometheus/Loki evidence, and land results in the
 corpus — without archaeology.
 
 The harness, scenarios, runner, dashboards, and the machine-parseable pipeline all live in
-`karmaterminal/karmaterminal-openclaw-docs` under `k6-proofs/`.
+`karmaterminal/karmaterminal-openclaw-docs` under `tools/k6-proofs/`.
 
 ## Read these two first (the source-of-truth content)
 
-1. **`k6-proofs/skill/SKILL.md`** — the detailed human-readable how-to: scenario template,
+1. **`tools/k6-proofs/skill/SKILL.md`** — the detailed human-readable how-to: scenario template,
    metrics-naming conventions, evidence-correlation patterns, the both-forms mandate, and the
    caps-test procedure. This is the substance; this AgentSkill is the discoverable wrapper over it.
-2. **`k6-proofs/k6-proofs-pipeline.xml`** — the structured XML decision tree for one-shot model
+2. **`tools/k6-proofs/k6-proofs-pipeline.xml`** — the structured XML decision tree for one-shot model
    parse. A model actor loads it whole and knows: which row, what behavior, who owns it, what to
    fire, how to verify, where artifacts land — no line-by-line scanning. Prefer this for
    "what do I do" routing; prefer the SKILL.md for the "how exactly" detail.
@@ -28,20 +28,26 @@ The harness, scenarios, runner, dashboards, and the machine-parseable pipeline a
 > Same reason `PROOFS/INDEX.json` + the per-SHA `manifest.json` made the corpus machine-legible.
 > XML/JSON for the queryable decision/index/manifest layer; Markdown for the human glue.
 
-## Components (already deployed)
+## Components
 
-- **k6 v2.0.0** — load-testing engine (currently on `ronan-dgx` at `/home/figs/bin/k6`)
-- **Prometheus** — metrics store, `prometheus.dandelion.cult` (k3s on silas)
-- **Grafana** — dashboards, `grafana.dandelion.cult` (dashboard JSON: `k6-proofs/dashboards/k6-proofs.json`)
-- **Loki** — log aggregation, `loki.dandelion.cult` (Alloy DaemonSet forwards journal logs)
-- **Tempo** — distributed tracing, `tempo.dandelion.cult` (OTel Collector on silas)
-- **Harness** — `k6-proofs/` (lib/gateway.js connection helpers + metrics, lib/report.js HTML report)
-- **Runner** — `k6-proofs/run-proof.sh` (auto-detects seat / SHA / Prometheus URL)
+The harness is environment-agnostic; the deployment endpoints below are an **internal-fleet
+example** — substitute your own. Resolve hosts/credentials from local config, never hard-code
+them into committed scenarios (see the runner's env auto-detection).
+
+- **k6 ≥ 0.53.0** (corpus standardizes on **v2.0.0**) — load-testing engine; native optional
+  chaining, no compat flag. Install per `tools/k6-proofs/README.md`; the runner resolves the
+  `k6` binary from `PATH`.
+- **Prometheus** — metrics store (example endpoint: `prometheus.<your-domain>`).
+- **Grafana** — dashboards (example: `grafana.<your-domain>`; dashboard JSON: `tools/k6-proofs/dashboards/k6-proofs.json`).
+- **Loki** — log aggregation (example: `loki.<your-domain>`; a log-forwarder DaemonSet ships journal logs).
+- **Tempo** — distributed tracing (example: `tempo.<your-domain>`; OTel Collector).
+- **Harness** — `tools/k6-proofs/` (lib/gateway.js connection helpers + metrics, lib/report.js HTML report).
+- **Runner** — `tools/k6-proofs/run-proof.sh` (auto-detects seat / SHA / Prometheus URL from local config).
 
 ## Quick start
 
 ```bash
-cd k6-proofs
+cd tools/k6-proofs
 
 # Preflight: verify gateway + observability stack reachable (#101)
 ./run-proof.sh preflight
@@ -50,17 +56,20 @@ cd k6-proofs
 ./run-proof.sh r-cd-1
 
 # Point at another seat's gateway
-./run-proof.sh r-cd-1 --env GATEWAY_HOST=10.0.0.246
+./run-proof.sh r-cd-1 --env GATEWAY_HOST=<gateway-ip-or-host>
 
 # Offline / no Prometheus push
 k6 run scenarios/preflight.js
 ```
 
-## Build a new proof scenario (summary — full detail in `k6-proofs/skill/SKILL.md`)
+## Build a new proof scenario (summary — full detail in `tools/k6-proofs/skill/SKILL.md`)
 
 1. **Find the row** in `PROOFS/PROOF-CORPUS-METHOD.md` (row name, expected behavior, owner, evidence shape) and its tracked issue on Project 81.
 2. **Create** `scenarios/r-<row-name>.js` (lowercase, hyphens) from the scenario template.
-3. **Name metrics** with the row prefix: `r_<row>_pass` / `_fail` / `_duration_ms` / `_pass_rate` (+ threshold `rate > 0.99`).
+3. **Name metrics** with the row prefix, but **sanitize the row tag to a valid metric name first** —
+   Prometheus metric names allow only `[a-zA-Z0-9_]`, so replace hyphens with underscores: row
+   `r-cd-1` → metrics `r_cd_1_pass` / `_fail` / `_duration_ms` / `_pass_rate` (+ threshold `rate > 0.99`).
+   Keep the hyphenated form for the row *name*; use the underscored form only inside metric names.
 4. **Honor both forms** — exercise the primitive as the typed tool AND the response token (`CONTINUE_WORK`, `[[CONTINUE_DELEGATE]]`); parity is a tested seam.
 5. **Correlate evidence** — capture the OTel trace (Tempo), Prometheus metrics, and Loki logs per the correlation pattern; the raw unedited trace JSON is the proof.
 6. **Caps tests** — for chain/cap rows, set low caps and restart-to-arm (mid-flight config patches do NOT propagate to a running scheduler); the over-limit rejection trace is the evidence.
@@ -69,12 +78,12 @@ k6 run scenarios/preflight.js
 ## Project-81 tracking
 
 Every k6 scenario and proof task is a tracked issue on **Project 81** ("k6 scenarios init —
-karmaterminal-openclaw-docs"), labeled `proofs:k6` + category (`scenario`/`integration`/`coordination`)
-+ row tag + `owner:<prince>`, with status set. Make-or-claim the issue, self-assign, status it, and
-land the proof artifact before/while the work runs. Discord is for discussion; the Project-81 board
-+ committed artifacts are the coordination-of-record.
+karmaterminal-openclaw-docs"), labeled `proofs:k6`, a category (`scenario` / `integration` /
+`coordination`), the row tag, and `owner:<prince>`, with status set. Make-or-claim the issue,
+self-assign, status it, and land the proof artifact before/while the work runs. Discord is for
+discussion; the Project-81 board + committed artifacts are the coordination-of-record.
 
 ## Source repo
 
-`karmaterminal/karmaterminal-openclaw-docs` → `k6-proofs/` (harness) and this skill at
+`karmaterminal/karmaterminal-openclaw-docs` → `tools/k6-proofs/` (harness) and this skill at
 `.agents/skills/k6-proofs/SKILL.md` (discoverable wrapper).


### PR DESCRIPTION
## What

Redirects the closed **`karmaterminal/openclaw#1078`** (k6-proofs discoverable AgentSkill) onto this docs repo, where it belongs — and folds in all **4 codex P2 review findings** from that PR.

#1078 was the wrong shape: it created a *new* skill file in `openclaw/skills/`, when this docs repo **already has** the discoverable wrapper at `.agents/skills/k6-proofs/SKILL.md`. That existing file just carried stale **pre-migration `k6-proofs/` paths** (from before the harness moved under `tools/`). So this PR updates the *existing* file rather than adding a duplicate. **#1078 stays closed.**

Single file changed: `.agents/skills/k6-proofs/SKILL.md`.

## Codex P2 findings → fixes (each byte-verified vs `origin/main`)

| # | Finding | Fix | Status |
|---|---------|-----|--------|
| 1 | Paths must resolve against the skill dir | Skill lives in this docs repo alongside `tools/k6-proofs/`; all refs repointed → within-repo resolution; not auto-bundled into OpenClaw installs | ✅ |
| 2 | Keep private proof infra out of bundled skills | Removed `ronan-dgx`, `/home/figs/bin/k6`, all `*.dandelion.cult` hosts, bare IP → genericized to `<your-domain>` / `<gateway-ip-or-host>`; added "resolve hosts/credentials from local config, never hard-code" guidance | ✅ |
| 3 | Sanitize row tags for k6 metric names | Metrics step now instructs hyphen→underscore sanitization (`r-cd-1` → `r_cd_1_pass`; Prometheus names allow only `[a-zA-Z0-9_]`), keeping the hyphenated form for the row *name* only | ✅ |
| 4 | Quick-start should point at the harness dir | `cd k6-proofs` → `cd tools/k6-proofs` | ✅ |

Plus: repointed all `k6-proofs/` → `tools/k6-proofs/` (zero stale refs), cleaned a malformed Project-81 bullet block, and added the k6 version floor (`≥ 0.53.0` / `v2.0.0`, native optional chaining, no compat flag).

## Verification

- `grep` confirms **zero** stale non-`tools` `k6-proofs/` paths and **zero** `dandelion.cult` occurrences remain.
- Quick-start `cd tools/k6-proofs`, the `r_cd_1_pass` sanitization guidance, and the genericized endpoints all present.
- YAML frontmatter (`name` / `description`) untouched and well-formed.

> Note: a rigorous byte-level review of the diff against all 4 criteria was performed manually (the copilot code-agent path hit local infra friction — classic-PAT incompatibility); happy to re-run the copilot `/code-review` for belt-and-suspenders if wanted.
