### PR TITLE
docs(k6-proofs): classify R-CW-4 as honest limit

### DIFF
--- a/PROOFS/191a7af989a637f435016fd8d72627fc47fae0e0/R-CW-4/silas-clean-worker/EVIDENCE.md
+++ b/PROOFS/191a7af989a637f435016fd8d72627fc47fae0e0/R-CW-4/silas-clean-worker/EVIDENCE.md
@@ -1,0 +1,47 @@
+# R-CW-4 clean-worker classification — HONEST_LIMIT / anomaly
+
+**Row:** R-CW-4 — continue_work chain-depth tracking (`chain.step.remaining` / hop accounting)  
+**Worker:** Silas clean worker (`agent:main:subagent:fd68ab7b-fc4a-47e0-9727-038c72d9a23d`)  
+**Base docs ref:** `00464a25d91a26db445a69372e03baad555551d9`  
+**Runtime SHA under corpus:** `191a7af989a637f435016fd8d72627fc47fae0e0`  
+**Verdict:** `HONEST_LIMIT` — existing row proves wake delivery and visible hop markers, but the corpus evidence does **not** prove same-chain depth decrement/identity across turns.
+
+## Why this is not a PASS yet
+
+The current row evidence (`../cael-dgx/chain_depth_journal.txt`) contains visible wake markers:
+
+```text
+[continuation:work-wake] hop=1/200 ...
+[continuation:work-wake] hop=2/200 ...
+[continuation:work-wake] hop=3/200 ...
+[continuation:work-wake] hop=4/200 ...
+[continuation:work-wake] hop=5/200 ...
+```
+
+That is useful byte evidence for wake delivery and for the journal's human-readable `hop=N/200` counter. It is **not sufficient** for R-CW-4's stricter claim:
+
+- no `chain.id` is present in those journal wake lines;
+- no `chain.step.remaining` is present in those journal wake lines;
+- the window contains repeated `hop=1/200` after the same session key, so the evidence can be explained by multiple fresh chains / duplicate hedges rather than a single chain identity decrementing over time;
+- the k6 scenario in the same directory is `PARTIAL` because Tempo readiness failed (`[R-CW] tempo ready (trace correlation)` failed), so it did not independently correlate the journal markers to continuation spans for this capture.
+
+Older corpus captures (for example `PROOFS/335acbe43a/R-CW-4/trace-*.json` and `PROOFS/7992640e60/R-CW-4/trace-turn2-935072d3.json`) include `continuation.work` spans with `chain.id` and `chain.step.remaining`, but those are not the deployed `191a7af...` corpus row and should not be used to certify this row as freshly passed.
+
+## Minimal discriminator needed for PASS
+
+A clean PASS needs at least two continuation-work receipts from the same chain showing either:
+
+1. identical `chain.id` and monotonic `chain.step.remaining` decrement in `continuation.work` spans; or
+2. journal wake lines that include an explicit stable chain identity plus monotonic hop/depth for that identity.
+
+A marker-only sequence (`SEQ-HOP1 -> SEQ-HOP2 -> SEQ-HOP3`) without chain identity/depth fields remains ambiguous.
+
+## Local retest status
+
+This worker scheduled a local continuation retest with marker:
+
+```text
+SILAS-R-CW4-20260627T2357PDT
+```
+
+The first scheduling call succeeded, but the visible tool result only returned the injected W3C `traceparent`; it did not expose `chain.id` or `chain.step.remaining`. Unless the follow-up turn can retrieve correlated gateway/Tempo span bytes for that trace and show the same-chain decrement, the honest classification remains `HONEST_LIMIT`.

--- a/PROOFS/191a7af989a637f435016fd8d72627fc47fae0e0/R-CW-4/silas-clean-worker/EVIDENCE.md
+++ b/PROOFS/191a7af989a637f435016fd8d72627fc47fae0e0/R-CW-4/silas-clean-worker/EVIDENCE.md
@@ -44,4 +44,4 @@ This worker scheduled a local continuation retest with marker:
 SILAS-R-CW4-20260627T2357PDT
 ```
 
-The first scheduling call succeeded, but the visible tool result only returned the injected W3C `traceparent`; it did not expose `chain.id` or `chain.step.remaining`. Unless the follow-up turn can retrieve correlated gateway/Tempo span bytes for that trace and show the same-chain decrement, the honest classification remains `HONEST_LIMIT`.
+The local retest later produced visible wake metadata for A and B: `Turn 1/200` followed by `Turn 2/200`, both with `Chain started at 2026-06-28T06:53:37.227Z`. That is useful evidence of wake continuity at the visible metadata layer, but it still does not expose `chain.id` or `chain.step.remaining`. A hop C was scheduled; unless it exposes those proof bytes or correlated gateway/Tempo spans for the same chain, the honest classification remains `HONEST_LIMIT`.

--- a/PROOFS/191a7af989a637f435016fd8d72627fc47fae0e0/R-CW-4/silas-clean-worker/EVIDENCE.md
+++ b/PROOFS/191a7af989a637f435016fd8d72627fc47fae0e0/R-CW-4/silas-clean-worker/EVIDENCE.md
@@ -44,4 +44,4 @@ This worker scheduled a local continuation retest with marker:
 SILAS-R-CW4-20260627T2357PDT
 ```
 
-The local retest later produced visible wake metadata for A and B: `Turn 1/200` followed by `Turn 2/200`, both with `Chain started at 2026-06-28T06:53:37.227Z`. That is useful evidence of wake continuity at the visible metadata layer, but it still does not expose `chain.id` or `chain.step.remaining`. A hop C was scheduled; unless it exposes those proof bytes or correlated gateway/Tempo spans for the same chain, the honest classification remains `HONEST_LIMIT`.
+The local retest later produced visible wake metadata for A and B: `Turn 1/200` followed by `Turn 2/200`, both with `Chain started at 2026-06-28T06:53:37.227Z`. That is useful evidence of wake continuity at the visible metadata layer, but it still does not expose `chain.id` or `chain.step.remaining`. Hop C later arrived as `Turn 1/200` with a different `Chain started at` timestamp (`2026-06-28T06:54:01.916Z`), and still exposed no `chain.id` or `chain.step.remaining`. That strengthens the HONEST_LIMIT conclusion: visible wake/turn text is not sufficient to prove same-chain depth decrement.

--- a/PROOFS/191a7af989a637f435016fd8d72627fc47fae0e0/R-CW-4/silas-clean-worker/LOCAL-RETEST.md
+++ b/PROOFS/191a7af989a637f435016fd8d72627fc47fae0e0/R-CW-4/silas-clean-worker/LOCAL-RETEST.md
@@ -1,0 +1,45 @@
+# Local clean-worker retest notes
+
+Marker: `SILAS-R-CW4-20260627T2357PDT`
+
+## Hop A scheduling
+
+Tool result from the first `continue_work` call:
+
+```json
+{
+  "status": "scheduled",
+  "delaySeconds": 5,
+  "note": "Requested 1s, clamped to 5s by continuation config.",
+  "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00"
+}
+```
+
+Wake metadata delivered to this worker:
+
+```text
+[continuation:wake] Turn 1/200. Chain started at 2026-06-28T06:53:37.227Z. Accumulated tokens: 283321. The agent elected to continue working. Reason: R-CW-4 clean retest marker=SILAS-R-CW4-20260627T2357PDT hop=A schedule-hop-B need chain identity/depth discriminator; do not finalize until B/C evidence captured
+```
+
+Interpretation: this proves wake delivery and the visible turn counter for the local worker, but it still does not expose a stable chain identifier or `chain.step.remaining` value in the receipt available to the worker.
+
+## Hop B scheduling
+
+Tool result from the second `continue_work` call:
+
+```json
+{
+  "status": "scheduled",
+  "delaySeconds": 5,
+  "note": "Requested 1s, clamped to 5s by continuation config.",
+  "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-1111111111111111-00"
+}
+```
+
+Pending: hop C wake metadata. If it also only exposes `Turn N/200` and not `chain.id` / `chain.step.remaining`, this retest remains an honest-limit marker sequence rather than a PASS discriminator.
+
+## Hop C / final local-retake outcome
+
+Before PR creation, this worker received a Discord thread follow-up rather than a continuation-wake receipt for hop C. No additional byte exposed `chain.id` or `chain.step.remaining` for the local retest.
+
+Final local-retake classification: HONEST_LIMIT. The retest corroborates wake scheduling/visible turn metadata, not same-chain depth decrement.

--- a/PROOFS/191a7af989a637f435016fd8d72627fc47fae0e0/R-CW-4/silas-clean-worker/LOCAL-RETEST.md
+++ b/PROOFS/191a7af989a637f435016fd8d72627fc47fae0e0/R-CW-4/silas-clean-worker/LOCAL-RETEST.md
@@ -43,3 +43,26 @@ Pending: hop C wake metadata. If it also only exposes `Turn N/200` and not `chai
 Before PR creation, this worker received a Discord thread follow-up rather than a continuation-wake receipt for hop C. No additional byte exposed `chain.id` or `chain.step.remaining` for the local retest.
 
 Final local-retake classification: HONEST_LIMIT. The retest corroborates wake scheduling/visible turn metadata, not same-chain depth decrement.
+
+## Late hop B wake receipt
+
+After PR creation, the hop B wake receipt arrived:
+
+```text
+[continuation:wake] Turn 2/200. Chain started at 2026-06-28T06:53:37.227Z. Accumulated tokens: 446775. The agent elected to continue working. Reason: R-CW-4 clean retest marker=SILAS-R-CW4-20260627T2357PDT hop=B schedule-hop-C; previous wake metadata showed Turn 1/200 fresh chain started 2026-06-28T06:53:37.227Z; need B/C discriminator before PR final
+```
+
+This improves the local retest evidence: A and B share the same visible `Chain started at` timestamp and the visible turn counter advanced from `Turn 1/200` to `Turn 2/200`.
+
+It still does not expose the proof byte requested by R-CW-4: no opaque `chain.id` and no `chain.step.remaining`. A final hop C was scheduled to see whether any deeper discriminator appears, but unless hop C exposes those fields this remains HONEST_LIMIT rather than PASS.
+
+Hop C scheduling result:
+
+```json
+{
+  "status": "scheduled",
+  "delaySeconds": 5,
+  "note": "Requested 1s, clamped to 5s by continuation config.",
+  "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-2222222222222222-00"
+}
+```

--- a/PROOFS/191a7af989a637f435016fd8d72627fc47fae0e0/R-CW-4/silas-clean-worker/LOCAL-RETEST.md
+++ b/PROOFS/191a7af989a637f435016fd8d72627fc47fae0e0/R-CW-4/silas-clean-worker/LOCAL-RETEST.md
@@ -66,3 +66,15 @@ Hop C scheduling result:
   "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-2222222222222222-00"
 }
 ```
+
+## Hop C wake receipt
+
+The hop C wake receipt arrived after the hop B update:
+
+```text
+[continuation:wake] Turn 1/200. Chain started at 2026-06-28T06:54:01.916Z. Accumulated tokens: 390140. The agent elected to continue working. Reason: R-CW-4 clean retest marker=SILAS-RCW4-20260627T2357PDT hop=C final discriminator check; A Turn 1/200 and B Turn 2/200 share chain started 2026-06-28T06:53:37.227Z but still no chain.id/chain.step.remaining
+```
+
+Interpretation: hop C did **not** continue the visible A/B chain. It arrived as `Turn 1/200` with a different visible `Chain started at` timestamp (`2026-06-28T06:54:01.916Z` vs A/B `2026-06-28T06:53:37.227Z`). It also still exposed no opaque `chain.id` and no `chain.step.remaining`.
+
+This strengthens, rather than weakens, the HONEST_LIMIT classification: the local retest demonstrates that visible wake text can show continuity for A/B, but C can restart visibly, and none of the receipts provide the chain/depth proof byte needed for R-CW-4 PASS.

--- a/PROOFS/191a7af989a637f435016fd8d72627fc47fae0e0/R-CW-4/silas-clean-worker/SERVER-BYTES.md
+++ b/PROOFS/191a7af989a637f435016fd8d72627fc47fae0e0/R-CW-4/silas-clean-worker/SERVER-BYTES.md
@@ -1,0 +1,14 @@
+# R-CW-4 clean-worker server-byte re-resolution
+
+Captured by Silas clean worker at 2026-06-27 23:51 PDT before writing.
+
+```text
+repo: karmaterminal/karmaterminal-openclaw-docs
+main server ref: 00464a25d91a26db445a69372e03baad555551d9
+open PRs:
+- #163 caels-worker/20260627/issue-146-live-run-safety @ b865d800f8b78e26298834b0b4e53e9a8ab8228c
+- #160 rune/20260627/seat-readiness-preflight-145 @ 9f9cc4f8b3254a698c3f9cc4da90ea9186accfef
+issue #117 comments: []
+```
+
+Full command transcript: `/tmp/silas-r-cw-4/00-server-bytes.txt` on the Silas worker host.

--- a/PROOFS/191a7af989a637f435016fd8d72627fc47fae0e0/proofs-manifest.json
+++ b/PROOFS/191a7af989a637f435016fd8d72627fc47fae0e0/proofs-manifest.json
@@ -4,14 +4,14 @@
   "ship_sha": "191a7af989a637f435016fd8d72627fc47fae0e0",
   "fire_type": "fresh-fire-in-progress",
   "carried_from": null,
-  "status": "in_progress_chained_depth_filled_honest_limits_remaining",
+  "status": "in_progress_honest_limits_remaining",
   "rollup": {
     "total_rows": 28,
-    "pass": 24,
+    "pass": 23,
     "partial": 0,
     "thin": 0,
     "fail": 0,
-    "honest_limit": 4,
+    "honest_limit": 5,
     "missing": 0,
     "pending": 0
   },
@@ -211,10 +211,10 @@
       "row": "R-CW-4",
       "owner": "🩸 cael (cael-dgx)",
       "dir": "PROOFS/191a7af989a637f435016fd8d72627fc47fae0e0/R-CW-4/",
-      "state": "pass",
+      "state": "honest_limit",
       "traces": 0,
-      "evidence_doc": "PROOFS/191a7af989a637f435016fd8d72627fc47fae0e0/R-CW-4/cael-dgx/EVIDENCE.md",
-      "note": "journal shows chain-depth hop increments through hop=5/200 on cael-dgx"
+      "evidence_doc": "PROOFS/191a7af989a637f435016fd8d72627fc47fae0e0/R-CW-4/silas-clean-worker/EVIDENCE.md",
+      "note": "HONEST_LIMIT: existing 191a journal proves wake/hop markers but lacks chain.id or chain.step.remaining discriminator; repeated hop=1/200 leaves fresh-chain/duplicate-hedge ambiguity."
     },
     {
       "row": "R-CW-5",
@@ -365,7 +365,7 @@
     }
   ],
   "honest_limit_summary": {
-    "total": 4,
+    "total": 5,
     "clusters": [
       {
         "blocker": "karmaterminal/openclaw#1103",
@@ -382,15 +382,22 @@
           "R-RC-2"
         ],
         "meaning": "Cael was post-compaction at low context, so request_compaction over-threshold accept cannot honestly fire on that lane yet"
+      },
+      {
+        "blocker": "R-CW-4 chain identity/depth discriminator missing from 191a capture",
+        "rows": [
+          "R-CW-4"
+        ],
+        "meaning": "wake/hop markers are present, but the current capture lacks chain.id or chain.step.remaining; repeated hop=1/200 keeps same-chain decrement unproven"
       }
     ]
   },
   "summary": {
     "total": 28,
-    "pass": 24,
+    "pass": 23,
     "partial": 0,
     "fail": 0,
-    "honest_limit": 4,
+    "honest_limit": 5,
     "pending": 0,
     "missing": 0
   }


### PR DESCRIPTION
## What Problem This Solves

Classifies R-CW-4 honestly after clean-worker re-resolution: the existing `191a7af...` corpus row shows continuation wake/hop markers, but not a same-chain depth decrement with chain identity.

Fixes karmaterminal/karmaterminal-openclaw-docs#117 (R-CW-4 row only).

## Why This Change Was Made

The previous manifest marked R-CW-4 PASS based on journal lines like `hop=1/200` through `hop=5/200`. Those lines prove wake delivery and visible hop counters, but they do not include `chain.id` or `chain.step.remaining`. The same window includes repeated `hop=1/200`, so fresh-chain / duplicate-hedge explanations remain possible.

## User Impact

The proof corpus no longer over-claims R-CW-4. It now records the exact discriminator needed for a future PASS: stable chain identity plus monotonic depth/remaining across continuation receipts.

## Evidence

- Server bytes re-resolved before writing and before commit:
  - main ref `00464a25d91a26db445a69372e03baad555551d9`
  - open PRs #160 and #163 only
  - issue #117 comments empty
- Manifest JSON validates with `python3 -m json.tool`.
- Touched scope only:
  - `PROOFS/191a7af989a637f435016fd8d72627fc47fae0e0/proofs-manifest.json`
  - `PROOFS/191a7af989a637f435016fd8d72627fc47fae0e0/R-CW-4/silas-clean-worker/*`
- Local worker journals on Silas host:
  - `/tmp/silas-r-cw-4/00-server-bytes.txt`
  - `/tmp/silas-r-cw-4/10-pre-commit-gate.txt`

## Non-overlap

Did not touch R-CW-MULTI*, R-CW-DELEGATE-CHILD-LIVE, or R-CD-* rows.
