### PR TITLE
docs(k6-proofs): add seat readiness preflight

### DIFF
--- a/.github/workflows/k6-proof.yml
+++ b/.github/workflows/k6-proof.yml
@@ -125,6 +125,27 @@ jobs:
           sudo apt-get install -y k6
           k6 version
 
+      - name: Seat readiness preflight
+        env:
+          OPENCLAW_GATEWAY_WS: ${{ github.event.inputs.gateway_ws }}
+          OPENCLAW_SESSION_KEY: ${{ github.event.inputs.session_key }}
+          OPENCLAW_CANDIDATE_SHA: ${{ github.event.inputs.candidate_sha }}
+          OPENCLAW_SEAT_NAME: ${{ github.event.inputs.seat }}
+          OPENCLAW_EXPECTED_K6_VERSION: v2.0.0
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          export OPENCLAW_GATEWAY_TOKEN="$(python3 -c 'import json, os; print(json.load(open(os.path.expanduser("~/.openclaw/openclaw.json")))["gateway"]["auth"]["token"])')"
+          set +x
+          set -euo pipefail
+          if ! node tools/k6-proofs/scripts/seat-readiness-preflight.mjs --json | tee /tmp/seat-readiness.json; then
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "::warning::seat readiness preflight did not pass; dry_run continues, but output is not proof-standard"
+              exit 0
+            fi
+            echo "::error::seat readiness preflight did not pass; inspect /tmp/seat-readiness.json before treating k6 output as proof-standard"
+            exit 1
+          fi
+
       - name: Run k6 scenario
         # Token is injected ONLY here, ONLY as env. Never echoed; runner masks
         # registered secrets in logs, and we keep `set +x` so the env line is

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -21,8 +21,9 @@ tools/k6-proofs/
 
 ## Prerequisites
 
-- [Grafana k6](https://grafana.com/docs/k6/latest/get-started/installation/) installed on the run seat.
+- [Grafana k6](https://grafana.com/docs/k6/latest/get-started/installation/) installed on the run seat. The proof-standard expectation is `v2.0.0` unless a row issue explicitly says otherwise.
 - A running OpenClaw gateway on the local seat.
+- Run `node tools/k6-proofs/scripts/seat-readiness-preflight.mjs` before treating row output as proof-standard. A version/env/gateway mismatch is `HONEST-LIMIT-candidate`, not product failure.
 - Environment variables:
   - `OPENCLAW_GATEWAY_WS` — WebSocket URL (default: `ws://127.0.0.1:18789`)
   - `OPENCLAW_GATEWAY_TOKEN` — operator auth token (**required, never in source**)
@@ -31,8 +32,31 @@ tools/k6-proofs/
   - `OPENCLAW_SEAT_NAME` — seat identifier (default: `ronan-dgx`)
   - `OPENCLAW_ROW_MANIFEST` — path to row manifest JSON (optional; enables manifest-driven mode)
   - `OPENCLAW_SEAT_CLASS` — `raw-final-text` or `message-body` (default: `message-body`; affects R-CD-TOKEN)
+  - `OPENCLAW_EXPECTED_K6_VERSION` — expected k6 version for seat-readiness preflight (default: `v2.0.0`)
 
 ## Usage
+
+### 0. Seat readiness / version preflight
+
+Run this before a proof row when the output may be folded or compared across seats:
+
+```bash
+OPENCLAW_CANDIDATE_SHA="<40-char-sha>" \
+OPENCLAW_SEAT_NAME="<seat>" \
+OPENCLAW_SESSION_KEY="<target-session>" \
+OPENCLAW_GATEWAY_TOKEN="***" \
+  node tools/k6-proofs/scripts/seat-readiness-preflight.mjs --json
+```
+
+The helper emits `openclaw.k6.seat-readiness.v1` JSON and never prints secret values. It records:
+
+- k6 binary path and version, compared to the single documented expectation (`v2.0.0` by default)
+- gateway health/status reachability shape
+- candidate SHA validity, seat name/class, and coarse session scope
+- required env-var presence as booleans only
+- whether the check is safe to run concurrently
+
+If k6 is missing, the version differs, required env is absent, or gateway health/status is unreachable, treat row output as `HONEST-LIMIT-candidate` / setup failure until the seat is fixed. Do not fold it as product behavior evidence. Use `--no-gateway` only for offline docs/schema checks; live proof rows need a checked gateway.
 
 ### 1. Preflight check
 

--- a/tools/k6-proofs/manifests/preflight.example.json
+++ b/tools/k6-proofs/manifests/preflight.example.json
@@ -1,7 +1,7 @@
 {
   "schema": "openclaw.k6.proof-row-manifest.v1",
   "rowId": "preflight",
-  "issue": 100,
+  "issue": 101,
   "candidateSha": "82827d3cbcba92ff6e19863b30615db028c2651c",
   "seat": "emeric-nuc",
   "sessionKey": "${OPENCLAW_SESSION_KEY}",
@@ -15,8 +15,13 @@
   },
   "scenario": {
     "name": "preflight inventory",
-    "description": "Authenticate/read-only gateway inventory: health/status, sessions.list, tools.effective. Offline mode validates manifest shape without gateway traffic.",
-    "methods": ["health", "status", "sessions.list", "tools.effective"]
+    "description": "Authenticate/read-only gateway inventory plus seat-readiness contract: health/status, sessions.list, tools.effective, k6 version/path, env presence, and candidate metadata. Offline mode validates manifest shape without gateway traffic.",
+    "methods": [
+      "health",
+      "status",
+      "sessions.list",
+      "tools.effective"
+    ]
   },
   "expectedReceipts": [
     {
@@ -30,6 +35,12 @@
       "required": true,
       "pathHint": "k6-summary.json",
       "description": "Raw k6 summary/export for the run."
+    },
+    {
+      "name": "seat-readiness",
+      "required": true,
+      "pathHint": "seat-readiness.json",
+      "description": "Public-safe seat/tooling preflight: k6 path/version, gateway reachability, candidate SHA validity, env presence booleans, seat/session class, and concurrency safety."
     },
     {
       "name": "tool-inventory",
@@ -54,6 +65,6 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Preflight is non-mutating and should never write a final proof verdict by itself."
+    "notes": "Preflight is non-mutating and should never write a final proof verdict by itself. k6 version/env/gateway mismatches are HONEST-LIMIT/setup candidates, not product failures."
   }
 }

--- a/tools/k6-proofs/scripts/seat-readiness-preflight.mjs
+++ b/tools/k6-proofs/scripts/seat-readiness-preflight.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+/**
+ * seat-readiness-preflight.mjs — public-safe seat/tooling readiness report.
+ *
+ * This is intentionally a Node helper, not a k6 row. It runs before proof rows
+ * so a bad seat/tooling environment becomes HONEST-LIMIT-candidate instead of
+ * being confused with product behavior.
+ */
+import { execFileSync } from 'node:child_process';
+
+const DEFAULT_EXPECTED_K6_VERSION = 'v2.0.0';
+const SECRET_ENV = new Set(['OPENCLAW_GATEWAY_TOKEN']);
+const REQUIRED_ENV = [
+  'OPENCLAW_GATEWAY_TOKEN',
+  'OPENCLAW_GATEWAY_WS',
+  'OPENCLAW_SESSION_KEY',
+  'OPENCLAW_CANDIDATE_SHA',
+  'OPENCLAW_SEAT_NAME',
+];
+
+function parseArgs(argv) {
+  const out = { gateway: true };
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--json') out.json = true;
+    else if (arg === '--no-gateway') out.gateway = false;
+    else if (arg === '--expected-k6-version') out.expectedK6Version = argv[++i];
+    else if (arg === '--help' || arg === '-h') out.help = true;
+    else throw new Error(`unknown arg: ${arg}`);
+  }
+  return out;
+}
+
+function usage() {
+  console.log(`Usage: node tools/k6-proofs/scripts/seat-readiness-preflight.mjs [--json] [--no-gateway] [--expected-k6-version v2.0.0]\n\nEmits no secret values. Exit 0 only for PASS-candidate.`);
+}
+
+function commandOrNull(cmd, args) {
+  try {
+    return execFileSync(cmd, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function detectK6() {
+  const path = commandOrNull('which', ['k6']);
+  if (!path) return { ok: false, path: null, version: null, rawVersion: null };
+  const rawVersion = commandOrNull('k6', ['version']);
+  const version = rawVersion && rawVersion.match(/\bv\d+\.\d+\.\d+\b/)?.[0] || null;
+  return { ok: Boolean(version), path, version, rawVersion };
+}
+
+async function fetchOk(url, token) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 2500);
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: token ? { authorization: `Bearer ${token}` } : {},
+    });
+    return res.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function httpBaseFromWs(wsUrl) {
+  if (!wsUrl) return 'http://127.0.0.1:18789';
+  try {
+    const url = new URL(wsUrl);
+    url.protocol = url.protocol === 'wss:' ? 'https:' : 'http:';
+    url.pathname = '';
+    url.search = '';
+    url.hash = '';
+    return url.toString().replace(/\/$/, '');
+  } catch {
+    return 'http://127.0.0.1:18789';
+  }
+}
+
+function sessionScope(sessionKey) {
+  if (!sessionKey) return 'missing';
+  if (sessionKey === 'main') return 'main';
+  if (/^agent:main(:|$)/.test(sessionKey)) return 'main-agent-session';
+  if (/^agent:/.test(sessionKey)) return 'agent-session';
+  return 'configured-session';
+}
+
+function envReport() {
+  return REQUIRED_ENV.map((name) => ({
+    name,
+    present: Boolean(process.env[name]),
+    secret: SECRET_ENV.has(name),
+    required: name !== 'OPENCLAW_GATEWAY_WS',
+  }));
+}
+
+function printText(report) {
+  console.log(`seat readiness: ${report.outcome}`);
+  console.log(`k6: ${report.k6.version || 'missing'} at ${report.k6.path || '(not found)'} (expected ${report.expectedK6Version})`);
+  console.log(`gateway: ${report.gateway.mode}; health=${report.gateway.healthReachable}; status=${report.gateway.statusReachable}; url=${report.gateway.url}`);
+  console.log(`candidate sha: ${report.candidate.valid40Hex ? 'valid' : 'missing/invalid'}`);
+  console.log(`seat: ${report.seat.name}; session scope: ${report.session.scope}`);
+  console.log(`concurrency: ${report.concurrency.safeToRunConcurrently ? 'safe' : 'serialized'} — ${report.concurrency.reason}`);
+  const missing = report.env.filter((e) => e.required && !e.present).map((e) => e.name);
+  if (missing.length) console.log(`missing required env: ${missing.join(', ')}`);
+  for (const note of report.notes) console.log(`note: ${note}`);
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    usage();
+    return 0;
+  }
+
+  const expectedK6Version = args.expectedK6Version || process.env.OPENCLAW_EXPECTED_K6_VERSION || DEFAULT_EXPECTED_K6_VERSION;
+  const k6 = detectK6();
+  k6.matchesExpected = k6.version === expectedK6Version;
+
+  const gatewayWs = process.env.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
+  const gatewayBase = httpBaseFromWs(gatewayWs);
+  const token = process.env.OPENCLAW_GATEWAY_TOKEN;
+  let gateway = { url: gatewayWs, healthReachable: false, statusReachable: false, mode: 'skipped-by-flag' };
+  if (args.gateway && !token) {
+    gateway = { ...gateway, mode: 'skipped-no-token' };
+  } else if (args.gateway) {
+    gateway = {
+      url: gatewayWs,
+      healthReachable: await fetchOk(`${gatewayBase}/health`, token),
+      statusReachable: await fetchOk(`${gatewayBase}/status`, token),
+      mode: 'checked',
+    };
+  }
+
+  const candidateSha = process.env.OPENCLAW_CANDIDATE_SHA || null;
+  const env = envReport();
+  const requiredMissing = env.filter((e) => e.required && !e.present).map((e) => e.name);
+  const notes = [];
+  if (!k6.ok) notes.push('k6 is not installed or did not report a parseable version.');
+  else if (!k6.matchesExpected) notes.push(`k6 version mismatch: expected ${expectedK6Version}, got ${k6.version}.`);
+  if (gateway.mode === 'checked' && (!gateway.healthReachable || !gateway.statusReachable)) notes.push('gateway health/status not reachable from this seat.');
+  if (gateway.mode === 'skipped-no-token') notes.push('gateway reachability skipped because OPENCLAW_GATEWAY_TOKEN is absent; token value was not printed.');
+  if (requiredMissing.length) notes.push(`missing required env: ${requiredMissing.join(', ')}.`);
+
+  const valid40Hex = typeof candidateSha === 'string' && /^[0-9a-f]{40}$/.test(candidateSha);
+  if (!valid40Hex) notes.push('OPENCLAW_CANDIDATE_SHA is missing or not a 40-char lowercase hex SHA.');
+
+  const pass = k6.ok && k6.matchesExpected && valid40Hex && requiredMissing.length === 0 && (gateway.mode !== 'checked' || (gateway.healthReachable && gateway.statusReachable));
+
+  const report = {
+    schema: 'openclaw.k6.seat-readiness.v1',
+    generatedAt: new Date().toISOString(),
+    outcome: pass ? 'PASS-candidate' : 'HONEST-LIMIT-candidate',
+    expectedK6Version,
+    k6,
+    gateway,
+    candidate: { sha: candidateSha, valid40Hex },
+    seat: {
+      name: process.env.OPENCLAW_SEAT_NAME || 'unknown-seat',
+      class: process.env.OPENCLAW_SEAT_CLASS || 'message-body',
+    },
+    session: { scope: sessionScope(process.env.OPENCLAW_SESSION_KEY) },
+    env,
+    concurrency: {
+      safeToRunConcurrently: true,
+      reason: 'read-only seat readiness preflight; no continuation/delegate/compaction calls are fired',
+    },
+    notes,
+  };
+
+  if (args.json) console.log(JSON.stringify(report, null, 2));
+  else printText(report);
+  return pass ? 0 : 2;
+}
+
+main().then((code) => process.exit(code)).catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/tools/k6-proofs/seat-readiness.schema.json
+++ b/tools/k6-proofs/seat-readiness.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/karmaterminal/karmaterminal-openclaw-docs/tools/k6-proofs/seat-readiness.schema.json",
+  "title": "OpenClaw k6 PROOFS seat readiness report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "generatedAt",
+    "outcome",
+    "expectedK6Version",
+    "k6",
+    "gateway",
+    "candidate",
+    "seat",
+    "session",
+    "env",
+    "concurrency",
+    "notes"
+  ],
+  "properties": {
+    "schema": { "const": "openclaw.k6.seat-readiness.v1" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "outcome": { "enum": ["PASS-candidate", "HONEST-LIMIT-candidate", "FAIL-candidate"] },
+    "expectedK6Version": { "type": "string", "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+$" },
+    "k6": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ok", "path", "version", "matchesExpected", "rawVersion"],
+      "properties": {
+        "ok": { "type": "boolean" },
+        "path": { "type": ["string", "null"] },
+        "version": { "type": ["string", "null"] },
+        "matchesExpected": { "type": "boolean" },
+        "rawVersion": { "type": ["string", "null"] }
+      }
+    },
+    "gateway": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["url", "healthReachable", "statusReachable", "mode"],
+      "properties": {
+        "url": { "type": "string" },
+        "healthReachable": { "type": "boolean" },
+        "statusReachable": { "type": "boolean" },
+        "mode": { "enum": ["checked", "skipped-no-token", "skipped-by-flag"] }
+      }
+    },
+    "candidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sha", "valid40Hex"],
+      "properties": {
+        "sha": { "type": ["string", "null"] },
+        "valid40Hex": { "type": "boolean" }
+      }
+    },
+    "seat": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "class"],
+      "properties": {
+        "name": { "type": "string" },
+        "class": { "type": "string" }
+      }
+    },
+    "session": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scope"],
+      "properties": {
+        "scope": { "type": "string" }
+      }
+    },
+    "env": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "present", "secret", "required"],
+        "properties": {
+          "name": { "type": "string" },
+          "present": { "type": "boolean" },
+          "secret": { "type": "boolean" },
+          "required": { "type": "boolean" }
+        }
+      }
+    },
+    "concurrency": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["safeToRunConcurrently", "reason"],
+      "properties": {
+        "safeToRunConcurrently": { "type": "boolean" },
+        "reason": { "type": "string" }
+      }
+    },
+    "notes": { "type": "array", "items": { "type": "string" } }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #145 by adding a public-safe seat readiness/version preflight contract before k6 proof rows are treated as proof-standard.

Changes:
- adds `tools/k6-proofs/scripts/seat-readiness-preflight.mjs`
  - records k6 binary path/version
  - checks candidate SHA validity
  - reports required env var presence as booleans only
  - reports coarse session scope and seat class
  - can check gateway health/status without printing token values
  - exits non-zero for `HONEST-LIMIT-candidate`
- adds `tools/k6-proofs/seat-readiness.schema.json`
- documents the standard k6 expectation (`v2.0.0`) and HONEST-LIMIT handling in the harness README
- updates the preflight manifest to require a `seat-readiness.json` receipt
- inserts the readiness check into the k6 workflow; dry-run logs a warning, non-dry proof runs fail before row execution if the seat is not proof-standard

## Validation

```text
$ node --check tools/k6-proofs/scripts/seat-readiness-preflight.mjs
# ok

$ python3 -m json.tool tools/k6-proofs/seat-readiness.schema.json >/dev/null
# ok

$ python3 -m json.tool tools/k6-proofs/manifests/preflight.example.json >/dev/null
# ok

$ OPENCLAW_CANDIDATE_SHA=82827d3cbcba92ff6e19863b30615db028c2651c \
  OPENCLAW_SEAT_NAME=rune \
  OPENCLAW_SESSION_KEY=main \
  OPENCLAW_GATEWAY_TOKEN=dummy \
  node tools/k6-proofs/scripts/seat-readiness-preflight.mjs --json --no-gateway
# outcome: HONEST-LIMIT-candidate
# k6.version: v0.51.0
# expectedK6Version: v2.0.0
# exit: 2

$ OPENCLAW_CANDIDATE_SHA=82827d3cbcba92ff6e19863b30615db028c2651c \
  OPENCLAW_SEAT_NAME=rune \
  OPENCLAW_SESSION_KEY=main \
  OPENCLAW_GATEWAY_TOKEN=dummy \
  OPENCLAW_EXPECTED_K6_VERSION=v0.51.0 \
  node tools/k6-proofs/scripts/seat-readiness-preflight.mjs --json --no-gateway
# outcome: PASS-candidate
# exit: 0

$ node tools/k6-proofs/scripts/validate-corpus.mjs --index
INDEX: /home/figs/source/karmaterminal-openclaw-docs/PROOFS/INDEX.json
  ✓ json-parse-index — /home/figs/source/karmaterminal-openclaw-docs/PROOFS/INDEX.json
  ✓ schema-index — openclaw.proofs.index.v1
  ✓ schema-index-keys — current_sha, corpus_path, manifest_path, rollup
  ✓ rollup-matches-manifest — INDEX rollup matches manifest tally (total_rows=24, pass=22, partial=0, thin=0, fail=0, honest_limit=2, missing=0)
  -- current_sha manifest --
  · ✓ json-parse-manifest — /home/figs/source/karmaterminal-openclaw-docs/PROOFS/82827d3cbcba92ff6e19863b30615db028c2651c/proofs-manifest.json
  · ✓ schema-manifest — openclaw.proofs.manifest.v1
  · ✓ schema-manifest-capture-sha — 82827d3cbcba92ff6e19863b30615db028c2651c
  · ✓ schema-manifest-rows — 24 rows
  · ✓ capture-sha-agreement — capture_sha == dir name (82827d3cbcba92ff6e19863b30615db028c2651c)
  · ✓ evidence-doc-exists — 24/24 evidence_doc paths exist
  · ✓ row-dirs-exist — 24/24 row dirs exist
  · ✓ no-orphan-row-dirs — 22 on-disk row dirs all referenced
  · ✓ state-values-known — all states ∈ {pass,partial,thin,fail,honest_limit,missing}
  · ✓ no-stale-pending-tokens — no occurrences of `pending_push`, `pending push`, `upload-blame`, `TODO-UPLOAD`, `pending_upload`
  OK: 4 passed, 0 failed
```

## Secret / safety notes

- The helper only reports env presence booleans; it does not print secret values.
- The check is read-only and safe to run concurrently; it fires no continuation/delegate/compaction calls.
- The observed Rune seat mismatch (`k6 v0.51.0` vs expected `v2.0.0`) is now surfaced explicitly as `HONEST-LIMIT-candidate`.
