### PR TITLE
k6-proofs: mark manifest scenario status

### DIFF
--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -161,6 +161,9 @@ node tools/k6-proofs/scripts/validate-corpus.mjs --index
 
 # Machine-readable
 node tools/k6-proofs/scripts/validate-corpus.mjs --index --json
+
+# Validate row-manifest scenario registry status vs runnable scenario files
+node tools/k6-proofs/scripts/check-manifest-scenarios.mjs
 ```
 
 Checks: JSON parse, schema sanity (`openclaw.proofs.index.v1` /
@@ -169,6 +172,10 @@ exists, no orphan row dirs, INDEX `rollup` tallies match the manifest `rows[].st
 counts, manifest `capture_sha` matches its directory name, and no stale
 `pending_push` / `upload-blame` / `TODO-UPLOAD` wording. Exit code is non-zero
 on any failure; the script never mutates corpus data.
+
+`check-manifest-scenarios.mjs` is the row-harness registry check: runnable
+manifests must point at an existing `tools/k6-proofs/scenarios/*.js`; rows with
+no runnable file must say `scenario.status` is `scaffold` or `construct-only`.
 
 ## Coordination
 

--- a/tools/k6-proofs/manifests/preflight.example.json
+++ b/tools/k6-proofs/manifests/preflight.example.json
@@ -16,7 +16,10 @@
   "scenario": {
     "name": "preflight inventory",
     "description": "Authenticate/read-only gateway inventory: health/status, sessions.list, tools.effective. Offline mode validates manifest shape without gateway traffic.",
-    "methods": ["health", "status", "sessions.list", "tools.effective"]
+    "methods": ["health", "status", "sessions.list", "tools.effective"],
+    "status": "scaffold",
+    "expectedFile": "preflight.js",
+    "registryNotes": "No runnable preflight.js exists yet; this manifest remains a preflight scaffold/example until that file lands."
   },
   "expectedReceipts": [
     {

--- a/tools/k6-proofs/manifests/r-cd-1.json
+++ b/tools/k6-proofs/manifests/r-cd-1.json
@@ -16,7 +16,10 @@
   "scenario": {
     "name": "r-cd-1-typed-delegate",
     "description": "Typed continue_delegate() schedule/spawn/return. Fires a delegate with a nonce-only child task, observes task ledger entry and parent return.",
-    "methods": ["tools.invoke", "tasks.list", "sessions.messages.subscribe"]
+    "methods": ["tools.invoke", "tasks.list", "sessions.messages.subscribe"],
+    "status": "scaffold",
+    "expectedFile": "r-cd-1-typed-delegate.js",
+    "registryNotes": "No runnable scenario file exists yet; this manifest is a registry contract only."
   },
   "invocation": {
     "tool": "continue_delegate",

--- a/tools/k6-proofs/manifests/r-cd-2.json
+++ b/tools/k6-proofs/manifests/r-cd-2.json
@@ -20,7 +20,9 @@
       "sessions.send",
       "sessions.messages.subscribe",
       "tasks.list"
-    ]
+    ],
+    "status": "runnable",
+    "file": "r-cd-2-silent-wake.js"
   },
   "invocation": {
     "tool": "continue_delegate",

--- a/tools/k6-proofs/manifests/r-cd-3.json
+++ b/tools/k6-proofs/manifests/r-cd-3.json
@@ -17,7 +17,10 @@
     "name": "r-cd-3-post-compaction",
     "description": "continue_delegate(mode='post-compaction') event-triggered lifeboat. Fires a post-compaction delegate, triggers compaction, and verifies the delegate fires post-compaction and returns to the rehydrated session.",
     "methods": ["tools.invoke", "tasks.list", "sessions.messages.subscribe"],
-    "notes": "Requires context >70% to trigger compaction, OR the test must use a low compaction threshold configuration."
+    "notes": "Requires context >70% to trigger compaction, OR the test must use a low compaction threshold configuration.",
+    "status": "scaffold",
+    "expectedFile": "r-cd-3-post-compaction.js",
+    "registryNotes": "No runnable scenario file exists yet; post-compaction runs need dedicated safe setup before this becomes runnable."
   },
   "invocation": {
     "tool": "continue_delegate",

--- a/tools/k6-proofs/manifests/r-cd-4.json
+++ b/tools/k6-proofs/manifests/r-cd-4.json
@@ -20,7 +20,9 @@
       "tools.invoke",
       "sessions.messages.subscribe",
       "tasks.list"
-    ]
+    ],
+    "status": "runnable",
+    "file": "r-cd-4-target-session-key.js"
   },
   "invocation": {
     "tool": "continue_delegate",

--- a/tools/k6-proofs/manifests/r-cd-chained-depth-2.json
+++ b/tools/k6-proofs/manifests/r-cd-chained-depth-2.json
@@ -25,7 +25,9 @@
       "chain-1-uptree-silent-wake",
       "chain-2-inter-session-return",
       "chain-3-echo-broadcast"
-    ]
+    ],
+    "status": "runnable",
+    "file": "r-cd-chained-depth-2.js"
   },
   "invocation": {
     "tool": "continue_delegate",

--- a/tools/k6-proofs/manifests/r-cd-token.json
+++ b/tools/k6-proofs/manifests/r-cd-token.json
@@ -16,7 +16,10 @@
   "scenario": {
     "name": "r-cd-token-bracket-delegate",
     "description": "Bracket [[CONTINUE_DELEGATE:...]] path. Injects prompt requiring terminal bracket token, observes child spawn and return.",
-    "methods": ["sessions.send", "tasks.list", "sessions.messages.subscribe"]
+    "methods": ["sessions.send", "tasks.list", "sessions.messages.subscribe"],
+    "status": "scaffold",
+    "expectedFile": "r-cd-token-bracket-delegate.js",
+    "registryNotes": "No runnable scenario file exists yet; bracket-token delegate coverage is scaffolded only."
   },
   "seatClassExpectation": {
     "raw-final-text-seat": "PASS-candidate",

--- a/tools/k6-proofs/manifests/r-config-defaults.json
+++ b/tools/k6-proofs/manifests/r-config-defaults.json
@@ -9,6 +9,11 @@
   "toolSurface": "read-only",
   "mutates": false,
   "timeoutSeconds": 60,
+  "scenario": {
+    "status": "scaffold",
+    "expectedFile": "r-config-defaults.js",
+    "registryNotes": "No runnable config/defaults scenario exists yet; this read-only manifest is scaffolded until a dedicated runner lands."
+  },
   "expectedReceipts": [
     { "name": "config-read", "required": true, "description": "Configuration read successful" }
   ],

--- a/tools/k6-proofs/manifests/r-cw-1.json
+++ b/tools/k6-proofs/manifests/r-cw-1.json
@@ -16,7 +16,10 @@
   "scenario": {
     "name": "r-cw-1-tool-schedule-wake",
     "description": "Typed continue_work() tool-form schedule + wake. Fires continue_work with a reason, observes the scheduled work entry and wake event on the session.",
-    "methods": ["tools.invoke", "sessions.messages.subscribe"]
+    "methods": ["tools.invoke", "sessions.messages.subscribe"],
+    "status": "scaffold",
+    "expectedFile": "r-cw-1-tool-schedule-wake.js",
+    "registryNotes": "Legacy scenarios/r-cw-1.js exists but is an infrastructure-only check that does not load this manifest, so this manifest is not marked runnable."
   },
   "invocation": {
     "tool": "continue_work",

--- a/tools/k6-proofs/manifests/r-cw-4.json
+++ b/tools/k6-proofs/manifests/r-cw-4.json
@@ -16,7 +16,10 @@
   "scenario": {
     "name": "r-cw-4-chain-depth",
     "description": "Chain depth hop counter: fires continue_work 3× in sequence, verifies hop increments from 1/200 → 3/200 in traced responses.",
-    "methods": ["tools.invoke", "sessions.messages.subscribe"]
+    "methods": ["tools.invoke", "sessions.messages.subscribe"],
+    "status": "scaffold",
+    "expectedFile": "r-cw-4-chain-depth.js",
+    "registryNotes": "No runnable row scenario file exists yet; this manifest is a registry contract only."
   },
   "invocation": {
     "tool": "continue_work",

--- a/tools/k6-proofs/manifests/r-cw-5.json
+++ b/tools/k6-proofs/manifests/r-cw-5.json
@@ -16,7 +16,10 @@
   "scenario": {
     "name": "r-cw-5-cost-cap-reject",
     "description": "Cost-cap exhaustion: fires continue_work after artificially exhausting costCapTokens budget, verifies dispatch-time rejection with appropriate error.",
-    "methods": ["tools.invoke", "config.patch", "config.restore"]
+    "methods": ["tools.invoke", "config.patch", "config.restore"],
+    "status": "scaffold",
+    "expectedFile": "r-cw-5-cost-cap-reject.js",
+    "registryNotes": "No runnable row scenario file exists yet; config mutation/restoration semantics need a dedicated scenario before this becomes runnable."
   },
   "invocation": {
     "tool": "continue_work",

--- a/tools/k6-proofs/manifests/r-cw-6.json
+++ b/tools/k6-proofs/manifests/r-cw-6.json
@@ -16,7 +16,10 @@
   "scenario": {
     "name": "r-cw-6-max-chain-length",
     "description": "maxChainLength boundary: sets maxChainLength=1 via config, fires continue_work twice, verifies second hop is rejected at chain depth 2>1. Restores originals after.",
-    "methods": ["tools.invoke", "config.patch", "config.restore", "gateway.restart"]
+    "methods": ["tools.invoke", "config.patch", "config.restore", "gateway.restart"],
+    "status": "scaffold",
+    "expectedFile": "r-cw-6-max-chain-length.js",
+    "registryNotes": "No runnable row scenario file exists yet; restart/restoration semantics need a dedicated scenario before this becomes runnable."
   },
   "invocation": {
     "tool": "continue_work",

--- a/tools/k6-proofs/manifests/r-cw-delegate-self.json
+++ b/tools/k6-proofs/manifests/r-cw-delegate-self.json
@@ -16,7 +16,10 @@
   "scenario": {
     "name": "r-cw-delegate-self-continuation",
     "description": "Fires continue_delegate that internally calls continue_work — proves hop-2 woke inside a delegate child session. The delegate dispatches, the child fires its own continue_work, and the hop-2 turn executes.",
-    "methods": ["tools.invoke", "sessions.messages.subscribe", "tasks.list"]
+    "methods": ["tools.invoke", "sessions.messages.subscribe", "tasks.list"],
+    "status": "scaffold",
+    "expectedFile": "r-cw-delegate-self-continuation.js",
+    "registryNotes": "No runnable row scenario file exists yet; this manifest is a registry contract only."
   },
   "invocation": {
     "tool": "continue_delegate",

--- a/tools/k6-proofs/manifests/r-cw-token.json
+++ b/tools/k6-proofs/manifests/r-cw-token.json
@@ -16,7 +16,10 @@
   "scenario": {
     "name": "r-cw-token-bracket",
     "description": "Bracket/token CONTINUE_WORK path: lightContext subagent emits bare CONTINUE_WORK token at end-of-turn, hop-2 drives. Proves the token-form continuation works for subagents (the #952 row lineage).",
-    "methods": ["sessions.send", "sessions.messages.subscribe", "subagents.spawn"]
+    "methods": ["sessions.send", "sessions.messages.subscribe", "subagents.spawn"],
+    "status": "scaffold",
+    "expectedFile": "r-cw-token-bracket.js",
+    "registryNotes": "No runnable row scenario file exists yet; bracket-token continue_work coverage is scaffolded only."
   },
   "seatClassExpectation": {
     "lightContext-subagent": "PASS-candidate",

--- a/tools/k6-proofs/manifests/r-obs-status.json
+++ b/tools/k6-proofs/manifests/r-obs-status.json
@@ -9,6 +9,11 @@
   "toolSurface": "read-only",
   "mutates": false,
   "timeoutSeconds": 60,
+  "scenario": {
+    "status": "scaffold",
+    "expectedFile": "r-obs-status.js",
+    "registryNotes": "No runnable observer/status scenario exists yet; this read-only manifest is scaffolded until a dedicated runner lands."
+  },
   "expectedReceipts": [
     { "name": "tempo-trace-id", "required": true, "description": "Tempo trace ID generated and resolvable" },
     { "name": "observer-receipt", "required": true, "description": "Observer/status receipt intact" }

--- a/tools/k6-proofs/manifests/r-rc-1.json
+++ b/tools/k6-proofs/manifests/r-rc-1.json
@@ -9,6 +9,11 @@
   "toolSurface": "typed-tool",
   "mutates": false,
   "timeoutSeconds": 60,
+  "scenario": {
+    "status": "scaffold",
+    "expectedFile": "r-rc-1.js",
+    "registryNotes": "No runnable request_compaction threshold-reject scenario exists yet; keep scaffolded until a serialized/opt-in runner lands."
+  },
   "expectedReceipts": [
     { "name": "tool-invoke-rejected", "required": true, "description": "Gateway rejected request_compaction due to <70% threshold or rate limit" }
   ],

--- a/tools/k6-proofs/manifests/r-rc-2.json
+++ b/tools/k6-proofs/manifests/r-rc-2.json
@@ -9,6 +9,11 @@
   "toolSurface": "typed-tool",
   "mutates": true,
   "timeoutSeconds": 120,
+  "scenario": {
+    "status": "scaffold",
+    "expectedFile": "r-rc-2.js",
+    "registryNotes": "No runnable request_compaction threshold-accept scenario exists yet; keep scaffolded until a serialized, human-confirmed runner lands."
+  },
   "expectedReceipts": [
     { "name": "tool-invoke-accepted", "required": true, "description": "Gateway accepted request_compaction at >=70% threshold" },
     { "name": "compaction-triggered", "required": true, "description": "Compaction cycle executed and rewrote session context" }

--- a/tools/k6-proofs/row-manifest.schema.json
+++ b/tools/k6-proofs/row-manifest.schema.json
@@ -41,9 +41,25 @@
       "type": "object",
       "additionalProperties": true,
       "properties": {
+        "status": {
+          "enum": ["runnable", "scaffold", "construct-only"],
+          "description": "Runnable means scenario.file/name resolves to tools/k6-proofs/scenarios/*.js. Scaffold/construct-only rows are intentional non-runnable manifest entries."
+        },
+        "file": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.-]+\\.js$",
+          "description": "Runnable scenario file basename under tools/k6-proofs/scenarios/."
+        },
+        "expectedFile": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9_.-]+\\.js$",
+          "description": "Planned scenario file basename for scaffold rows. The file is not expected to exist yet."
+        },
         "name": { "type": "string" },
         "description": { "type": "string" },
-        "methods": { "type": "array", "items": { "type": "string" } }
+        "methods": { "type": "array", "items": { "type": "string" } },
+        "notes": { "type": "string" },
+        "registryNotes": { "type": "string" }
       }
     },
     "expectedReceipts": {

--- a/tools/k6-proofs/scripts/check-manifest-scenarios.mjs
+++ b/tools/k6-proofs/scripts/check-manifest-scenarios.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * check-manifest-scenarios.mjs — manifest ↔ runnable scenario registry check.
+ *
+ * A manifest is OK when it either:
+ *   - declares scenario.status="runnable" and points at an existing
+ *     tools/k6-proofs/scenarios/*.js file via scenario.file (or scenario.name), or
+ *   - declares scenario.status="scaffold" / "construct-only" to make a missing
+ *     scenario intentionally non-runnable instead of accidental.
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const proofsDir = path.join(root, 'tools', 'k6-proofs');
+const manifestsDir = path.join(proofsDir, 'manifests');
+const scenariosDir = path.join(proofsDir, 'scenarios');
+const validStatuses = new Set(['runnable', 'scaffold', 'construct-only']);
+
+function withoutJs(value) {
+  return String(value || '').replace(/\.js$/u, '');
+}
+
+function manifestFiles() {
+  return readdirSync(manifestsDir)
+    .filter((name) => name.endsWith('.json'))
+    .sort();
+}
+
+const scenarioBasenames = new Set(
+  readdirSync(scenariosDir)
+    .filter((name) => name.endsWith('.js'))
+    .map(withoutJs),
+);
+
+const failures = [];
+const rows = [];
+
+for (const file of manifestFiles()) {
+  const manifestPath = path.join(manifestsDir, file);
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  const scenario = manifest.scenario || {};
+  const status = scenario.status;
+  const runnableRef = withoutJs(scenario.file || (status === 'runnable' ? scenario.name : ''));
+  const expectedRef = withoutJs(scenario.expectedFile || scenario.name);
+  const existing = runnableRef ? scenarioBasenames.has(runnableRef) : false;
+
+  rows.push({ file, rowId: manifest.rowId, status, runnableRef, expectedRef, existing });
+
+  if (!validStatuses.has(status)) {
+    failures.push(`${file}: scenario.status must be one of ${[...validStatuses].join(', ')}`);
+    continue;
+  }
+
+  if (status === 'runnable') {
+    if (!runnableRef) {
+      failures.push(`${file}: runnable manifest must set scenario.file or scenario.name`);
+    } else if (!existing) {
+      failures.push(`${file}: runnable scenario '${runnableRef}.js' is missing under tools/k6-proofs/scenarios/`);
+    }
+  }
+
+  if (status === 'construct-only' && (scenario.file || scenario.expectedFile)) {
+    failures.push(`${file}: construct-only manifest should not declare scenario.file/expectedFile`);
+  }
+}
+
+for (const row of rows) {
+  const ref = row.runnableRef || row.expectedRef || '-';
+  const suffix = row.status === 'runnable'
+    ? (row.existing ? 'OK' : 'MISSING')
+    : 'intentional non-runnable';
+  console.log(`${row.file}\t${row.rowId}\t${row.status}\t${ref}\t${suffix}`);
+}
+
+if (failures.length) {
+  console.error('\nManifest scenario registry check failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exitCode = 1;
+} else {
+  console.log(`\nManifest scenario registry check passed: ${rows.length} manifests; ${scenarioBasenames.size} scenario files.`);
+}


### PR DESCRIPTION
## Summary

Addresses the registry reconciliation portion of #142 for the k6 proof row manifests.

- adds explicit `scenario.status` / `scenario.file` / `scenario.expectedFile` metadata to the row-manifest schema
- marks the three existing manifest-to-runner matches as `runnable` (`r-cd-2`, `r-cd-4`, `r-cd-chained-depth-2`)
- marks missing scenario rows as intentional `scaffold` entries with registry notes
- adds `check-manifest-scenarios.mjs` to verify manifest registry status against files under `tools/k6-proofs/scenarios/`
- documents the new checker in `tools/k6-proofs/README.md`

## Scope / non-goals

This is metadata/checker only. It does **not** create placeholder runnable scenario files, and it does not make scaffold rows executable.

## Validation

```bash
node tools/k6-proofs/scripts/check-manifest-scenarios.mjs
# Manifest scenario registry check passed: 17 manifests; 5 scenario files.

node - <<'NODE'
const fs = require('fs');
const path = require('path');
const files = [
  'tools/k6-proofs/row-manifest.schema.json',
  ...fs.readdirSync('tools/k6-proofs/manifests').filter(f => f.endsWith('.json')).sort().map(f => path.join('tools/k6-proofs/manifests', f)),
];
for (const file of files) JSON.parse(fs.readFileSync(file, 'utf8'));
console.log(`JSON parse OK: ${files.length} files`);
NODE
# JSON parse OK: 18 files

git diff --check
```
