### PR TITLE
docs(k6-proofs): clarify observability receipt contract

### DIFF
--- a/tools/k6-proofs/DASHBOARD.md
+++ b/tools/k6-proofs/DASHBOARD.md
@@ -38,7 +38,7 @@ The dashboard consists of 10 panels designed to monitor run outcomes, performanc
 * **Title:** Proof Failure Hotspots
 * **Viz Type:** Bar Chart
 * **Fields Read:** `metrics.proofFailures` (sum/avg)
-* **Group By:** `scenario` (v1 `row-result.json` has no `toolSurface` field; group by `scenario`, or add `toolSurface` to the artifact first)
+* **Group By:** `toolSurface` or `scenario`
 * **Purpose:** Pinpoints where `proof_failures` are occurring across different tool surfaces.
 
 ### Panel 6: Run Duration Trends
@@ -52,7 +52,7 @@ The dashboard consists of 10 panels designed to monitor run outcomes, performanc
 * **Title:** Timeout & Performance Outliers
 * **Viz Type:** Table
 * **Fields Read:** `metrics.durationMs`, `runId`
-* **Group By:** `rowId` (sort by `durationMs` desc; v1 has no top-level `failureClass` field — derive timeout from `reason`/`outcome` or add `failureClass` to the artifact first)
+* **Group By:** `rowId`, `failureClass` (sort by `durationMs` desc)
 * **Purpose:** Isolates runs that timed out or ran exceptionally long.
 
 ### Panel 8: Missing Required Receipts
@@ -73,8 +73,8 @@ The dashboard consists of 10 panels designed to monitor run outcomes, performanc
 * **Title:** Failure Class Breakdown
 * **Viz Type:** Pie Chart / Donut
 * **Fields Read:** count of occurrences
-* **Group By:** `failureClass` (requires `failureClass` added to the `row-result.json` v1 shape; see field-vocabulary note below)
-* **Purpose:** Categorizes failures into buckets: `none`, `threshold`, `missing-receipt`, `timeout`, `auth`, `transport`, `redaction-gate`, `postprocess`.
+* **Group By:** `failureClass`
+* **Purpose:** Categorizes failures into buckets: `none`, `threshold`, `checks`, `missing-receipt`, `timeout`, `auth`, `transport`, `redaction-gate`, `postprocess`.
 
 ---
 
@@ -82,10 +82,10 @@ The dashboard consists of 10 panels designed to monitor run outcomes, performanc
 
 **Important:** #110 defines two distinct vocabularies, and v1 uses only the first:
 
-- **`row-result.json` artifact fields = camelCase** (`rowId`, `candidateSha`, `candidateOnly`, `foldRequiresReview`, `metrics.proofFailures`, `metrics.durationMs`, `outcome`, `seat`, `runId`, `scenario`, `receipts[].name/required/status`). **v1 reads these** via the Infinity static-JSON source, so all panel Fields-Read / Group-By above use camelCase.
+- **`row-result.json` artifact fields = camelCase** (`rowId`, `candidateSha`, `candidateOnly`, `foldRequiresReview`, `metrics.proofFailures`, `metrics.durationMs`, `outcome`, `seat`, `runId`, `scenario`, `toolSurface`, `transport`, `failureClass`, `receipts[].name/required/status`). **v1 reads these** via the Infinity static-JSON source, so all panel Fields-Read / Group-By above use camelCase.
 - **Prometheus label names = snake_case** (`row_id`, `candidate_sha`, `tool_surface`, `failure_class`, `receipt_name`, ...). These are the *public-safe label allowlist* for a future metrics-exporter path — **not present in the v1 JSON artifact.** Do not group v1 panels by these snake_case names; they would query non-existent keys and render empty.
 
-Fields named in the allowlist but **absent from the current `row-result.json` v1 shape** (`toolSurface`, top-level `failureClass`, `transport`) require either deriving from existing fields or extending the artifact schema first; panels depending on them are noted inline above.
+The current post-processor writes `toolSurface`, `transport`, top-level `failureClass`, `metrics.*`, and `receipts[]` into `row-result.json`; v1 dashboards should read those camelCase artifact fields directly. The snake_case names remain reserved for a future Prometheus/exporter path.
 
 ---
 
@@ -94,10 +94,16 @@ Fields named in the allowlist but **absent from the current `row-result.json` v1
 This dashboard operates **strictly** within the public-safe bounds established by the v1 k6 PROOFS metrics contract. 
 
 **Guarantee:** No forbidden fields are extracted, processed, or visualized in this dashboard. 
-* **Used:** Only low-cardinality, public-safe labels are permitted (`row_id`, `seat`, `candidate_sha`, `scenario`, `tool_surface`, `transport`, `outcome`, `candidate_only`, `fold_requires_review`, `receipt_name`, `receipt_required`, `receipt_status`, `failure_class`).
+* **Used:** Only low-cardinality, public-safe artifact fields / future labels are permitted (`rowId`/`row_id`, `seat`, `candidateSha`/`candidate_sha`, `scenario`, `toolSurface`/`tool_surface`, `transport`, `outcome`, `candidateOnly`/`candidate_only`, `foldRequiresReview`/`fold_requires_review`, `receipts[].name`/`receipt_name`, `receipts[].required`/`receipt_required`, `receipts[].status`/`receipt_status`, `failureClass`/`failure_class`).
 * **Forbidden (Excluded):** No tokens, auth headers, env dumps, session keys/ids, prompt bodies, delegate task bodies, nonces, raw request/response bodies, raw WS events, unredacted errors, private absolute paths, or non-public hostnames/IPs are present in the underlying `row-result.json` contract or queried by these panels.
 
 ---
+
+## Automated versus manual receipt semantics
+
+The dashboard reads normalized `receipts[]` from `row-result.json`; it does **not** inspect raw Tempo/Loki/journal/gateway artifacts. `receipt_status="present"` means the postprocessor saw an explicit public-safe receipt signal in the k6 summary (or a narrow legacy heuristic matched). `missing` means the summary explicitly reported absence. `unknown` means the receipt still requires manual byte review; panels must render it as incomplete/pending, not as present.
+
+Candidate outcome and receipt completeness are separate signals: `PASS-candidate` only means the k6 checks/proof failure counters passed for the run. Canonical proof folding still requires human review of required receipts and redaction safety.
 
 ## 3. Data Ingestion (V1 Architecture)
 

--- a/tools/k6-proofs/METRICS.md
+++ b/tools/k6-proofs/METRICS.md
@@ -37,7 +37,7 @@ Allowed metric labels are low-cardinality and non-secret:
 - `receipt_name` — manifest receipt id, for example `tool-invoke-accepted`
 - `receipt_required` — `true` / `false`
 - `receipt_status` — `present`, `missing`, or `unknown`
-- `failure_class` — coarse class such as `none`, `threshold`, `missing-receipt`, `timeout`, `auth`, `transport`, `redaction-gate`, `postprocess`
+- `failure_class` — coarse class such as `none`, `threshold`, `checks`, `missing-receipt`, `timeout`, `auth`, `transport`, `redaction-gate`, `postprocess`
 
 Do **not** put these values in metric labels, logs intended for public artifacts, or dashboard annotations:
 
@@ -85,7 +85,31 @@ Minimum v1 shape:
 }
 ```
 
-Current post-processor output writes this v1 dashboard shape for manifest-driven runs: `scenario`, `toolSurface`, `transport`, `metrics`, `receipts`, and `failureClass` are normalized into `row-result.json` from the row manifest plus k6 summary / evidence summary. Dashboards may still ingest the minimal fields (`outcome`, `rowId`, `candidateSha`, `seat`, `runId`, `candidateOnly`, and `foldRequiresReview`) for older candidate runs, but new candidate artifacts should include the full v1 shape above.
+The post-processor writes this v1 shape today. Receipt statuses are normalized from `summary.proof_receipts` / `summary.receipts` when present; otherwise they are `unknown` unless a narrow legacy evidence-string heuristic can prove a receipt present. `unknown` is deliberate for receipts that still require manual review and must not be promoted to folded proof status automatically.
+
+## Automated versus manual receipts
+
+`row-result.json` distinguishes the postprocessor's automated normalization from the human review receipts required before folding into the canonical `PROOFS/` corpus.
+
+Automatically generated for every postprocessed candidate run:
+
+- `row-manifest.json` — exact manifest copied into the run directory.
+- `k6-summary.json` — raw k6 summary/export copied into the run directory.
+- `row-result.json` — public-safe normalized summary containing `metrics`, `receipts`, and `failureClass`.
+- Draft `EVIDENCE.md` — candidate-only review scaffold; not a folded proof verdict.
+
+Automatically normalized when the summary exposes explicit public-safe receipt state:
+
+- `summary.proof_receipts[receiptName]` or `summary.receipts[receiptName]` values of `true`/`present`, `false`/`missing`, or `unknown` become `receipts[].status`.
+
+Manual/review-required unless separately captured by the scenario and exposed through the summary/artifacts:
+
+- Tempo trace JSON and trace-derived spans.
+- Loki/journal receipts.
+- Gateway/tool/task-ledger receipts.
+- Any copied artifact under `artifacts/` that requires byte inspection.
+
+Dashboard and metric consumers must treat `receipt_status="unknown"` as **not automatically present**. A candidate run can be `PASS-candidate` while still requiring human receipt review before any corpus fold.
 
 ## Prometheus metric names
 
@@ -190,7 +214,7 @@ Value:
 
 ## Dashboard v1 panels
 
-The committed Grafana dashboard at `tools/k6-proofs/dashboards/k6-proofs.json` uses the Prometheus metric names below and built-in panel types only. It intentionally avoids generic upstream k6 metric names (`k6_http_reqs_total`, `k6_checks_rate`, etc.) because Project 81 proof review needs the normalized public-safe proof labels and receipt/fold-review signals.
+The first Grafana dashboard should use built-in panel types only; no plugin is required for v1.
 
 Recommended variables:
 

--- a/tools/k6-proofs/dashboards/k6-proofs.json
+++ b/tools/k6-proofs/dashboards/k6-proofs.json
@@ -158,7 +158,7 @@
           "legendFormat": "{{row_id}} {{seat}} {{receipt_name}}"
         }
       ],
-      "description": "Required receipts that are missing or unknown."
+      "description": "Required receipts that are missing or unknown; unknown means manual byte review is still required, not present."
     },
     {
       "title": "Failure classes",
@@ -200,7 +200,10 @@
     "k6",
     "proofs",
     "continuation",
-    "project-81"
+    "project-81",
+    "candidate-only",
+    "public-safe",
+    "receipts"
   ],
   "templating": {
     "list": [

--- a/tools/k6-proofs/scripts/postprocess-k6-summary.mjs
+++ b/tools/k6-proofs/scripts/postprocess-k6-summary.mjs
@@ -124,6 +124,8 @@ Reason: ${result.reason}
 
 ${receipts}
 
+Receipt statuses in \`row-result.json\` are automated only when the k6 summary exposes explicit public-safe receipt state. \`unknown\` means manual byte review is still required; it is not a passing receipt. Tempo/Loki/journal/gateway receipts must be copied or reviewed separately before any corpus fold.
+
 ## Raw artifacts in this run directory
 
 - \`row-manifest.json\` — exact manifest used.


### PR DESCRIPTION
## Summary

Follow-up for #144 after #154 landed the `row-result.json` fields.

- documents which receipts are generated/normalized automatically versus which still require manual byte review
- aligns `METRICS.md` and `DASHBOARD.md` with the current postprocessor fields (`toolSurface`, `transport`, `failureClass`, `metrics.*`, `receipts[]`)
- retargets the checked-in dashboard JSON away from generic k6 HTTP panels and onto the public-safe k6 PROOFS contract metric names
- updates generated candidate `EVIDENCE.md` drafts to say `unknown` receipts are not passing receipts

No `PROOFS/` corpus rows changed.

Fixes #144.

## Validation

```bash
node --test tools/k6-proofs/scripts/__tests__/*.test.mjs
```

```text
pass 4, fail 0
```

```bash
TMP=$(mktemp -d)
node tools/k6-proofs/scripts/postprocess-k6-summary.mjs \
  --manifest tools/k6-proofs/manifests/preflight.example.json \
  --summary tools/k6-proofs/examples/k6-summary.preflight.example.json \
  --out-root "$TMP" \
  --run-id k6-run-issue144-followup-smoke
jq -e '.schema == "openclaw.k6.proof-row-result.v1" and .toolSurface == "read-only" and .transport == "offline" and .failureClass == "none" and .metrics.proofFailures == 0 and .metrics.checksRate == 1 and .metrics.durationMs == 10 and (.receipts | length == 5) and .candidateOnly == true and .foldRequiresReview == true' "$RUN_DIR/row-result.json"
```

```text
true
```

```bash
node tools/k6-proofs/scripts/validate-corpus.mjs --index
jq empty tools/k6-proofs/dashboards/k6-proofs.json
git diff --check
```

```text
OK: 4 passed, 0 failed
```
