### PR TITLE
fix(k6-proofs): reconcile scenario and seat preflight

### DIFF
--- a/.github/workflows/k6-proof.yml
+++ b/.github/workflows/k6-proof.yml
@@ -20,14 +20,17 @@ on:
   workflow_dispatch:
     inputs:
       scenario:
-        description: "Scenario file under tools/k6-proofs/scenarios/ (without path)"
+        description: "Scenario basename under tools/k6-proofs/scenarios/ (without .js)"
         required: true
         type: choice
-        default: preflight.js
+        default: preflight
         options:
-          - preflight.js
-          - r-cd-1-typed-delegate.js
-          - r-cd-token-bracket-delegate.js
+          - preflight
+          - r-cd-2-silent-wake
+          - r-cd-4-target-session-key
+          - r-cd-chained-depth-2
+          - r-cw-1
+          - r-cw
       row:
         description: "Row id for evidence (e.g. R-CD-1, R-CD-TOKEN). Ignored when dry_run=true."
         required: false
@@ -92,7 +95,11 @@ jobs:
           MANIFEST_PATH: ${{ github.event.inputs.manifest_path }}
         run: |
           set -euo pipefail
-          scenario_file="tools/k6-proofs/scenarios/${SCENARIO}"
+          if printf '%s' "$SCENARIO" | grep -Eq '/|\.js$'; then
+            echo "::error::scenario must be a basename without path or .js suffix: $SCENARIO"
+            exit 1
+          fi
+          scenario_file="tools/k6-proofs/scenarios/${SCENARIO}.js"
           if [ ! -f "$scenario_file" ]; then
             echo "::error::scenario file not found: $scenario_file"
             exit 1
@@ -125,6 +132,27 @@ jobs:
           sudo apt-get install -y k6
           k6 version
 
+      - name: Seat readiness preflight
+        env:
+          OPENCLAW_GATEWAY_WS: ${{ github.event.inputs.gateway_ws }}
+          OPENCLAW_SESSION_KEY: ${{ github.event.inputs.session_key }}
+          OPENCLAW_CANDIDATE_SHA: ${{ github.event.inputs.candidate_sha }}
+          OPENCLAW_SEAT_NAME: ${{ github.event.inputs.seat }}
+          OPENCLAW_EXPECTED_K6_VERSION: v2.0.0
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          export OPENCLAW_GATEWAY_TOKEN=$(python3 -c "import json, os; print(json.load(open(os.path.expanduser('~/.openclaw/openclaw.json')))['gateway']['auth']['token'])")
+          set +x
+          set -euo pipefail
+          if ! node tools/k6-proofs/scripts/seat-readiness-preflight.mjs --json | tee /tmp/seat-readiness.json; then
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "::warning::seat readiness preflight did not pass; dry_run continues, but output is not proof-standard"
+              exit 0
+            fi
+            echo "::error::seat readiness preflight did not pass; inspect /tmp/seat-readiness.json before treating k6 output as proof-standard"
+            exit 1
+          fi
+
       - name: Run k6 scenario
         # Token is injected ONLY here, ONLY as env. Never echoed; runner masks
         # registered secrets in logs, and we keep `set +x` so the env line is
@@ -137,7 +165,7 @@ jobs:
           OPENCLAW_ROW_MANIFEST: ${{ github.event.inputs.manifest_path }}
           SCENARIO: ${{ github.event.inputs.scenario }}
         run: |
-          export OPENCLAW_GATEWAY_TOKEN="$(python3 -c 'import json, os; print(json.load(open(os.path.expanduser(\"~/.openclaw/openclaw.json\")))[\"gateway\"][\"auth\"][\"token\"])')"
+          export OPENCLAW_GATEWAY_TOKEN=$(python3 -c "import json, os; print(json.load(open(os.path.expanduser('~/.openclaw/openclaw.json')))['gateway']['auth']['token'])")
           set +x
           set -euo pipefail
           if [ -z "${OPENCLAW_GATEWAY_TOKEN:-}" ]; then
@@ -147,7 +175,7 @@ jobs:
           mkdir -p /tmp/k6-out
           # tee to a file for the evidence post-processor; k6's own stdout is the
           # human log. The token is never printed by k6 or by us.
-          k6 run "tools/k6-proofs/scenarios/${SCENARIO}" 2>&1 | tee /tmp/k6-out/run.txt
+          k6 run "tools/k6-proofs/scenarios/${SCENARIO}.js" 2>&1 | tee /tmp/k6-out/run.txt
           echo "k6 run complete"
 
       - name: Write evidence artifacts

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -50,6 +50,13 @@ node tools/k6-proofs/scripts/postprocess-k6-summary.mjs \
 See [`docs/GOLDEN-PATH.md`](docs/GOLDEN-PATH.md). Output remains
 `PASS-candidate` / review-required and must not be folded automatically.
 
+### 0a. Seat readiness preflight (public-safe)
+
+Before treating a live k6 row as proof-standard, record the seat/tooling readiness receipt.
+The helper prints secret-presence booleans only, never token values. Exit 0 means
+`PASS-candidate`; non-zero means `HONEST-LIMIT-candidate`. The workflow runs this
+check before live proof rows and allows dry-runs to continue with a warning.
+
 ### 1. Preflight check
 
 ```bash
@@ -180,6 +187,9 @@ node tools/k6-proofs/scripts/validate-corpus.mjs --index --json
 
 # Validate row-manifest scenario registry status vs runnable scenario files
 node tools/k6-proofs/scripts/check-manifest-scenarios.mjs
+
+# Validate workflow_dispatch scenario choices against runnable scenario files
+node tools/k6-proofs/scripts/check-scenario-alignment.mjs
 ```
 
 Checks: JSON parse, schema sanity (`openclaw.proofs.index.v1` /

--- a/tools/k6-proofs/manifests/preflight.example.json
+++ b/tools/k6-proofs/manifests/preflight.example.json
@@ -14,12 +14,18 @@
     "tokenEnv": "OPENCLAW_GATEWAY_TOKEN"
   },
   "scenario": {
-    "name": "preflight inventory",
+    "name": "preflight",
     "description": "Authenticate/read-only gateway inventory: health/status, sessions.list, tools.effective. Offline mode validates manifest shape without gateway traffic.",
-    "methods": ["health", "status", "sessions.list", "tools.effective"],
-    "status": "scaffold",
+    "methods": [
+      "health",
+      "status",
+      "sessions.list",
+      "tools.effective"
+    ],
+    "status": "runnable",
     "expectedFile": "preflight.js",
-    "registryNotes": "No runnable preflight.js exists yet; this manifest remains a preflight scaffold/example until that file lands."
+    "registryNotes": "Runnable read-only preflight scenario exists at tools/k6-proofs/scenarios/preflight.js.",
+    "file": "preflight"
   },
   "expectedReceipts": [
     {

--- a/tools/k6-proofs/scenarios/preflight.js
+++ b/tools/k6-proofs/scenarios/preflight.js
@@ -1,0 +1,150 @@
+/**
+ * Scenario: preflight — read-only gateway/session/tool inventory.
+ *
+ * Verifies the proof harness can authenticate to the target gateway and collect
+ * the basic session/tool inventory needed before firing live proof rows. This
+ * scenario is intentionally non-mutating and safe for workflow dry-runs.
+ *
+ * Manifest-driven: reads row config from OPENCLAW_ROW_MANIFEST env var when set.
+ * References:
+ *   - Issue: karmaterminal/karmaterminal-openclaw-docs#101
+ *   - Manifest: tools/k6-proofs/manifests/preflight.example.json
+ */
+import ws from 'k6/ws';
+import { check } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+import { connectFrame, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
+import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+
+export const options = {
+  scenarios: {
+    preflight_inventory: {
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 1,
+      maxDuration: '45s',
+    },
+  },
+  thresholds: {
+    proof_failures: ['count==0'],
+    preflight_duration: ['p(95)<30000'],
+  },
+};
+
+const failures = new Counter('proof_failures');
+const duration = new Trend('preflight_duration');
+
+const manifest = loadManifestFromEnv();
+const DEFAULTS = {
+  sessionKey: 'main',
+  seat: 'ci-runner',
+};
+
+export default function () {
+  const url = __ENV.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
+  const token = __ENV.OPENCLAW_GATEWAY_TOKEN;
+  const sessionKey = manifest?.sessionKey || __ENV.OPENCLAW_SESSION_KEY || DEFAULTS.sessionKey;
+  const seat = manifest?.seat || __ENV.OPENCLAW_SEAT_NAME || DEFAULTS.seat;
+
+  if (!token) {
+    console.error('OPENCLAW_GATEWAY_TOKEN is required');
+    failures.add(1);
+    return;
+  }
+
+  if (manifest) {
+    const errors = validateManifest(manifest);
+    if (errors.length > 0) {
+      console.warn(`Manifest validation warnings: ${errors.join('; ')}`);
+    }
+  }
+
+  const evidence = {
+    row: 'preflight',
+    manifest_loaded: !!manifest,
+    seat,
+    sessionKey,
+    candidateSha: manifest?.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
+    started: new Date().toISOString(),
+    connected: false,
+    sessions_list_ok: false,
+    tools_effective_ok: false,
+    tool_inventory_count: 0,
+    redacted_events: [],
+  };
+
+  const started = Date.now();
+
+  const res = ws.connect(url, {}, (socket) => {
+    const tracker = new RequestTracker();
+
+    socket.on('open', () => {
+      evidence.connected = true;
+      socket.send(connectFrame(token));
+
+      socket.setTimeout(() => tracker.send(socket, 'sessions.list', { limit: 10 }), 500);
+      socket.setTimeout(() => tracker.send(socket, 'tools.effective', { sessionKey }), 1000);
+      socket.setTimeout(() => socket.close(), 12000);
+    });
+
+    socket.on('message', (raw) => {
+      try {
+        const msg = JSON.parse(raw);
+        const classified = tracker.classify(msg);
+        evidence.redacted_events.push({
+          ts: Date.now(),
+          kind: classified.kind,
+          method: classified.method || null,
+          event: classified.event || null,
+          ok: classified.ok !== undefined ? classified.ok : null,
+          data: classified.payload ? redactEvent(classified.payload) : null,
+        });
+
+        if (classified.kind === 'response' && classified.method === 'sessions.list') {
+          evidence.sessions_list_ok = classified.ok;
+          if (!classified.ok) {
+            console.error(`sessions.list failed: ${JSON.stringify(classified.error)}`);
+            failures.add(1);
+          }
+        }
+
+        if (classified.kind === 'response' && classified.method === 'tools.effective') {
+          evidence.tools_effective_ok = classified.ok;
+          const tools = classified.payload?.tools || classified.payload?.items || [];
+          evidence.tool_inventory_count = Array.isArray(tools) ? tools.length : 0;
+          if (!classified.ok) {
+            console.error(`tools.effective failed: ${JSON.stringify(classified.error)}`);
+            failures.add(1);
+          }
+        }
+
+        if (evidence.sessions_list_ok && evidence.tools_effective_ok) {
+          socket.close();
+        }
+      } catch (e) {
+        console.warn(`parse error: ${e}`);
+      }
+    });
+
+    socket.on('error', (e) => {
+      console.error(`ws error: ${e && e.error ? e.error() : e}`);
+      failures.add(1);
+    });
+  });
+
+  evidence.ended = new Date().toISOString();
+  evidence.duration_ms = Date.now() - started;
+  duration.add(evidence.duration_ms);
+
+  check(res, { 'websocket connected': (r) => r && r.status === 101 });
+  check(null, {
+    'sessions.list accepted': () => evidence.sessions_list_ok,
+    'tools.effective accepted': () => evidence.tools_effective_ok,
+  });
+
+  if (!evidence.sessions_list_ok || !evidence.tools_effective_ok) {
+    failures.add(1);
+  }
+
+  console.log(`PREFLIGHT_EVIDENCE ${JSON.stringify(evidence)}`);
+}

--- a/tools/k6-proofs/scripts/check-scenario-alignment.mjs
+++ b/tools/k6-proofs/scripts/check-scenario-alignment.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * Check Project-81 k6 scenario alignment.
+ *
+ * Invariants:
+ * - workflow_dispatch scenario choices are basenames (no path, no .js suffix)
+ * - every workflow choice has tools/k6-proofs/scenarios/<choice>.js
+ * - every manifest with scenario.status="runnable" points at an existing scenario via scenario.file or scenario.name
+ * - every non-runnable manifest explicitly uses scenario.status scaffold/construct-only
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const SCENARIO_DIR = path.join(ROOT, 'tools/k6-proofs/scenarios');
+const MANIFEST_DIR = path.join(ROOT, 'tools/k6-proofs/manifests');
+const WORKFLOW_PATH = path.join(ROOT, '.github/workflows/k6-proof.yml');
+
+function readWorkflowScenarioChoices(workflowText) {
+  const lines = workflowText.split('\n');
+  const choices = [];
+  let inScenarioInput = false;
+  let inOptions = false;
+  let scenarioIndent = 0;
+
+  for (const line of lines) {
+    const scenarioMatch = line.match(/^(\s*)scenario:\s*$/);
+    if (scenarioMatch && !inScenarioInput) {
+      inScenarioInput = true;
+      scenarioIndent = scenarioMatch[1].length;
+      continue;
+    }
+
+    if (inScenarioInput) {
+      const topLevelInput = line.match(/^(\s*)[a-zA-Z_][a-zA-Z0-9_]*:\s*$/);
+      if (topLevelInput && topLevelInput[1].length === scenarioIndent && !line.includes('scenario:')) {
+        break;
+      }
+      if (line.match(/^\s*options:\s*$/)) {
+        inOptions = true;
+        continue;
+      }
+      if (inOptions) {
+        const item = line.match(/^\s*-\s+([^\s#]+)/);
+        if (item) choices.push(item[1]);
+        else if (line.trim() && !line.match(/^\s*#/)) inOptions = false;
+      }
+    }
+  }
+
+  return choices;
+}
+
+function main() {
+  const scenarios = new Set(
+    fs.readdirSync(SCENARIO_DIR)
+      .filter((file) => file.endsWith('.js'))
+      .map((file) => path.basename(file, '.js')),
+  );
+
+  const choices = readWorkflowScenarioChoices(fs.readFileSync(WORKFLOW_PATH, 'utf8'));
+  const errors = [];
+
+  if (choices.length === 0) {
+    errors.push('workflow scenario input has no choices');
+  }
+
+  for (const choice of choices) {
+    if (choice.includes('/') || choice.endsWith('.js')) {
+      errors.push(`workflow choice must be a scenario basename without path/.js: ${choice}`);
+    }
+    if (!scenarios.has(choice)) {
+      errors.push(`workflow choice has no scenario file: tools/k6-proofs/scenarios/${choice}.js`);
+    }
+  }
+
+  for (const file of fs.readdirSync(MANIFEST_DIR).filter((entry) => entry.endsWith('.json')).sort()) {
+    const manifestPath = path.join(MANIFEST_DIR, file);
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    const scenario = manifest.scenario || {};
+    const name = scenario.name;
+    if (!name) continue;
+
+    if (name.includes('/') || name.endsWith('.js')) {
+      errors.push(`${file}: scenario.name must be a basename without path/.js: ${name}`);
+    }
+
+    const status = scenario.status;
+    const ref = (scenario.file || name || '').replace(/\.js$/u, '');
+    const exists = scenarios.has(ref);
+    if (!['runnable', 'scaffold', 'construct-only'].includes(status)) {
+      errors.push(`${file}: scenario.status must be runnable, scaffold, or construct-only`);
+    }
+    if (status === 'runnable' && !exists) {
+      errors.push(`${file}: runnable scenario has no file: tools/k6-proofs/scenarios/${ref}.js`);
+    }
+    if (status !== 'runnable' && exists) {
+      errors.push(`${file}: scenario ${ref}.js exists but scenario.status is ${status}, not runnable`);
+    }
+  }
+
+  const result = {
+    workflowChoices: choices,
+    scenarioFiles: [...scenarios].sort(),
+    ok: errors.length === 0,
+    errors,
+  };
+  console.log(JSON.stringify(result, null, 2));
+  if (errors.length > 0) process.exit(1);
+}
+
+main();

--- a/tools/k6-proofs/scripts/seat-readiness-preflight.mjs
+++ b/tools/k6-proofs/scripts/seat-readiness-preflight.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+/**
+ * seat-readiness-preflight.mjs — public-safe seat/tooling readiness report.
+ *
+ * This is intentionally a Node helper, not a k6 row. It runs before proof rows
+ * so a bad seat/tooling environment becomes HONEST-LIMIT-candidate instead of
+ * being confused with product behavior.
+ */
+import { execFileSync } from 'node:child_process';
+
+const DEFAULT_EXPECTED_K6_VERSION = 'v2.0.0';
+const SECRET_ENV = new Set(['OPENCLAW_GATEWAY_TOKEN']);
+const REQUIRED_ENV = [
+  'OPENCLAW_GATEWAY_TOKEN',
+  'OPENCLAW_GATEWAY_WS',
+  'OPENCLAW_SESSION_KEY',
+  'OPENCLAW_CANDIDATE_SHA',
+  'OPENCLAW_SEAT_NAME',
+];
+
+function parseArgs(argv) {
+  const out = { gateway: true };
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--json') out.json = true;
+    else if (arg === '--no-gateway') out.gateway = false;
+    else if (arg === '--expected-k6-version') out.expectedK6Version = argv[++i];
+    else if (arg === '--help' || arg === '-h') out.help = true;
+    else throw new Error(`unknown arg: ${arg}`);
+  }
+  return out;
+}
+
+function usage() {
+  console.log(`Usage: node tools/k6-proofs/scripts/seat-readiness-preflight.mjs [--json] [--no-gateway] [--expected-k6-version v2.0.0]\n\nEmits no secret values. Exit 0 only for PASS-candidate.`);
+}
+
+function commandOrNull(cmd, args) {
+  try {
+    return execFileSync(cmd, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function detectK6() {
+  const path = commandOrNull('which', ['k6']);
+  if (!path) return { ok: false, path: null, version: null, rawVersion: null };
+  const rawVersion = commandOrNull('k6', ['version']);
+  const version = rawVersion && rawVersion.match(/\bv\d+\.\d+\.\d+\b/)?.[0] || null;
+  return { ok: Boolean(version), path, version, rawVersion };
+}
+
+async function fetchOk(url, token) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 2500);
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: token ? { authorization: `Bearer ${token}` } : {},
+    });
+    return res.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function httpBaseFromWs(wsUrl) {
+  if (!wsUrl) return 'http://127.0.0.1:18789';
+  try {
+    const url = new URL(wsUrl);
+    url.protocol = url.protocol === 'wss:' ? 'https:' : 'http:';
+    url.pathname = '';
+    url.search = '';
+    url.hash = '';
+    return url.toString().replace(/\/$/, '');
+  } catch {
+    return 'http://127.0.0.1:18789';
+  }
+}
+
+function sessionScope(sessionKey) {
+  if (!sessionKey) return 'missing';
+  if (sessionKey === 'main') return 'main';
+  if (/^agent:main(:|$)/.test(sessionKey)) return 'main-agent-session';
+  if (/^agent:/.test(sessionKey)) return 'agent-session';
+  return 'configured-session';
+}
+
+function envReport() {
+  return REQUIRED_ENV.map((name) => ({
+    name,
+    present: Boolean(process.env[name]),
+    secret: SECRET_ENV.has(name),
+    required: name !== 'OPENCLAW_GATEWAY_WS',
+  }));
+}
+
+function printText(report) {
+  console.log(`seat readiness: ${report.outcome}`);
+  console.log(`k6: ${report.k6.version || 'missing'} at ${report.k6.path || '(not found)'} (expected ${report.expectedK6Version})`);
+  console.log(`gateway: ${report.gateway.mode}; health=${report.gateway.healthReachable}; status=${report.gateway.statusReachable}; url=${report.gateway.url}`);
+  console.log(`candidate sha: ${report.candidate.valid40Hex ? 'valid' : 'missing/invalid'}`);
+  console.log(`seat: ${report.seat.name}; session scope: ${report.session.scope}`);
+  console.log(`concurrency: ${report.concurrency.safeToRunConcurrently ? 'safe' : 'serialized'} — ${report.concurrency.reason}`);
+  const missing = report.env.filter((e) => e.required && !e.present).map((e) => e.name);
+  if (missing.length) console.log(`missing required env: ${missing.join(', ')}`);
+  for (const note of report.notes) console.log(`note: ${note}`);
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    usage();
+    return 0;
+  }
+
+  const expectedK6Version = args.expectedK6Version || process.env.OPENCLAW_EXPECTED_K6_VERSION || DEFAULT_EXPECTED_K6_VERSION;
+  const k6 = detectK6();
+  k6.matchesExpected = k6.version === expectedK6Version;
+
+  const gatewayWs = process.env.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
+  const gatewayBase = httpBaseFromWs(gatewayWs);
+  const token = process.env.OPENCLAW_GATEWAY_TOKEN;
+  let gateway = { url: gatewayWs, healthReachable: false, statusReachable: false, mode: 'skipped-by-flag' };
+  if (args.gateway && !token) {
+    gateway = { ...gateway, mode: 'skipped-no-token' };
+  } else if (args.gateway) {
+    gateway = {
+      url: gatewayWs,
+      healthReachable: await fetchOk(`${gatewayBase}/health`, token),
+      statusReachable: await fetchOk(`${gatewayBase}/status`, token),
+      mode: 'checked',
+    };
+  }
+
+  const candidateSha = process.env.OPENCLAW_CANDIDATE_SHA || null;
+  const env = envReport();
+  const requiredMissing = env.filter((e) => e.required && !e.present).map((e) => e.name);
+  const notes = [];
+  if (!k6.ok) notes.push('k6 is not installed or did not report a parseable version.');
+  else if (!k6.matchesExpected) notes.push(`k6 version mismatch: expected ${expectedK6Version}, got ${k6.version}.`);
+  if (gateway.mode === 'checked' && (!gateway.healthReachable || !gateway.statusReachable)) notes.push('gateway health/status not reachable from this seat.');
+  if (gateway.mode === 'skipped-no-token') notes.push('gateway reachability skipped because OPENCLAW_GATEWAY_TOKEN is absent; token value was not printed.');
+  if (requiredMissing.length) notes.push(`missing required env: ${requiredMissing.join(', ')}.`);
+
+  const valid40Hex = typeof candidateSha === 'string' && /^[0-9a-f]{40}$/.test(candidateSha);
+  if (!valid40Hex) notes.push('OPENCLAW_CANDIDATE_SHA is missing or not a 40-char lowercase hex SHA.');
+
+  const pass = k6.ok && k6.matchesExpected && valid40Hex && requiredMissing.length === 0 && (gateway.mode !== 'checked' || (gateway.healthReachable && gateway.statusReachable));
+
+  const report = {
+    schema: 'openclaw.k6.seat-readiness.v1',
+    generatedAt: new Date().toISOString(),
+    outcome: pass ? 'PASS-candidate' : 'HONEST-LIMIT-candidate',
+    expectedK6Version,
+    k6,
+    gateway,
+    candidate: { sha: candidateSha, valid40Hex },
+    seat: {
+      name: process.env.OPENCLAW_SEAT_NAME || 'unknown-seat',
+      class: process.env.OPENCLAW_SEAT_CLASS || 'message-body',
+    },
+    session: { scope: sessionScope(process.env.OPENCLAW_SESSION_KEY) },
+    env,
+    concurrency: {
+      safeToRunConcurrently: true,
+      reason: 'read-only seat readiness preflight; no continuation/delegate/compaction calls are fired',
+    },
+    notes,
+  };
+
+  if (args.json) console.log(JSON.stringify(report, null, 2));
+  else printText(report);
+  return pass ? 0 : 2;
+}
+
+main().then((code) => process.exit(code)).catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/tools/k6-proofs/seat-readiness.schema.json
+++ b/tools/k6-proofs/seat-readiness.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/karmaterminal/karmaterminal-openclaw-docs/tools/k6-proofs/seat-readiness.schema.json",
+  "title": "OpenClaw k6 PROOFS seat readiness report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "generatedAt",
+    "outcome",
+    "expectedK6Version",
+    "k6",
+    "gateway",
+    "candidate",
+    "seat",
+    "session",
+    "env",
+    "concurrency",
+    "notes"
+  ],
+  "properties": {
+    "schema": { "const": "openclaw.k6.seat-readiness.v1" },
+    "generatedAt": { "type": "string", "format": "date-time" },
+    "outcome": { "enum": ["PASS-candidate", "HONEST-LIMIT-candidate", "FAIL-candidate"] },
+    "expectedK6Version": { "type": "string", "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+$" },
+    "k6": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ok", "path", "version", "matchesExpected", "rawVersion"],
+      "properties": {
+        "ok": { "type": "boolean" },
+        "path": { "type": ["string", "null"] },
+        "version": { "type": ["string", "null"] },
+        "matchesExpected": { "type": "boolean" },
+        "rawVersion": { "type": ["string", "null"] }
+      }
+    },
+    "gateway": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["url", "healthReachable", "statusReachable", "mode"],
+      "properties": {
+        "url": { "type": "string" },
+        "healthReachable": { "type": "boolean" },
+        "statusReachable": { "type": "boolean" },
+        "mode": { "enum": ["checked", "skipped-no-token", "skipped-by-flag"] }
+      }
+    },
+    "candidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sha", "valid40Hex"],
+      "properties": {
+        "sha": { "type": ["string", "null"] },
+        "valid40Hex": { "type": "boolean" }
+      }
+    },
+    "seat": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "class"],
+      "properties": {
+        "name": { "type": "string" },
+        "class": { "type": "string" }
+      }
+    },
+    "session": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scope"],
+      "properties": {
+        "scope": { "type": "string" }
+      }
+    },
+    "env": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "present", "secret", "required"],
+        "properties": {
+          "name": { "type": "string" },
+          "present": { "type": "boolean" },
+          "secret": { "type": "boolean" },
+          "required": { "type": "boolean" }
+        }
+      }
+    },
+    "concurrency": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["safeToRunConcurrently", "reason"],
+      "properties": {
+        "safeToRunConcurrently": { "type": "boolean" },
+        "reason": { "type": "string" }
+      }
+    },
+    "notes": { "type": "array", "items": { "type": "string" } }
+  }
+}


### PR DESCRIPTION
## Summary

Salvages the intended #141/#145 k6 harness fixes onto current `main` without carrying the stale corpus-deletion conflicts from PR #148/#149.

Changes:
- switches workflow scenario input to scenario basenames and validates no `.js`/path suffix is supplied
- adds runnable read-only `preflight` scenario
- adds workflow scenario-alignment checker for dispatch choices vs scenario files
- adds public-safe seat readiness preflight + schema
- marks `preflight.example.json` runnable now that `preflight.js` exists
- documents the seat readiness preflight and alignment check

Closes #141.
Closes #145.

## Validation

```text
node --check tools/k6-proofs/scenarios/preflight.js
node --check tools/k6-proofs/scripts/check-scenario-alignment.mjs
node --check tools/k6-proofs/scripts/seat-readiness-preflight.mjs
python3 -m json.tool tools/k6-proofs/seat-readiness.schema.json >/dev/null
python3 -m json.tool tools/k6-proofs/manifests/preflight.example.json >/dev/null
node tools/k6-proofs/scripts/check-manifest-scenarios.mjs
node tools/k6-proofs/scripts/check-scenario-alignment.mjs
node tools/k6-proofs/scripts/validate-corpus.mjs --index
node tools/k6-proofs/scripts/validate-corpus.mjs --sha 2723dbee783c113cae70e4fb63a4cff9f55402e3
git diff --check
```

Results:
- manifest scenario registry passed: 17 manifests / 6 scenario files
- scenario alignment `ok: true`
- current INDEX validation OK: 4 passed / 0 failed
- 2723dbee corpus validation OK: 10 passed / 0 failed

## Safety note

This branch intentionally does not touch `PROOFS/`. PR #148/#149 are currently conflicting and include broad stale PROOFS deletions; this PR carries only the intended harness files onto current `main`.
