### PR TITLE
k6 proofs: add live-run safety guard

### DIFF
--- a/tools/k6-proofs/CONTRIBUTING-ROWS.md
+++ b/tools/k6-proofs/CONTRIBUTING-ROWS.md
@@ -32,15 +32,33 @@ into `PROOFS/<sha>/` without back-and-forth.
    from the seat's environment or GH Actions repo secrets — **zero secrets in source,
    manifests, evidence, or PR body**. If the token leaks into a log, rotate before
    pushing.
+4. For any live row, fill or verify the manifest's `liveRunSafety` block before firing:
+   `classification`, `requiresLiveGatewayToken`, `requiresTargetSessionKey`,
+   `requiresCandidateSha`, `requiresExternalAgentOrToolInvocation`, `sameSessionConcurrencySafe`,
+   `expectedArtifactClass`, `requiredReceipts`, and `foldRequiresReview:true`.
+   `OPENCLAW_SESSION_KEY` must be explicit when the row mutates/wakes a session; do
+   not rely on the `main` fallback for live continuation rows.
 
 ## Running the row
 
 Use the harness as documented in [`README.md`](README.md):
 
 1. Optional preflight: `k6 run tools/k6-proofs/scenarios/preflight.js`.
-2. Run the row scenario with the manifest pointed via `OPENCLAW_ROW_MANIFEST` and the
+2. Run the fail-closed guard before the live row (the wrapper does this automatically
+   when `OPENCLAW_ROW_MANIFEST` is set):
+
+   ```bash
+   OPENCLAW_GATEWAY_TOKEN="***" \
+   OPENCLAW_SESSION_KEY="<target-session>" \
+     node tools/k6-proofs/scripts/live-run-guard.mjs \
+       --manifest tools/k6-proofs/manifests/<row>.json --json
+   ```
+
+   If it reports missing token/session env or an active same-session lock, stop; the
+   output is setup/coordination failure, not row evidence.
+3. Run the row scenario with the manifest pointed via `OPENCLAW_ROW_MANIFEST` and the
    deployed SHA in `OPENCLAW_CANDIDATE_SHA`. Tee the output to a local file.
-3. Post-process into proof artifacts with `evidence-writer.mjs` (or
+4. Post-process into proof artifacts with `evidence-writer.mjs` (or
    `postprocess-k6-summary.mjs` for the summary-driven path):
 
    ```bash
@@ -48,7 +66,8 @@ Use the harness as documented in [`README.md`](README.md):
      --input /tmp/<row>-output.txt \
      --row <ROW-ID> \
      --seat <seat> \
-     --sha <40-char-sha>
+     --sha <40-char-sha> \
+     --manifest tools/k6-proofs/manifests/<row>.json
    ```
 
    The script writes into `PROOFS/<sha>/<row>/<seat>/k6-run-<timestamp>/`.
@@ -77,6 +96,8 @@ Every `PROOFS/<sha>/<row>/<seat>/k6-run-<ts>/` directory must contain:
   manifest loaded).
 - A "no secrets" line — explicit statement that the captured artifacts contain no
   tokens, no prompt bodies, no user content.
+- The live-run safety classification, expected artifact class, required receipts,
+  same-session concurrency safety, and `foldRequiresReview:true`.
 - For HONEST-LIMIT outcomes: the declared seat-class expectation that explains
   why it is honest-limit and not a fail (e.g. message-body seat killed the bracket
   scanner — must be declared in the manifest before the run, not retro-justified).

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -26,8 +26,8 @@ tools/k6-proofs/
 - Run `node tools/k6-proofs/scripts/seat-readiness-preflight.mjs` before treating row output as proof-standard. A version/env/gateway mismatch is `HONEST-LIMIT-candidate`, not product failure.
 - Environment variables:
   - `OPENCLAW_GATEWAY_WS` — WebSocket URL (default: `ws://127.0.0.1:18789`)
-  - `OPENCLAW_GATEWAY_TOKEN` — operator auth token (**required, never in source**)
-  - `OPENCLAW_SESSION_KEY` — target session key (default: `main`)
+  - `OPENCLAW_GATEWAY_TOKEN` — operator auth token (**required for live rows, never in source**)
+  - `OPENCLAW_SESSION_KEY` — target session key (**required explicitly for live rows that set `liveRunSafety.requiresTargetSessionKey=true`**)
   - `OPENCLAW_CANDIDATE_SHA` — 40-char deploy SHA for this proof run
   - `OPENCLAW_SEAT_NAME` — seat identifier (default: `ronan-dgx`)
   - `OPENCLAW_ROW_MANIFEST` — path to row manifest JSON (optional; enables manifest-driven mode)
@@ -129,6 +129,24 @@ Manifests use `${ENV_VAR:-default}` placeholders resolved at runtime — no secr
 
 Manifests follow the schema defined by #100 (foundation): `openclaw.k6.proof-row-manifest.v1`.
 
+### Live-run safety contract
+
+Rows may declare a `liveRunSafety` block so reviewers and runners can tell the difference between static/preflight-only rows, k6-runnable live rows, orchestration-required rows, and construct-only registry entries before any gateway traffic starts.
+
+The block records:
+
+- `classification`: `static-preflight-only`, `k6-runnable`, `orchestration-required`, or `construct-only`.
+- `requiresLiveGatewayToken`: whether `OPENCLAW_GATEWAY_TOKEN` must be present before the row can run.
+- `requiresTargetSessionKey`: whether `OPENCLAW_SESSION_KEY` must be set explicitly instead of falling back to `main`.
+- `requiresCandidateSha`: whether `OPENCLAW_CANDIDATE_SHA` must be present and a 40-character hex SHA before the row can run.
+- `requiresExternalAgentOrToolInvocation`: whether k6 REST/WS alone is insufficient and an agent/tool invocation is part of the proof path.
+- `sameSessionConcurrencySafe`: `false` means the runner serializes the row per `(rowId, target session)` and fails closed if another run already holds that lock.
+- `expectedArtifactClass`: the highest candidate class the row should emit before review, for example `PASS-candidate`, `HONEST-LIMIT-candidate`, or `construct-only`.
+- `requiredReceipts`: the review receipts that must exist before folding.
+- `foldRequiresReview`: always `true`; generated artifacts are candidates, never final proof verdicts.
+
+When `OPENCLAW_ROW_MANIFEST` is set, `run-proof.sh` calls `scripts/live-run-guard.mjs` before invoking k6. The guard fails closed if required token/session/SHA env is absent, if the manifest's live/static classification contradicts its scenario status, or if a same-session unsafe row is already running against the same target session.
+
 ### Redaction boundary
 
 **No secrets in source or public artifacts.** Gateway tokens come from env vars only.
@@ -228,6 +246,9 @@ node tools/k6-proofs/scripts/validate-corpus.mjs --index --json
 
 # Validate row-manifest scenario registry status vs runnable scenario files
 node tools/k6-proofs/scripts/check-manifest-scenarios.mjs
+
+# Fail-closed live-run safety guard for one manifest
+node tools/k6-proofs/scripts/live-run-guard.mjs --manifest tools/k6-proofs/manifests/r-cd-2.json --json
 
 # Validate workflow scenario choices and row-manifest scenario alignment
 node tools/k6-proofs/scripts/check-scenario-alignment.mjs

--- a/tools/k6-proofs/lib/manifest-loader.js
+++ b/tools/k6-proofs/lib/manifest-loader.js
@@ -60,12 +60,35 @@ export function loadManifestFromEnv() {
 export function validateManifest(manifest) {
   const errors = [];
   if (!manifest.rowId) errors.push('missing rowId');
-  if (!manifest.candidateSha || manifest.candidateSha.length !== 40) {
+  if (!manifest.candidateSha || !/^[0-9a-f]{40}$/.test(manifest.candidateSha)) {
     errors.push(`candidateSha must be a 40-char hex SHA (got: "${manifest.candidateSha}")`);
   }
   if (!manifest.seat) errors.push('missing seat');
   if (!manifest.sessionKey) errors.push('missing sessionKey');
   if ((manifest.review && manifest.review.candidateOnly) !== true) errors.push('review.candidateOnly must be true');
   if ((manifest.review && manifest.review.foldRequiresReview) !== true) errors.push('review.foldRequiresReview must be true');
+
+  const safety = manifest.liveRunSafety;
+  if (safety) {
+    if (safety.foldRequiresReview !== true) errors.push('liveRunSafety.foldRequiresReview must be true');
+    if (safety.requiresLiveGatewayToken && !__ENV.OPENCLAW_GATEWAY_TOKEN) {
+      errors.push('OPENCLAW_GATEWAY_TOKEN is required by liveRunSafety');
+    }
+    if (safety.requiresTargetSessionKey && !__ENV.OPENCLAW_SESSION_KEY) {
+      errors.push('OPENCLAW_SESSION_KEY must be explicitly set by liveRunSafety');
+    }
+    if (safety.requiresCandidateSha && !/^[0-9a-f]{40}$/.test(__ENV.OPENCLAW_CANDIDATE_SHA || '')) {
+      errors.push('OPENCLAW_CANDIDATE_SHA must be a 40-character hex SHA by liveRunSafety');
+    }
+    if (safety.requiresLiveGatewayToken && manifest.transport === 'offline') {
+      errors.push('offline transport cannot require a live gateway token');
+    }
+    if (safety.classification === 'k6-runnable' && manifest.scenario?.status !== 'runnable') {
+      errors.push('liveRunSafety.classification=k6-runnable requires scenario.status=runnable');
+    }
+    if (!Array.isArray(safety.requiredReceipts) || safety.requiredReceipts.length === 0) {
+      errors.push('liveRunSafety.requiredReceipts must be a non-empty array');
+    }
+  }
   return errors;
 }

--- a/tools/k6-proofs/manifests/preflight.example.json
+++ b/tools/k6-proofs/manifests/preflight.example.json
@@ -25,6 +25,22 @@
     "status": "runnable",
     "file": "preflight.js"
   },
+  "liveRunSafety": {
+    "classification": "static-preflight-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": false,
+    "requiresExternalAgentOrToolInvocation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "PASS-candidate",
+    "requiredReceipts": [
+      "manifest-loaded",
+      "k6-summary",
+      "seat-readiness"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Offline golden-path/preflight metadata is concurrency-safe. Live preflight may use a token, but this example must remain safe without secrets."
+  },
   "expectedReceipts": [
     {
       "name": "manifest-loaded",

--- a/tools/k6-proofs/manifests/r-cd-2.json
+++ b/tools/k6-proofs/manifests/r-cd-2.json
@@ -31,6 +31,24 @@
     "promptTemplate": "Proof nonce {{nonce}}: reply with DONE and the nonce only. Do not mutate files. Do not post to any channel.",
     "idempotencyKeyPrefix": "R-CD-2"
   },
+  "liveRunSafety": {
+    "classification": "k6-runnable",
+    "requiresLiveGatewayToken": true,
+    "requiresTargetSessionKey": true,
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": true,
+    "sameSessionConcurrencySafe": false,
+    "expectedArtifactClass": "PASS-candidate",
+    "requiredReceipts": [
+      "seat-readiness",
+      "dispatch-accepted",
+      "parent-wake-event",
+      "no-channel-delivery",
+      "trace-id"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Live continuation row. Fail closed when token/session env is missing, serialize per target session, and treat generated output as a PASS-candidate until required receipts are reviewed."
+  },
   "expectedReceipts": [
     {
       "name": "dispatch-accepted",
@@ -59,8 +77,8 @@
     },
     {
       "name": "trace-id",
-      "required": false,
-      "description": "Trace ID from dispatch response or optional task metadata for Tempo fetch"
+      "required": true,
+      "description": "Trace ID from dispatch response or optional task metadata; Tempo trace JSON must be fetched before folding a PASS."
     }
   ],
   "artifactDestination": {
@@ -73,6 +91,6 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Silent-wake path. PASS-candidate when: (1) dispatching agent turn accepted, (2) parent session emits wake/agent events, (3) NO channel message delivered from the delegate return. A nonce-correlated tasks.list row is optional because continue_delegate uses pending-delegate/subagent surfaces, not the generic task registry."
+    "notes": "Silent-wake path. PASS-candidate when: (1) dispatching agent turn accepted, (2) parent session emits wake/agent events, (3) NO channel message delivered from the delegate return, and (4) trace/receipt artifacts are fetched for review. A nonce-correlated tasks.list row is optional because continue_delegate uses pending-delegate/subagent surfaces, not the generic task registry."
   }
 }

--- a/tools/k6-proofs/row-manifest.schema.json
+++ b/tools/k6-proofs/row-manifest.schema.json
@@ -62,6 +62,52 @@
         "registryNotes": { "type": "string" }
       }
     },
+    "liveRunSafety": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "classification",
+        "requiresLiveGatewayToken",
+        "requiresTargetSessionKey",
+        "requiresCandidateSha",
+        "requiresExternalAgentOrToolInvocation",
+        "sameSessionConcurrencySafe",
+        "expectedArtifactClass",
+        "requiredReceipts",
+        "foldRequiresReview"
+      ],
+      "properties": {
+        "classification": {
+          "enum": ["static-preflight-only", "k6-runnable", "orchestration-required", "construct-only"],
+          "description": "Static/preflight-only rows never fire the live gateway; k6-runnable rows may be started by run-proof.sh; orchestration-required rows need an external agent/tool/human step; construct-only rows document planned/non-runnable proof contracts."
+        },
+        "requiresLiveGatewayToken": { "type": "boolean" },
+        "requiresTargetSessionKey": { "type": "boolean" },
+        "requiresCandidateSha": {
+          "type": "boolean",
+          "description": "True when OPENCLAW_CANDIDATE_SHA must be present and a 40-character hex SHA before the row can run."
+        },
+        "requiresExternalAgentOrToolInvocation": {
+          "type": "boolean",
+          "description": "True when k6 REST/WS alone is not enough and an agent/tool invocation outside the raw k6 transport is required."
+        },
+        "sameSessionConcurrencySafe": {
+          "type": "boolean",
+          "description": "False means do not run this row concurrently against the same target session unless the row explicitly proves concurrency behavior."
+        },
+        "expectedArtifactClass": {
+          "enum": ["PASS-candidate", "HONEST-LIMIT-candidate", "PARTIAL-candidate", "FAIL-candidate", "construct-only"],
+          "description": "The highest artifact class this run should emit before maintainer review/fold."
+        },
+        "requiredReceipts": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "foldRequiresReview": { "type": "boolean", "const": true },
+        "notes": { "type": "string" }
+      }
+    },
     "expectedReceipts": {
       "type": "array",
       "minItems": 1,

--- a/tools/k6-proofs/run-proof.sh
+++ b/tools/k6-proofs/run-proof.sh
@@ -26,6 +26,20 @@ if [[ ! -f "$SCENARIO_FILE" ]]; then
   exit 1
 fi
 
+LOCK_FD=""
+if [[ -n "${OPENCLAW_ROW_MANIFEST:-}" ]]; then
+  GUARD_VARS="$(node "${SCRIPT_DIR}/scripts/live-run-guard.mjs" --manifest "${OPENCLAW_ROW_MANIFEST}" --shell)"
+  eval "$GUARD_VARS"
+  if [[ "${K6_PROOF_LOCK_REQUIRED:-0}" == "1" ]]; then
+    LOCK_FD=9
+    exec 9>"${K6_PROOF_LOCK_PATH}"
+    if ! flock -n 9; then
+      echo "ERROR: another k6 proof run is active for ${K6_PROOF_LOCK_LABEL}; same-session concurrency is not safe for this row" >&2
+      exit 1
+    fi
+  fi
+fi
+
 # Auto-detect seat and SHA. Prefer OPENCLAW_* names used by manifests/workflow,
 # but keep legacy PROOF_* as compatibility aliases.
 SEAT="${OPENCLAW_SEAT_NAME:-${PROOF_SEAT:-$(hostname)}}"

--- a/tools/k6-proofs/scripts/check-manifest-scenarios.mjs
+++ b/tools/k6-proofs/scripts/check-manifest-scenarios.mjs
@@ -16,6 +16,8 @@ const proofsDir = path.join(root, 'tools', 'k6-proofs');
 const manifestsDir = path.join(proofsDir, 'manifests');
 const scenariosDir = path.join(proofsDir, 'scenarios');
 const validStatuses = new Set(['runnable', 'scaffold', 'construct-only']);
+const validSafetyClasses = new Set(['static-preflight-only', 'k6-runnable', 'orchestration-required', 'construct-only']);
+const validArtifactClasses = new Set(['PASS-candidate', 'HONEST-LIMIT-candidate', 'PARTIAL-candidate', 'FAIL-candidate', 'construct-only']);
 
 function withoutJs(value) {
   return String(value || '').replace(/\.js$/u, '');
@@ -62,6 +64,44 @@ for (const file of manifestFiles()) {
 
   if (status === 'construct-only' && (scenario.file || scenario.expectedFile)) {
     failures.push(`${file}: construct-only manifest should not declare scenario.file/expectedFile`);
+  }
+
+  const safety = manifest.liveRunSafety;
+  if (safety) {
+    if (!validSafetyClasses.has(safety.classification)) {
+      failures.push(`${file}: liveRunSafety.classification must be one of ${[...validSafetyClasses].join(', ')}`);
+    }
+    if (!validArtifactClasses.has(safety.expectedArtifactClass)) {
+      failures.push(`${file}: liveRunSafety.expectedArtifactClass must be one of ${[...validArtifactClasses].join(', ')}`);
+    }
+    if (safety.foldRequiresReview !== true) {
+      failures.push(`${file}: liveRunSafety.foldRequiresReview must be true`);
+    }
+    if (safety.classification === 'k6-runnable' && status !== 'runnable') {
+      failures.push(`${file}: liveRunSafety.classification=k6-runnable requires scenario.status=runnable`);
+    }
+    if (safety.classification === 'construct-only' && status === 'runnable') {
+      failures.push(`${file}: liveRunSafety.classification=construct-only cannot be paired with scenario.status=runnable`);
+    }
+    if (safety.requiresLiveGatewayToken === true && manifest.transport === 'offline') {
+      failures.push(`${file}: offline transport cannot require a live gateway token`);
+    }
+    if (typeof safety.requiresCandidateSha !== 'boolean') {
+      failures.push(`${file}: liveRunSafety.requiresCandidateSha must be boolean`);
+    }
+    if (safety.requiresExternalAgentOrToolInvocation === true && manifest.toolSurface === 'read-only') {
+      failures.push(`${file}: read-only toolSurface cannot require external agent/tool invocation`);
+    }
+    if (!Array.isArray(safety.requiredReceipts) || safety.requiredReceipts.length === 0) {
+      failures.push(`${file}: liveRunSafety.requiredReceipts must be non-empty`);
+    } else {
+      const expected = new Set((manifest.expectedReceipts || []).map((receipt) => receipt.name));
+      for (const receiptName of safety.requiredReceipts) {
+        if (receiptName !== 'seat-readiness' && !expected.has(receiptName)) {
+          failures.push(`${file}: liveRunSafety.requiredReceipts references '${receiptName}' but expectedReceipts has no matching receipt`);
+        }
+      }
+    }
   }
 }
 

--- a/tools/k6-proofs/scripts/check-scenario-alignment.mjs
+++ b/tools/k6-proofs/scripts/check-scenario-alignment.mjs
@@ -17,6 +17,8 @@ const SCENARIO_DIR = path.join(ROOT, 'tools/k6-proofs/scenarios');
 const MANIFEST_DIR = path.join(ROOT, 'tools/k6-proofs/manifests');
 const WORKFLOW_PATH = path.join(ROOT, '.github/workflows/k6-proof.yml');
 const VALID_STATUSES = new Set(['runnable', 'scaffold', 'construct-only']);
+const VALID_SAFETY_CLASSES = new Set(['static-preflight-only', 'k6-runnable', 'orchestration-required', 'construct-only']);
+const VALID_ARTIFACT_CLASSES = new Set(['PASS-candidate', 'HONEST-LIMIT-candidate', 'PARTIAL-candidate', 'FAIL-candidate', 'construct-only']);
 
 function withoutJs(value) {
   return String(value || '').replace(/\.js$/u, '');
@@ -107,6 +109,44 @@ for (const file of fs.readdirSync(MANIFEST_DIR).filter((entry) => entry.endsWith
 
   if (status === 'construct-only' && (scenario.file || scenario.expectedFile)) {
     errors.push(`${file}: construct-only manifest should not declare scenario.file/expectedFile`);
+  }
+
+  const safety = manifest.liveRunSafety;
+  if (safety) {
+    if (!VALID_SAFETY_CLASSES.has(safety.classification)) {
+      errors.push(`${file}: liveRunSafety.classification must be one of ${[...VALID_SAFETY_CLASSES].join(', ')}`);
+    }
+    if (!VALID_ARTIFACT_CLASSES.has(safety.expectedArtifactClass)) {
+      errors.push(`${file}: liveRunSafety.expectedArtifactClass must be one of ${[...VALID_ARTIFACT_CLASSES].join(', ')}`);
+    }
+    if (safety.foldRequiresReview !== true) {
+      errors.push(`${file}: liveRunSafety.foldRequiresReview must be true`);
+    }
+    if (safety.classification === 'k6-runnable' && status !== 'runnable') {
+      errors.push(`${file}: liveRunSafety.classification=k6-runnable requires scenario.status=runnable`);
+    }
+    if (safety.classification === 'construct-only' && status === 'runnable') {
+      errors.push(`${file}: liveRunSafety.classification=construct-only cannot be paired with scenario.status=runnable`);
+    }
+    if (safety.requiresLiveGatewayToken === true && manifest.transport === 'offline') {
+      errors.push(`${file}: offline transport cannot require a live gateway token`);
+    }
+    if (typeof safety.requiresCandidateSha !== 'boolean') {
+      errors.push(`${file}: liveRunSafety.requiresCandidateSha must be boolean`);
+    }
+    if (safety.requiresExternalAgentOrToolInvocation === true && manifest.toolSurface === 'read-only') {
+      errors.push(`${file}: read-only toolSurface cannot require external agent/tool invocation`);
+    }
+    if (!Array.isArray(safety.requiredReceipts) || safety.requiredReceipts.length === 0) {
+      errors.push(`${file}: liveRunSafety.requiredReceipts must be non-empty`);
+    } else {
+      const expected = new Set((manifest.expectedReceipts || []).map((receipt) => receipt.name));
+      for (const receiptName of safety.requiredReceipts) {
+        if (receiptName !== 'seat-readiness' && !expected.has(receiptName)) {
+          errors.push(`${file}: liveRunSafety.requiredReceipts references '${receiptName}' but expectedReceipts has no matching receipt`);
+        }
+      }
+    }
   }
 }
 

--- a/tools/k6-proofs/scripts/evidence-writer.mjs
+++ b/tools/k6-proofs/scripts/evidence-writer.mjs
@@ -11,7 +11,8 @@
  *     --input /tmp/r-cd-1-output.txt \
  *     --row R-CD-1 \
  *     --seat ronan-dgx \
- *     --sha <40-char-hex>
+ *     --sha <40-char-hex> \
+ *     [--manifest tools/k6-proofs/manifests/r-cd-1.json]
  *
  * Writes:
  *   PROOFS/<sha>/<row>/<seat>/k6-run-<timestamp>/
@@ -43,7 +44,7 @@ function stamp() {
 }
 
 function usage() {
-  console.error(`Usage: node evidence-writer.mjs --input <k6-output> --row <ROW> --seat <SEAT> --sha <SHA>`);
+  console.error(`Usage: node evidence-writer.mjs --input <k6-output> --row <ROW> --seat <SEAT> --sha <SHA> [--manifest <row-manifest.json>]`);
   process.exit(2);
 }
 
@@ -54,6 +55,12 @@ if (!args.input || !args.row || !args.seat || !args.sha) usage();
 // Validate SHA is 40-char hex
 if (!/^[0-9a-f]{40}$/.test(args.sha)) {
   console.error(`ERROR: --sha must be a 40-character hex string (got: "${args.sha}")`);
+  process.exit(1);
+}
+
+const manifest = args.manifest ? JSON.parse(readFileSync(args.manifest, 'utf-8')) : null;
+if (manifest && (manifest.review?.foldRequiresReview !== true || manifest.liveRunSafety?.foldRequiresReview === false)) {
+  console.error('ERROR: manifest must keep foldRequiresReview=true for candidate evidence');
   process.exit(1);
 }
 
@@ -138,6 +145,17 @@ const result = {
   candidateSha: args.sha,
   seat: args.seat,
   outcome: verdict,
+  liveRunSafety: manifest?.liveRunSafety ? {
+    classification: manifest.liveRunSafety.classification,
+    requiresLiveGatewayToken: Boolean(manifest.liveRunSafety.requiresLiveGatewayToken),
+    requiresTargetSessionKey: Boolean(manifest.liveRunSafety.requiresTargetSessionKey),
+    requiresCandidateSha: Boolean(manifest.liveRunSafety.requiresCandidateSha),
+    requiresExternalAgentOrToolInvocation: Boolean(manifest.liveRunSafety.requiresExternalAgentOrToolInvocation),
+    sameSessionConcurrencySafe: Boolean(manifest.liveRunSafety.sameSessionConcurrencySafe),
+    expectedArtifactClass: manifest.liveRunSafety.expectedArtifactClass,
+    requiredReceipts: manifest.liveRunSafety.requiredReceipts || [],
+    foldRequiresReview: manifest.liveRunSafety.foldRequiresReview === true,
+  } : null,
   candidateOnly: true,
   foldRequiresReview: true,
 };
@@ -178,6 +196,18 @@ const md = `# ${args.row} — ${args.seat} — ${verdict}
 - \`gateway-events.ndjson\` — redacted WS frames (${events.length} captured)
 - \`row-result.json\` — normalized outcome
 - \`artifacts/\` — optional copied receipts (Tempo trace, logs)
+
+## Live-run safety
+
+${manifest?.liveRunSafety ? `- Classification: \`${manifest.liveRunSafety.classification}\`
+- Requires live gateway token: ${manifest.liveRunSafety.requiresLiveGatewayToken ? 'yes' : 'no'}
+- Requires explicit target session key: ${manifest.liveRunSafety.requiresTargetSessionKey ? 'yes' : 'no'}
+- Requires candidate SHA: ${manifest.liveRunSafety.requiresCandidateSha ? 'yes' : 'no'}
+- Requires external agent/tool invocation: ${manifest.liveRunSafety.requiresExternalAgentOrToolInvocation ? 'yes' : 'no'}
+- Same-session concurrency safe: ${manifest.liveRunSafety.sameSessionConcurrencySafe ? 'yes' : 'no'}
+- Expected artifact class: \`${manifest.liveRunSafety.expectedArtifactClass}\`
+- Required receipts: ${manifest.liveRunSafety.requiredReceipts.map((r) => `\`${r}\``).join(', ')}
+- Fold requires review: ${manifest.liveRunSafety.foldRequiresReview ? 'yes' : 'no'}` : '- No manifest supplied to evidence-writer; reviewer must verify live-run safety from the row manifest.'}
 
 ## Redaction boundary
 

--- a/tools/k6-proofs/scripts/live-run-guard.mjs
+++ b/tools/k6-proofs/scripts/live-run-guard.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * live-run-guard.mjs — fail-closed preflight for manifest-declared live proof safety.
+ *
+ * This script is intentionally dependency-free so run-proof.sh and CI can call it
+ * before k6 starts. It validates only the safety contract that affects live runs:
+ * required env presence and same-session concurrency lock metadata.
+ */
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+
+function usage() {
+  console.error('Usage: node tools/k6-proofs/scripts/live-run-guard.mjs --manifest <row-manifest.json> [--shell|--json]');
+}
+
+function parseArgs(argv) {
+  const out = { mode: 'text' };
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--shell') {
+      out.mode = 'shell';
+      continue;
+    }
+    if (arg === '--json') {
+      out.mode = 'json';
+      continue;
+    }
+    if (arg === '--manifest') {
+      out.manifest = argv[++i];
+      continue;
+    }
+    throw new Error(`unexpected argument: ${arg}`);
+  }
+  return out;
+}
+
+function resolveEnvPlaceholders(value, env) {
+  if (typeof value !== 'string') return value;
+  return value.replace(/\$\{([^}]+)\}/g, (_, expr) => {
+    const [name, fallback] = expr.split(':-');
+    return env[name] || fallback || '';
+  });
+}
+
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
+
+function safetyErrors(manifest, env = process.env) {
+  const errors = [];
+  const safety = manifest.liveRunSafety;
+
+  if (!safety) {
+    errors.push('manifest missing liveRunSafety block');
+    return errors;
+  }
+
+  if (manifest.review?.foldRequiresReview !== true || safety.foldRequiresReview !== true) {
+    errors.push('liveRunSafety.foldRequiresReview and review.foldRequiresReview must both be true');
+  }
+
+  if (safety.requiresLiveGatewayToken && !env.OPENCLAW_GATEWAY_TOKEN) {
+    errors.push('OPENCLAW_GATEWAY_TOKEN is required by liveRunSafety.requiresLiveGatewayToken');
+  }
+
+  if (safety.requiresTargetSessionKey && !env.OPENCLAW_SESSION_KEY) {
+    errors.push('OPENCLAW_SESSION_KEY must be set explicitly when liveRunSafety.requiresTargetSessionKey=true');
+  }
+
+  if (safety.requiresCandidateSha && !/^[0-9a-f]{40}$/.test(env.OPENCLAW_CANDIDATE_SHA || '')) {
+    errors.push('OPENCLAW_CANDIDATE_SHA must be a 40-character hex SHA when liveRunSafety.requiresCandidateSha=true');
+  }
+
+  if (safety.requiresLiveGatewayToken && manifest.transport === 'offline') {
+    errors.push('offline transport cannot require a live gateway token');
+  }
+
+  if (safety.classification === 'k6-runnable' && manifest.scenario?.status !== 'runnable') {
+    errors.push('liveRunSafety.classification=k6-runnable requires scenario.status=runnable');
+  }
+
+  if (safety.classification === 'construct-only' && manifest.scenario?.status === 'runnable') {
+    errors.push('liveRunSafety.classification=construct-only cannot be paired with scenario.status=runnable');
+  }
+
+  if (safety.requiresExternalAgentOrToolInvocation && manifest.toolSurface === 'read-only') {
+    errors.push('read-only toolSurface cannot require external agent/tool invocation');
+  }
+
+  if (!Array.isArray(safety.requiredReceipts) || safety.requiredReceipts.length === 0) {
+    errors.push('liveRunSafety.requiredReceipts must list the receipts required for review');
+  } else {
+    const expected = new Set((manifest.expectedReceipts || []).map((receipt) => receipt.name));
+    for (const receiptName of safety.requiredReceipts) {
+      if (receiptName !== 'seat-readiness' && !expected.has(receiptName)) {
+        errors.push(`liveRunSafety.requiredReceipts references '${receiptName}' but expectedReceipts has no matching receipt`);
+      }
+    }
+  }
+
+  return errors;
+}
+
+function buildResult(manifest, env = process.env) {
+  const safety = manifest.liveRunSafety || {};
+  const explicitSession = env.OPENCLAW_SESSION_KEY || '';
+  const resolvedSession = explicitSession || resolveEnvPlaceholders(manifest.sessionKey || '', env) || 'unset';
+  const rowId = manifest.rowId || 'unknown-row';
+  const lockRequired = safety.sameSessionConcurrencySafe === false;
+  const lockBasis = `${rowId}\0${resolvedSession}`;
+  const lockHash = createHash('sha256').update(lockBasis).digest('hex').slice(0, 24);
+  return {
+    ok: true,
+    rowId,
+    classification: safety.classification || null,
+    expectedArtifactClass: safety.expectedArtifactClass || null,
+    foldRequiresReview: safety.foldRequiresReview === true,
+    requiresLiveGatewayToken: safety.requiresLiveGatewayToken === true,
+    requiresTargetSessionKey: safety.requiresTargetSessionKey === true,
+    requiresCandidateSha: safety.requiresCandidateSha === true,
+    requiresExternalAgentOrToolInvocation: safety.requiresExternalAgentOrToolInvocation === true,
+    sameSessionConcurrencySafe: safety.sameSessionConcurrencySafe === true,
+    lockRequired,
+    lockPath: lockRequired ? `/tmp/openclaw-k6-proof-${lockHash}.lock` : '',
+    lockLabel: lockRequired ? `${rowId}:${resolvedSession}` : '',
+  };
+}
+
+let args;
+try {
+  args = parseArgs(process.argv);
+  if (!args.manifest) {
+    usage();
+    process.exit(2);
+  }
+} catch (error) {
+  usage();
+  console.error(error.message);
+  process.exit(2);
+}
+
+const manifest = JSON.parse(readFileSync(args.manifest, 'utf8'));
+const errors = safetyErrors(manifest);
+if (errors.length) {
+  const result = { ok: false, errors };
+  if (args.mode === 'json') console.log(JSON.stringify(result, null, 2));
+  else for (const error of errors) console.error(`ERROR: ${error}`);
+  process.exit(1);
+}
+
+const result = buildResult(manifest);
+if (args.mode === 'json') {
+  console.log(JSON.stringify(result, null, 2));
+} else if (args.mode === 'shell') {
+  console.log(`K6_PROOF_LOCK_REQUIRED=${result.lockRequired ? '1' : '0'}`);
+  console.log(`K6_PROOF_LOCK_PATH=${shellQuote(result.lockPath)}`);
+  console.log(`K6_PROOF_LOCK_LABEL=${shellQuote(result.lockLabel)}`);
+} else {
+  console.log(`live-run safety OK: ${result.rowId} (${result.classification}, expected ${result.expectedArtifactClass})`);
+  if (result.lockRequired) console.log(`same-session lock: ${result.lockPath} (${result.lockLabel})`);
+}

--- a/tools/k6-proofs/scripts/postprocess-k6-summary.mjs
+++ b/tools/k6-proofs/scripts/postprocess-k6-summary.mjs
@@ -165,6 +165,9 @@ async function main() {
   if (manifest.review?.candidateOnly !== true || manifest.review?.foldRequiresReview !== true) {
     throw new Error('manifest must declare candidateOnly=true and foldRequiresReview=true');
   }
+  if (manifest.liveRunSafety && manifest.liveRunSafety.foldRequiresReview !== true) {
+    throw new Error('manifest liveRunSafety must declare foldRequiresReview=true');
+  }
 
   const dest = manifest.artifactDestination || {};
   const outRoot = args['out-root'] || dest.root || 'PROOFS';
@@ -202,6 +205,17 @@ async function main() {
       durationMs: durationMsFromSummary(summary, manifest.rowId),
     },
     receipts,
+    liveRunSafety: manifest.liveRunSafety ? {
+      classification: manifest.liveRunSafety.classification,
+      requiresLiveGatewayToken: Boolean(manifest.liveRunSafety.requiresLiveGatewayToken),
+      requiresTargetSessionKey: Boolean(manifest.liveRunSafety.requiresTargetSessionKey),
+      requiresCandidateSha: Boolean(manifest.liveRunSafety.requiresCandidateSha),
+      requiresExternalAgentOrToolInvocation: Boolean(manifest.liveRunSafety.requiresExternalAgentOrToolInvocation),
+      sameSessionConcurrencySafe: Boolean(manifest.liveRunSafety.sameSessionConcurrencySafe),
+      expectedArtifactClass: manifest.liveRunSafety.expectedArtifactClass,
+      requiredReceipts: manifest.liveRunSafety.requiredReceipts || [],
+      foldRequiresReview: manifest.liveRunSafety.foldRequiresReview === true,
+    } : null,
     failureClass,
     reason: outcome === 'FAIL-candidate'
       ? 'k6 proof_failures metric is non-zero'


### PR DESCRIPTION
## Summary

Closes #146.

Adds a fail-closed live-run safety contract for Project 81 k6 proof row manifests and wires it into the runner/postprocessors without touching PROOFS corpus rows.

## What changed

- Adds `liveRunSafety` schema fields for:
  - live gateway token requirement
  - explicit target session requirement
  - candidate SHA requirement
  - external agent/tool invocation requirement
  - same-session concurrency safety
  - expected artifact class
  - required receipts
  - `foldRequiresReview`
- Adds `tools/k6-proofs/scripts/live-run-guard.mjs`.
  - Fails closed when required env is absent.
  - Emits lock metadata for rows unsafe to run concurrently on the same target session.
- Updates `run-proof.sh` to call the guard when `OPENCLAW_ROW_MANIFEST` is set and take a per-row/per-session `flock` for unsafe rows.
- Carries live-run safety metadata into candidate `row-result.json` / generated evidence.
- Adds docs/checks in README, CONTRIBUTING, manifest registry checks, and scenario alignment checks.
- Adds concrete manifest examples for `preflight.example.json` and live runnable `r-cd-2.json`.

## Validation

Fresh main SHA: `4bd0d03382e784f2754d7329f320609d72d7ab36`

```text
node --check tools/k6-proofs/scripts/live-run-guard.mjs
node --check tools/k6-proofs/scripts/evidence-writer.mjs
node --check tools/k6-proofs/scripts/postprocess-k6-summary.mjs
node --check tools/k6-proofs/scripts/check-manifest-scenarios.mjs
node --check tools/k6-proofs/scripts/check-scenario-alignment.mjs
node tools/k6-proofs/scripts/check-manifest-scenarios.mjs
# Manifest scenario registry check passed: 22 manifests; 7 scenario files.
node tools/k6-proofs/scripts/check-scenario-alignment.mjs
# ok=true, manifests=22
node --test tools/k6-proofs/scripts/__tests__/*.test.mjs
# pass 4 / fail 0
node tools/k6-proofs/scripts/live-run-guard.mjs --manifest tools/k6-proofs/manifests/preflight.example.json --json
# ok=true, static-preflight-only, no lock
node tools/k6-proofs/scripts/live-run-guard.mjs --manifest tools/k6-proofs/manifests/r-cd-2.json --json
# rc=1 without token/session/SHA env, fails closed as intended
OPENCLAW_GATEWAY_TOKEN=dummy OPENCLAW_SESSION_KEY=agent:main:test OPENCLAW_CANDIDATE_SHA=4bd0d03382e784f2754d7329f320609d72d7ab36 \
  node tools/k6-proofs/scripts/live-run-guard.mjs --manifest tools/k6-proofs/manifests/r-cd-2.json --json
# ok=true, lockRequired=true
node tools/k6-proofs/scripts/postprocess-k6-summary.mjs --manifest tools/k6-proofs/manifests/preflight.example.json --summary tools/k6-proofs/examples/k6-summary.preflight.example.json --out-root /tmp/oc-docs-146/golden-out --run-id k6-run-live-safety-test
# PASS-candidate
node tools/k6-proofs/scripts/evidence-writer.mjs --input /tmp/oc-docs-146/sample-k6-output.txt --row R-CD-2 --seat test-seat --sha 4bd0d03382e784f2754d7329f320609d72d7ab36 --manifest tools/k6-proofs/manifests/r-cd-2.json
# PASS-candidate synthetic writer smoke; generated PROOFS temp removed before commit
python touched-manifest liveRunSafety validation
# liveRunSafety touched-manifest validation passed
git diff --check
# clean
```

## Notes

- No PROOFS corpus rows were changed.
- The full existing row-manifest schema still has legacy gaps unrelated to this issue (for example existing manifests already use `invocation` while the schema is `additionalProperties:false`). I added targeted live-run checks without attempting a broad schema migration.
