### PR TITLE
docs(k6-proofs): standardize seat readiness preflight

### DIFF
--- a/.github/workflows/k6-proof.yml
+++ b/.github/workflows/k6-proof.yml
@@ -191,7 +191,8 @@ jobs:
             --input /tmp/k6-out/run.txt \
             --row "$ROW" \
             --seat "$SEAT" \
-            --sha "$CANDIDATE_SHA"
+            --sha "$CANDIDATE_SHA" \
+            --seat-readiness /tmp/seat-readiness.json
           echo "evidence written under PROOFS/${CANDIDATE_SHA}/${ROW}/${SEAT}/"
 
       - name: Upload run log (dry_run)
@@ -199,7 +200,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: k6-dry-run-log
-          path: /tmp/k6-out/run.txt
+          path: |
+            /tmp/k6-out/run.txt
+            /tmp/seat-readiness.json
           if-no-files-found: warn
           retention-days: 14
 

--- a/tools/k6-proofs/CONTRIBUTING-ROWS.md
+++ b/tools/k6-proofs/CONTRIBUTING-ROWS.md
@@ -11,7 +11,23 @@ into `PROOFS/<sha>/` without back-and-forth.
 1. **Claim the labelled issue on [Project 81](https://github.com/orgs/karmaterminal/projects/81)
    BEFORE doing row work.** Assign yourself. If you don't see it on the board, ping the
    coordinator — don't shadow-run.
-2. **Verify the gateway you fire against is actually deployed to the corpus-pin SHA.**
+2. **Run seat readiness before row fire.**
+   The proof-standard k6 version and public-safe env contract live in
+   [`seat-readiness.policy.json`](seat-readiness.policy.json). Run the helper and
+   save the JSON beside your candidate artifacts:
+   ```bash
+   OPENCLAW_CANDIDATE_SHA="<40-char-sha>" \
+   OPENCLAW_SEAT_NAME="<seat>" \
+   OPENCLAW_SESSION_KEY="<target-session>" \
+   OPENCLAW_GATEWAY_TOKEN="***" \
+     node tools/k6-proofs/scripts/seat-readiness-preflight.mjs --json \
+       > /tmp/seat-readiness.json
+   ```
+   A missing/mismatched k6 binary, missing required env, invalid candidate SHA, or
+   unreachable checked gateway is `HONEST-LIMIT-candidate` / setup failure — not
+   product behavior evidence. The report prints env presence booleans only; no
+   token/secret values, prompt bodies, or raw gateway payloads are allowed.
+3. **Verify the gateway you fire against is actually deployed to the corpus-pin SHA.**
    This is a PRE-FIRE gate the validator CANNOT do for you: `validate-corpus.mjs`
    checks that your *artifacts* are consistent with a SHA, but it cannot verify your
    running *gateway* is on that SHA. Confirm both, on the seat you will run from:
@@ -28,7 +44,7 @@ into `PROOFS/<sha>/` without back-and-forth.
    gateway produces rows that fail at the gateway-lacks-feature layer, not the harness
    layer, and the failure is easy to misread. The fleet can run mixed SHAs; check
    *your* seat, not someone else's.
-3. Confirm secrets are in env, not on disk. `OPENCLAW_GATEWAY_TOKEN` and friends come
+4. Confirm secrets are in env, not on disk. `OPENCLAW_GATEWAY_TOKEN` and friends come
    from the seat's environment or GH Actions repo secrets — **zero secrets in source,
    manifests, evidence, or PR body**. If the token leaks into a log, rotate before
    pushing.
@@ -57,6 +73,10 @@ Use the harness as documented in [`README.md`](README.md):
 
 Every `PROOFS/<sha>/<row>/<seat>/k6-run-<ts>/` directory must contain:
 
+- `seat-readiness.json` — public-safe readiness report from
+  `scripts/seat-readiness-preflight.mjs`. If this is not `PASS-candidate`, the row
+  must stay setup/HONEST-LIMIT until the seat is fixed or the row issue declares a
+  different expectation.
 - `EVIDENCE.md` — candidate evidence document. Captures the run context, the
   candidate outcome, receipts table, and the review checklist (`evidence-writer.mjs`
   emits the right shape; do not hand-edit the schema).

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -21,7 +21,7 @@ tools/k6-proofs/
 
 ## Prerequisites
 
-- [Grafana k6](https://grafana.com/docs/k6/latest/get-started/installation/) installed on the run seat. The proof-standard expectation is `v2.0.0` unless a row issue explicitly says otherwise.
+- [Grafana k6](https://grafana.com/docs/k6/latest/get-started/installation/) installed on the run seat. The proof-standard expectation is centralized in [`seat-readiness.policy.json`](seat-readiness.policy.json) (`v2.0.0` unless the policy or row issue explicitly says otherwise).
 - A running OpenClaw gateway on the local seat.
 - Run `node tools/k6-proofs/scripts/seat-readiness-preflight.mjs` before treating row output as proof-standard. A version/env/gateway mismatch is `HONEST-LIMIT-candidate`, not product failure.
 - Environment variables:
@@ -66,10 +66,11 @@ OPENCLAW_GATEWAY_TOKEN="***" \
 
 The helper emits `openclaw.k6.seat-readiness.v1` JSON and never prints secret values. It records:
 
-- k6 binary path and version, compared to the documented expectation (`v2.0.0` by default)
+- k6 binary path and version, compared to the centralized policy expectation (`tools/k6-proofs/seat-readiness.policy.json`; override with `OPENCLAW_EXPECTED_K6_VERSION` or `--expected-k6-version` only when the row issue says so)
+- every binary candidate checked (`/home/figs/bin/k6`, common system paths, and `K6_BIN` when set)
 - gateway health/status reachability shape
 - candidate SHA validity, seat name/class, and coarse session scope
-- required env-var presence as booleans only
+- required env-var presence as booleans only, plus public-safe purpose strings from the policy
 - whether the check is safe to run concurrently
 
 If k6 is missing, the version differs, required env is absent, or gateway health/status is unreachable, treat row output as `HONEST-LIMIT-candidate` / setup failure until the seat is fixed. Do not fold it as product behavior evidence. Use `--no-gateway` only for offline docs/schema checks; live proof rows need a checked gateway.

--- a/tools/k6-proofs/scripts/__tests__/seat-readiness.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/seat-readiness.test.mjs
@@ -1,0 +1,108 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile, mkdtemp, rm, writeFile, chmod } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+
+const repoRoot = new URL('../../../..', import.meta.url).pathname;
+const script = join(repoRoot, 'tools/k6-proofs/scripts/seat-readiness-preflight.mjs');
+const policy = join(repoRoot, 'tools/k6-proofs/seat-readiness.policy.json');
+const schema = join(repoRoot, 'tools/k6-proofs/seat-readiness.schema.json');
+
+async function withTmp(fn) {
+  const dir = await mkdtemp(join(tmpdir(), 'p81-seat-readiness-'));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+function runPreflight(args, env) {
+  return spawnSync(process.execPath, [script, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+}
+
+test('seat readiness policy keeps the k6 proof-standard version in one place', async () => {
+  const parsed = JSON.parse(await readFile(policy, 'utf8'));
+  assert.equal(parsed.schema, 'openclaw.k6.seat-readiness-policy.v1');
+  assert.equal(parsed.k6.expectedVersion, 'v2.0.0');
+  assert.ok(parsed.env.some((entry) => entry.name === 'OPENCLAW_GATEWAY_TOKEN' && entry.secret === true));
+  assert.ok(parsed.env.some((entry) => entry.name === 'OPENCLAW_CANDIDATE_SHA' && entry.required === true));
+});
+
+test('seat readiness JSON contains no env secret values and reports booleans only', async () => {
+  await withTmp(async (dir) => {
+    const fakeK6 = join(dir, 'k6');
+    await writeFile(fakeK6, '#!/bin/sh\necho "k6 v2.0.0 (commit/test)"\n');
+    await chmod(fakeK6, 0o755);
+
+    const token = 'CANARY-TOKEN-VALUE-DO-NOT-PRINT';
+    const run = runPreflight(['--json', '--no-gateway', '--expected-k6-version', 'v2.0.0'], {
+      K6_BIN: fakeK6,
+      OPENCLAW_GATEWAY_TOKEN: token,
+      OPENCLAW_CANDIDATE_SHA: '2723dbee783c113cae70e4fb63a4cff9f55402e3',
+      OPENCLAW_SEAT_NAME: 'unit-seat',
+      OPENCLAW_SESSION_KEY: 'agent:main:discord:channel:test',
+      OPENCLAW_GATEWAY_WS: 'ws://127.0.0.1:18789',
+    });
+
+    assert.equal(run.status, 0, run.stderr || run.stdout);
+    assert.doesNotMatch(run.stdout, new RegExp(token));
+    const report = JSON.parse(run.stdout);
+    assert.equal(report.schema, 'openclaw.k6.seat-readiness.v1');
+    assert.equal(report.outcome, 'PASS-candidate');
+    assert.equal(report.policy.name, 'k6 PROOFS seat readiness policy');
+    assert.equal(report.k6.path, fakeK6);
+    assert.equal(report.k6.version, 'v2.0.0');
+    assert.equal(report.gateway.mode, 'skipped-by-flag');
+    const tokenEnv = report.env.find((entry) => entry.name === 'OPENCLAW_GATEWAY_TOKEN');
+    assert.deepEqual(
+      { present: tokenEnv.present, secret: tokenEnv.secret, value: tokenEnv.value },
+      { present: true, secret: true, value: undefined },
+    );
+    assert.equal(report.session.scope, 'main-agent-session');
+  });
+});
+
+test('seat readiness schema tracks policy, checked k6 candidates, and env purposes', async () => {
+  const parsed = JSON.parse(await readFile(schema, 'utf8'));
+  assert.ok(parsed.required.includes('policy'));
+  assert.ok(parsed.properties.k6.required.includes('checked'));
+  assert.ok(parsed.properties.env.items.required.includes('purpose'));
+});
+
+test('evidence writer copies supplied seat-readiness report into candidate artifacts', async () => {
+  await withTmp(async (dir) => {
+    const k6Output = join(dir, 'run.txt');
+    const readiness = join(dir, 'seat-readiness.json');
+    await writeFile(k6Output, `=== K6-PROOF-EVIDENCE ===\n${JSON.stringify({
+      manifest_loaded: true,
+      tool_accepted: true,
+      child_spawned: true,
+      redacted_events: [{ type: 'res', ok: true }],
+    })}\n--- END EVIDENCE ---\n`);
+    await writeFile(readiness, `${JSON.stringify({ schema: 'openclaw.k6.seat-readiness.v1', outcome: 'PASS-candidate' })}\n`);
+
+    const writer = join(repoRoot, 'tools/k6-proofs/scripts/evidence-writer.mjs');
+    const run = spawnSync(process.execPath, [
+      writer,
+      '--input', k6Output,
+      '--row', 'R-UNIT-SEAT-READINESS',
+      '--seat', 'unit-seat',
+      '--sha', '2723dbee783c113cae70e4fb63a4cff9f55402e3',
+      '--seat-readiness', readiness,
+    ], { cwd: dir, encoding: 'utf8' });
+
+    assert.equal(run.status, 0, run.stderr || run.stdout);
+    const printed = JSON.parse(run.stdout);
+    const copied = JSON.parse(await readFile(join(dir, printed.runDir, 'seat-readiness.json'), 'utf8'));
+    assert.equal(copied.schema, 'openclaw.k6.seat-readiness.v1');
+    const evidence = await readFile(join(dir, printed.runDir, 'EVIDENCE.md'), 'utf8');
+    assert.match(evidence, /seat-readiness\.json.*captured/);
+  });
+});

--- a/tools/k6-proofs/scripts/evidence-writer.mjs
+++ b/tools/k6-proofs/scripts/evidence-writer.mjs
@@ -18,10 +18,11 @@
  *     ├── EVIDENCE.md
  *     ├── k6-summary.json
  *     ├── gateway-events.ndjson  (redacted only)
- *     └── row-result.json
+ *     ├── row-result.json
+ *     └── seat-readiness.json  (when --seat-readiness is supplied)
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { copyFileSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 
 function parseArgs(argv) {
@@ -113,6 +114,10 @@ const runId = `k6-run-${stamp()}`;
 const outDir = join('PROOFS', args.sha, args.row, args.seat, runId);
 mkdirSync(join(outDir, 'artifacts'), { recursive: true });
 
+if (args['seat-readiness']) {
+  copyFileSync(args['seat-readiness'], join(outDir, 'seat-readiness.json'));
+}
+
 // Write k6-summary.json (evidence without raw events)
 const summary = { ...evidence };
 delete summary.redacted_events; // events go to ndjson, not summary
@@ -177,6 +182,7 @@ const md = `# ${args.row} — ${args.seat} — ${verdict}
 - \`k6-summary.json\` — structured evidence (no raw events)
 - \`gateway-events.ndjson\` — redacted WS frames (${events.length} captured)
 - \`row-result.json\` — normalized outcome
+- \`seat-readiness.json\` — public-safe seat/tooling preflight (${args['seat-readiness'] ? 'captured' : 'not supplied to writer'})
 - \`artifacts/\` — optional copied receipts (Tempo trace, logs)
 
 ## Redaction boundary

--- a/tools/k6-proofs/scripts/seat-readiness-preflight.mjs
+++ b/tools/k6-proofs/scripts/seat-readiness-preflight.mjs
@@ -7,16 +7,19 @@
  * being confused with product behavior.
  */
 import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const DEFAULT_EXPECTED_K6_VERSION = 'v2.0.0';
-const SECRET_ENV = new Set(['OPENCLAW_GATEWAY_TOKEN']);
-const REQUIRED_ENV = [
-  'OPENCLAW_GATEWAY_TOKEN',
-  'OPENCLAW_GATEWAY_WS',
-  'OPENCLAW_SESSION_KEY',
-  'OPENCLAW_CANDIDATE_SHA',
-  'OPENCLAW_SEAT_NAME',
-];
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '../../..');
+const DEFAULT_POLICY_PATH = join(REPO_ROOT, 'tools/k6-proofs/seat-readiness.policy.json');
+const SECRET_NAME_PATTERN = /(?:TOKEN|SECRET|PASSWORD|KEY|CREDENTIAL|COOKIE|AUTH)/i;
+
+function loadPolicy(policyPath = DEFAULT_POLICY_PATH) {
+  const raw = readFileSync(policyPath, 'utf8');
+  return JSON.parse(raw);
+}
 
 function parseArgs(argv) {
   const out = { gateway: true };
@@ -25,6 +28,7 @@ function parseArgs(argv) {
     if (arg === '--json') out.json = true;
     else if (arg === '--no-gateway') out.gateway = false;
     else if (arg === '--expected-k6-version') out.expectedK6Version = argv[++i];
+    else if (arg === '--policy') out.policyPath = argv[++i];
     else if (arg === '--help' || arg === '-h') out.help = true;
     else throw new Error(`unknown arg: ${arg}`);
   }
@@ -32,7 +36,7 @@ function parseArgs(argv) {
 }
 
 function usage() {
-  console.log(`Usage: node tools/k6-proofs/scripts/seat-readiness-preflight.mjs [--json] [--no-gateway] [--expected-k6-version v2.0.0]\n\nEmits no secret values. Exit 0 only for PASS-candidate.`);
+  console.log(`Usage: node tools/k6-proofs/scripts/seat-readiness-preflight.mjs [--json] [--no-gateway] [--policy path] [--expected-k6-version v2.0.0]\n\nEmits no secret values. Exit 0 only for PASS-candidate. Version/env defaults come from tools/k6-proofs/seat-readiness.policy.json.`);
 }
 
 function commandOrNull(cmd, args) {
@@ -43,12 +47,30 @@ function commandOrNull(cmd, args) {
   }
 }
 
-function detectK6() {
-  const path = commandOrNull('which', ['k6']);
-  if (!path) return { ok: false, path: null, version: null, rawVersion: null };
-  const rawVersion = commandOrNull('k6', ['version']);
-  const version = rawVersion && rawVersion.match(/\bv\d+\.\d+\.\d+\b/)?.[0] || null;
-  return { ok: Boolean(version), path, version, rawVersion };
+function unique(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function detectK6(policy) {
+  const candidates = unique([
+    process.env.K6_BIN,
+    ...(policy.k6?.binaryCandidates || []),
+    commandOrNull('which', ['k6']),
+  ]);
+
+  const checked = [];
+  for (const path of candidates) {
+    if (!existsSync(path)) {
+      checked.push({ path, exists: false, version: null, rawVersion: null });
+      continue;
+    }
+    const rawVersion = commandOrNull(path, ['version']);
+    const version = rawVersion && rawVersion.match(/\bv\d+\.\d+\.\d+\b/)?.[0] || null;
+    checked.push({ path, exists: true, version, rawVersion });
+    if (version) return { ok: true, path, version, rawVersion, checked };
+  }
+
+  return { ok: false, path: null, version: null, rawVersion: null, checked };
 }
 
 async function fetchOk(url, token) {
@@ -89,17 +111,26 @@ function sessionScope(sessionKey) {
   return 'configured-session';
 }
 
-function envReport() {
-  return REQUIRED_ENV.map((name) => ({
-    name,
-    present: Boolean(process.env[name]),
-    secret: SECRET_ENV.has(name),
-    required: name !== 'OPENCLAW_GATEWAY_WS',
+function envReport(policy) {
+  return (policy.env || []).map((entry) => ({
+    name: entry.name,
+    present: Boolean(process.env[entry.name]),
+    secret: Boolean(entry.secret) || SECRET_NAME_PATTERN.test(entry.name),
+    required: entry.required !== false,
+    purpose: entry.purpose || null,
   }));
+}
+
+function redactRawVersion(rawVersion) {
+  // k6 version output is public-safe today; keep this guard so future tooling
+  // that appends build metadata cannot accidentally leak shell/env material.
+  if (!rawVersion) return null;
+  return rawVersion.replace(/(token|secret|password|authorization|bearer)=[^\s]+/gi, '$1=<redacted>');
 }
 
 function printText(report) {
   console.log(`seat readiness: ${report.outcome}`);
+  console.log(`policy: ${report.policy.name} ${report.policy.version}`);
   console.log(`k6: ${report.k6.version || 'missing'} at ${report.k6.path || '(not found)'} (expected ${report.expectedK6Version})`);
   console.log(`gateway: ${report.gateway.mode}; health=${report.gateway.healthReachable}; status=${report.gateway.statusReachable}; url=${report.gateway.url}`);
   console.log(`candidate sha: ${report.candidate.valid40Hex ? 'valid' : 'missing/invalid'}`);
@@ -117,11 +148,14 @@ async function main() {
     return 0;
   }
 
-  const expectedK6Version = args.expectedK6Version || process.env.OPENCLAW_EXPECTED_K6_VERSION || DEFAULT_EXPECTED_K6_VERSION;
-  const k6 = detectK6();
+  const policy = loadPolicy(args.policyPath);
+  const expectedK6Version = args.expectedK6Version || process.env.OPENCLAW_EXPECTED_K6_VERSION || policy.k6.expectedVersion;
+  const k6 = detectK6(policy);
   k6.matchesExpected = k6.version === expectedK6Version;
+  k6.rawVersion = redactRawVersion(k6.rawVersion);
+  k6.checked = k6.checked.map((item) => ({ ...item, rawVersion: redactRawVersion(item.rawVersion) }));
 
-  const gatewayWs = process.env.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
+  const gatewayWs = process.env.OPENCLAW_GATEWAY_WS || policy.gateway.defaultWsUrl || 'ws://127.0.0.1:18789';
   const gatewayBase = httpBaseFromWs(gatewayWs);
   const token = process.env.OPENCLAW_GATEWAY_TOKEN;
   let gateway = { url: gatewayWs, healthReachable: false, statusReachable: false, mode: 'skipped-by-flag' };
@@ -137,7 +171,7 @@ async function main() {
   }
 
   const candidateSha = process.env.OPENCLAW_CANDIDATE_SHA || null;
-  const env = envReport();
+  const env = envReport(policy);
   const requiredMissing = env.filter((e) => e.required && !e.present).map((e) => e.name);
   const notes = [];
   if (!k6.ok) notes.push('k6 is not installed or did not report a parseable version.');
@@ -155,19 +189,24 @@ async function main() {
     schema: 'openclaw.k6.seat-readiness.v1',
     generatedAt: new Date().toISOString(),
     outcome: pass ? 'PASS-candidate' : 'HONEST-LIMIT-candidate',
+    policy: {
+      name: policy.name,
+      version: policy.version,
+      source: args.policyPath || 'tools/k6-proofs/seat-readiness.policy.json',
+    },
     expectedK6Version,
     k6,
     gateway,
     candidate: { sha: candidateSha, valid40Hex },
     seat: {
-      name: process.env.OPENCLAW_SEAT_NAME || 'unknown-seat',
-      class: process.env.OPENCLAW_SEAT_CLASS || 'message-body',
+      name: process.env.OPENCLAW_SEAT_NAME || policy.seat?.defaultName || 'unknown-seat',
+      class: process.env.OPENCLAW_SEAT_CLASS || policy.seat?.defaultClass || 'message-body',
     },
     session: { scope: sessionScope(process.env.OPENCLAW_SESSION_KEY) },
     env,
     concurrency: {
       safeToRunConcurrently: true,
-      reason: 'read-only seat readiness preflight; no continuation/delegate/compaction calls are fired',
+      reason: policy.concurrency?.reason || 'read-only seat readiness preflight; no continuation/delegate/compaction calls are fired',
     },
     notes,
   };

--- a/tools/k6-proofs/seat-readiness.policy.json
+++ b/tools/k6-proofs/seat-readiness.policy.json
@@ -1,0 +1,70 @@
+{
+  "schema": "openclaw.k6.seat-readiness-policy.v1",
+  "name": "k6 PROOFS seat readiness policy",
+  "version": "2026-06-27",
+  "k6": {
+    "expectedVersion": "v2.0.0",
+    "binaryCandidates": [
+      "/home/figs/bin/k6",
+      "/usr/local/bin/k6",
+      "/usr/bin/k6"
+    ]
+  },
+  "gateway": {
+    "defaultWsUrl": "ws://127.0.0.1:18789"
+  },
+  "seat": {
+    "defaultName": "unknown-seat",
+    "defaultClass": "message-body"
+  },
+  "env": [
+    {
+      "name": "OPENCLAW_GATEWAY_TOKEN",
+      "required": true,
+      "secret": true,
+      "purpose": "operator auth token; presence only is reported"
+    },
+    {
+      "name": "OPENCLAW_GATEWAY_WS",
+      "required": false,
+      "secret": false,
+      "purpose": "target gateway websocket URL; defaults to local gateway"
+    },
+    {
+      "name": "OPENCLAW_SESSION_KEY",
+      "required": true,
+      "secret": false,
+      "purpose": "target session key or coarse session class"
+    },
+    {
+      "name": "OPENCLAW_CANDIDATE_SHA",
+      "required": true,
+      "secret": false,
+      "purpose": "40-character OpenClaw deploy SHA under test"
+    },
+    {
+      "name": "OPENCLAW_SEAT_NAME",
+      "required": true,
+      "secret": false,
+      "purpose": "public seat identifier used in proof artifacts"
+    },
+    {
+      "name": "OPENCLAW_SEAT_CLASS",
+      "required": false,
+      "secret": false,
+      "purpose": "seat behavior class used by token/bracket rows"
+    },
+    {
+      "name": "OPENCLAW_ROW_MANIFEST",
+      "required": false,
+      "secret": false,
+      "purpose": "manifest path for a specific row run"
+    }
+  ],
+  "concurrency": {
+    "reason": "read-only seat readiness preflight; no continuation/delegate/compaction calls are fired"
+  },
+  "redaction": {
+    "guarantee": "Report env values as booleans only; never print token/secret values, prompt bodies, session keys beyond coarse scope, or raw gateway payloads."
+  }
+}

--- a/tools/k6-proofs/seat-readiness.schema.json
+++ b/tools/k6-proofs/seat-readiness.schema.json
@@ -8,6 +8,7 @@
     "schema",
     "generatedAt",
     "outcome",
+    "policy",
     "expectedK6Version",
     "k6",
     "gateway",
@@ -19,57 +20,168 @@
     "notes"
   ],
   "properties": {
-    "schema": { "const": "openclaw.k6.seat-readiness.v1" },
-    "generatedAt": { "type": "string", "format": "date-time" },
-    "outcome": { "enum": ["PASS-candidate", "HONEST-LIMIT-candidate", "FAIL-candidate"] },
-    "expectedK6Version": { "type": "string", "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+$" },
+    "schema": {
+      "const": "openclaw.k6.seat-readiness.v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "outcome": {
+      "enum": [
+        "PASS-candidate",
+        "HONEST-LIMIT-candidate",
+        "FAIL-candidate"
+      ]
+    },
+    "expectedK6Version": {
+      "type": "string",
+      "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
     "k6": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["ok", "path", "version", "matchesExpected", "rawVersion"],
+      "required": [
+        "ok",
+        "path",
+        "version",
+        "matchesExpected",
+        "rawVersion",
+        "checked"
+      ],
       "properties": {
-        "ok": { "type": "boolean" },
-        "path": { "type": ["string", "null"] },
-        "version": { "type": ["string", "null"] },
-        "matchesExpected": { "type": "boolean" },
-        "rawVersion": { "type": ["string", "null"] }
+        "ok": {
+          "type": "boolean"
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "matchesExpected": {
+          "type": "boolean"
+        },
+        "rawVersion": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "checked": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "path",
+              "exists",
+              "version",
+              "rawVersion"
+            ],
+            "properties": {
+              "path": {
+                "type": "string"
+              },
+              "exists": {
+                "type": "boolean"
+              },
+              "version": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "rawVersion": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        }
       }
     },
     "gateway": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["url", "healthReachable", "statusReachable", "mode"],
+      "required": [
+        "url",
+        "healthReachable",
+        "statusReachable",
+        "mode"
+      ],
       "properties": {
-        "url": { "type": "string" },
-        "healthReachable": { "type": "boolean" },
-        "statusReachable": { "type": "boolean" },
-        "mode": { "enum": ["checked", "skipped-no-token", "skipped-by-flag"] }
+        "url": {
+          "type": "string"
+        },
+        "healthReachable": {
+          "type": "boolean"
+        },
+        "statusReachable": {
+          "type": "boolean"
+        },
+        "mode": {
+          "enum": [
+            "checked",
+            "skipped-no-token",
+            "skipped-by-flag"
+          ]
+        }
       }
     },
     "candidate": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["sha", "valid40Hex"],
+      "required": [
+        "sha",
+        "valid40Hex"
+      ],
       "properties": {
-        "sha": { "type": ["string", "null"] },
-        "valid40Hex": { "type": "boolean" }
+        "sha": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "valid40Hex": {
+          "type": "boolean"
+        }
       }
     },
     "seat": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["name", "class"],
+      "required": [
+        "name",
+        "class"
+      ],
       "properties": {
-        "name": { "type": "string" },
-        "class": { "type": "string" }
+        "name": {
+          "type": "string"
+        },
+        "class": {
+          "type": "string"
+        }
       }
     },
     "session": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["scope"],
+      "required": [
+        "scope"
+      ],
       "properties": {
-        "scope": { "type": "string" }
+        "scope": {
+          "type": "string"
+        }
       }
     },
     "env": {
@@ -77,24 +189,76 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["name", "present", "secret", "required"],
+        "required": [
+          "name",
+          "present",
+          "secret",
+          "required",
+          "purpose"
+        ],
         "properties": {
-          "name": { "type": "string" },
-          "present": { "type": "boolean" },
-          "secret": { "type": "boolean" },
-          "required": { "type": "boolean" }
+          "name": {
+            "type": "string"
+          },
+          "present": {
+            "type": "boolean"
+          },
+          "secret": {
+            "type": "boolean"
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "purpose": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
         }
       }
     },
     "concurrency": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["safeToRunConcurrently", "reason"],
+      "required": [
+        "safeToRunConcurrently",
+        "reason"
+      ],
       "properties": {
-        "safeToRunConcurrently": { "type": "boolean" },
-        "reason": { "type": "string" }
+        "safeToRunConcurrently": {
+          "type": "boolean"
+        },
+        "reason": {
+          "type": "string"
+        }
       }
     },
-    "notes": { "type": "array", "items": { "type": "string" } }
+    "notes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "version",
+        "source"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

- centralizes the k6 proof-standard seat readiness policy in `tools/k6-proofs/seat-readiness.policy.json`
- extends `seat-readiness-preflight.mjs` to report checked k6 candidates, policy source, env purposes, and secret-safe boolean env presence
- wires `seat-readiness.json` into workflow dry-run artifacts and non-dry candidate evidence output
- documents the pre-fire seat readiness gate in README and CONTRIBUTING
- adds node:test coverage for policy/schema/report redaction and evidence-writer copying

Fixes #145.

## Validation

- `node --check tools/k6-proofs/scripts/seat-readiness-preflight.mjs`
- `node --check tools/k6-proofs/scripts/evidence-writer.mjs`
- `node --test tools/k6-proofs/scripts/__tests__/*.test.mjs` → 8/8 PASS
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs` → passed, 22 manifests / 7 scenario files
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs` → ok true
- `node tools/k6-proofs/scripts/validate-corpus.mjs --index` → OK: 4 passed, 0 failed
- `node tools/k6-proofs/scripts/validate-corpus.mjs --sha 2723dbee783c113cae70e4fb63a4cff9f55402e3` → OK: 10 passed, 0 failed
- `git diff --check`

## Notes

This is harness/docs/schema plumbing only. It does not mutate folded proof rows, manifests, or corpus verdicts.
