### PR TITLE
docs(k6-proofs): register continue_delegate model rows

### DIFF
--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -182,6 +182,10 @@ This is **declared in the manifest before the run**, not a post-hoc excuse. The 
 | R-CD-2 | `r-cd-2-silent-wake` | typed-tool | PASS-candidate when dispatch/session-events observed and no channel delivery appears |
 | R-CD-4 | `r-cd-4-target-session-key` | typed-tool | Candidate; verify target-vs-parent session events, not `tasks.list` |
 | R-CD-CHAINED-DEPTH-2 | `r-cd-chained-depth-2` | typed-tool | Candidate; verify nonce-correlated chain return on subscribed session stream |
+| R-CD-MODEL-DEFAULT | planned `r-cd-model-default` | mixed | Scaffold; tool + bracket/token no-override inheritance contrast row |
+| R-CD-MODEL-TOOL | planned `r-cd-model-tool` | typed-tool | Scaffold; explicit model override request byte must match observed child model byte |
+| R-CD-MODEL-TOKEN | planned `r-cd-model-token` | bracket-token | Scaffold; bracket `model=` modifier parse + observed child model byte |
+| R-CD-MODEL-CHAINED-ALT | planned `r-cd-model-chained-alt` | typed-tool | Scaffold; depth-2 delegate observes explicit alternate model |
 | R-CW-1 | `r-cw-1` | typed-tool | Candidate; continue_work schedule + wake |
 | R-CW overview | `r-cw` | read-only/infrastructure | Candidate; combined continue_work infrastructure check |
 

--- a/tools/k6-proofs/k6-proofs-pipeline.xml
+++ b/tools/k6-proofs/k6-proofs-pipeline.xml
@@ -157,6 +157,30 @@
       <Evidence>Root(A) receives C sentinel across dead intermediate; negative-guard no-orphan</Evidence>
       <Constraint>Mode-conditional: default=one-level-up; fanoutMode="tree"=reaches-root</Constraint>
     </Row>
+    <Row id="R-CD-MODEL-DEFAULT" owner="unclaimed" forms="tool+token" issue="140">
+      <Behavior>continue_delegate with no model override inherits the parent provider/model</Behavior>
+      <FireMethod>Fire both typed-tool and bracket/token no-override forms</FireMethod>
+      <Evidence>Parent model byte + child session model byte match; return includes nonce</Evidence>
+      <Manifest>tools/k6-proofs/manifests/r-cd-model-default.json</Manifest>
+    </Row>
+    <Row id="R-CD-MODEL-TOOL" owner="unclaimed" forms="tool" issue="140">
+      <Behavior>continue_delegate(model=&lt;provider/model&gt;) forwards explicit model override to the child</Behavior>
+      <Evidence>Request byte records model override; child runtime model byte matches requested model</Evidence>
+      <Constraint>Currently blocked by karmaterminal/openclaw#1103 if child observes inherited gpt-5.5 instead</Constraint>
+      <Manifest>tools/k6-proofs/manifests/r-cd-model-tool.json</Manifest>
+    </Row>
+    <Row id="R-CD-MODEL-TOKEN" owner="unclaimed" forms="token" issue="140">
+      <Behavior>[[CONTINUE_DELEGATE: ... | model=&lt;provider/model&gt;]] parses and forwards explicit model override</Behavior>
+      <Evidence>Bracket parse origin + requested model byte + child runtime model byte</Evidence>
+      <Constraint>Declare seat class before firing; message-body seats may suppress terminal bracket scan</Constraint>
+      <Manifest>tools/k6-proofs/manifests/r-cd-model-token.json</Manifest>
+    </Row>
+    <Row id="R-CD-MODEL-CHAINED-ALT" owner="unclaimed" forms="tool" issue="140">
+      <Behavior>Depth-1 delegate creates depth-2 continue_delegate with explicit alternate model; depth-2 reports observed model/provider</Behavior>
+      <Evidence>Depth-1 and depth-2 child receipts, plus depth-2 requested-vs-observed model byte</Evidence>
+      <Constraint>Sequential nested row; do not run concurrently with other continuation rows in the same session</Constraint>
+      <Manifest>tools/k6-proofs/manifests/r-cd-model-chained-alt.json</Manifest>
+    </Row>
 
     <!-- request_compaction family -->
     <Row id="R-RC-1" owner="silas" forms="tool-only" issue="104">

--- a/tools/k6-proofs/manifests/r-cd-model-chained-alt.json
+++ b/tools/k6-proofs/manifests/r-cd-model-chained-alt.json
@@ -1,0 +1,90 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "issue": 140,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-ronan-dgx}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "websocket",
+  "mutates": false,
+  "timeoutSeconds": 180,
+  "gateway": {
+    "wsEnv": "OPENCLAW_GATEWAY_WS",
+    "tokenEnv": "OPENCLAW_GATEWAY_TOKEN"
+  },
+  "rowId": "R-CD-MODEL-CHAINED-ALT",
+  "toolSurface": "typed-tool",
+  "scenario": {
+    "name": "r-cd-model-chained-alt",
+    "description": "Depth-1 delegate schedules a depth-2 continue_delegate with explicit alternate model; depth-2 reports observed model/provider.",
+    "methods": [
+      "sessions.send",
+      "sessions.messages.subscribe"
+    ],
+    "status": "scaffold",
+    "expectedFile": "r-cd-model-chained-alt.js",
+    "notes": "Nested model override row; fire sequentially and avoid concurrent continuation rows in the same session."
+  },
+  "invocation": {
+    "tool": "continue_delegate",
+    "forms": [
+      "typed-tool-depth1-spawns-depth2-model-override"
+    ],
+    "model": "${OPENCLAW_ALT_MODEL:-github-copilot/goldeneye}",
+    "promptTemplate": "Proof nonce {{nonce}} depth-1: schedule one depth-2 continue_delegate with model=${OPENCLAW_ALT_MODEL:-github-copilot/goldeneye}; depth-2 reports current time, observed model/provider, and nonce. Do not mutate files.",
+    "idempotencyKeyPrefix": "R-CD-MODEL-CHAINED-ALT"
+  },
+  "expectedReceipts": [
+    {
+      "name": "dispatch-accepted",
+      "required": true,
+      "description": "Gateway accepted the parent request that asks the agent to call continue_delegate for this model row"
+    },
+    {
+      "name": "child-session-observed",
+      "required": true,
+      "description": "A nonce-correlated delegate child session/run is observed on the subscribed session stream or session history"
+    },
+    {
+      "name": "child-model-byte",
+      "required": true,
+      "description": "Observed child runtime model/provider byte from status/session metadata or child self-report backed by session metadata"
+    },
+    {
+      "name": "return-payload",
+      "required": true,
+      "description": "Delegate return includes the row nonce and observed model/provider summary"
+    },
+    {
+      "name": "trace-or-session-correlation",
+      "required": false,
+      "description": "Trace id, span tree, or session-event correlation tying dispatch to child and return"
+    },
+    {
+      "name": "depth-1-child-observed",
+      "required": true,
+      "description": "Depth-1 delegate session/run observed"
+    },
+    {
+      "name": "depth-2-child-observed",
+      "required": true,
+      "description": "Depth-2 delegate session/run observed"
+    },
+    {
+      "name": "depth-2-model-byte",
+      "required": true,
+      "description": "Depth-2 child reports/records the requested alternate provider/model"
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CD-MODEL-CHAINED-ALT",
+    "seat": "${OPENCLAW_SEAT_NAME:-ronan-dgx}",
+    "runDirPrefix": "k6-run"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "PASS-candidate only when depth-2, not just depth-1, observes the explicit alternate model. If #1103 persists, this row should honestly limit on observed fallback/inheritance."
+  }
+}

--- a/tools/k6-proofs/manifests/r-cd-model-default.json
+++ b/tools/k6-proofs/manifests/r-cd-model-default.json
@@ -1,0 +1,79 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "issue": 140,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-ronan-dgx}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "websocket",
+  "mutates": false,
+  "timeoutSeconds": 180,
+  "gateway": {
+    "wsEnv": "OPENCLAW_GATEWAY_WS",
+    "tokenEnv": "OPENCLAW_GATEWAY_TOKEN"
+  },
+  "rowId": "R-CD-MODEL-DEFAULT",
+  "toolSurface": "mixed",
+  "scenario": {
+    "name": "r-cd-model-default",
+    "description": "Default provider/model inheritance for continue_delegate tool and bracket/token forms when no override is supplied.",
+    "methods": [
+      "sessions.send",
+      "sessions.messages.subscribe"
+    ],
+    "status": "scaffold",
+    "expectedFile": "r-cd-model-default.js"
+  },
+  "invocation": {
+    "tool": "continue_delegate",
+    "forms": [
+      "typed-tool-no-model",
+      "bracket-token-no-model"
+    ],
+    "promptTemplate": "Proof nonce {{nonce}}: report your observed provider/model and the nonce only. Do not mutate files. Do not post to any channel.",
+    "idempotencyKeyPrefix": "R-CD-MODEL-DEFAULT"
+  },
+  "expectedReceipts": [
+    {
+      "name": "dispatch-accepted",
+      "required": true,
+      "description": "Gateway accepted the parent request that asks the agent to call continue_delegate for this model row"
+    },
+    {
+      "name": "child-session-observed",
+      "required": true,
+      "description": "A nonce-correlated delegate child session/run is observed on the subscribed session stream or session history"
+    },
+    {
+      "name": "child-model-byte",
+      "required": true,
+      "description": "Observed child runtime model/provider byte from status/session metadata or child self-report backed by session metadata"
+    },
+    {
+      "name": "return-payload",
+      "required": true,
+      "description": "Delegate return includes the row nonce and observed model/provider summary"
+    },
+    {
+      "name": "trace-or-session-correlation",
+      "required": false,
+      "description": "Trace id, span tree, or session-event correlation tying dispatch to child and return"
+    },
+    {
+      "name": "parent-model-byte",
+      "required": true,
+      "description": "Parent/provider model byte used as the inheritance baseline"
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CD-MODEL-DEFAULT",
+    "seat": "${OPENCLAW_SEAT_NAME:-ronan-dgx}",
+    "runDirPrefix": "k6-run"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "PASS-candidate only when both tool and bracket/token no-override forms produce child sessions whose model/provider matches the parent baseline. This is the contrast row for explicit override rows."
+  }
+}

--- a/tools/k6-proofs/manifests/r-cd-model-token.json
+++ b/tools/k6-proofs/manifests/r-cd-model-token.json
@@ -1,0 +1,80 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "issue": 140,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-ronan-dgx}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "websocket",
+  "mutates": false,
+  "timeoutSeconds": 180,
+  "gateway": {
+    "wsEnv": "OPENCLAW_GATEWAY_WS",
+    "tokenEnv": "OPENCLAW_GATEWAY_TOKEN"
+  },
+  "rowId": "R-CD-MODEL-TOKEN",
+  "toolSurface": "bracket-token",
+  "scenario": {
+    "name": "r-cd-model-token",
+    "description": "continue_delegate bracket/token form parses and forwards model=<provider/model> to the delegate child.",
+    "methods": [
+      "sessions.send",
+      "sessions.messages.subscribe"
+    ],
+    "status": "scaffold",
+    "expectedFile": "r-cd-model-token.js",
+    "notes": "Requires a seat/session surface where final bracket text is scanned; message-body seats may be HONEST_LIMIT by declared seat class."
+  },
+  "invocation": {
+    "tool": "continue_delegate",
+    "forms": [
+      "bracket-token-model-override"
+    ],
+    "model": "${OPENCLAW_ALT_MODEL:-github-copilot/goldeneye}",
+    "tokenTemplate": "[[CONTINUE_DELEGATE: Proof nonce {{nonce}}: report observed provider/model and nonce only. Do not mutate files. | silent-wake | model=${OPENCLAW_ALT_MODEL:-github-copilot/goldeneye}]]",
+    "idempotencyKeyPrefix": "R-CD-MODEL-TOKEN"
+  },
+  "expectedReceipts": [
+    {
+      "name": "dispatch-accepted",
+      "required": true,
+      "description": "Gateway accepted the parent request that asks the agent to call continue_delegate for this model row"
+    },
+    {
+      "name": "child-session-observed",
+      "required": true,
+      "description": "A nonce-correlated delegate child session/run is observed on the subscribed session stream or session history"
+    },
+    {
+      "name": "child-model-byte",
+      "required": true,
+      "description": "Observed child runtime model/provider byte from status/session metadata or child self-report backed by session metadata"
+    },
+    {
+      "name": "return-payload",
+      "required": true,
+      "description": "Delegate return includes the row nonce and observed model/provider summary"
+    },
+    {
+      "name": "trace-or-session-correlation",
+      "required": false,
+      "description": "Trace id, span tree, or session-event correlation tying dispatch to child and return"
+    },
+    {
+      "name": "bracket-parse-origin",
+      "required": true,
+      "description": "Journal/session evidence that the delegate originated from bracket-token parsing with model modifier present"
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CD-MODEL-TOKEN",
+    "seat": "${OPENCLAW_SEAT_NAME:-ronan-dgx}",
+    "runDirPrefix": "k6-run"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "PASS-candidate only when bracket parse origin, requested model, and observed child model all match. Declare seat-class before firing; do not retro-justify scanner suppression."
+  }
+}

--- a/tools/k6-proofs/manifests/r-cd-model-tool.json
+++ b/tools/k6-proofs/manifests/r-cd-model-tool.json
@@ -1,0 +1,80 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "issue": 140,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-ronan-dgx}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "websocket",
+  "mutates": false,
+  "timeoutSeconds": 180,
+  "gateway": {
+    "wsEnv": "OPENCLAW_GATEWAY_WS",
+    "tokenEnv": "OPENCLAW_GATEWAY_TOKEN"
+  },
+  "rowId": "R-CD-MODEL-TOOL",
+  "toolSurface": "typed-tool",
+  "scenario": {
+    "name": "r-cd-model-tool",
+    "description": "continue_delegate typed tool form forwards an explicit model override to the delegate child.",
+    "methods": [
+      "sessions.send",
+      "sessions.messages.subscribe"
+    ],
+    "status": "scaffold",
+    "expectedFile": "r-cd-model-tool.js",
+    "notes": "Alternate-model rows are blocked on karmaterminal/openclaw#1103 until the child runtime observes the requested model instead of inheriting gpt-5.5."
+  },
+  "invocation": {
+    "tool": "continue_delegate",
+    "forms": [
+      "typed-tool-model-override"
+    ],
+    "model": "${OPENCLAW_ALT_MODEL:-github-copilot/goldeneye}",
+    "promptTemplate": "Proof nonce {{nonce}}: report your observed provider/model and the nonce only. Do not mutate files. Do not post to any channel.",
+    "idempotencyKeyPrefix": "R-CD-MODEL-TOOL"
+  },
+  "expectedReceipts": [
+    {
+      "name": "dispatch-accepted",
+      "required": true,
+      "description": "Gateway accepted the parent request that asks the agent to call continue_delegate for this model row"
+    },
+    {
+      "name": "child-session-observed",
+      "required": true,
+      "description": "A nonce-correlated delegate child session/run is observed on the subscribed session stream or session history"
+    },
+    {
+      "name": "child-model-byte",
+      "required": true,
+      "description": "Observed child runtime model/provider byte from status/session metadata or child self-report backed by session metadata"
+    },
+    {
+      "name": "return-payload",
+      "required": true,
+      "description": "Delegate return includes the row nonce and observed model/provider summary"
+    },
+    {
+      "name": "trace-or-session-correlation",
+      "required": false,
+      "description": "Trace id, span tree, or session-event correlation tying dispatch to child and return"
+    },
+    {
+      "name": "requested-model-byte",
+      "required": true,
+      "description": "Committed request byte showing continue_delegate model=<provider/model>"
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CD-MODEL-TOOL",
+    "seat": "${OPENCLAW_SEAT_NAME:-ronan-dgx}",
+    "runDirPrefix": "k6-run"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "PASS-candidate only when requested model byte and observed child model byte match. If #1103 reproduces, fold as HONEST-LIMIT-candidate with the mismatch evidence, not as pass."
+  }
+}


### PR DESCRIPTION
## Summary
- add scaffold manifests for the `continue_delegate` model-selection proof rows tracked in #140:
  - `R-CD-MODEL-DEFAULT`
  - `R-CD-MODEL-TOOL`
  - `R-CD-MODEL-TOKEN`
  - `R-CD-MODEL-CHAINED-ALT`
- register the rows in `tools/k6-proofs/k6-proofs-pipeline.xml`
- list the planned rows in the k6 harness README row coverage table

## Scope / caveats
- Scaffold/registry only; no live proof claim and no PROOFS corpus fold.
- Alternate-model rows explicitly keep the #1103 blocker caveat: requested model byte must match observed child model byte before PASS; mismatch should fold as honest-limit, not pass.
- Token row records the seat-class caveat up front.

## Verification
- JSON parse for all four new manifests
- XML parse for `tools/k6-proofs/k6-proofs-pipeline.xml`
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs` → passed, 21 manifests / 6 scenario files
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs` → `ok: true`
- `node --test tools/k6-proofs/scripts/__tests__/*.test.mjs` → 4/4 pass
- `node tools/k6-proofs/scripts/validate-corpus.mjs --sha 2723dbee783c113cae70e4fb63a4cff9f55402e3 --json` → `failed: false`; existing corpus remains 16 rows / 15 pass / 1 honest_limit

Advances #140.
