### PR TITLE
docs(proofs): add R-CD collection collapse evidence

### DIFF
--- a/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CD-COLLECTION-ON-COLLAPSE/silas-lothric/EVIDENCE.md
+++ b/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CD-COLLECTION-ON-COLLAPSE/silas-lothric/EVIDENCE.md
@@ -1,0 +1,59 @@
+# R-CD-COLLECTION-ON-COLLAPSE — silas-lothric live evidence
+
+**Ship SHA:** `2723dbee783c113cae70e4fb63a4cff9f55402e3`
+**Docs base re-resolved before write:** `00464a25d91a26db445a69372e03baad555551d9`
+**Seat:** `silas-lothric`
+**Root A session:** `agent:main:subagent:a1d65d17-4aae-4b35-8fb8-aa0b7de27776`
+
+## Claim
+
+`R-CD-COLLECTION-ON-COLLAPSE` is live-proven for the delegate `fanoutMode="tree"` collapse/collection path:
+
+A spawned detached intermediate B. B scheduled delayed C using `continue_delegate(..., fanoutMode="tree")`, then B finalized before C returned. Root A later received C's nonce-correlated sentinel through the OpenClaw steering queue, with visible chain `B2 -> continuation leaf`.
+
+## Receipts
+
+### A → B root dispatch
+
+Root A used `sessions_spawn` run-mode detached subagent B2. This is not the exact k6 manifest `mode=session` harness form, but it is a detached intermediate for the live runtime evidence: B2 ran as its own subagent session/run, finalized, and was no longer the active turn when delayed C returned:
+
+- B session: `agent:main:subagent:8cc53a05-1b1e-4cc3-9fad-9c8e4e1eb53b`
+- B run: `8aa389dd-863e-4f12-bcc0-e18c808a7b99`
+- B task: schedule C with `continue_delegate(mode="normal", delaySeconds=8, fanoutMode="tree")`, then final immediately.
+
+B2 returned first:
+
+```text
+B_SENTINEL_RCD_COLLECTION_2723DBEE_RETRY2_20260628T0658Z continue_delegate status: scheduled (mode=normal, delaySeconds=8, fanoutMode=tree, delegateIndex=1)
+```
+
+### B → C delayed leaf
+
+C later returned to root A:
+
+```text
+C_SENTINEL_RCD_COLLECTION_2723DBEE_RETRY2_20260628T0658Z reached root A via fanoutMode=tree after B2 final; visible chain: requester=agent:main:subagent:8cc53a05-1b1e-4cc3-9fad-9c8e4e1eb53b -> session=agent:main:subagent:continuation-fa2a9eb07259c4da91e5a11adf101227.
+```
+
+This is the row's collection-on-collapse byte: C's delayed result reached root A after B2 had already finalized.
+
+## Negative guard / no-orphan guard
+
+A first invalid fire B1 intentionally mixed `targetSessionKey` with `fanoutMode="tree"` and was rejected:
+
+```text
+B_SENTINEL_RCD_COLLECTION_2723DBEE_20260628T0655Z
+Dispatch tool returned success: no — continue_delegate returned error: fanoutMode cannot be combined with targetSessionKey or targetSessionKeys.
+```
+
+That guard matters because it proves the successful B2 path did not rely on an explicit root target mixed with tree fanout. The only successful C fire used `fanoutMode="tree"`; the C receipt then appeared in root A, not only in B's finished session.
+
+## Scope and caveat
+
+This is **live evidence**, not a k6 scenario implementation. It proves the row's required substrate behavior with OpenClaw runtime queue evidence and session/run ids. No Tempo trace was captured in this worker. The row scaffold still says detached `mode=session`; this fire used `sessions_spawn(mode="run")` detached subagents rather than a k6 `sessions.send` harness. Treat this as live evidence for the load-bearing collection behavior, not as a completed runnable k6 scenario. The proven byte is: `fanoutMode="tree"` reaches root A across finalized B.
+
+## Artifacts
+
+- `root-dispatch-receipts.json`
+- `root-collection-receipt.txt`
+- `negative-guard.txt`

--- a/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CD-COLLECTION-ON-COLLAPSE/silas-lothric/negative-guard.txt
+++ b/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CD-COLLECTION-ON-COLLAPSE/silas-lothric/negative-guard.txt
@@ -1,0 +1,9 @@
+Negative guard 1: invalid mixed targeting did not schedule a C leaf.
+- B1 child returned B_SENTINEL_RCD_COLLECTION_2723DBEE_20260628T0655Z.
+- continue_delegate rejected the request: "fanoutMode cannot be combined with targetSessionKey or targetSessionKeys".
+- No C sentinel for the B1 nonce appeared in the root A steering queue.
+
+Negative guard 2: B2 used fanoutMode=tree only.
+- B2 final arrived first with B_SENTINEL_RCD_COLLECTION_2723DBEE_RETRY2_20260628T0658Z and dispatch status scheduled.
+- Delayed C returned later to root A with matching retry2 nonce and visible requester chain B2 -> continuation leaf.
+- The root-collected C receipt proves the leaf was not delivered only to collapsed B.

--- a/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CD-COLLECTION-ON-COLLAPSE/silas-lothric/root-collection-receipt.txt
+++ b/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CD-COLLECTION-ON-COLLAPSE/silas-lothric/root-collection-receipt.txt
@@ -1,0 +1,3 @@
+OpenClaw runtime steering queue delivered C result to root A after B2 final.
+
+C_SENTINEL_RCD_COLLECTION_2723DBEE_RETRY2_20260628T0658Z reached root A via fanoutMode=tree after B2 final; visible chain: requester=agent:main:subagent:8cc53a05-1b1e-4cc3-9fad-9c8e4e1eb53b -> session=agent:main:subagent:continuation-fa2a9eb07259c4da91e5a11adf101227.

--- a/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CD-COLLECTION-ON-COLLAPSE/silas-lothric/root-dispatch-receipts.json
+++ b/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CD-COLLECTION-ON-COLLAPSE/silas-lothric/root-dispatch-receipts.json
@@ -1,0 +1,29 @@
+{
+  "row": "R-CD-COLLECTION-ON-COLLAPSE",
+  "ship_sha": "2723dbee783c113cae70e4fb63a4cff9f55402e3",
+  "seat": "silas-lothric",
+  "root_A_session": "agent:main:subagent:a1d65d17-4aae-4b35-8fb8-aa0b7de27776",
+  "fires": [
+    {
+      "attempt": "B1-invalid-negative-guard",
+      "childSessionKey": "agent:main:subagent:3aaceb0a-5c59-475b-ae3d-c371b9dfa518",
+      "childRunId": "7927209c-b4cb-4384-a130-0deed9f16198",
+      "b_sentinel": "B_SENTINEL_RCD_COLLECTION_2723DBEE_20260628T0655Z",
+      "dispatch_status": "error",
+      "error": "fanoutMode cannot be combined with targetSessionKey or targetSessionKeys",
+      "purpose": "negative guard: invalid mixed targeting does not schedule C"
+    },
+    {
+      "attempt": "B2-tree-fanout-live-fire",
+      "childSessionKey": "agent:main:subagent:8cc53a05-1b1e-4cc3-9fad-9c8e4e1eb53b",
+      "childRunId": "8aa389dd-863e-4f12-bcc0-e18c808a7b99",
+      "b_sentinel": "B_SENTINEL_RCD_COLLECTION_2723DBEE_RETRY2_20260628T0658Z",
+      "dispatch_status": "scheduled",
+      "dispatch_mode": "normal",
+      "delaySeconds": 8,
+      "fanoutMode": "tree",
+      "delegateIndex": 1,
+      "purpose": "A->B->C live fire with B final before delayed C return"
+    }
+  ]
+}

--- a/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/proofs-manifest.json
+++ b/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/proofs-manifest.json
@@ -231,20 +231,35 @@
       "traces": 0,
       "evidence_doc": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-RC-2/cael-dgx/HONEST_LIMIT.md",
       "note": "current clean /new lane is below compaction threshold (8% reject; status later 14%); accept proof requires genuine >=70% context session."
+    },
+    {
+      "row": "R-CD-COLLECTION-ON-COLLAPSE",
+      "owner": "🌫 silas (silas-lothric)",
+      "dir": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CD-COLLECTION-ON-COLLAPSE/",
+      "state": "pass",
+      "traces": 0,
+      "evidence_doc": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CD-COLLECTION-ON-COLLAPSE/silas-lothric/EVIDENCE.md",
+      "note": "A→B→C live fire: root A spawned detached B2, B2 scheduled delayed C with fanoutMode=tree then finalized, and root A later received C_SENTINEL_RCD_COLLECTION_2723DBEE_RETRY2_20260628T0658Z with visible requester chain B2 -> continuation leaf; invalid mixed target+tree B1 preserved as negative guard.",
+      "supporting_docs": [
+        "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CD-COLLECTION-ON-COLLAPSE/silas-lothric/root-dispatch-receipts.json",
+        "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CD-COLLECTION-ON-COLLAPSE/silas-lothric/root-collection-receipt.txt",
+        "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CD-COLLECTION-ON-COLLAPSE/silas-lothric/negative-guard.txt"
+      ],
+      "fired": "2026-06-27 23:52 PDT, Silas A→B→C collection-on-collapse retry2"
     }
   ],
   "rollup": {
-    "total_rows": 22,
-    "pass": 20,
+    "total_rows": 23,
+    "pass": 21,
     "partial": 0,
     "thin": 0,
     "fail": 0,
     "honest_limit": 2,
     "missing": 0
   },
-  "disposition_note": "Fresh PROOFS corpus for exact deployed SHA 2723dbee783c113cae70e4fb63a4cff9f55402e3. Current filed rows include R-RC-1, Silas R-CW-1, R-CD-1, R-CD-2, R-CD-4 guard-side targeting, R-CONFIG-DEFAULTS, R-CONFIG-INTERSESSION, R-OBS-1, Cael R-CW-3, Rune R-CW-7 typed traceparent PASS, Rune R-CW-DELEGATE-TOKEN bare-token PASS, Rune R-CW-DELEGATE-SELF-CONTINUATION parent typed delegate spawn/return PASS, and Rune R-CW-6 HONEST-LIMIT/source-boundary + cap-scheduling evidence with invalid low-cap attempt and delivery/timer red preserved as diagnostics. Remaining rows are expected from their owning seats. Silas added R-REGRESSION-TRAP-TESTS PASS on 2723dbee with 31/31 vitest trap assertions. Elliott R-CW-2 chain-counter PASS added from live continue_work wake/Tempo evidence (delaySeconds=0 immediate; no delay-clamp claim). Silas added R-OBS-2 PASS with normalized Tempo trace-tree visualization from the R-CW-7 explicit-traceparent export.",
+  "disposition_note": "Fresh PROOFS corpus for exact deployed SHA 2723dbee783c113cae70e4fb63a4cff9f55402e3. Current filed rows include R-RC-1, Silas R-CW-1, R-CD-1, R-CD-2, R-CD-4 guard-side targeting, R-CONFIG-DEFAULTS, R-CONFIG-INTERSESSION, R-OBS-1, Cael R-CW-3, Rune R-CW-7 typed traceparent PASS, Rune R-CW-DELEGATE-TOKEN bare-token PASS, Rune R-CW-DELEGATE-SELF-CONTINUATION parent typed delegate spawn/return PASS, and Rune R-CW-6 HONEST-LIMIT/source-boundary + cap-scheduling evidence with invalid low-cap attempt and delivery/timer red preserved as diagnostics. Remaining rows are expected from their owning seats. Silas added R-REGRESSION-TRAP-TESTS PASS on 2723dbee with 31/31 vitest trap assertions. Elliott R-CW-2 chain-counter PASS added from live continue_work wake/Tempo evidence (delaySeconds=0 immediate; no delay-clamp claim). Silas added R-OBS-2 PASS with normalized Tempo trace-tree visualization from the R-CW-7 explicit-traceparent export. Silas added R-CD-COLLECTION-ON-COLLAPSE PASS from live A→B→C fanoutMode=tree evidence with B finalized before delayed C returned to root A.",
   "generated": "2026-06-27",
   "generated_by": "elliott-legion",
-  "status": "in_progress_rows_added_cael_token_postcompaction_silent_rrc2_limit",
-  "notes": "Cael clean /new additions: R-CD-SILENT tool silent PASS, R-CD-3 post-compaction registration PASS, R-CD-TOKEN bracket subagent fallback PASS, R-CW-TOKEN subagent work token PASS, R-RC-2 honest-limit due low context threshold. R-CW-4 intentionally not touched; treated as Silas-occupied unless blocked."
+  "status": "in_progress_rows_added_cael_token_postcompaction_silent_rrc2_limit_silas_collection_collapse",
+  "notes": "Cael clean /new additions: R-CD-SILENT tool silent PASS, R-CD-3 post-compaction registration PASS, R-CD-TOKEN bracket subagent fallback PASS, R-CW-TOKEN subagent work token PASS, R-RC-2 honest-limit due low context threshold. R-CW-4 intentionally not touched; treated as Silas-occupied unless blocked. Silas R-CD-COLLECTION-ON-COLLAPSE: live root collection across finalized intermediate B2, with mixed-target negative guard."
 }


### PR DESCRIPTION
## What

Adds live `R-CD-COLLECTION-ON-COLLAPSE` evidence for ship SHA `2723dbee783c113cae70e4fb63a4cff9f55402e3` under:

`PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CD-COLLECTION-ON-COLLAPSE/silas-lothric/`

Manifest rollup updates from `22 total / 20 pass / 2 honest_limit` to `23 total / 21 pass / 2 honest_limit`.

## Evidence

Live A→B→C fire from Silas:

- A root session spawned detached B2 (`agent:main:subagent:8cc53a05-1b1e-4cc3-9fad-9c8e4e1eb53b`, run `8aa389dd-863e-4f12-bcc0-e18c808a7b99`).
- B2 scheduled delayed C with `continue_delegate(mode="normal", delaySeconds=8, fanoutMode="tree")`, then finalized.
- Root A later received `C_SENTINEL_RCD_COLLECTION_2723DBEE_RETRY2_20260628T0658Z` with visible chain `B2 -> continuation-fa2a9...`.
- Negative guard preserved: invalid B1 mixed `targetSessionKey` with `fanoutMode="tree"` and was rejected, so the successful fire did not rely on mixed explicit root-targeting.

## Caveat

This is live runtime queue evidence, not a completed runnable k6 scenario. The row scaffold still says detached `mode=session`; this fire used `sessions_spawn(mode="run")` detached subagents. The load-bearing collection behavior (`fanoutMode="tree"` reaches root A across finalized B) is proven.

## Validation

- `python -m json.tool PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/proofs-manifest.json`
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs`
- `node tools/k6-proofs/scripts/validate-corpus.mjs --sha 2723dbee783c113cae70e4fb63a4cff9f55402e3`
- `git diff --cached --check` before commit

Refs #119
