### PR TITLE
docs(k6-proofs): scaffold R-CD collection-on-collapse row

### DIFF
--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -182,6 +182,7 @@ This is **declared in the manifest before the run**, not a post-hoc excuse. The 
 | R-CD-2 | `r-cd-2-silent-wake` | typed-tool | PASS-candidate when dispatch/session-events observed and no channel delivery appears |
 | R-CD-4 | `r-cd-4-target-session-key` | typed-tool | Candidate; verify target-vs-parent session events, not `tasks.list` |
 | R-CD-CHAINED-DEPTH-2 | `r-cd-chained-depth-2` | typed-tool | Candidate; verify nonce-correlated chain return on subscribed session stream |
+| R-CD-COLLECTION-ON-COLLAPSE | planned `r-cd-collection-on-collapse` | typed-tool | Scaffold; A→B→C detached-intermediate collapse with root collection + no-orphan guard |
 | R-CD-MODEL-DEFAULT | planned `r-cd-model-default` | mixed | Scaffold; tool + bracket/token no-override inheritance contrast row |
 | R-CD-MODEL-TOOL | planned `r-cd-model-tool` | typed-tool | Scaffold; explicit model override request byte must match observed child model byte |
 | R-CD-MODEL-TOKEN | planned `r-cd-model-token` | bracket-token | Scaffold; bracket `model=` modifier parse + observed child model byte |

--- a/tools/k6-proofs/manifests/r-cd-collection-on-collapse.json
+++ b/tools/k6-proofs/manifests/r-cd-collection-on-collapse.json
@@ -1,0 +1,81 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CD-COLLECTION-ON-COLLAPSE",
+  "issue": 119,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "websocket",
+  "toolSurface": "typed-tool",
+  "mutates": false,
+  "timeoutSeconds": 180,
+  "gateway": {
+    "wsEnv": "OPENCLAW_GATEWAY_WS",
+    "tokenEnv": "OPENCLAW_GATEWAY_TOKEN"
+  },
+  "scenario": {
+    "name": "r-cd-collection-on-collapse",
+    "description": "A\u2192B\u2192C delegate chain where intermediate B is detached/collapsed before C returns; root A still collects C sentinel.",
+    "methods": [
+      "sessions.send",
+      "sessions.messages.subscribe"
+    ],
+    "status": "scaffold",
+    "expectedFile": "r-cd-collection-on-collapse.js",
+    "notes": "Scaffold only. Requires reviewed mode=session/detached intermediate design before live fire; do not run concurrently with other continuation rows in the same session."
+  },
+  "invocation": {
+    "tool": "continue_delegate",
+    "forms": [
+      "typed-tool"
+    ],
+    "mode": "silent-wake",
+    "delaySeconds": 1,
+    "promptTemplate": "Proof nonce {{nonce}}: construct A\u2192B\u2192C collection-on-collapse chain with detached intermediate only when explicitly live-fired. Do not mutate files. Do not post to any channel.",
+    "idempotencyKeyPrefix": "R-CD-COLLECT-COLLAPSE"
+  },
+  "expectedReceipts": [
+    {
+      "name": "root-dispatch-accepted",
+      "required": true,
+      "description": "Root A accepts dispatch that creates detached intermediate B."
+    },
+    {
+      "name": "intermediate-session-detached",
+      "required": true,
+      "description": "Intermediate B is created as a session/detached participant, not a run-mode transient."
+    },
+    {
+      "name": "grandchild-sentinel",
+      "required": true,
+      "description": "Grandchild C emits nonce-correlated sentinel after B is collapsed or unavailable."
+    },
+    {
+      "name": "root-collection",
+      "required": true,
+      "description": "Root A receives/collects C sentinel despite intermediate B collapse."
+    },
+    {
+      "name": "negative-orphan-guard",
+      "required": true,
+      "description": "Evidence shows C return is not orphaned or delivered only to collapsed B."
+    },
+    {
+      "name": "trace-or-session-correlation",
+      "required": false,
+      "description": "Trace id, span tree, or session-event correlation tying A\u2192B\u2192C and root collection."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CD-COLLECTION-ON-COLLAPSE",
+    "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+    "runDirPrefix": "k6-run"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "Scaffold/registry only until a human-reviewed live-fire design handles the mode=session detached intermediate and collapse trigger. Never fold as pass without root-collection and negative-orphan evidence."
+  }
+}

--- a/tools/k6-proofs/scenarios/r-cd-collection-on-collapse.js
+++ b/tools/k6-proofs/scenarios/r-cd-collection-on-collapse.js
@@ -1,0 +1,26 @@
+/**
+ * Scenario scaffold: R-CD-COLLECTION-ON-COLLAPSE.
+ *
+ * This row proves an A→B→C delegate chain where intermediate B is detached
+ * (mode=session) and then collapses/unavailable before C returns; root A must
+ * still collect C's nonce-correlated sentinel, with a negative guard that the
+ * return was not orphaned or delivered only to B.
+ *
+ * Intentionally not runnable yet. The collapse trigger and detached
+ * intermediate semantics need review before live fire; see manifest
+ * r-cd-collection-on-collapse.json.
+ */
+export const options = {
+  scenarios: {
+    r_cd_collection_on_collapse_scaffold: {
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 1,
+      maxDuration: '10s',
+    },
+  },
+};
+
+export default function () {
+  throw new Error('R-CD-COLLECTION-ON-COLLAPSE is scaffold-only; live-fire design not implemented.');
+}


### PR DESCRIPTION
## Summary

Scaffolds the Cael-owned `R-CD-COLLECTION-ON-COLLAPSE` proof row without firing it or mutating the proof corpus.

Adds:
- `tools/k6-proofs/manifests/r-cd-collection-on-collapse.json`
- `tools/k6-proofs/scenarios/r-cd-collection-on-collapse.js` as an intentional scaffold-only guard
- README row coverage entry

## Scope / guardrails

- No `PROOFS/` corpus mutation.
- No live continuation fire.
- No `update_plan` work.
- Scenario intentionally throws if run; the detached intermediate / collapse trigger design needs review before live fire.

## Why this row

`R-CD-COLLECTION-ON-COLLAPSE` is absent from the current `2723dbee` manifest, has no open PR overlap from the clean server state, and is distinct from the already-filed `R-CD-CHAINED-DEPTH-2` row: it proves root collection across a collapsed intermediate, not ordinary depth-2 delegate chaining.

## Validation

Ran locally:

```bash
node --check tools/k6-proofs/scenarios/r-cd-collection-on-collapse.js
node tools/k6-proofs/scripts/check-manifest-scenarios.mjs
node tools/k6-proofs/scripts/validate-corpus.mjs --sha 2723dbee783c113cae70e4fb63a4cff9f55402e3
node tools/k6-proofs/scripts/validate-corpus.mjs --index
```
