### PR TITLE
PROOFS: add R-CW-MULTI typed wake receipts

### DIFF
--- a/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI/silas-lothric/EVIDENCE.md
+++ b/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI/silas-lothric/EVIDENCE.md
@@ -1,0 +1,40 @@
+# R-CW-MULTI — typed-tool multi-election live proof (silas-lothric)
+
+- Ship SHA: `2723dbee783c113cae70e4fb63a4cff9f55402e3`
+- Seat/session: `silas-lothric`, `agent:main:subagent:08a8f21b-6d4c-4ab1-b4cd-0dc80112eef8`
+- Scope: **R-CW-MULTI only**. This directory does not touch R-CW-4, R-CW-MULTI-COLLAPSE, R-CW-DELEGATE-CHILD-LIVE, or any R-CD row.
+
+## Verdict
+
+PASS for the typed-tool R-CW-MULTI behavior: three `continue_work()` elections made in one turn produced three distinct continuation wake turns.
+
+## What fired
+
+In one assistant turn, the session called `continue_work()` three times:
+
+| Election | delaySeconds | traceparent suffix | marker |
+|---|---:|---|---|
+| A | 0 | `0000000000c00101` | `election A immediate/default` |
+| B | 60 | `0000000000c00102` | `RCWMULTI-B` |
+| C | 120 | `0000000000c00103` | `RCWMULTI-C` |
+
+All three tool calls returned `status: scheduled`; see `wake-receipts.json`.
+
+## What executed
+
+The same transcript later received three distinct continuation wake messages with the same chain start:
+
+- Turn `1/200`: election A reason.
+- Turn `2/200`: election B reason with `RCWMULTI-B`.
+- Turn `3/200`: election C reason with `RCWMULTI-C`.
+
+See `session-history-excerpt.md` for the exact wake text.
+
+## Hazard / honesty note
+
+A `sessions_yield` call was mistakenly made after the three scheduling calls. Because that can abort queued delivery in some paths, this row is **not** claimed from scheduling receipts alone. It is claimed only because the transcript then byte-confirmed A/B/C as three actual wake events.
+
+## Limitations
+
+- No Tempo export is included for this narrow proof.
+- Token/bracket form is not advanced here; this PR is the typed-tool receipt requested by the narrow R-CW-MULTI worker assignment.

--- a/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI/silas-lothric/session-history-excerpt.md
+++ b/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI/silas-lothric/session-history-excerpt.md
@@ -1,0 +1,26 @@
+# R-CW-MULTI session-history excerpt — silas-lothric
+
+Session key: `agent:main:subagent:08a8f21b-6d4c-4ab1-b4cd-0dc80112eef8`
+Ship SHA: `2723dbee783c113cae70e4fb63a4cff9f55402e3`
+
+## Scheduling receipts
+
+- `continue_work` election A returned `status: scheduled`, `delaySeconds: 0`, traceparent `00-2723dbee783c113cae70e4fb63a4cff9-0000000000c00101-01`.
+- `continue_work` election B returned `status: scheduled`, `delaySeconds: 60`, traceparent `00-2723dbee783c113cae70e4fb63a4cff9-0000000000c00102-01`.
+- `continue_work` election C returned `status: scheduled`, `delaySeconds: 120`, traceparent `00-2723dbee783c113cae70e4fb63a4cff9-0000000000c00103-01`.
+
+## Wake receipts
+
+The following wake messages arrived in this same subagent transcript after the same-turn elections:
+
+```text
+[continuation:wake] Turn 1/200. Chain started at 2026-06-28T06:51:46.118Z. Accumulated tokens: 196740. The agent elected to continue working. Reason: R-CW-MULTI proof 2723dbee election A immediate/default: collect wake A marker and continue evidence assembly.
+
+[continuation:wake] Turn 2/200. Chain started at 2026-06-28T06:51:46.118Z. Accumulated tokens: 196740. The agent elected to continue working. Reason: R-CW-MULTI proof 2723dbee election B delayed distinct wake; marker RCWMULTI-B.
+
+[continuation:wake] Turn 3/200. Chain started at 2026-06-28T06:51:46.118Z. Accumulated tokens: 196740. The agent elected to continue working. Reason: R-CW-MULTI proof 2723dbee election C delayed distinct wake; marker RCWMULTI-C.
+```
+
+## Guard note
+
+This run mistakenly called `sessions_yield` after scheduling the three elections. The row is not claimed from scheduling alone: the PASS basis is the later byte-observed wake messages above, which prove the queued elections actually executed despite that hazard.

--- a/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI/silas-lothric/wake-receipts.json
+++ b/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI/silas-lothric/wake-receipts.json
@@ -1,0 +1,58 @@
+{
+  "schema": "openclaw.proofs.r_cw_multi.receipt.v1",
+  "row": "R-CW-MULTI",
+  "ship_sha": "2723dbee783c113cae70e4fb63a4cff9f55402e3",
+  "seat": "silas-lothric",
+  "sessionKey": "agent:main:subagent:08a8f21b-6d4c-4ab1-b4cd-0dc80112eef8",
+  "fired_at": "2026-06-28T06:51:35Z",
+  "chain_started": "2026-06-28T06:51:46.118Z",
+  "tool_calls": [
+    {
+      "election": "A",
+      "delaySeconds": 0,
+      "tool_status": "scheduled",
+      "traceparent": "00-2723dbee783c113cae70e4fb63a4cff9-0000000000c00101-01",
+      "reason": "R-CW-MULTI proof 2723dbee election A immediate/default: collect wake A marker and continue evidence assembly."
+    },
+    {
+      "election": "B",
+      "delaySeconds": 60,
+      "tool_status": "scheduled",
+      "traceparent": "00-2723dbee783c113cae70e4fb63a4cff9-0000000000c00102-01",
+      "reason": "R-CW-MULTI proof 2723dbee election B delayed distinct wake; marker RCWMULTI-B."
+    },
+    {
+      "election": "C",
+      "delaySeconds": 120,
+      "tool_status": "scheduled",
+      "traceparent": "00-2723dbee783c113cae70e4fb63a4cff9-0000000000c00103-01",
+      "reason": "R-CW-MULTI proof 2723dbee election C delayed distinct wake; marker RCWMULTI-C."
+    }
+  ],
+  "observed_wakes": [
+    {
+      "election": "A",
+      "turn": "1/200",
+      "observed_at_transcript": "2026-06-28T06:52:16Z",
+      "reason_contains": "election A immediate/default"
+    },
+    {
+      "election": "B",
+      "turn": "2/200",
+      "observed_at_transcript": "2026-06-28T06:52:46Z",
+      "reason_contains": "RCWMULTI-B"
+    },
+    {
+      "election": "C",
+      "turn": "3/200",
+      "observed_at_transcript": "2026-06-28T06:53:??Z",
+      "reason_contains": "RCWMULTI-C"
+    }
+  ],
+  "pass_basis": "All three same-turn continue_work tool elections returned scheduled and later arrived as three distinct continuation wake messages Turn 1/200, 2/200, and 3/200 with their election-specific reason markers. A sessions_yield was mistakenly called after scheduling; evidence is therefore based on byte-confirmed actual wake messages, not scheduling alone.",
+  "limitations": [
+    "No Tempo export was captured for this narrow proof; transcript/tool receipts are committed as row evidence.",
+    "Token/bracket form was not fired in this scope; this PR advances only the typed-tool R-CW-MULTI receipt requested by the narrow worker assignment."
+  ],
+  "created_at": "2026-06-28T06:54:41Z"
+}

--- a/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/proofs-manifest.json
+++ b/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/proofs-manifest.json
@@ -231,20 +231,33 @@
       "traces": 0,
       "evidence_doc": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-RC-2/cael-dgx/HONEST_LIMIT.md",
       "note": "current clean /new lane is below compaction threshold (8% reject; status later 14%); accept proof requires genuine >=70% context session."
+    },
+    {
+      "row": "R-CW-MULTI",
+      "owner": "🌫 silas (silas-lothric)",
+      "dir": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI/",
+      "state": "pass",
+      "traces": 0,
+      "evidence_doc": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI/silas-lothric/EVIDENCE.md",
+      "note": "typed continue_work multi-election: three same-turn elections returned scheduled and then executed as distinct transcript wakes Turn 1/200, 2/200, and 3/200 with A/B/C markers; no Tempo export; token form not claimed.",
+      "supporting_docs": [
+        "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI/silas-lothric/wake-receipts.json",
+        "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI/silas-lothric/session-history-excerpt.md"
+      ]
     }
   ],
   "rollup": {
-    "total_rows": 22,
-    "pass": 20,
+    "total_rows": 23,
+    "pass": 21,
     "partial": 0,
     "thin": 0,
     "fail": 0,
     "honest_limit": 2,
     "missing": 0
   },
-  "disposition_note": "Fresh PROOFS corpus for exact deployed SHA 2723dbee783c113cae70e4fb63a4cff9f55402e3. Current filed rows include R-RC-1, Silas R-CW-1, R-CD-1, R-CD-2, R-CD-4 guard-side targeting, R-CONFIG-DEFAULTS, R-CONFIG-INTERSESSION, R-OBS-1, Cael R-CW-3, Rune R-CW-7 typed traceparent PASS, Rune R-CW-DELEGATE-TOKEN bare-token PASS, Rune R-CW-DELEGATE-SELF-CONTINUATION parent typed delegate spawn/return PASS, and Rune R-CW-6 HONEST-LIMIT/source-boundary + cap-scheduling evidence with invalid low-cap attempt and delivery/timer red preserved as diagnostics. Remaining rows are expected from their owning seats. Silas added R-REGRESSION-TRAP-TESTS PASS on 2723dbee with 31/31 vitest trap assertions. Elliott R-CW-2 chain-counter PASS added from live continue_work wake/Tempo evidence (delaySeconds=0 immediate; no delay-clamp claim). Silas added R-OBS-2 PASS with normalized Tempo trace-tree visualization from the R-CW-7 explicit-traceparent export.",
+  "disposition_note": "Fresh PROOFS corpus for exact deployed SHA 2723dbee783c113cae70e4fb63a4cff9f55402e3. Current filed rows include R-RC-1, Silas R-CW-1, R-CD-1, R-CD-2, R-CD-4 guard-side targeting, R-CONFIG-DEFAULTS, R-CONFIG-INTERSESSION, R-OBS-1, Cael R-CW-3, Rune R-CW-7 typed traceparent PASS, Rune R-CW-DELEGATE-TOKEN bare-token PASS, Rune R-CW-DELEGATE-SELF-CONTINUATION parent typed delegate spawn/return PASS, and Rune R-CW-6 HONEST-LIMIT/source-boundary + cap-scheduling evidence with invalid low-cap attempt and delivery/timer red preserved as diagnostics. Remaining rows are expected from their owning seats. Silas added R-REGRESSION-TRAP-TESTS PASS on 2723dbee with 31/31 vitest trap assertions. Elliott R-CW-2 chain-counter PASS added from live continue_work wake/Tempo evidence (delaySeconds=0 immediate; no delay-clamp claim). Silas added R-OBS-2 PASS with normalized Tempo trace-tree visualization from the R-CW-7 explicit-traceparent export. Silas added R-CW-MULTI typed-tool PASS: 3 same-turn continue_work elections produced Turn 1/200, 2/200, and 3/200 wake receipts; no R-CW-4/MULTI-COLLAPSE/DELEGATE-CHILD-LIVE/R-CD rows touched.",
   "generated": "2026-06-27",
   "generated_by": "elliott-legion",
-  "status": "in_progress_rows_added_cael_token_postcompaction_silent_rrc2_limit",
+  "status": "in_progress_rows_added_rcw_multi",
   "notes": "Cael clean /new additions: R-CD-SILENT tool silent PASS, R-CD-3 post-compaction registration PASS, R-CD-TOKEN bracket subagent fallback PASS, R-CW-TOKEN subagent work token PASS, R-RC-2 honest-limit due low context threshold. R-CW-4 intentionally not touched; treated as Silas-occupied unless blocked."
 }


### PR DESCRIPTION
## What
- Adds R-CW-MULTI typed-tool proof receipts for ship SHA `2723dbee783c113cae70e4fb63a4cff9f55402e3` under `PROOFS/2723dbee.../R-CW-MULTI/silas-lothric/`.
- Updates the 2723dbee proof manifest only for `R-CW-MULTI`.

## Evidence
- `wake-receipts.json`: three same-turn `continue_work()` elections returned `status: scheduled`.
- `session-history-excerpt.md`: byte-observed continuation wakes arrived as Turn 1/200, Turn 2/200, and Turn 3/200 with A/B/C markers.
- `EVIDENCE.md`: documents the sessions_yield hazard and claims PASS only from actual wake delivery, not scheduling alone.

## Scope guard
- Does not touch R-CW-4, R-CW-MULTI-COLLAPSE, R-CW-DELEGATE-CHILD-LIVE, or any R-CD rows.

Fixes #118