### PR TITLE
docs(k6-proofs): align skill and pipeline paths

### DIFF
--- a/tools/k6-proofs/k6-proofs-pipeline.xml
+++ b/tools/k6-proofs/k6-proofs-pipeline.xml
@@ -4,7 +4,7 @@
   Domain: Continuation feature behavioral proof automation
   
   Use: Machine-actor navigation when building/running/verifying proof rows.
-  Companion: k6-proofs/skill/SKILL.md (human-readable, detailed)
+  Companion: tools/k6-proofs/skill/SKILL.md (human-readable, detailed)
   
   One-shot parse: a model loads this whole and knows which row, what to fire,
   how to verify, and where artifacts land — no line-by-line scanning.
@@ -21,8 +21,8 @@
     <Component id="loki" url="http://loki.dandelion.cult" port="80" host="silas-k3s"/>
     <Component id="tempo" url="http://tempo.dandelion.cult" port="80" host="silas-k3s"/>
     <Component id="gateway" url="http://127.0.0.1:18789" path="/health" expect="ok:true"/>
-    <Component id="harness" repo="karmaterminal/karmaterminal-openclaw-docs" path="k6-proofs/"/>
-    <Component id="runner" path="k6-proofs/run-proof.sh" auto-detects="sha,seat,prometheus-url"/>
+    <Component id="harness" repo="karmaterminal/karmaterminal-openclaw-docs" path="tools/k6-proofs/"/>
+    <Component id="runner" path="tools/k6-proofs/run-proof.sh" auto-detects="sha,seat,prometheus-url"/>
   </Infrastructure>
 
   <!-- ═══════════════════════════════════════════════════════════════
@@ -30,12 +30,12 @@
        ═══════════════════════════════════════════════════════════════ -->
   <Pipeline>
     <Step order="1" id="preflight">
-      <Action>./run-proof.sh preflight</Action>
+      <Action>./tools/k6-proofs/run-proof.sh preflight</Action>
       <Verifies>Gateway alive, Tempo reachable, Loki reachable, Prometheus accepting writes</Verifies>
       <FailAction>Do not proceed — infrastructure not ready</FailAction>
     </Step>
     <Step order="2" id="fire-row">
-      <Action>./run-proof.sh r-{row-name}</Action>
+      <Action>./tools/k6-proofs/run-proof.sh r-{scenario-basename}</Action>
       <Metrics>Auto-ship to Prometheus via Remote Write</Metrics>
       <Output>r-{row-name}-summary.json</Output>
     </Step>
@@ -45,8 +45,8 @@
       <Destination>PROOFS/{SHA}/R-{ROW-NAME}/</Destination>
     </Step>
     <Step order="4" id="commit">
-      <Action>git add PROOFS/{SHA}/; git commit; git push origin main</Action>
-      <Constraint>Proofs land on main directly (no branch/PR detour per figs directive)</Constraint>
+      <Action>Review generated artifacts, add PROOFS/{SHA}/... intentionally, then commit/push through the current coordination lane</Action>
+      <Constraint>Proof artifacts may land direct-to-main when explicitly coordinated; harness/docs changes use normal PR review.</Constraint>
     </Step>
   </Pipeline>
 
@@ -206,9 +206,9 @@
       <Rule>Cap-exhaustion rows MUST be proven by actually hitting the cap</Rule>
       <Procedure>Lower caps → reload gateway → fire → verify reject → restore → reload</Procedure>
     </Mandate>
-    <Mandate id="corpus-direct">
-      <Rule>Proofs land on main directly — no branch/PR detour</Rule>
-      <Path>PROOFS/{CANDIDATE_SHA}/R-{ROW-NAME}/EVIDENCE.md</Path>
+    <Mandate id="corpus-fold">
+      <Rule>Proof artifacts fold only after review/coordination; docs and harness changes use normal PR review</Rule>
+      <Path>PROOFS/{CANDIDATE_SHA}/R-{ROW-NAME}/{seat}/EVIDENCE.md</Path>
     </Mandate>
     <Mandate id="nonce-correlation">
       <Rule>Use unique nonces and idempotency keys per proof-fire</Rule>

--- a/tools/k6-proofs/skill/SKILL.md
+++ b/tools/k6-proofs/skill/SKILL.md
@@ -5,36 +5,38 @@ Build, run, and maintain k6 proof-row scenarios for the OpenClaw continuation fe
 
 ## Components
 
-### Infrastructure (already deployed)
-- **k6 v2.0.0** — load testing tool, installed on ronan-dgx (`/home/figs/bin/k6`)
-- **Prometheus** — metrics store at `prometheus.dandelion.cult` (k3s on silas)
-- **Grafana** — dashboards at `grafana.dandelion.cult`
-- **Loki** — log aggregation at `loki.dandelion.cult`
-- **Tempo** — distributed tracing at `tempo.dandelion.cult`
-- **Alloy** — DaemonSet on all nodes, forwards logs to Loki
-- **OTel Collector** — trace collection on silas
+### Infrastructure (resolve per seat before proof-standard runs)
+- **k6** — proof-standard expectation is `v2.0.0`; run `node tools/k6-proofs/scripts/seat-readiness-preflight.mjs --json` on the target seat before folding evidence.
+- **Prometheus** — metrics store for candidate rows (fleet example: `prometheus.dandelion.cult`).
+- **Grafana** — dashboards (contract in `tools/k6-proofs/METRICS.md`; JSON in `tools/k6-proofs/dashboards/k6-proofs.json`).
+- **Loki** — log aggregation for nonce-correlated journal receipts.
+- **Tempo** — distributed tracing; raw trace JSON is the proof surface for continuation spans.
+- **Alloy / OTel Collector** — forwards logs and traces from seats into Loki/Tempo.
 
 ### Repo Structure
 ```
-karmaterminal-openclaw-docs/k6-proofs/
-├── README.md              — full documentation
-├── run-proof.sh           — universal runner (auto-detect seat/SHA + Prometheus output)
+tools/k6-proofs/
+├── README.md                       — canonical operator docs + runnable scenario list
+├── run-proof.sh                    — runner for workflow-runnable scenario basenames
 ├── lib/
-│   ├── gateway.js         — WebSocket helpers, custom metrics, nonce generation
-│   └── report.js          — HTML report generator (handleSummary)
-├── scenarios/
-│   ├── preflight.js       — gateway health verification (#101)
-│   └── r-cd-1.js          — continue_delegate infrastructure (#103)
-├── dashboards/
-│   └── k6-proofs.json     — Grafana dashboard for proof metrics
+│   ├── gateway-ws.js               — WS helpers, request tracking, nonce/redaction boundary
+│   └── manifest-loader.js          — row-manifest loading + env placeholder resolution
+├── manifests/                      — row manifests (broader than runnable scenario coverage)
+├── scenarios/                      — k6 scenarios currently promoted to runnable
+├── scripts/                        — seat preflight, evidence writer, postprocessor, corpus validator
+├── dashboards/                     — Grafana dashboard JSON
+├── docs/                           — golden path / safety / regression-trap notes
 └── skill/
-    └── SKILL.md           — this file
+    └── SKILL.md                    — this detailed how-to
+
+.agents/skills/k6-proofs/SKILL.md   — discoverable wrapper that points agents here
+tools/k6-proofs/k6-proofs-pipeline.xml — structured one-shot decision tree
 ```
 
 ## How to Build a New Proof Scenario
 
 ### 1. Identify the Row
-Check `PROOFS/PROOF-CORPUS-METHOD.md` for the row definition:
+Check `tools/k6-proofs/k6-proofs-pipeline.xml`, `tools/k6-proofs/CONTRIBUTING-ROWS.md`, and the Project-81 issue for the row definition:
 - Row name (e.g., `R-CD-2`)
 - Expected behavior
 - Owner assignment
@@ -43,7 +45,7 @@ Check `PROOFS/PROOF-CORPUS-METHOD.md` for the row definition:
 ### 2. Create the Scenario File
 ```bash
 # Name convention: scenarios/r-<row-name>.js (lowercase, hyphens)
-touch karmaterminal-openclaw-docs/k6-proofs/scenarios/r-cd-2.js
+touch tools/k6-proofs/scenarios/r-cd-2.js
 ```
 
 ### 3. Scenario Template
@@ -126,31 +128,34 @@ export function handleSummary(data) {
 
 ### 4. Run It
 ```bash
-# Local test (no Prometheus output)
-k6 run scenarios/r-cd-2.js
+# Local test from repo root (no Prometheus output)
+k6 run tools/k6-proofs/scenarios/r-cd-2.js
 
-# Full pipeline (metrics → Grafana)
-./run-proof.sh r-cd-2
+# Full runner path from repo root; use a promoted scenario basename
+./tools/k6-proofs/run-proof.sh r-cd-2-silent-wake
 
-# Custom target
-./run-proof.sh r-cd-2 --env GATEWAY_HOST=10.0.0.246
+# Custom target/env is passed through k6 as environment
+OPENCLAW_GATEWAY_WS=ws://10.0.0.246:18789 ./tools/k6-proofs/run-proof.sh r-cd-2-silent-wake
 ```
 
 ### 5. Commit Evidence
 After a successful run on the target SHA:
 ```bash
-# Copy summary to corpus
-cp r-cd-2-summary.json ../PROOFS/<SHA>/R-CD-2/
-# Write EVIDENCE.md with verdict, trace links, nonce correlation
+node tools/k6-proofs/scripts/evidence-writer.mjs \
+  --input /tmp/r-cd-2-output.txt \
+  --row R-CD-2 \
+  --seat <seat> \
+  --sha <40-char-sha>
+# Review the candidate run directory, add raw trace/log receipts, then fold intentionally.
 ```
 
 ## Key Patterns
 
 ### Evidence Correlation
 The gateway doesn't expose a REST API for delegate dispatch — delegates fire via the agent's tool surface. The k6 harness verifies infrastructure readiness and captures evidence post-run:
-1. **Journal grep** — `journalctl -u openclaw-gateway --since "5min ago" | grep <nonce>`
-2. **Tempo trace pull** — `curl http://tempo.dandelion.cult/api/traces/<traceId>`
-3. **Loki query** — via Grafana or `logcli`
+1. **Journal/Loki grep** — query the gateway journal or Loki for the nonce window; do not commit secrets.
+2. **Tempo trace pull** — export raw trace JSON for the trace id; summarize span tree separately.
+3. **Session/event receipt** — use redacted `sessions.messages.subscribe` / response receipts where the row depends on session delivery.
 
 ### Both-Forms Mandate
 Every continuation row must prove BOTH the typed tool path AND the bracket/token path:
@@ -162,9 +167,9 @@ Every continuation row must prove BOTH the typed tool path AND the bracket/token
 ### Caps-Test Procedure
 For rows that test cap exhaustion (R-CW-5, R-CW-6):
 1. Lower caps in `openclaw.json` (record originals)
-2. Reload gateway config
+2. Restart/reload as required by the config lever; record the exact arm step
 3. Fire the row — verify reject
-4. Restore originals + reload
+4. Restore originals + restart/reload back to baseline
 
 ### Custom Metrics Naming
 Prefix all custom metrics with the row name (underscores, lowercase):
@@ -174,11 +179,11 @@ This ensures Grafana queries can filter by row.
 
 ## Project Tracking
 - **EPIC**: #106
-- **Issues**: #101–#121 in karmaterminal-openclaw-docs
+- **Issues**: Project 81 issues in `karmaterminal/karmaterminal-openclaw-docs` (currently #100–#146+)
 - **Project Board**: [P81](https://github.com/orgs/karmaterminal/projects/81)
-- **Method Spec**: `PROOFS/PROOF-CORPUS-METHOD.md` (in openclaw-bootstrap evacuated)
+- **Row registry**: `tools/k6-proofs/k6-proofs-pipeline.xml`, row manifests, and per-SHA `PROOFS/<sha>/proofs-manifest.json`
 
 ## Dependencies
-- k6 binary (currently ronan-dgx only; #121 tracks fleet-wide install)
+- k6 binary present on the target seat at the expected version
 - Gateway running on target seat
-- Observability stack on silas k3s
+- Observability stack reachable for the evidence surfaces the row claims


### PR DESCRIPTION
## Summary
- refresh `tools/k6-proofs/skill/SKILL.md` so the detailed skill points at the current `tools/k6-proofs/` harness, runnable scenario names, seat preflight, and reviewed evidence fold path
- refresh `tools/k6-proofs/k6-proofs-pipeline.xml` root paths from stale `k6-proofs/` to `tools/k6-proofs/`
- clarify that proof artifacts/docs changes follow the current coordination lane instead of hard-coding direct-main behavior for every change

## Verification
- `python - <<'PY' ... ET.parse('tools/k6-proofs/k6-proofs-pipeline.xml') ... PY` → XML parse ok
- `node --test tools/k6-proofs/scripts/__tests__/*.test.mjs` → 4/4 pass
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs` → ok=true, no errors
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs` → passed, 17 manifests / 6 scenario files
- `node tools/k6-proofs/scripts/validate-corpus.mjs --sha 2723dbee783c113cae70e4fb63a4cff9f55402e3 --json` → failed=false, 16 rows / 15 pass / 1 honest_limit

## Notes
- Non-overlap with Cael's #148/#149 salvage: this touches only the existing skill + XML navigation docs for #123; no PROOFS corpus deletions or harness scenario changes.

Closes/advances #123.
