### PR TITLE
docs(k6): clarify continue_delegate observability

### DIFF
--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -9,15 +9,14 @@ tools/k6-proofs/
 ├── lib/
 │   ├── gateway-ws.js              # WS helpers (frame, connect, nonce, RequestTracker, redaction)
 │   └── manifest-loader.js         # Manifest loading, env-var resolution, validation
-├── manifests/
-│   ├── r-cd-1.json                # Row manifest: R-CD-1 typed delegate
-│   └── r-cd-token.json            # Row manifest: R-CD-TOKEN bracket delegate
+├── manifests/                    # Row manifests (R-CD, R-CW, R-RC, R-OBS, safety/config rows)
 ├── scenarios/
 │   ├── preflight.js               # Scenario 0: auth + tool inventory check
-│   ├── r-cd-1-typed-delegate.js   # R-CD-1: typed continue_delegate()
-│   └── r-cd-token-bracket-delegate.js  # R-CD-TOKEN: [[CONTINUE_DELEGATE:...]]
-└── scripts/
-    └── evidence-writer.mjs        # Transforms k6 output → PROOFS/<sha>/<row>/k6-run-<ts>/ artifacts
+│   ├── r-cd-*.js                  # continue_delegate rows
+│   └── r-cw*.js                   # continue_work rows
+├── dashboards/                    # Grafana dashboard JSON
+├── docs/                          # Folded row-family docs
+└── scripts/                       # evidence writer, postprocessor, corpus validator
 ```
 
 ## Prerequisites
@@ -90,6 +89,28 @@ Gateway WS responses use `{ type: "res", id, payload?, error? }` — NOT `{ resu
 
 The `RequestTracker` class maps request IDs to method names for reliable response correlation (responses don't echo method names).
 
+### Continuation observability surfaces
+
+`continue_delegate` proof rows must not require a `tasks.list` row as the primary
+spawn receipt. The generic `tasks.list` method reads the TaskFlow / scheduled-task
+registry; `continue_delegate` uses the pending-delegate queue and then the
+subagent/session run surfaces. A delegate can fire successfully while never writing
+a nonce-correlated record to `tasks.list`.
+
+For R-CD rows, prefer these public-safe receipts instead:
+
+- `sessions.send` or `tools.invoke` accepted the dispatch request.
+- `sessions.messages.subscribe` emitted `session.message` / agent events for the
+  dispatching or target session.
+- Nonce-correlated parent/target return events appeared on the subscribed session
+  stream.
+- `tasks.list` may be kept as optional extra context only; a missing task-ledger
+  row is not a delegate failure by itself.
+
+This avoids the false-negative filed in #134, where a live delegate fired but the
+scenario failed because it queried the wrong registry surface.
+
+
 ### Seat-class awareness (R-CD-TOKEN)
 
 The bracket scanner fires only on scanned-final-text (terminal position). Seats that route final-text through `message(send)` body kill the scanner.
@@ -104,6 +125,9 @@ This is **declared in the manifest before the run**, not a post-hoc excuse. The 
 | Row | Scenario | Surface | Expected outcome |
 |-----|----------|---------|-----------------|
 | R-CD-1 | Typed `continue_delegate()` | typed-tool | PASS-candidate |
+| R-CD-2 | `continue_delegate(mode="silent-wake")` | typed-tool | PASS-candidate when dispatch/session-events observed and no channel delivery appears |
+| R-CD-4 | `continue_delegate(targetSessionKey=...)` | typed-tool | Candidate; verify target-vs-parent session events, not `tasks.list` |
+| R-CD-CHAINED-DEPTH-2 | Depth-2 delegate chain | typed-tool | Candidate; verify nonce-correlated chain return on subscribed session stream |
 | R-CD-TOKEN | Bracket `[[CONTINUE_DELEGATE:...]]` | bracket-token | Seat-dependent (see manifest) |
 
 ## Guardrails

--- a/tools/k6-proofs/manifests/r-cd-2.json
+++ b/tools/k6-proofs/manifests/r-cd-2.json
@@ -16,7 +16,11 @@
   "scenario": {
     "name": "r-cd-2-silent-wake",
     "description": "continue_delegate(mode='silent-wake') full path. Fires a delegate that returns silently and triggers a fresh parent turn without channel output.",
-    "methods": ["tools.invoke", "tasks.list", "sessions.messages.subscribe"]
+    "methods": [
+      "sessions.send",
+      "sessions.messages.subscribe",
+      "tasks.list"
+    ]
   },
   "invocation": {
     "tool": "continue_delegate",
@@ -26,12 +30,36 @@
     "idempotencyKeyPrefix": "R-CD-2"
   },
   "expectedReceipts": [
-    { "name": "tool-invoke-accepted", "required": true, "description": "Gateway accepted the continue_delegate(mode=silent-wake) tool invocation" },
-    { "name": "task-ledger-entry", "required": true, "description": "Task created in ledger with nonce correlation and mode=silent-wake" },
-    { "name": "child-session-key", "required": false, "description": "Child session key from task metadata" },
-    { "name": "parent-wake-event", "required": true, "description": "Parent session wakes after silent return (session.message or run event with no channel delivery)" },
-    { "name": "no-channel-delivery", "required": true, "description": "Delegate return does NOT produce a channel message (silent mode verified)" },
-    { "name": "trace-id", "required": false, "description": "Trace ID from tool response or task metadata for Tempo fetch" }
+    {
+      "name": "dispatch-accepted",
+      "required": true,
+      "description": "Gateway accepted the dispatching sessions.send request that asks the agent to call continue_delegate(mode=silent-wake)"
+    },
+    {
+      "name": "task-ledger-entry",
+      "required": false,
+      "description": "Optional extra context from the generic TaskFlow task ledger; continue_delegate does not reliably write here"
+    },
+    {
+      "name": "child-session-key",
+      "required": false,
+      "description": "Child session key from task metadata"
+    },
+    {
+      "name": "parent-wake-event",
+      "required": true,
+      "description": "Parent session wakes after silent return (session.message or run event with no channel delivery)"
+    },
+    {
+      "name": "no-channel-delivery",
+      "required": true,
+      "description": "Delegate return does NOT produce a channel message (silent mode verified)"
+    },
+    {
+      "name": "trace-id",
+      "required": false,
+      "description": "Trace ID from dispatch response or optional task metadata for Tempo fetch"
+    }
   ],
   "artifactDestination": {
     "root": "PROOFS",
@@ -43,6 +71,6 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Silent-wake path. PASS-candidate when: (1) tool accepted, (2) task created with mode=silent-wake, (3) parent wakes with enriched context, (4) NO channel message delivered from the delegate return. The negative assertion (no-channel-delivery) distinguishes this from R-CD-1's mode=normal."
+    "notes": "Silent-wake path. PASS-candidate when: (1) dispatching agent turn accepted, (2) parent session emits wake/agent events, (3) NO channel message delivered from the delegate return. A nonce-correlated tasks.list row is optional because continue_delegate uses pending-delegate/subagent surfaces, not the generic task registry."
   }
 }

--- a/tools/k6-proofs/manifests/r-cd-4.json
+++ b/tools/k6-proofs/manifests/r-cd-4.json
@@ -16,7 +16,11 @@
   "scenario": {
     "name": "r-cd-4-target-session-key",
     "description": "continue_delegate with targetSessionKey: delegate return lands in a SPECIFIED target session, not the dispatching session. Cross-session targeted delivery.",
-    "methods": ["tools.invoke", "tasks.list", "sessions.messages.subscribe"]
+    "methods": [
+      "tools.invoke",
+      "sessions.messages.subscribe",
+      "tasks.list"
+    ]
   },
   "invocation": {
     "tool": "continue_delegate",
@@ -27,12 +31,36 @@
     "idempotencyKeyPrefix": "R-CD-4"
   },
   "expectedReceipts": [
-    { "name": "tool-invoke-accepted", "required": true, "description": "Gateway accepted continue_delegate with targetSessionKey" },
-    { "name": "task-ledger-entry", "required": true, "description": "Task created with targetSessionKey metadata" },
-    { "name": "child-completes", "required": true, "description": "Child delegate completes its task" },
-    { "name": "return-lands-in-target", "required": true, "description": "Delegate return arrives in the TARGET session (not the dispatching session)" },
-    { "name": "no-return-to-parent", "required": true, "description": "Dispatching session does NOT receive the return (delivery went to target)" },
-    { "name": "trace-id", "required": false, "description": "Trace ID for Tempo correlation" }
+    {
+      "name": "tool-invoke-accepted",
+      "required": true,
+      "description": "Gateway accepted continue_delegate with targetSessionKey"
+    },
+    {
+      "name": "task-ledger-entry",
+      "required": false,
+      "description": "Optional extra context only; target-session proof must use subscribed session events rather than the generic TaskFlow task ledger"
+    },
+    {
+      "name": "child-completes",
+      "required": true,
+      "description": "Child delegate completes its task"
+    },
+    {
+      "name": "return-lands-in-target",
+      "required": true,
+      "description": "Delegate return arrives in the TARGET session (not the dispatching session)"
+    },
+    {
+      "name": "no-return-to-parent",
+      "required": true,
+      "description": "Dispatching session does NOT receive the return (delivery went to target)"
+    },
+    {
+      "name": "trace-id",
+      "required": false,
+      "description": "Trace ID for Tempo correlation"
+    }
   ],
   "artifactDestination": {
     "root": "PROOFS",
@@ -44,6 +72,6 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Cross-session targeted return. PASS-candidate when: (1) tool accepted with targetSessionKey, (2) child completes, (3) return lands in TARGET session, (4) dispatching session does NOT receive the return. Requires two session subscriptions to verify routing."
+    "notes": "Cross-session targeted return. PASS-candidate when: (1) dispatch accepted with targetSessionKey, (2) return lands in TARGET session, (3) dispatching session does NOT receive the return. A nonce-correlated tasks.list row is optional because continue_delegate uses pending-delegate/subagent surfaces, not the generic task registry."
   }
 }

--- a/tools/k6-proofs/manifests/r-cd-chained-depth-2.json
+++ b/tools/k6-proofs/manifests/r-cd-chained-depth-2.json
@@ -16,7 +16,11 @@
   "scenario": {
     "name": "r-cd-chained-depth-2",
     "description": "Depth-2 delegate chain: parent→child→grandchild→return path. Three sub-tests: (1) up-tree silent-wake, (2) inter-session return, (3) echo+broadcast via fanoutMode.",
-    "methods": ["tools.invoke", "tasks.list", "sessions.messages.subscribe"],
+    "methods": [
+      "tools.invoke",
+      "sessions.messages.subscribe",
+      "tasks.list"
+    ],
     "subtests": [
       "chain-1-uptree-silent-wake",
       "chain-2-inter-session-return",
@@ -31,13 +35,41 @@
     "idempotencyKeyPrefix": "R-CD-CHAIN"
   },
   "expectedReceipts": [
-    { "name": "parent-dispatch-accepted", "required": true, "description": "Parent fires continue_delegate → accepted" },
-    { "name": "child-spawns", "required": true, "description": "Child session created (depth-1)" },
-    { "name": "child-fires-grandchild", "required": true, "description": "Child fires its own continue_delegate (depth-2 chain)" },
-    { "name": "grandchild-spawns", "required": true, "description": "Grandchild session created (depth-2)" },
-    { "name": "grandchild-returns", "required": true, "description": "Grandchild completes and return propagates up-tree" },
-    { "name": "parent-receives-chain-return", "required": true, "description": "Parent session receives the chained return (nonce-correlated)" },
-    { "name": "trace-id", "required": false, "description": "Trace ID for chain visualization in Tempo" }
+    {
+      "name": "parent-dispatch-accepted",
+      "required": true,
+      "description": "Parent fires continue_delegate → accepted"
+    },
+    {
+      "name": "child-spawns",
+      "required": true,
+      "description": "Child session created (depth-1)"
+    },
+    {
+      "name": "child-fires-grandchild",
+      "required": true,
+      "description": "Child fires its own continue_delegate (depth-2 chain)"
+    },
+    {
+      "name": "grandchild-spawns",
+      "required": true,
+      "description": "Grandchild session created (depth-2)"
+    },
+    {
+      "name": "grandchild-returns",
+      "required": true,
+      "description": "Grandchild completes and return propagates up-tree"
+    },
+    {
+      "name": "parent-receives-chain-return",
+      "required": true,
+      "description": "Parent session receives the chained return (nonce-correlated)"
+    },
+    {
+      "name": "trace-id",
+      "required": false,
+      "description": "Trace ID for chain visualization in Tempo"
+    }
   ],
   "artifactDestination": {
     "root": "PROOFS",
@@ -49,6 +81,6 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Depth-2 chain proof. PASS-candidate when parent→child→grandchild→return completes with nonce correlation at each hop. Chain depth limit enforcement tested implicitly (depth-2 should succeed; gateway caps apply). Sequential fire per issue #119 guardrails."
+    "notes": "Depth-2 chain proof. PASS-candidate when parent→child→grandchild→return completes with nonce correlation at each hop. Chain depth limit enforcement tested implicitly (depth-2 should succeed; gateway caps apply). Do not require tasks.list for child/grandchild spawn receipts; continue_delegate uses pending-delegate/subagent surfaces, not the generic task registry."
   }
 }

--- a/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
+++ b/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
@@ -167,7 +167,8 @@ export default function () {
           }
         }
 
-        // Check task ledger — look for mode=silent-wake in task metadata
+        // Optional TaskFlow ledger context. Absence here is not a failure:
+        // continue_delegate uses pending-delegate/subagent surfaces.
         if (classified.kind === 'response' && classified.method === 'tasks.list') {
           const tasks = classified.payload?.tasks || [];
           for (const task of tasks) {
@@ -205,9 +206,9 @@ export default function () {
           }
         }
 
-        // Early close if all evidence gathered
-        if (evidence.tool_accepted && evidence.task_created && evidence.parent_wake_observed) {
-          console.log('All required evidence gathered, closing early');
+        // Early close if primary evidence is gathered; task ledger context is optional.
+        if (evidence.tool_accepted && evidence.parent_wake_observed) {
+          console.log('Primary silent-wake evidence gathered, closing early');
           socket.close();
         }
       } catch (e) {

--- a/tools/k6-proofs/scenarios/r-cd-4-target-session-key.js
+++ b/tools/k6-proofs/scenarios/r-cd-4-target-session-key.js
@@ -139,7 +139,9 @@ export default function () {
         });
       }, 1000);
 
-      // Poll task ledger
+      // Optional context only: continue_delegate does not write to the generic
+      // TaskFlow task registry. Target-vs-parent routing is verified from the
+      // subscribed session event stream below.
       socket.setTimeout(() => tracker.send(socket, 'tasks.list', { limit: 10 }), 8000);
       socket.setTimeout(() => tracker.send(socket, 'tasks.list', { limit: 10 }), 25000);
       socket.setTimeout(() => tracker.send(socket, 'tasks.list', { limit: 10 }), 50000);
@@ -173,7 +175,8 @@ export default function () {
           }
         }
 
-        // Task ledger check
+        // Optional TaskFlow ledger check. Absence here is not a failure:
+        // continue_delegate uses pending-delegate/subagent surfaces.
         if (classified.kind === 'response' && classified.method === 'tasks.list') {
           const tasks = classified.payload?.tasks || [];
           for (const task of tasks) {
@@ -210,7 +213,7 @@ export default function () {
         }
 
         // Early close if definitive evidence
-        if (evidence.tool_accepted && evidence.task_created &&
+        if (evidence.tool_accepted &&
             (evidence.return_in_target || evidence.return_in_parent)) {
           sleep(2); // Brief grace for any late events
           socket.close();
@@ -233,7 +236,7 @@ export default function () {
   check(res, { 'websocket connected': (r) => r && r.status === 101 });
   check(null, {
     'tool invocation accepted': () => evidence.tool_accepted,
-    'delegate task created': () => evidence.task_created,
+    'optional task ledger context captured': () => true,
     'return landed in target session': () => evidence.return_in_target,
     'no return in parent session (routing verified)': () => !evidence.return_in_parent,
   });
@@ -242,7 +245,7 @@ export default function () {
     failures.add(1);
   }
 
-  const passed = evidence.tool_accepted && evidence.task_created &&
+  const passed = evidence.tool_accepted &&
     evidence.return_in_target && !evidence.return_in_parent;
 
   console.log(`\n--- R-CD-4 EVIDENCE SUMMARY ---`);

--- a/tools/k6-proofs/scenarios/r-cd-chained-depth-2.js
+++ b/tools/k6-proofs/scenarios/r-cd-chained-depth-2.js
@@ -135,7 +135,9 @@ export default function () {
         });
       }, 1000);
 
-      // Poll task ledger repeatedly to observe chain progression
+      // Optional context only: continue_delegate does not write to the generic
+      // TaskFlow task registry. Chain progression is verified primarily from
+      // nonce-correlated subscribed session events.
       socket.setTimeout(() => tracker.send(socket, 'tasks.list', { limit: 20 }), 8000);
       socket.setTimeout(() => tracker.send(socket, 'tasks.list', { limit: 20 }), 20000);
       socket.setTimeout(() => tracker.send(socket, 'tasks.list', { limit: 20 }), 40000);
@@ -173,7 +175,8 @@ export default function () {
           }
         }
 
-        // Task ledger: observe chain depth progression
+        // Optional TaskFlow ledger context. Absence here is not a failure:
+        // continue_delegate uses pending-delegate/subagent surfaces.
         if (classified.kind === 'response' && classified.method === 'tasks.list') {
           const tasks = classified.payload?.tasks || [];
           let childFound = false;
@@ -208,13 +211,28 @@ export default function () {
           if (grandchildFound) console.log('✓ Grandchild (depth-2) observed in task ledger');
         }
 
-        // Chain return event on parent
+        // Chain progression on subscribed session events. These are the primary
+        // public proof surface for continue_delegate chains; task registry rows
+        // are only optional context.
         if (classified.kind === 'event') {
           const eventStr = JSON.stringify(classified.data || {});
-          if ((eventStr.includes('delegate') || eventStr.includes('completion') ||
-               eventStr.includes('return')) && eventStr.includes(chainNonce)) {
-            evidence.chain_return_received = true;
-            console.log('✓ Chain return received at parent session');
+          if (eventStr.includes(chainNonce)) {
+            if (eventStr.includes('depth-1') || eventStr.includes('CHILD-DONE')) {
+              evidence.child_spawned = true;
+              if (evidence.max_depth_observed < 1) evidence.max_depth_observed = 1;
+              console.log('✓ Child/depth-1 event observed on session stream');
+            }
+            if (eventStr.includes('Grandchild') || eventStr.includes('GRANDCHILD-DONE')) {
+              evidence.grandchild_spawned = true;
+              if (evidence.max_depth_observed < 2) evidence.max_depth_observed = 2;
+              console.log('✓ Grandchild/depth-2 event observed on session stream');
+            }
+            if (eventStr.includes('delegate') || eventStr.includes('completion') ||
+                eventStr.includes('return') || eventStr.includes('CHILD-DONE') ||
+                eventStr.includes('GRANDCHILD-DONE')) {
+              evidence.chain_return_received = true;
+              console.log('✓ Chain return/progression received at parent session');
+            }
           }
         }
 


### PR DESCRIPTION
## Summary
- document that `continue_delegate` proofs should use session/subagent event surfaces instead of `tasks.list` as the primary spawn receipt
- mark TaskFlow ledger receipts optional in R-CD-2, R-CD-4, and chained depth-2 manifests
- adjust affected k6 scenarios so missing `tasks.list` rows do not fail otherwise valid delegate evidence

Fixes #134.

## Checks
- `node -e "const fs=require('fs'); const files=['tools/k6-proofs/manifests/r-cd-2.json','tools/k6-proofs/manifests/r-cd-4.json','tools/k6-proofs/manifests/r-cd-chained-depth-2.json']; for (const f of files) { JSON.parse(fs.readFileSync(f,'utf8')); console.log('ok', f); }"`
- `node --check tools/k6-proofs/scenarios/r-cd-2-silent-wake.js`
- `node --check tools/k6-proofs/scenarios/r-cd-4-target-session-key.js`
- `node --check tools/k6-proofs/scenarios/r-cd-chained-depth-2.js`
- `git diff --check`
- `node tools/k6-proofs/scripts/validate-corpus.mjs --index`
