### PR TITLE
fix(k6-proofs): align workflow scenario choices

### DIFF
--- a/.github/workflows/k6-proof.yml
+++ b/.github/workflows/k6-proof.yml
@@ -20,14 +20,17 @@ on:
   workflow_dispatch:
     inputs:
       scenario:
-        description: "Scenario file under tools/k6-proofs/scenarios/ (without path)"
+        description: "Scenario basename under tools/k6-proofs/scenarios/ (without .js)"
         required: true
         type: choice
-        default: preflight.js
+        default: preflight
         options:
-          - preflight.js
-          - r-cd-1-typed-delegate.js
-          - r-cd-token-bracket-delegate.js
+          - preflight
+          - r-cd-2-silent-wake
+          - r-cd-4-target-session-key
+          - r-cd-chained-depth-2
+          - r-cw-1
+          - r-cw
       row:
         description: "Row id for evidence (e.g. R-CD-1, R-CD-TOKEN). Ignored when dry_run=true."
         required: false
@@ -92,7 +95,11 @@ jobs:
           MANIFEST_PATH: ${{ github.event.inputs.manifest_path }}
         run: |
           set -euo pipefail
-          scenario_file="tools/k6-proofs/scenarios/${SCENARIO}"
+          if printf '%s' "$SCENARIO" | grep -Eq '/|\.js$'; then
+            echo "::error::scenario must be a basename without path or .js suffix: $SCENARIO"
+            exit 1
+          fi
+          scenario_file="tools/k6-proofs/scenarios/${SCENARIO}.js"
           if [ ! -f "$scenario_file" ]; then
             echo "::error::scenario file not found: $scenario_file"
             exit 1
@@ -147,7 +154,7 @@ jobs:
           mkdir -p /tmp/k6-out
           # tee to a file for the evidence post-processor; k6's own stdout is the
           # human log. The token is never printed by k6 or by us.
-          k6 run "tools/k6-proofs/scenarios/${SCENARIO}" 2>&1 | tee /tmp/k6-out/run.txt
+          k6 run "tools/k6-proofs/scenarios/${SCENARIO}.js" 2>&1 | tee /tmp/k6-out/run.txt
           echo "k6 run complete"
 
       - name: Write evidence artifacts

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -37,29 +37,43 @@ tools/k6-proofs/
 ### 1. Preflight check
 
 ```bash
-OPENCLAW_GATEWAY_TOKEN="***" k6 run tools/k6-proofs/scenarios/preflight.js
+OPENCLAW_GATEWAY_TOKEN="***" \
+OPENCLAW_ROW_MANIFEST="tools/k6-proofs/manifests/preflight.example.json" \
+  k6 run tools/k6-proofs/scenarios/preflight.js
 ```
 
-### 2. Run R-CD-1 (manifest-driven)
+### 2. Run an existing scenario (manifest-driven)
+
+Scenario names are **basenames without `.js`**, matching `run-proof.sh` and the
+GitHub Actions workflow choices. Current workflow-runnable basenames are:
+
+- `preflight`
+- `r-cd-2-silent-wake`
+- `r-cd-4-target-session-key`
+- `r-cd-chained-depth-2`
+- `r-cw-1`
+- `r-cw`
+
+Example:
 
 ```bash
 OPENCLAW_GATEWAY_TOKEN="***" \
 OPENCLAW_CANDIDATE_SHA="<40-char-sha>" \
-OPENCLAW_ROW_MANIFEST="tools/k6-proofs/manifests/r-cd-1.json" \
-  k6 run tools/k6-proofs/scenarios/r-cd-1-typed-delegate.js 2>&1 | tee /tmp/r-cd-1-output.txt
+OPENCLAW_ROW_MANIFEST="tools/k6-proofs/manifests/r-cd-2.json" \
+  ./tools/k6-proofs/run-proof.sh r-cd-2-silent-wake 2>&1 | tee /tmp/r-cd-2-output.txt
 ```
 
 ### 3. Post-process into proof artifacts
 
 ```bash
 node tools/k6-proofs/scripts/evidence-writer.mjs \
-  --input /tmp/r-cd-1-output.txt \
-  --row R-CD-1 \
+  --input /tmp/r-cd-2-output.txt \
+  --row R-CD-2 \
   --seat ronan-dgx \
   --sha <40-char-sha>
 ```
 
-Writes candidate evidence into `PROOFS/<SHA>/R-CD-1/ronan-dgx/k6-run-<timestamp>/`.
+Writes candidate evidence into `PROOFS/<SHA>/R-CD-2/ronan-dgx/k6-run-<timestamp>/`.
 
 ## Metrics and dashboard contract
 
@@ -124,11 +138,16 @@ This is **declared in the manifest before the run**, not a post-hoc excuse. The 
 
 | Row | Scenario | Surface | Expected outcome |
 |-----|----------|---------|-----------------|
-| R-CD-1 | Typed `continue_delegate()` | typed-tool | PASS-candidate |
-| R-CD-2 | `continue_delegate(mode="silent-wake")` | typed-tool | PASS-candidate when dispatch/session-events observed and no channel delivery appears |
-| R-CD-4 | `continue_delegate(targetSessionKey=...)` | typed-tool | Candidate; verify target-vs-parent session events, not `tasks.list` |
-| R-CD-CHAINED-DEPTH-2 | Depth-2 delegate chain | typed-tool | Candidate; verify nonce-correlated chain return on subscribed session stream |
-| R-CD-TOKEN | Bracket `[[CONTINUE_DELEGATE:...]]` | bracket-token | Seat-dependent (see manifest) |
+| Row | Scenario | Surface | Expected outcome |
+|-----|----------|---------|-----------------|
+| preflight | `preflight` | read-only | Candidate; gateway/session/tool inventory check |
+| R-CD-2 | `r-cd-2-silent-wake` | typed-tool | PASS-candidate when dispatch/session-events observed and no channel delivery appears |
+| R-CD-4 | `r-cd-4-target-session-key` | typed-tool | Candidate; verify target-vs-parent session events, not `tasks.list` |
+| R-CD-CHAINED-DEPTH-2 | `r-cd-chained-depth-2` | typed-tool | Candidate; verify nonce-correlated chain return on subscribed session stream |
+| R-CW-1 | `r-cw-1` | typed-tool | Candidate; continue_work schedule + wake |
+| R-CW overview | `r-cw` | read-only/infrastructure | Candidate; combined continue_work infrastructure check |
+
+Other manifests may be `scaffold-only`: they are tracked rows, but not workflow-runnable until a matching `tools/k6-proofs/scenarios/<name>.js` exists.
 
 ## Guardrails
 
@@ -161,6 +180,9 @@ node tools/k6-proofs/scripts/validate-corpus.mjs --index
 
 # Machine-readable
 node tools/k6-proofs/scripts/validate-corpus.mjs --index --json
+
+# Validate workflow scenario choices + manifest runnable/scaffold status
+node tools/k6-proofs/scripts/check-scenario-alignment.mjs
 ```
 
 Checks: JSON parse, schema sanity (`openclaw.proofs.index.v1` /

--- a/tools/k6-proofs/manifests/preflight.example.json
+++ b/tools/k6-proofs/manifests/preflight.example.json
@@ -14,9 +14,17 @@
     "tokenEnv": "OPENCLAW_GATEWAY_TOKEN"
   },
   "scenario": {
-    "name": "preflight inventory",
+    "name": "preflight-inventory",
     "description": "Authenticate/read-only gateway inventory: health/status, sessions.list, tools.effective. Offline mode validates manifest shape without gateway traffic.",
-    "methods": ["health", "status", "sessions.list", "tools.effective"]
+    "methods": [
+      "health",
+      "status",
+      "sessions.list",
+      "tools.effective"
+    ],
+    "runnable": false,
+    "implementationStatus": "scaffold-only",
+    "statusReason": "No matching tools/k6-proofs/scenarios/preflight-inventory.js file exists yet; manifest is tracked but not workflow-runnable."
   },
   "expectedReceipts": [
     {

--- a/tools/k6-proofs/manifests/r-cd-1.json
+++ b/tools/k6-proofs/manifests/r-cd-1.json
@@ -16,7 +16,14 @@
   "scenario": {
     "name": "r-cd-1-typed-delegate",
     "description": "Typed continue_delegate() schedule/spawn/return. Fires a delegate with a nonce-only child task, observes task ledger entry and parent return.",
-    "methods": ["tools.invoke", "tasks.list", "sessions.messages.subscribe"]
+    "methods": [
+      "tools.invoke",
+      "tasks.list",
+      "sessions.messages.subscribe"
+    ],
+    "runnable": false,
+    "implementationStatus": "scaffold-only",
+    "statusReason": "No matching tools/k6-proofs/scenarios/r-cd-1-typed-delegate.js file exists yet; manifest is tracked but not workflow-runnable."
   },
   "invocation": {
     "tool": "continue_delegate",
@@ -26,11 +33,32 @@
     "idempotencyKeyPrefix": "R-CD-1"
   },
   "expectedReceipts": [
-    { "name": "tool-invoke-accepted", "required": true, "description": "Gateway accepted the continue_delegate tool invocation" },
-    { "name": "task-ledger-entry", "required": true, "description": "Task created in ledger with nonce correlation" },
-    { "name": "child-session-key", "required": false, "description": "Child session key or run ID from task metadata" },
-    { "name": "parent-return-event", "required": false, "description": "Delegate completion/return event observed on parent session", "pathHint": "gateway-events.ndjson" },
-    { "name": "trace-id", "required": false, "description": "Trace ID from tool response or task metadata for Tempo fetch" }
+    {
+      "name": "tool-invoke-accepted",
+      "required": true,
+      "description": "Gateway accepted the continue_delegate tool invocation"
+    },
+    {
+      "name": "task-ledger-entry",
+      "required": true,
+      "description": "Task created in ledger with nonce correlation"
+    },
+    {
+      "name": "child-session-key",
+      "required": false,
+      "description": "Child session key or run ID from task metadata"
+    },
+    {
+      "name": "parent-return-event",
+      "required": false,
+      "description": "Delegate completion/return event observed on parent session",
+      "pathHint": "gateway-events.ndjson"
+    },
+    {
+      "name": "trace-id",
+      "required": false,
+      "description": "Trace ID from tool response or task metadata for Tempo fetch"
+    }
   ],
   "artifactDestination": {
     "root": "PROOFS",

--- a/tools/k6-proofs/manifests/r-cd-2.json
+++ b/tools/k6-proofs/manifests/r-cd-2.json
@@ -20,7 +20,8 @@
       "sessions.send",
       "sessions.messages.subscribe",
       "tasks.list"
-    ]
+    ],
+    "runnable": true
   },
   "invocation": {
     "tool": "continue_delegate",

--- a/tools/k6-proofs/manifests/r-cd-3.json
+++ b/tools/k6-proofs/manifests/r-cd-3.json
@@ -16,8 +16,15 @@
   "scenario": {
     "name": "r-cd-3-post-compaction",
     "description": "continue_delegate(mode='post-compaction') event-triggered lifeboat. Fires a post-compaction delegate, triggers compaction, and verifies the delegate fires post-compaction and returns to the rehydrated session.",
-    "methods": ["tools.invoke", "tasks.list", "sessions.messages.subscribe"],
-    "notes": "Requires context >70% to trigger compaction, OR the test must use a low compaction threshold configuration."
+    "methods": [
+      "tools.invoke",
+      "tasks.list",
+      "sessions.messages.subscribe"
+    ],
+    "notes": "Requires context >70% to trigger compaction, OR the test must use a low compaction threshold configuration.",
+    "runnable": false,
+    "implementationStatus": "scaffold-only",
+    "statusReason": "No matching tools/k6-proofs/scenarios/r-cd-3-post-compaction.js file exists yet; manifest is tracked but not workflow-runnable."
   },
   "invocation": {
     "tool": "continue_delegate",
@@ -31,12 +38,36 @@
     "notes": "post-compaction delegates only fire on a compaction event. The scenario either needs a session near compaction threshold, or must lower the threshold for testing purposes."
   },
   "expectedReceipts": [
-    { "name": "tool-invoke-accepted", "required": true, "description": "Gateway accepted the continue_delegate(mode=post-compaction) tool invocation" },
-    { "name": "delegate-staged", "required": true, "description": "Delegate registered as post-compaction hook (not immediately spawned)" },
-    { "name": "compaction-triggered", "required": true, "description": "Compaction event fired (via request_compaction or natural pressure)" },
-    { "name": "delegate-fires-post-compaction", "required": true, "description": "Delegate spawns AFTER compaction completes (not before)" },
-    { "name": "return-reaches-post-compaction-session", "required": true, "description": "Delegate return lands in the post-compaction session with rehydrated context" },
-    { "name": "trace-id", "required": false, "description": "Trace ID for Tempo correlation" }
+    {
+      "name": "tool-invoke-accepted",
+      "required": true,
+      "description": "Gateway accepted the continue_delegate(mode=post-compaction) tool invocation"
+    },
+    {
+      "name": "delegate-staged",
+      "required": true,
+      "description": "Delegate registered as post-compaction hook (not immediately spawned)"
+    },
+    {
+      "name": "compaction-triggered",
+      "required": true,
+      "description": "Compaction event fired (via request_compaction or natural pressure)"
+    },
+    {
+      "name": "delegate-fires-post-compaction",
+      "required": true,
+      "description": "Delegate spawns AFTER compaction completes (not before)"
+    },
+    {
+      "name": "return-reaches-post-compaction-session",
+      "required": true,
+      "description": "Delegate return lands in the post-compaction session with rehydrated context"
+    },
+    {
+      "name": "trace-id",
+      "required": false,
+      "description": "Trace ID for Tempo correlation"
+    }
   ],
   "artifactDestination": {
     "root": "PROOFS",
@@ -48,6 +79,6 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Post-compaction lifeboat path. PASS-candidate when: (1) delegate staged, (2) compaction triggers, (3) delegate fires AFTER compaction, (4) return lands in post-compaction session. Timing order is critical: staged → compaction → fires → returns. Out-of-order = FAIL."
+    "notes": "Post-compaction lifeboat path. PASS-candidate when: (1) delegate staged, (2) compaction triggers, (3) delegate fires AFTER compaction, (4) return lands in post-compaction session. Timing order is critical: staged \u2192 compaction \u2192 fires \u2192 returns. Out-of-order = FAIL."
   }
 }

--- a/tools/k6-proofs/manifests/r-cd-4.json
+++ b/tools/k6-proofs/manifests/r-cd-4.json
@@ -20,7 +20,8 @@
       "tools.invoke",
       "sessions.messages.subscribe",
       "tasks.list"
-    ]
+    ],
+    "runnable": true
   },
   "invocation": {
     "tool": "continue_delegate",

--- a/tools/k6-proofs/manifests/r-cd-chained-depth-2.json
+++ b/tools/k6-proofs/manifests/r-cd-chained-depth-2.json
@@ -15,7 +15,7 @@
   },
   "scenario": {
     "name": "r-cd-chained-depth-2",
-    "description": "Depth-2 delegate chain: parent→child→grandchild→return path. Three sub-tests: (1) up-tree silent-wake, (2) inter-session return, (3) echo+broadcast via fanoutMode.",
+    "description": "Depth-2 delegate chain: parent\u2192child\u2192grandchild\u2192return path. Three sub-tests: (1) up-tree silent-wake, (2) inter-session return, (3) echo+broadcast via fanoutMode.",
     "methods": [
       "tools.invoke",
       "sessions.messages.subscribe",
@@ -25,7 +25,8 @@
       "chain-1-uptree-silent-wake",
       "chain-2-inter-session-return",
       "chain-3-echo-broadcast"
-    ]
+    ],
+    "runnable": true
   },
   "invocation": {
     "tool": "continue_delegate",
@@ -38,7 +39,7 @@
     {
       "name": "parent-dispatch-accepted",
       "required": true,
-      "description": "Parent fires continue_delegate → accepted"
+      "description": "Parent fires continue_delegate \u2192 accepted"
     },
     {
       "name": "child-spawns",
@@ -81,6 +82,6 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Depth-2 chain proof. PASS-candidate when parent→child→grandchild→return completes with nonce correlation at each hop. Chain depth limit enforcement tested implicitly (depth-2 should succeed; gateway caps apply). Do not require tasks.list for child/grandchild spawn receipts; continue_delegate uses pending-delegate/subagent surfaces, not the generic task registry."
+    "notes": "Depth-2 chain proof. PASS-candidate when parent\u2192child\u2192grandchild\u2192return completes with nonce correlation at each hop. Chain depth limit enforcement tested implicitly (depth-2 should succeed; gateway caps apply). Do not require tasks.list for child/grandchild spawn receipts; continue_delegate uses pending-delegate/subagent surfaces, not the generic task registry."
   }
 }

--- a/tools/k6-proofs/manifests/r-cd-token.json
+++ b/tools/k6-proofs/manifests/r-cd-token.json
@@ -16,18 +16,41 @@
   "scenario": {
     "name": "r-cd-token-bracket-delegate",
     "description": "Bracket [[CONTINUE_DELEGATE:...]] path. Injects prompt requiring terminal bracket token, observes child spawn and return.",
-    "methods": ["sessions.send", "tasks.list", "sessions.messages.subscribe"]
+    "methods": [
+      "sessions.send",
+      "tasks.list",
+      "sessions.messages.subscribe"
+    ],
+    "runnable": false,
+    "implementationStatus": "scaffold-only",
+    "statusReason": "No matching tools/k6-proofs/scenarios/r-cd-token-bracket-delegate.js file exists yet; manifest is tracked but not workflow-runnable."
   },
   "seatClassExpectation": {
     "raw-final-text-seat": "PASS-candidate",
     "message-body-seat": "HONEST-LIMIT-candidate",
-    "reason": "Bracket scanner fires only on scanned-final-text. Seats that route final-text through message(send) body kill the scanner (bracketIdx=-1). ronan-dgx IS a message-body seat in its default Discord delivery — expected HONEST-LIMIT unless raw-final-text mode is forced (no message-tool call that turn). See TOOLS.md bracket-position-sensitive notes."
+    "reason": "Bracket scanner fires only on scanned-final-text. Seats that route final-text through message(send) body kill the scanner (bracketIdx=-1). ronan-dgx IS a message-body seat in its default Discord delivery \u2014 expected HONEST-LIMIT unless raw-final-text mode is forced (no message-tool call that turn). See TOOLS.md bracket-position-sensitive notes."
   },
   "expectedReceipts": [
-    { "name": "prompt-injected", "required": true, "description": "sessions.send accepted the bracket-instructing prompt" },
-    { "name": "bracket-token-observed", "required": false, "description": "Bracket delegate token observed in session event stream (may be absent on message-body seats)" },
-    { "name": "child-spawned", "required": false, "description": "Child task/session created with nonce correlation" },
-    { "name": "parent-return-event", "required": false, "description": "Delegate return/silent-wake observed on parent session" }
+    {
+      "name": "prompt-injected",
+      "required": true,
+      "description": "sessions.send accepted the bracket-instructing prompt"
+    },
+    {
+      "name": "bracket-token-observed",
+      "required": false,
+      "description": "Bracket delegate token observed in session event stream (may be absent on message-body seats)"
+    },
+    {
+      "name": "child-spawned",
+      "required": false,
+      "description": "Child task/session created with nonce correlation"
+    },
+    {
+      "name": "parent-return-event",
+      "required": false,
+      "description": "Delegate return/silent-wake observed on parent session"
+    }
   ],
   "artifactDestination": {
     "root": "PROOFS",

--- a/tools/k6-proofs/manifests/r-cw-1.json
+++ b/tools/k6-proofs/manifests/r-cw-1.json
@@ -16,7 +16,13 @@
   "scenario": {
     "name": "r-cw-1-tool-schedule-wake",
     "description": "Typed continue_work() tool-form schedule + wake. Fires continue_work with a reason, observes the scheduled work entry and wake event on the session.",
-    "methods": ["tools.invoke", "sessions.messages.subscribe"]
+    "methods": [
+      "tools.invoke",
+      "sessions.messages.subscribe"
+    ],
+    "runnable": false,
+    "implementationStatus": "scaffold-only",
+    "statusReason": "No matching tools/k6-proofs/scenarios/r-cw-1-tool-schedule-wake.js file exists yet; manifest is tracked but not workflow-runnable."
   },
   "invocation": {
     "tool": "continue_work",
@@ -25,10 +31,26 @@
     "idempotencyKeyPrefix": "R-CW-1"
   },
   "expectedReceipts": [
-    { "name": "tool-invoke-accepted", "required": true, "description": "Gateway accepted the continue_work tool invocation" },
-    { "name": "work-scheduled-event", "required": true, "description": "continuation.work.scheduled event with reason field" },
-    { "name": "work-woke-event", "required": true, "description": "Session wake event delivered after delaySeconds" },
-    { "name": "trace-id", "required": false, "description": "Trace ID from tool response for Tempo fetch" }
+    {
+      "name": "tool-invoke-accepted",
+      "required": true,
+      "description": "Gateway accepted the continue_work tool invocation"
+    },
+    {
+      "name": "work-scheduled-event",
+      "required": true,
+      "description": "continuation.work.scheduled event with reason field"
+    },
+    {
+      "name": "work-woke-event",
+      "required": true,
+      "description": "Session wake event delivered after delaySeconds"
+    },
+    {
+      "name": "trace-id",
+      "required": false,
+      "description": "Trace ID from tool response for Tempo fetch"
+    }
   ],
   "artifactDestination": {
     "root": "PROOFS",

--- a/tools/k6-proofs/manifests/r-cw-4.json
+++ b/tools/k6-proofs/manifests/r-cw-4.json
@@ -15,8 +15,14 @@
   },
   "scenario": {
     "name": "r-cw-4-chain-depth",
-    "description": "Chain depth hop counter: fires continue_work 3× in sequence, verifies hop increments from 1/200 → 3/200 in traced responses.",
-    "methods": ["tools.invoke", "sessions.messages.subscribe"]
+    "description": "Chain depth hop counter: fires continue_work 3\u00d7 in sequence, verifies hop increments from 1/200 \u2192 3/200 in traced responses.",
+    "methods": [
+      "tools.invoke",
+      "sessions.messages.subscribe"
+    ],
+    "runnable": false,
+    "implementationStatus": "scaffold-only",
+    "statusReason": "No matching tools/k6-proofs/scenarios/r-cw-4-chain-depth.js file exists yet; manifest is tracked but not workflow-runnable."
   },
   "invocation": {
     "tool": "continue_work",
@@ -26,10 +32,26 @@
     "idempotencyKeyPrefix": "R-CW-4"
   },
   "expectedReceipts": [
-    { "name": "hop-1-accepted", "required": true, "description": "First continue_work accepted, chain.step shows 1/N" },
-    { "name": "hop-2-accepted", "required": true, "description": "Second continue_work accepted after wake, chain.step shows 2/N" },
-    { "name": "hop-3-accepted", "required": true, "description": "Third continue_work accepted after wake, chain.step shows 3/N" },
-    { "name": "trace-ids", "required": false, "description": "Trace IDs from each hop for Tempo chain verification" }
+    {
+      "name": "hop-1-accepted",
+      "required": true,
+      "description": "First continue_work accepted, chain.step shows 1/N"
+    },
+    {
+      "name": "hop-2-accepted",
+      "required": true,
+      "description": "Second continue_work accepted after wake, chain.step shows 2/N"
+    },
+    {
+      "name": "hop-3-accepted",
+      "required": true,
+      "description": "Third continue_work accepted after wake, chain.step shows 3/N"
+    },
+    {
+      "name": "trace-ids",
+      "required": false,
+      "description": "Trace IDs from each hop for Tempo chain verification"
+    }
   ],
   "artifactDestination": {
     "root": "PROOFS",

--- a/tools/k6-proofs/manifests/r-cw-5.json
+++ b/tools/k6-proofs/manifests/r-cw-5.json
@@ -16,7 +16,14 @@
   "scenario": {
     "name": "r-cw-5-cost-cap-reject",
     "description": "Cost-cap exhaustion: fires continue_work after artificially exhausting costCapTokens budget, verifies dispatch-time rejection with appropriate error.",
-    "methods": ["tools.invoke", "config.patch", "config.restore"]
+    "methods": [
+      "tools.invoke",
+      "config.patch",
+      "config.restore"
+    ],
+    "runnable": false,
+    "implementationStatus": "scaffold-only",
+    "statusReason": "No matching tools/k6-proofs/scenarios/r-cw-5-cost-cap-reject.js file exists yet; manifest is tracked but not workflow-runnable."
   },
   "invocation": {
     "tool": "continue_work",
@@ -30,9 +37,21 @@
     }
   },
   "expectedReceipts": [
-    { "name": "config-lowered", "required": true, "description": "costCapTokens set to 1 (exhausted boundary)" },
-    { "name": "tool-invoke-rejected", "required": true, "description": "continue_work rejected at dispatch with cost-cap exceeded error" },
-    { "name": "config-restored", "required": true, "description": "Original costCapTokens restored after proof" }
+    {
+      "name": "config-lowered",
+      "required": true,
+      "description": "costCapTokens set to 1 (exhausted boundary)"
+    },
+    {
+      "name": "tool-invoke-rejected",
+      "required": true,
+      "description": "continue_work rejected at dispatch with cost-cap exceeded error"
+    },
+    {
+      "name": "config-restored",
+      "required": true,
+      "description": "Original costCapTokens restored after proof"
+    }
   ],
   "artifactDestination": {
     "root": "PROOFS",
@@ -44,6 +63,6 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Cost-cap boundary. PASS when rejection is delivered at the cap boundary. MUTATES config temporarily (costCapTokens→1 then restore). The reject IS the proof."
+    "notes": "Cost-cap boundary. PASS when rejection is delivered at the cap boundary. MUTATES config temporarily (costCapTokens\u21921 then restore). The reject IS the proof."
   }
 }

--- a/tools/k6-proofs/manifests/r-cw-6.json
+++ b/tools/k6-proofs/manifests/r-cw-6.json
@@ -16,7 +16,15 @@
   "scenario": {
     "name": "r-cw-6-max-chain-length",
     "description": "maxChainLength boundary: sets maxChainLength=1 via config, fires continue_work twice, verifies second hop is rejected at chain depth 2>1. Restores originals after.",
-    "methods": ["tools.invoke", "config.patch", "config.restore", "gateway.restart"]
+    "methods": [
+      "tools.invoke",
+      "config.patch",
+      "config.restore",
+      "gateway.restart"
+    ],
+    "runnable": false,
+    "implementationStatus": "scaffold-only",
+    "statusReason": "No matching tools/k6-proofs/scenarios/r-cw-6-max-chain-length.js file exists yet; manifest is tracked but not workflow-runnable."
   },
   "invocation": {
     "tool": "continue_work",
@@ -31,10 +39,26 @@
     }
   },
   "expectedReceipts": [
-    { "name": "config-set-to-1", "required": true, "description": "maxChainLength set to 1 + gateway restart" },
-    { "name": "hop-1-accepted", "required": true, "description": "First continue_work accepted (chain 1/1)" },
-    { "name": "hop-2-rejected", "required": true, "description": "Second continue_work rejected (chain length 2>1)" },
-    { "name": "config-restored", "required": true, "description": "Original maxChainLength restored + restart" }
+    {
+      "name": "config-set-to-1",
+      "required": true,
+      "description": "maxChainLength set to 1 + gateway restart"
+    },
+    {
+      "name": "hop-1-accepted",
+      "required": true,
+      "description": "First continue_work accepted (chain 1/1)"
+    },
+    {
+      "name": "hop-2-rejected",
+      "required": true,
+      "description": "Second continue_work rejected (chain length 2>1)"
+    },
+    {
+      "name": "config-restored",
+      "required": true,
+      "description": "Original maxChainLength restored + restart"
+    }
   ],
   "artifactDestination": {
     "root": "PROOFS",
@@ -46,6 +70,6 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "maxChainLength boundary proof. MUTATES config (maxChainLength→1) + requires restart. PASS when boundary enforced at hop-2. Originals MUST be restored (includes restart)."
+    "notes": "maxChainLength boundary proof. MUTATES config (maxChainLength\u21921) + requires restart. PASS when boundary enforced at hop-2. Originals MUST be restored (includes restart)."
   }
 }

--- a/tools/k6-proofs/manifests/r-cw-delegate-self.json
+++ b/tools/k6-proofs/manifests/r-cw-delegate-self.json
@@ -15,8 +15,15 @@
   },
   "scenario": {
     "name": "r-cw-delegate-self-continuation",
-    "description": "Fires continue_delegate that internally calls continue_work — proves hop-2 woke inside a delegate child session. The delegate dispatches, the child fires its own continue_work, and the hop-2 turn executes.",
-    "methods": ["tools.invoke", "sessions.messages.subscribe", "tasks.list"]
+    "description": "Fires continue_delegate that internally calls continue_work \u2014 proves hop-2 woke inside a delegate child session. The delegate dispatches, the child fires its own continue_work, and the hop-2 turn executes.",
+    "methods": [
+      "tools.invoke",
+      "sessions.messages.subscribe",
+      "tasks.list"
+    ],
+    "runnable": false,
+    "implementationStatus": "scaffold-only",
+    "statusReason": "No matching tools/k6-proofs/scenarios/r-cw-delegate-self-continuation.js file exists yet; manifest is tracked but not workflow-runnable."
   },
   "invocation": {
     "tool": "continue_delegate",
@@ -26,11 +33,31 @@
     "idempotencyKeyPrefix": "R-CW-DELEGATE-SELF"
   },
   "expectedReceipts": [
-    { "name": "delegate-accepted", "required": true, "description": "continue_delegate accepted by gateway" },
-    { "name": "child-spawned", "required": true, "description": "Child session spawned for the delegate" },
-    { "name": "child-continue-work-accepted", "required": true, "description": "Child's own continue_work was accepted" },
-    { "name": "child-hop-2-woke", "required": false, "description": "Child's hop-2 turn executed (DONE + nonce in return)" },
-    { "name": "parent-return", "required": false, "description": "Delegate return event on parent session" }
+    {
+      "name": "delegate-accepted",
+      "required": true,
+      "description": "continue_delegate accepted by gateway"
+    },
+    {
+      "name": "child-spawned",
+      "required": true,
+      "description": "Child session spawned for the delegate"
+    },
+    {
+      "name": "child-continue-work-accepted",
+      "required": true,
+      "description": "Child's own continue_work was accepted"
+    },
+    {
+      "name": "child-hop-2-woke",
+      "required": false,
+      "description": "Child's hop-2 turn executed (DONE + nonce in return)"
+    },
+    {
+      "name": "parent-return",
+      "required": false,
+      "description": "Delegate return event on parent session"
+    }
   ],
   "artifactDestination": {
     "root": "PROOFS",

--- a/tools/k6-proofs/manifests/r-cw-token.json
+++ b/tools/k6-proofs/manifests/r-cw-token.json
@@ -16,18 +16,41 @@
   "scenario": {
     "name": "r-cw-token-bracket",
     "description": "Bracket/token CONTINUE_WORK path: lightContext subagent emits bare CONTINUE_WORK token at end-of-turn, hop-2 drives. Proves the token-form continuation works for subagents (the #952 row lineage).",
-    "methods": ["sessions.send", "sessions.messages.subscribe", "subagents.spawn"]
+    "methods": [
+      "sessions.send",
+      "sessions.messages.subscribe",
+      "subagents.spawn"
+    ],
+    "runnable": false,
+    "implementationStatus": "scaffold-only",
+    "statusReason": "No matching tools/k6-proofs/scenarios/r-cw-token-bracket.js file exists yet; manifest is tracked but not workflow-runnable."
   },
   "seatClassExpectation": {
     "lightContext-subagent": "PASS-candidate",
     "message-body-main-session": "HONEST-LIMIT-candidate",
-    "reason": "CONTINUE_WORK bare token only fires from auto-delivered final-text (subagent-announce path). On main-session message-body delivery seats, the token scanner doesn't walk the payload. lightContext subagents auto-deliver → scanner fires → hop-2 drives."
+    "reason": "CONTINUE_WORK bare token only fires from auto-delivered final-text (subagent-announce path). On main-session message-body delivery seats, the token scanner doesn't walk the payload. lightContext subagents auto-deliver \u2192 scanner fires \u2192 hop-2 drives."
   },
   "expectedReceipts": [
-    { "name": "subagent-spawned", "required": true, "description": "lightContext subagent spawned with continuation-instructing prompt" },
-    { "name": "token-emitted", "required": false, "description": "CONTINUE_WORK token observed in subagent final-text (may not surface in events)" },
-    { "name": "hop-2-executed", "required": true, "description": "Subagent's hop-2 turn fired (the continuation drove)" },
-    { "name": "parent-return", "required": false, "description": "Subagent result returned to parent" }
+    {
+      "name": "subagent-spawned",
+      "required": true,
+      "description": "lightContext subagent spawned with continuation-instructing prompt"
+    },
+    {
+      "name": "token-emitted",
+      "required": false,
+      "description": "CONTINUE_WORK token observed in subagent final-text (may not surface in events)"
+    },
+    {
+      "name": "hop-2-executed",
+      "required": true,
+      "description": "Subagent's hop-2 turn fired (the continuation drove)"
+    },
+    {
+      "name": "parent-return",
+      "required": false,
+      "description": "Subagent result returned to parent"
+    }
   ],
   "artifactDestination": {
     "root": "PROOFS",
@@ -39,6 +62,6 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Token/bracket CONTINUE_WORK path. PASS when hop-2 drives on the subagent. This is the #952 lineage proof — the lightContext bracket path that was broken pre-fix."
+    "notes": "Token/bracket CONTINUE_WORK path. PASS when hop-2 drives on the subagent. This is the #952 lineage proof \u2014 the lightContext bracket path that was broken pre-fix."
   }
 }

--- a/tools/k6-proofs/run-proof.sh
+++ b/tools/k6-proofs/run-proof.sh
@@ -26,9 +26,10 @@ if [[ ! -f "$SCENARIO_FILE" ]]; then
   exit 1
 fi
 
-# Auto-detect seat and SHA
-SEAT="${PROOF_SEAT:-$(hostname)}"
-SHA="${PROOF_SHA:-$(openclaw --version 2>/dev/null | awk '{print $3}' | tr -d '()' || echo 'unknown')}"
+# Auto-detect seat and SHA. Prefer OPENCLAW_* names used by manifests/workflow,
+# but keep legacy PROOF_* as compatibility aliases.
+SEAT="${OPENCLAW_SEAT_NAME:-${PROOF_SEAT:-$(hostname)}}"
+SHA="${OPENCLAW_CANDIDATE_SHA:-${PROOF_SHA:-$(openclaw --version 2>/dev/null | awk '{print $3}' | tr -d '()' || echo 'unknown')}}"
 
 # Prometheus Remote Write target
 PROM_URL="${K6_PROMETHEUS_RW_SERVER_URL:-http://prometheus.dandelion.cult/api/v1/write}"
@@ -43,5 +44,7 @@ exec k6 run "${SCENARIO_FILE}" \
   --out "experimental-prometheus-rw" \
   --env "PROOF_SHA=${SHA}" \
   --env "PROOF_SEAT=${SEAT}" \
+  --env "OPENCLAW_CANDIDATE_SHA=${SHA}" \
+  --env "OPENCLAW_SEAT_NAME=${SEAT}" \
   --env "K6_PROMETHEUS_RW_SERVER_URL=${PROM_URL}" \
   "$@"

--- a/tools/k6-proofs/scenarios/preflight.js
+++ b/tools/k6-proofs/scenarios/preflight.js
@@ -1,0 +1,150 @@
+/**
+ * Scenario: preflight — read-only gateway/session/tool inventory.
+ *
+ * Verifies the proof harness can authenticate to the target gateway and collect
+ * the basic session/tool inventory needed before firing live proof rows. This
+ * scenario is intentionally non-mutating and safe for workflow dry-runs.
+ *
+ * Manifest-driven: reads row config from OPENCLAW_ROW_MANIFEST env var when set.
+ * References:
+ *   - Issue: karmaterminal/karmaterminal-openclaw-docs#101
+ *   - Manifest: tools/k6-proofs/manifests/preflight.example.json
+ */
+import ws from 'k6/ws';
+import { check } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+import { connectFrame, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
+import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+
+export const options = {
+  scenarios: {
+    preflight_inventory: {
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 1,
+      maxDuration: '45s',
+    },
+  },
+  thresholds: {
+    proof_failures: ['count==0'],
+    preflight_duration: ['p(95)<30000'],
+  },
+};
+
+const failures = new Counter('proof_failures');
+const duration = new Trend('preflight_duration');
+
+const manifest = loadManifestFromEnv();
+const DEFAULTS = {
+  sessionKey: 'main',
+  seat: 'ci-runner',
+};
+
+export default function () {
+  const url = __ENV.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
+  const token = __ENV.OPENCLAW_GATEWAY_TOKEN;
+  const sessionKey = manifest?.sessionKey || __ENV.OPENCLAW_SESSION_KEY || DEFAULTS.sessionKey;
+  const seat = manifest?.seat || __ENV.OPENCLAW_SEAT_NAME || DEFAULTS.seat;
+
+  if (!token) {
+    console.error('OPENCLAW_GATEWAY_TOKEN is required');
+    failures.add(1);
+    return;
+  }
+
+  if (manifest) {
+    const errors = validateManifest(manifest);
+    if (errors.length > 0) {
+      console.warn(`Manifest validation warnings: ${errors.join('; ')}`);
+    }
+  }
+
+  const evidence = {
+    row: 'preflight',
+    manifest_loaded: !!manifest,
+    seat,
+    sessionKey,
+    candidateSha: manifest?.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
+    started: new Date().toISOString(),
+    connected: false,
+    sessions_list_ok: false,
+    tools_effective_ok: false,
+    tool_inventory_count: 0,
+    redacted_events: [],
+  };
+
+  const started = Date.now();
+
+  const res = ws.connect(url, {}, (socket) => {
+    const tracker = new RequestTracker();
+
+    socket.on('open', () => {
+      evidence.connected = true;
+      socket.send(connectFrame(token));
+
+      socket.setTimeout(() => tracker.send(socket, 'sessions.list', { limit: 10 }), 500);
+      socket.setTimeout(() => tracker.send(socket, 'tools.effective', { sessionKey }), 1000);
+      socket.setTimeout(() => socket.close(), 12000);
+    });
+
+    socket.on('message', (raw) => {
+      try {
+        const msg = JSON.parse(raw);
+        const classified = tracker.classify(msg);
+        evidence.redacted_events.push({
+          ts: Date.now(),
+          kind: classified.kind,
+          method: classified.method || null,
+          event: classified.event || null,
+          ok: classified.ok !== undefined ? classified.ok : null,
+          data: classified.payload ? redactEvent(classified.payload) : null,
+        });
+
+        if (classified.kind === 'response' && classified.method === 'sessions.list') {
+          evidence.sessions_list_ok = classified.ok;
+          if (!classified.ok) {
+            console.error(`sessions.list failed: ${JSON.stringify(classified.error)}`);
+            failures.add(1);
+          }
+        }
+
+        if (classified.kind === 'response' && classified.method === 'tools.effective') {
+          evidence.tools_effective_ok = classified.ok;
+          const tools = classified.payload?.tools || classified.payload?.items || [];
+          evidence.tool_inventory_count = Array.isArray(tools) ? tools.length : 0;
+          if (!classified.ok) {
+            console.error(`tools.effective failed: ${JSON.stringify(classified.error)}`);
+            failures.add(1);
+          }
+        }
+
+        if (evidence.sessions_list_ok && evidence.tools_effective_ok) {
+          socket.close();
+        }
+      } catch (e) {
+        console.warn(`parse error: ${e}`);
+      }
+    });
+
+    socket.on('error', (e) => {
+      console.error(`ws error: ${e && e.error ? e.error() : e}`);
+      failures.add(1);
+    });
+  });
+
+  evidence.ended = new Date().toISOString();
+  evidence.duration_ms = Date.now() - started;
+  duration.add(evidence.duration_ms);
+
+  check(res, { 'websocket connected': (r) => r && r.status === 101 });
+  check(null, {
+    'sessions.list accepted': () => evidence.sessions_list_ok,
+    'tools.effective accepted': () => evidence.tools_effective_ok,
+  });
+
+  if (!evidence.sessions_list_ok || !evidence.tools_effective_ok) {
+    failures.add(1);
+  }
+
+  console.log(`PREFLIGHT_EVIDENCE ${JSON.stringify(evidence)}`);
+}

--- a/tools/k6-proofs/scripts/check-scenario-alignment.mjs
+++ b/tools/k6-proofs/scripts/check-scenario-alignment.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Check Project-81 k6 scenario alignment.
+ *
+ * Invariants:
+ * - workflow_dispatch scenario choices are basenames (no path, no .js suffix)
+ * - every workflow choice has tools/k6-proofs/scenarios/<choice>.js
+ * - every manifest with scenario.name either points at an existing scenario and
+ *   marks scenario.runnable=true, or explicitly marks itself scaffold-only with
+ *   scenario.runnable=false + implementationStatus.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const SCENARIO_DIR = path.join(ROOT, 'tools/k6-proofs/scenarios');
+const MANIFEST_DIR = path.join(ROOT, 'tools/k6-proofs/manifests');
+const WORKFLOW_PATH = path.join(ROOT, '.github/workflows/k6-proof.yml');
+
+function readWorkflowScenarioChoices(workflowText) {
+  const lines = workflowText.split('\n');
+  const choices = [];
+  let inScenarioInput = false;
+  let inOptions = false;
+  let scenarioIndent = 0;
+
+  for (const line of lines) {
+    const scenarioMatch = line.match(/^(\s*)scenario:\s*$/);
+    if (scenarioMatch && !inScenarioInput) {
+      inScenarioInput = true;
+      scenarioIndent = scenarioMatch[1].length;
+      continue;
+    }
+
+    if (inScenarioInput) {
+      const topLevelInput = line.match(/^(\s*)[a-zA-Z_][a-zA-Z0-9_]*:\s*$/);
+      if (topLevelInput && topLevelInput[1].length === scenarioIndent && !line.includes('scenario:')) {
+        break;
+      }
+      if (line.match(/^\s*options:\s*$/)) {
+        inOptions = true;
+        continue;
+      }
+      if (inOptions) {
+        const item = line.match(/^\s*-\s+([^\s#]+)/);
+        if (item) choices.push(item[1]);
+        else if (line.trim() && !line.match(/^\s*#/)) inOptions = false;
+      }
+    }
+  }
+
+  return choices;
+}
+
+function main() {
+  const scenarios = new Set(
+    fs.readdirSync(SCENARIO_DIR)
+      .filter((file) => file.endsWith('.js'))
+      .map((file) => path.basename(file, '.js')),
+  );
+
+  const choices = readWorkflowScenarioChoices(fs.readFileSync(WORKFLOW_PATH, 'utf8'));
+  const errors = [];
+
+  if (choices.length === 0) {
+    errors.push('workflow scenario input has no choices');
+  }
+
+  for (const choice of choices) {
+    if (choice.includes('/') || choice.endsWith('.js')) {
+      errors.push(`workflow choice must be a scenario basename without path/.js: ${choice}`);
+    }
+    if (!scenarios.has(choice)) {
+      errors.push(`workflow choice has no scenario file: tools/k6-proofs/scenarios/${choice}.js`);
+    }
+  }
+
+  for (const file of fs.readdirSync(MANIFEST_DIR).filter((entry) => entry.endsWith('.json')).sort()) {
+    const manifestPath = path.join(MANIFEST_DIR, file);
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    const scenario = manifest.scenario || {};
+    const name = scenario.name;
+    if (!name) continue;
+
+    if (name.includes('/') || name.endsWith('.js')) {
+      errors.push(`${file}: scenario.name must be a basename without path/.js: ${name}`);
+    }
+
+    const exists = scenarios.has(name);
+    if (exists && scenario.runnable !== true) {
+      errors.push(`${file}: scenario ${name}.js exists but scenario.runnable is not true`);
+    }
+    if (!exists) {
+      if (scenario.runnable !== false) {
+        errors.push(`${file}: scenario ${name}.js is missing but scenario.runnable is not false`);
+      }
+      if (!scenario.implementationStatus) {
+        errors.push(`${file}: scenario ${name}.js is missing but implementationStatus is absent`);
+      }
+      if (!scenario.statusReason) {
+        errors.push(`${file}: scenario ${name}.js is missing but statusReason is absent`);
+      }
+    }
+  }
+
+  const result = {
+    workflowChoices: choices,
+    scenarioFiles: [...scenarios].sort(),
+    ok: errors.length === 0,
+    errors,
+  };
+  console.log(JSON.stringify(result, null, 2));
+  if (errors.length > 0) process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary
- align the Project 81 k6 workflow scenario choices with scenarios that actually exist
- switch workflow input semantics to scenario basenames, matching `run-proof.sh`
- add a real read-only `preflight` scenario for safe dry-run dispatch
- mark manifests as runnable vs scaffold-only so registry drift is explicit
- add `check-scenario-alignment.mjs` to guard workflow choices and manifest scenario status

Closes #141.

## Verification
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs`
- `python3 - <<'PY' ... yaml.safe_load('.github/workflows/k6-proof.yml') ... PY`
- `for f in tools/k6-proofs/manifests/*.json; do jq empty "$f"; done`
- `k6 run tools/k6-proofs/scenarios/preflight.js` without token: expected auth failure after successful script/import load
- `git diff --check`

## Notes
This does not implement every scaffold-only row. It makes the workflow dispatch surface honest and gives manifests an explicit scaffold-only status until matching scenarios exist.
