### PR TITLE
fix(k6-proofs): expose observability row-result fields

### DIFF
--- a/tools/k6-proofs/scripts/__tests__/observability-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/observability-contract.test.mjs
@@ -1,0 +1,82 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+
+const repoRoot = new URL('../../../..', import.meta.url).pathname;
+const script = join(repoRoot, 'tools/k6-proofs/scripts/postprocess-k6-summary.mjs');
+const manifest = join(repoRoot, 'tools/k6-proofs/manifests/preflight.example.json');
+const summary = join(repoRoot, 'tools/k6-proofs/examples/k6-summary.preflight.example.json');
+
+async function withTmp(fn) {
+  const dir = await mkdtemp(join(tmpdir(), 'p81-k6-observability-'));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+function runPostprocess(args) {
+  return spawnSync(process.execPath, [script, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+}
+
+test('row-result exposes the dashboard v1 observability fields', async () => {
+  await withTmp(async (outRoot) => {
+    const run = runPostprocess([
+      '--manifest', manifest,
+      '--summary', summary,
+      '--out-root', outRoot,
+      '--run-id', 'k6-run-observability-contract',
+    ]);
+
+    assert.equal(run.status, 0, run.stderr || run.stdout);
+    const printed = JSON.parse(run.stdout);
+    const result = JSON.parse(await readFile(join(printed.runDir, 'row-result.json'), 'utf8'));
+
+    assert.equal(result.schema, 'openclaw.k6.proof-row-result.v1');
+    assert.equal(result.scenario, 'preflight inventory');
+    assert.equal(result.toolSurface, 'read-only');
+    assert.equal(result.transport, 'offline');
+    assert.equal(result.failureClass, 'none');
+    assert.equal(result.metrics.proofFailures, 0);
+    assert.equal(result.metrics.checksRate, 1);
+    assert.equal(result.metrics.durationMs, 10);
+    assert.ok(Array.isArray(result.receipts));
+    assert.equal(result.candidateOnly, true);
+    assert.equal(result.foldRequiresReview, true);
+  });
+});
+
+test('receipt summary statuses are normalized into row-result receipts', async () => {
+  await withTmp(async (outRoot) => {
+    const customSummary = join(outRoot, 'summary.json');
+    const parsed = JSON.parse(await readFile(summary, 'utf8'));
+    parsed.proof_receipts = {
+      'manifest-loaded': 'present',
+      'k6-summary': false,
+    };
+    await writeFile(customSummary, `${JSON.stringify(parsed, null, 2)}\n`);
+
+    const run = runPostprocess([
+      '--manifest', manifest,
+      '--summary', customSummary,
+      '--out-root', outRoot,
+      '--run-id', 'k6-run-observability-receipts',
+    ]);
+
+    assert.equal(run.status, 0, run.stderr || run.stdout);
+    const printed = JSON.parse(run.stdout);
+    const result = JSON.parse(await readFile(join(printed.runDir, 'row-result.json'), 'utf8'));
+    const receipts = Object.fromEntries(result.receipts.map((r) => [r.name, r.status]));
+
+    assert.equal(receipts['manifest-loaded'], 'present');
+    assert.equal(receipts['k6-summary'], 'missing');
+    assert.equal(result.failureClass, 'missing-receipt');
+  });
+});

--- a/tools/k6-proofs/scripts/postprocess-k6-summary.mjs
+++ b/tools/k6-proofs/scripts/postprocess-k6-summary.mjs
@@ -31,6 +31,10 @@ function requiredMetric(summary, name) {
   return summary?.metrics?.[name]?.values || null;
 }
 
+function scenarioFromManifest(manifest) {
+  return manifest?.scenario?.name || manifest?.scenario?.file?.replace(/\.js$/, '') || manifest?.scenario?.expectedFile?.replace(/\.js$/, '') || null;
+}
+
 function durationMsFromSummary(summary, rowId) {
   const candidates = [
     'proof_row_duration_ms',
@@ -45,9 +49,14 @@ function durationMsFromSummary(summary, rowId) {
   return null;
 }
 
-function failureClassFrom({ outcome, failureCount, checkRate, receipts }) {
-  if (failureCount > 0) return 'threshold';
+function failureClassFrom({ outcome, failureCount, checkRate, receipts, summary }) {
+  const statusText = JSON.stringify(summary?.root_group || {}) + JSON.stringify(summary?.errors || {});
+  if (/timeout|timed out/i.test(statusText)) return 'timeout';
+  if (/auth|unauthorized|forbidden|token/i.test(statusText)) return 'auth';
+  if (/transport|websocket|network|ECONNREFUSED|connection/i.test(statusText)) return 'transport';
+  if (/redaction/i.test(statusText)) return 'redaction-gate';
   if (receipts.some((r) => r.required && r.status === 'missing')) return 'missing-receipt';
+  if (failureCount > 0) return 'threshold';
   if (checkRate !== null && checkRate < 1) return 'checks';
   if (outcome === 'FAIL-candidate') return 'postprocess';
   return 'none';
@@ -55,6 +64,13 @@ function failureClassFrom({ outcome, failureCount, checkRate, receipts }) {
 
 function receiptStatusFromName(name, summary) {
   const summaryText = JSON.stringify(summary);
+  const receiptStatuses = summary?.proof_receipts || summary?.receipts || {};
+  if (Object.prototype.hasOwnProperty.call(receiptStatuses, name)) {
+    const value = receiptStatuses[name];
+    if (value === true || value === 'present') return 'present';
+    if (value === false || value === 'missing') return 'missing';
+    if (value === 'unknown') return 'unknown';
+  }
   switch (name) {
     case 'tool-invoke-accepted':
       return summaryText.includes('tool invocation accepted') || summaryText.includes('tools.invoke accepted') ? 'present' : 'unknown';
@@ -168,7 +184,7 @@ async function main() {
     required: Boolean(r.required),
     status: receiptStatusFromName(r.name, summary),
   }));
-  const failureClass = failureClassFrom({ outcome, failureCount, checkRate, receipts });
+  const failureClass = failureClassFrom({ outcome, failureCount, checkRate, receipts, summary });
   const result = {
     schema: 'openclaw.k6.proof-row-result.v1',
     runId,
@@ -176,6 +192,9 @@ async function main() {
     rowId: manifest.rowId,
     candidateSha: manifest.candidateSha,
     seat: manifest.seat,
+    scenario: scenarioFromManifest(manifest),
+    toolSurface: manifest.toolSurface,
+    transport: manifest.transport,
     outcome,
     metrics: {
       proofFailures: failureCount,


### PR DESCRIPTION
## Summary

Addresses #144 with a narrow observability-contract slice for Project 81 k6 PROOFS.

This PR makes `row-result.json` expose the dashboard-facing v1 fields that `METRICS.md` / `DASHBOARD.md` already describe:

- `scenario`
- `toolSurface`
- `transport`
- `metrics.proofFailures`
- `metrics.checksRate`
- `metrics.durationMs`
- `receipts[]`
- `failureClass`

It also adds tests for the postprocessor contract and receipt-status normalization.

## Validation

```text
$ node --test tools/k6-proofs/scripts/__tests__/*.test.mjs
✔ offline preflight summary writes candidate golden-path artifacts
✔ postprocessor rejects manifests that do not declare candidateOnly
✔ row-result exposes the dashboard v1 observability fields
✔ receipt summary statuses are normalized into row-result receipts
ℹ pass 4
ℹ fail 0
```

Smoke output check:

```text
$ node tools/k6-proofs/scripts/postprocess-k6-summary.mjs \
  --manifest tools/k6-proofs/manifests/preflight.example.json \
  --summary tools/k6-proofs/examples/k6-summary.preflight.example.json \
  --out-root /tmp/p81-k6-obs-smoke-final \
  --run-id k6-run-obs-smoke-final

$ jq -e '.scenario and .toolSurface and .transport and (.metrics.proofFailures == 0) and (.failureClass == "none") and (.candidateOnly == true) and (.foldRequiresReview == true)' \
  /tmp/p81-k6-obs-smoke-final/82827d3cbcba92ff6e19863b30615db028c2651c/preflight/emeric-nuc/k6-run-obs-smoke-final/row-result.json
true
```

## Safety / secrets

No live gateway run. No token/session/env dump added. This is postprocess/test-only against committed fixture data.
