### PR TITLE
proofs: document R-CW-MULTI-COLLAPSE honest limit

### DIFF
--- a/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI-COLLAPSE/elliott-legion/HONEST_LIMIT.md
+++ b/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI-COLLAPSE/elliott-legion/HONEST_LIMIT.md
@@ -1,0 +1,80 @@
+# R-CW-MULTI-COLLAPSE — elliott-legion honest-limit at ship SHA 2723dbee
+
+**Seat:** elliott-legion
+**Capture/ship SHA:** `2723dbee783c113cae70e4fb63a4cff9f55402e3`
+**Disposition:** ⚠️ **HONEST_LIMIT** — source/test substrate is pinned and green, but a live elapsed-overlap stale-fold fire is not ethically/operationally induced on this worker session because the current configured fold grace is 48h.
+
+## What this row tests
+
+`R-CW-MULTI-COLLAPSE` is the grace-conditional multi-`continue_work()` collapse behavior:
+
+- close/on-time matured siblings within grace must **all drive**;
+- genuinely stale queued backlog older than the grace folds older siblings into the newest election;
+- recovered/running work must **never** be folded out from under an in-flight turn;
+- elapsed model-turn time before scheduling must not pre-collapse a same-turn multi-election batch.
+
+## Source byte at exact ship SHA
+
+`source-test-byte.txt` captures the exact deployed source and tests from `2723dbee783c113cae70e4fb63a4cff9f55402e3`.
+
+Key source bytes:
+
+- `src/auto-reply/continuation/work-dispatch.ts` defines `SUPERSEDED_GRACE_MULTIPLIER = 2`.
+- `dispatchPendingContinuationWork` computes `supersededGraceMs = runtimeConfig.maxDelayMs * SUPERSEDED_GRACE_MULTIPLIER` before calling `partitionSupersededWork`.
+- `partitionSupersededWork`:
+  - keeps a single newest-elected member by `electedAt`, tie-broken by `hop`;
+  - only marks queued, non-newest work as superseded when `now - work.dueAt > graceMs`;
+  - always drives `status === "running"` work, regardless of age.
+
+Key test bytes:
+
+- `work-dispatch.test.ts` pins stale older siblings folding into newest, close bursts within grace preserving all, stale running work never folding, and mixed running/queued behavior.
+- `attempt-execution.continue-work-opts.test.ts` pins that same-turn multi-`continue_work()` elections schedule independent rows, and that elapsed model-turn time before post-turn scheduling does not collapse/pre-mature that batch.
+
+## Test receipt
+
+Narrow test command run locally on elliott at the exact ship checkout (`/home/figs/flesh_beast_tmp/openclaw` HEAD = `2723dbee783c113cae70e4fb63a4cff9f55402e3`):
+
+```bash
+cd /home/figs/flesh_beast_tmp/openclaw
+node scripts/run-vitest.mjs run \
+  src/auto-reply/continuation/work-dispatch.test.ts \
+  src/agents/command/attempt-execution.continue-work-opts.test.ts
+```
+
+Result (`rcw-multi-collapse-vitest-2723.log`, summarized in `test-summary.txt`):
+
+```text
+PASS — 2 Vitest project shards passed in 25.48s
+auto-reply: src/auto-reply/continuation/work-dispatch.test.ts — 71 tests passed
+agents: src/agents/command/attempt-execution.continue-work-opts.test.ts — 15 tests passed
+```
+
+## Why this is HONEST_LIMIT, not PASS
+
+The issue #118 acceptance asks for the live behavior, not only mocked/static proof. I did not claim live PASS.
+
+Current elliott continuation config (`gateway-config-continuation.json`) reports:
+
+```json
+{
+  "maxDelayMs": 86400000,
+  "derived": {
+    "supersededGraceMultiplier": 2,
+    "supersededGraceMs": 172800000,
+    "supersededGraceHuman": "48h"
+  }
+}
+```
+
+Because the production fold condition is strict `now - work.dueAt > graceMs`, a live stale-fold fire under current config requires queued work to sit overdue for **more than 48 hours** before co-drain, or else a deliberate temporary production config mutation to shrink `agents.defaults.continuation.maxDelayMs`. I did neither from this clean worker channel.
+
+So the byte-grounded state is:
+
+- ✅ deployed source implements the grace-conditional fold exactly at `2723dbee`;
+- ✅ deterministic source-level tests for the row are green (`86/86` across the two narrow files);
+- ⚠️ live elapsed-overlap stale-fold capture remains not performed here because the configured live grace is 48h and shrinking it would be a production config mutation rather than a normal proof fire.
+
+## Verdict
+
+⚠️ **HONEST_LIMIT** — source/test substrate green and exact-SHA pinned, but live proof remains owed unless the proof plan explicitly authorizes either a 48h+ stale-backlog wait or a coordinated temporary maxDelayMs reduction/restoration window.

--- a/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI-COLLAPSE/elliott-legion/artifact-checksums.json
+++ b/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI-COLLAPSE/elliott-legion/artifact-checksums.json
@@ -1,0 +1,27 @@
+[
+  {
+    "path": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI-COLLAPSE/elliott-legion/HONEST_LIMIT.md",
+    "bytes": 4150,
+    "sha256": "d4c98573ac065e1410ec8e32ce851d67823517bf601770ab3f58ef5368b9de72"
+  },
+  {
+    "path": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI-COLLAPSE/elliott-legion/source-test-byte.txt",
+    "bytes": 12195,
+    "sha256": "1aaf985a7ee17435c3589ad3e55769c39d0e95e58dc56728561b4ffb7585c569"
+  },
+  {
+    "path": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI-COLLAPSE/elliott-legion/gateway-config-continuation.json",
+    "bytes": 661,
+    "sha256": "7168286c1afda71ab1be1ac2e0b7a41c23dce5b4d21dfe6ea07ea82ed118b8ae"
+  },
+  {
+    "path": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI-COLLAPSE/elliott-legion/test-summary.txt",
+    "bytes": 832,
+    "sha256": "f76caea2bcab4388062c77cf02f25ef8c909518e97175049c69d9ef11e63dd21"
+  },
+  {
+    "path": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI-COLLAPSE/elliott-legion/rcw-multi-collapse-vitest-2723.log",
+    "bytes": 1084,
+    "sha256": "02e825dd648a38c063a5ae3d2372e4c59343ef42a7b82e93b35befadd4f446fd"
+  }
+]

--- a/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI-COLLAPSE/elliott-legion/gateway-config-continuation.json
+++ b/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI-COLLAPSE/elliott-legion/gateway-config-continuation.json
@@ -1,0 +1,23 @@
+{
+  "path": "agents.defaults.continuation",
+  "config": {
+    "enabled": true,
+    "defaultDelayMs": 15000,
+    "minDelayMs": 5000,
+    "maxDelayMs": 86400000,
+    "maxChainLength": 200,
+    "costCapTokens": 50000000,
+    "maxDelegatesPerTurn": 500,
+    "crossSessionTargeting": "enabled",
+    "contextPressureThreshold": 0.4,
+    "earlyWarningBand": 0.3125
+  },
+  "derived": {
+    "supersededGraceMultiplier": 2,
+    "supersededGraceMs": 172800000,
+    "supersededGraceHuman": "48h"
+  },
+  "captured_by": "elliott-legion",
+  "captured_at": "2026-06-28T07:05:00Z",
+  "capture_note": "gateway config.get agents.defaults.continuation; secret-free excerpt only"
+}

--- a/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI-COLLAPSE/elliott-legion/rcw-multi-collapse-vitest-2723.log
+++ b/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI-COLLAPSE/elliott-legion/rcw-multi-collapse-vitest-2723.log
@@ -1,0 +1,19 @@
+
+[1m[30m[46m RUN [49m[39m[22m [36mv4.1.8 [39m[90m/home/figs/flesh_beast_tmp/openclaw[39m
+
+ [32m✓[39m [30m[45m auto-reply [49m[39m src/auto-reply/continuation/work-dispatch.test.ts [2m([22m[2m71 tests[22m[2m)[22m[32m 225[2mms[22m[39m
+
+[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
+[2m      Tests [22m [1m[32m71 passed[39m[22m[90m (71)[39m
+[2m   Start at [22m 00:00:25
+[2m   Duration [22m 966ms[2m (transform 726ms, setup 376ms, import 211ms, tests 225ms, environment 0ms)[22m
+
+
+[1m[30m[46m RUN [49m[39m[22m [36mv4.1.8 [39m[90m/home/figs/flesh_beast_tmp/openclaw[39m
+
+ [32m✓[39m [30m[46m agents [49m[39m src/agents/command/attempt-execution.continue-work-opts.test.ts [2m([22m[2m15 tests[22m[2m)[22m[33m 379[2mms[22m[39m
+
+[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
+[2m      Tests [22m [1m[32m15 passed[39m[22m[90m (15)[39m
+[2m   Start at [22m 00:00:29
+[2m   Duration [22m 14.94s[2m (transform 11.62s, setup 394ms, import 14.02s, tests 379ms, environment 0ms)[22m

--- a/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI-COLLAPSE/elliott-legion/source-test-byte.txt
+++ b/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI-COLLAPSE/elliott-legion/source-test-byte.txt
@@ -1,0 +1,256 @@
+# R-CW-MULTI-COLLAPSE source/test byte — 2723dbee783c113cae70e4fb63a4cff9f55402e3
+
+## work-dispatch.ts: superseded partition and grace calculation
+```ts
+const CONTINUATION_TURN_DRAINING_REASON = "draining";
+const MAIN_COMMAND_LANE = "main";
+const RUNNING_WORK_RECOVERY_STALE_MS = 60_000;
+// #986 Guard 2: a matured backlog member is "stale" (superseded-eligible) when it
+// is overdue past this multiple of the configured maxDelayMs. Close bursts stay
+// below the grace and are NOT collapsed; only a genuine stale pile is folded.
+const SUPERSEDED_GRACE_MULTIPLIER = 2;
+export function partitionSupersededWork(
+  works: readonly PendingContinuationWork[],
+  graceMs: number,
+  now: number,
+): { drive: PendingContinuationWork[]; superseded: PendingContinuationWork[] } {
+  if (works.length <= 1 || graceMs <= 0) {
+    return { drive: [...works], superseded: [] };
+  }
+  // Identify the single newest-elected member. A synchronous batch enqueue can
+  // stamp identical `electedAt` (the store writes are sync), so ties are broken
+  // by `hop` (durable monotonic enqueue order within a chain) — the higher hop
+  // is the newer intent. Without the tie-break, same-ms rows fall to array
+  // order and the OLDEST stale wake could be kept while the newest is folded
+  // (Codex #988 review :252).
+  let newestIdx = 0;
+  for (let i = 1; i < works.length; i++) {
+    const w = works[i];
+    const best = works[newestIdx];
+    if (w.electedAt > best.electedAt || (w.electedAt === best.electedAt && w.hop > best.hop)) {
+      newestIdx = i;
+    }
+  }
+  const drive: PendingContinuationWork[] = [];
+  const superseded: PendingContinuationWork[] = [];
+  for (let i = 0; i < works.length; i++) {
+    const work = works[i];
+    // #988-P2-1 fold-side write-guard: a recovered `running` member is live
+    // intent already being driven (it may be observing requests-in-flight). It
+    // is NEVER supersede-eligible, regardless of staleness or election order —
+    // folding it would finish an in-flight turn as superseded out from under
+    // itself. Only `queued` backlog members can be coalesced into the newest.
+    if (work.status === "running") {
+      drive.push(work);
+      continue;
+    }
+    const isNewest = i === newestIdx;
+    const isStale = now - work.dueAt > graceMs;
+    if (isNewest) {
+      // The single newest-elected member always drives (live intent).
+      drive.push(work);
+    } else if (isStale) {
+      superseded.push(work);
+    } else {
+      drive.push(work);
+    }
+  }
+  return { drive, superseded };
+}
+  // #986 Guard 2: fold a stale backlog. Only matured works reach here, so a
+  // batch of >1 means they piled up (the session was busy through the window);
+  // on-time staggered elections drain one-per-poll and never co-arrive.
+  const runtimeConfig = resolveContinuationRuntimeConfig();
+  const supersededGraceMs = runtimeConfig.maxDelayMs * SUPERSEDED_GRACE_MULTIPLIER;
+  const { drive: worksToDrive, superseded } = partitionSupersededWork(
+    works,
+    supersededGraceMs,
+    Date.now(),
+  );
+```
+
+## work-dispatch.test.ts: grace-conditional fold tests
+```ts
+describe("#986 partitionSupersededWork (drain-superseded)", () => {
+  const GRACE = 120_000;
+  const NOW = 1_000_000;
+
+  it("passes a single matured work through untouched", () => {
+    const works = [work({ hop: 1, electedAt: 1, dueAt: 1 })];
+    const { drive, superseded } = partitionSupersededWork(works, GRACE, NOW);
+    expect(drive).toHaveLength(1);
+    expect(superseded).toHaveLength(0);
+  });
+
+  it("never collapses when grace is non-positive (guard disabled)", () => {
+    const works = [
+      work({ hop: 1, electedAt: 1, dueAt: 1 }),
+      work({ hop: 2, electedAt: 2, dueAt: 2 }),
+      work({ hop: 3, electedAt: 3, dueAt: 3 }),
+    ];
+    const { drive, superseded } = partitionSupersededWork(works, 0, NOW);
+    expect(drive).toHaveLength(3);
+    expect(superseded).toHaveLength(0);
+  });
+
+  it("folds stale older siblings into the newest-elected member (backlog)", () => {
+    // All three matured long ago (overdue >> grace): a genuine stale pile.
+    const works = [
+      work({ hop: 1, electedAt: 100, dueAt: NOW - 500_000 }),
+      work({ hop: 2, electedAt: 200, dueAt: NOW - 400_000 }),
+      work({ hop: 3, electedAt: 300, dueAt: NOW - 300_000 }),
+    ];
+    const { drive, superseded } = partitionSupersededWork(works, GRACE, NOW);
+    expect(drive.map((w) => w.hop)).toEqual([3]); // newest-elected drives
+    expect(superseded.map((w) => w.hop).toSorted((a, b) => a - b)).toEqual([1, 2]);
+  });
+
+  it("preserves a close burst that is not yet stale (within grace)", () => {
+    // Three matured just now, none overdue past grace: distinct close burst.
+    const works = [
+      work({ hop: 1, electedAt: 100, dueAt: NOW - 10 }),
+      work({ hop: 2, electedAt: 200, dueAt: NOW - 5 }),
+      work({ hop: 3, electedAt: 300, dueAt: NOW }),
+    ];
+    const { drive, superseded } = partitionSupersededWork(works, GRACE, NOW);
+    expect(drive).toHaveLength(3);
+    expect(superseded).toHaveLength(0);
+  });
+
+  it("keeps the newest even if it is itself overdue, folds only stale older", () => {
+    const works = [
+      work({ hop: 1, electedAt: 100, dueAt: NOW - 500_000 }), // stale older
+      work({ hop: 2, electedAt: 200, dueAt: NOW - 1_000 }), // recent, not stale
+      work({ hop: 3, electedAt: 300, dueAt: NOW - 300_000 }), // newest, stale-but-newest
+    ];
+    const { drive, superseded } = partitionSupersededWork(works, GRACE, NOW);
+    // newest (hop 3) always drives; hop 2 within grace drives; hop 1 stale folds.
+    expect(drive.map((w) => w.hop).toSorted((a, b) => a - b)).toEqual([2, 3]);
+    expect(superseded.map((w) => w.hop)).toEqual([1]);
+  });
+
+  it("tie-breaks same-millisecond electedAt by hop — keeps the highest-hop newest intent (#988 :252)", () => {
+    // Synchronous batch enqueue can stamp identical electedAt; the newest intent
+    // is the highest hop, NOT the first array-order row. consumePendingWork
+    // sorts createdAt asc, so the stale older sibling appears first.
+    const works = [
+      work({ hop: 1, electedAt: 5_000, dueAt: NOW - 500_000 }), // same ms, oldest hop, stale
+      work({ hop: 2, electedAt: 5_000, dueAt: NOW - 400_000 }), // same ms, middle hop, stale
+      work({ hop: 3, electedAt: 5_000, dueAt: NOW - 300_000 }), // same ms, NEWEST hop
+    ];
+    const { drive, superseded } = partitionSupersededWork(works, GRACE, NOW);
+    // The highest-hop (3) is the kept newest — NOT the first array row (hop 1).
+    expect(drive.map((w) => w.hop)).toEqual([3]);
+    expect(superseded.map((w) => w.hop).toSorted((a, b) => a - b)).toEqual([1, 2]);
+  });
+
+  it("never supersedes a recovered running member even when stale and not newest (#988-P2-1)", () => {
+    // A recovered `running` turn is actively executing (it may be observing
+    // requests-in-flight). It must drive, never fold, even though it is overdue
+    // past grace and a newer queued election exists. RED before the write-guard:
+    // the stale, non-newest running member was classified `superseded`.
+    const works = [
+      work({ hop: 1, electedAt: 100, dueAt: NOW - 500_000, status: "running" }), // stale running, oldest
+      work({ hop: 2, electedAt: 300, dueAt: NOW - 300_000, status: "queued" }), // newest queued election
+    ];
+    const { drive, superseded } = partitionSupersededWork(works, GRACE, NOW);
+    expect(drive.map((w) => w.hop).toSorted((a, b) => a - b)).toEqual([1, 2]);
+    expect(superseded).toHaveLength(0);
+  });
+
+  it("still folds a stale queued member into a newer election (#986 Guard 2 intact)", () => {
+    // The only supersede-eligible member is `queued`; the #986 behavior is
+    // unchanged for genuine queued backlog.
+    const works = [
+      work({ hop: 1, electedAt: 100, dueAt: NOW - 500_000, status: "queued" }), // stale queued backlog
+      work({ hop: 2, electedAt: 300, dueAt: NOW - 300_000, status: "queued" }), // newest queued election
+    ];
+    const { drive, superseded } = partitionSupersededWork(works, GRACE, NOW);
+    expect(drive.map((w) => w.hop)).toEqual([2]);
+    expect(superseded.map((w) => w.hop)).toEqual([1]);
+  });
+
+  it("mixed batch: stale running drives, stale queued folds, newest queued drives (#988-P2-1)", () => {
+    const works = [
+      work({ hop: 1, electedAt: 100, dueAt: NOW - 500_000, status: "running" }), // stale running → drives
+      work({ hop: 2, electedAt: 200, dueAt: NOW - 400_000, status: "queued" }), // stale queued → folds
+      work({ hop: 3, electedAt: 300, dueAt: NOW - 300_000, status: "queued" }), // newest queued → drives
+    ];
+    const { drive, superseded } = partitionSupersededWork(works, GRACE, NOW);
+    expect(drive.map((w) => w.hop).toSorted((a, b) => a - b)).toEqual([1, 3]);
+    expect(superseded.map((w) => w.hop)).toEqual([2]);
+  });
+```
+
+## attempt-execution.continue-work-opts.test.ts: same-turn multi-election scheduling / elapsed-turn guard
+```ts
+  it("schedules every same-turn continue_work tool election with independent delays", async () => {
+    runEmbeddedAgentMock.mockImplementationOnce(async (callArgs: unknown) => {
+      const opts = (
+        callArgs as {
+          continueWorkOpts?: {
+            requestContinuation: (req: { reason: string; delaySeconds: number }) => void;
+          };
+        }
+      ).continueWorkOpts;
+      opts?.requestContinuation({ reason: "first immediate-ish wake", delaySeconds: 60 });
+      opts?.requestContinuation({ reason: "second slower wake", delaySeconds: 120 });
+      opts?.requestContinuation({ reason: "third default-ish wake", delaySeconds: 15 });
+      return makeEmbeddedResult();
+    });
+
+    await runEmbeddedAttempt(makeContinuationEnabledConfig());
+
+    const { listTaskFlowsForOwnerKey } = await import("../../tasks/task-flow-registry.js");
+    const states = listTaskFlowsForOwnerKey(sessionKey)
+      .map((flow) => flow.stateJson as { delayMs?: number; hop?: number; reason?: string })
+      .toSorted((left, right) => (left.hop ?? 0) - (right.hop ?? 0));
+
+    expect(states).toHaveLength(3);
+    expect(states.map((state) => state.hop)).toEqual([1, 2, 3]);
+    expect(states.map((state) => state.delayMs)).toEqual([60_000, 120_000, 15_000]);
+    expect(states.map((state) => state.reason)).toEqual([
+      "first immediate-ish wake",
+      "second slower wake",
+      "third default-ish wake",
+    ]);
+    expect(sessionStore[sessionKey]?.continuationChainCount).toBe(3);
+  });
+
+  it("does not collapse a multi continue_work tool batch when the model turn returns after the requested delays elapsed", async () => {
+    const electedAt = Date.parse("2026-06-20T00:00:00.000Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(electedAt);
+    runEmbeddedAgentMock.mockImplementationOnce(async (callArgs: unknown) => {
+      const opts = (
+        callArgs as {
+          continueWorkOpts?: {
+            requestContinuation: (req: { reason: string; delaySeconds: number }) => void;
+          };
+        }
+      ).continueWorkOpts;
+      opts?.requestContinuation({ reason: "sixty seconds", delaySeconds: 60 });
+      opts?.requestContinuation({ reason: "one hundred twenty seconds", delaySeconds: 120 });
+      opts?.requestContinuation({ reason: "default delay", delaySeconds: 15 });
+      // The runner schedules captured tool requests only after the agent turn
+      // yields. Advancing time here pins that current behavior: elapsed time
+      // during the model turn does not collapse or pre-mature the batch.
+      vi.setSystemTime(electedAt + 120_000);
+      return makeEmbeddedResult();
+    });
+
+    await runEmbeddedAttempt(makeContinuationEnabledConfig());
+
+    const { listTaskFlowsForOwnerKey } = await import("../../tasks/task-flow-registry.js");
+    const states = listTaskFlowsForOwnerKey(sessionKey)
+      .map((flow) => flow.stateJson as { delayMs?: number; dueAt?: number; hop?: number })
+      .toSorted((left, right) => (left.hop ?? 0) - (right.hop ?? 0));
+
+    expect(states).toHaveLength(3);
+    expect(states.map((state) => state.delayMs)).toEqual([60_000, 120_000, 15_000]);
+    expect(states.map((state) => state.dueAt)).toEqual([
+      electedAt + 180_000,
+      electedAt + 240_000,
+      electedAt + 135_000,
+    ]);
+```

--- a/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI-COLLAPSE/elliott-legion/test-summary.txt
+++ b/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI-COLLAPSE/elliott-legion/test-summary.txt
@@ -1,0 +1,13 @@
+Command:
+  cd /home/figs/flesh_beast_tmp/openclaw
+  node scripts/run-vitest.mjs run src/auto-reply/continuation/work-dispatch.test.ts src/agents/command/attempt-execution.continue-work-opts.test.ts
+
+Result:
+  PASS — 2 Vitest project shards passed in 25.48s
+  auto-reply: src/auto-reply/continuation/work-dispatch.test.ts — 71 tests passed
+  agents: src/agents/command/attempt-execution.continue-work-opts.test.ts — 15 tests passed
+
+Initial incorrect command, preserved for methodology:
+  node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts ...
+  Result: no test files found because that unit config excludes src/auto-reply/** and src/agents/**.
+  Corrected by using scripts/run-vitest.mjs without forcing the wrong project config, which selected vitest.auto-reply.config.ts and vitest.agents.config.ts.

--- a/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/proofs-manifest.json
+++ b/PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/proofs-manifest.json
@@ -7,7 +7,7 @@
   "rows": [
     {
       "row": "R-RC-1",
-      "owner": "🌫 silas (silas-lothric)",
+      "owner": "\ud83c\udf2b silas (silas-lothric)",
       "dir": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-RC-1/",
       "state": "pass",
       "traces": 0,
@@ -16,7 +16,7 @@
     },
     {
       "row": "R-CD-1",
-      "owner": "🌻 elliott (elliott-legion)",
+      "owner": "\ud83c\udf3b elliott (elliott-legion)",
       "dir": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CD-1/",
       "state": "pass",
       "traces": 1,
@@ -32,7 +32,7 @@
     },
     {
       "row": "R-CW-6",
-      "owner": "🪨 rune (rune-rog-ally)",
+      "owner": "\ud83e\udea8 rune (rune-rog-ally)",
       "dir": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-6/",
       "state": "honest_limit",
       "traces": 0,
@@ -41,16 +41,16 @@
     },
     {
       "row": "R-CW-7",
-      "owner": "🪨 rune (rune-rog-ally)",
+      "owner": "\ud83e\udea8 rune (rune-rog-ally)",
       "dir": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-7/",
       "state": "pass",
       "traces": 1,
       "evidence_doc": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-7/rune-rog-ally/EVIDENCE.md",
-      "note": "typed continue_delegate traceparent path: explicit W3C traceparent accepted; child spawned; Tempo shows dispatch → child run → tree fanout/drain under supplied trace id 2723dbee000000000000000000000007"
+      "note": "typed continue_delegate traceparent path: explicit W3C traceparent accepted; child spawned; Tempo shows dispatch \u2192 child run \u2192 tree fanout/drain under supplied trace id 2723dbee000000000000000000000007"
     },
     {
       "row": "R-CW-DELEGATE-TOKEN",
-      "owner": "🪨 rune (rune-rog-ally)",
+      "owner": "\ud83e\udea8 rune (rune-rog-ally)",
       "dir": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-DELEGATE-TOKEN/",
       "state": "pass",
       "traces": 0,
@@ -59,7 +59,7 @@
     },
     {
       "row": "R-CW-DELEGATE-SELF-CONTINUATION",
-      "owner": "🪨 rune (rune-rog-ally)",
+      "owner": "\ud83e\udea8 rune (rune-rog-ally)",
       "dir": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-DELEGATE-SELF-CONTINUATION/",
       "state": "pass",
       "traces": 0,
@@ -68,16 +68,16 @@
     },
     {
       "row": "R-CD-2",
-      "owner": "🌊 ronan (ronan-dgx)",
+      "owner": "\ud83c\udf0a ronan (ronan-dgx)",
       "dir": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CD-2/",
       "state": "pass",
       "traces": 1,
       "evidence_doc": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CD-2/ronan-dgx/EVIDENCE.md",
-      "note": "continue_delegate(mode=\"silent-wake\") schedule → child spawn → silent return → parent wake; trace 4bf92f3577b34da6a3ce929d0e0e4736"
+      "note": "continue_delegate(mode=\"silent-wake\") schedule \u2192 child spawn \u2192 silent return \u2192 parent wake; trace 4bf92f3577b34da6a3ce929d0e0e4736"
     },
     {
       "row": "R-CD-SILENT",
-      "owner": "🩸 cael (cael-dgx)",
+      "owner": "\ud83e\ude78 cael (cael-dgx)",
       "dir": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CD-SILENT",
       "state": "pass",
       "traces": 0,
@@ -86,7 +86,7 @@
     },
     {
       "row": "R-CD-4",
-      "owner": "🪨 rune (rune-rog-ally)",
+      "owner": "\ud83e\udea8 rune (rune-rog-ally)",
       "dir": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CD-4/",
       "state": "pass",
       "traces": 0,
@@ -95,7 +95,7 @@
     },
     {
       "row": "R-CONFIG-DEFAULTS",
-      "owner": "🕯 emeric (emeric-nuc)",
+      "owner": "\ud83d\udd6f emeric (emeric-nuc)",
       "dir": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CONFIG-DEFAULTS/",
       "state": "pass",
       "traces": 0,
@@ -104,7 +104,7 @@
     },
     {
       "row": "R-CONFIG-INTERSESSION",
-      "owner": "🪨 rune (rune-rog-ally)",
+      "owner": "\ud83e\udea8 rune (rune-rog-ally)",
       "dir": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CONFIG-INTERSESSION/",
       "state": "pass",
       "traces": 0,
@@ -113,7 +113,7 @@
     },
     {
       "row": "R-OBS-1",
-      "owner": "🪨 rune (rune-rog-ally)",
+      "owner": "\ud83e\udea8 rune (rune-rog-ally)",
       "dir": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-OBS-1/",
       "state": "pass",
       "traces": 0,
@@ -122,7 +122,7 @@
     },
     {
       "row": "R-CW-1",
-      "owner": "🌫 silas (silas-lothric)",
+      "owner": "\ud83c\udf2b silas (silas-lothric)",
       "dir": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-1/",
       "state": "pass",
       "traces": 1,
@@ -131,7 +131,7 @@
     },
     {
       "row": "R-CW-2",
-      "owner": "🌻 elliott (elliott-legion)",
+      "owner": "\ud83c\udf3b elliott (elliott-legion)",
       "dir": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-2/",
       "state": "pass",
       "traces": 1,
@@ -148,7 +148,7 @@
     },
     {
       "row": "R-CW-3",
-      "owner": "🩸 cael (cael-dgx)",
+      "owner": "\ud83e\ude78 cael (cael-dgx)",
       "dir": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-3/",
       "state": "pass",
       "traces": 1,
@@ -157,7 +157,7 @@
     },
     {
       "row": "R-REGRESSION-TRAP-TESTS",
-      "owner": "🌫 silas (silas-lothric)",
+      "owner": "\ud83c\udf2b silas (silas-lothric)",
       "dir": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-REGRESSION-TRAP-TESTS/",
       "state": "pass",
       "traces": 0,
@@ -169,7 +169,7 @@
     },
     {
       "row": "R-OBS-2",
-      "owner": "🌫 silas (silas-lothric)",
+      "owner": "\ud83c\udf2b silas (silas-lothric)",
       "dir": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-OBS-2/",
       "state": "pass",
       "traces": 1,
@@ -183,7 +183,7 @@
     },
     {
       "row": "R-CW-5",
-      "owner": "🌊 ronan (ronan-dgx)",
+      "owner": "\ud83c\udf0a ronan (ronan-dgx)",
       "dir": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-5/",
       "state": "pass",
       "traces": 0,
@@ -198,7 +198,7 @@
     },
     {
       "row": "R-CD-3",
-      "owner": "🩸 cael (cael-dgx)",
+      "owner": "\ud83e\ude78 cael (cael-dgx)",
       "dir": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CD-3",
       "state": "pass",
       "traces": 0,
@@ -207,7 +207,7 @@
     },
     {
       "row": "R-CD-TOKEN",
-      "owner": "🩸 cael (cael-dgx)",
+      "owner": "\ud83e\ude78 cael (cael-dgx)",
       "dir": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CD-TOKEN",
       "state": "pass",
       "traces": 0,
@@ -216,7 +216,7 @@
     },
     {
       "row": "R-CW-TOKEN",
-      "owner": "🩸 cael (cael-dgx)",
+      "owner": "\ud83e\ude78 cael (cael-dgx)",
       "dir": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-TOKEN",
       "state": "pass",
       "traces": 0,
@@ -225,26 +225,42 @@
     },
     {
       "row": "R-RC-2",
-      "owner": "🩸 cael (cael-dgx)",
+      "owner": "\ud83e\ude78 cael (cael-dgx)",
       "dir": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-RC-2",
       "state": "honest_limit",
       "traces": 0,
       "evidence_doc": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-RC-2/cael-dgx/HONEST_LIMIT.md",
       "note": "current clean /new lane is below compaction threshold (8% reject; status later 14%); accept proof requires genuine >=70% context session."
+    },
+    {
+      "row": "R-CW-MULTI-COLLAPSE",
+      "owner": "\ud83c\udf3b elliott (elliott-legion)",
+      "dir": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI-COLLAPSE/",
+      "state": "honest_limit",
+      "traces": 0,
+      "evidence_doc": "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI-COLLAPSE/elliott-legion/HONEST_LIMIT.md",
+      "note": "HONEST-LIMIT: exact-SHA source/test substrate green for grace-conditional multi continue_work fold, but live stale-fold induction would require >48h overdue backlog under current maxDelayMs=86400000 (grace=maxDelayMs*2) or a temporary production config mutation; neither performed.",
+      "supporting_docs": [
+        "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI-COLLAPSE/elliott-legion/source-test-byte.txt",
+        "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI-COLLAPSE/elliott-legion/gateway-config-continuation.json",
+        "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI-COLLAPSE/elliott-legion/test-summary.txt",
+        "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI-COLLAPSE/elliott-legion/rcw-multi-collapse-vitest-2723.log",
+        "PROOFS/2723dbee783c113cae70e4fb63a4cff9f55402e3/R-CW-MULTI-COLLAPSE/elliott-legion/artifact-checksums.json"
+      ]
     }
   ],
   "rollup": {
-    "total_rows": 22,
+    "total_rows": 23,
     "pass": 20,
     "partial": 0,
     "thin": 0,
     "fail": 0,
-    "honest_limit": 2,
+    "honest_limit": 3,
     "missing": 0
   },
   "disposition_note": "Fresh PROOFS corpus for exact deployed SHA 2723dbee783c113cae70e4fb63a4cff9f55402e3. Current filed rows include R-RC-1, Silas R-CW-1, R-CD-1, R-CD-2, R-CD-4 guard-side targeting, R-CONFIG-DEFAULTS, R-CONFIG-INTERSESSION, R-OBS-1, Cael R-CW-3, Rune R-CW-7 typed traceparent PASS, Rune R-CW-DELEGATE-TOKEN bare-token PASS, Rune R-CW-DELEGATE-SELF-CONTINUATION parent typed delegate spawn/return PASS, and Rune R-CW-6 HONEST-LIMIT/source-boundary + cap-scheduling evidence with invalid low-cap attempt and delivery/timer red preserved as diagnostics. Remaining rows are expected from their owning seats. Silas added R-REGRESSION-TRAP-TESTS PASS on 2723dbee with 31/31 vitest trap assertions. Elliott R-CW-2 chain-counter PASS added from live continue_work wake/Tempo evidence (delaySeconds=0 immediate; no delay-clamp claim). Silas added R-OBS-2 PASS with normalized Tempo trace-tree visualization from the R-CW-7 explicit-traceparent export.",
   "generated": "2026-06-27",
   "generated_by": "elliott-legion",
-  "status": "in_progress_rows_added_cael_token_postcompaction_silent_rrc2_limit",
-  "notes": "Cael clean /new additions: R-CD-SILENT tool silent PASS, R-CD-3 post-compaction registration PASS, R-CD-TOKEN bracket subagent fallback PASS, R-CW-TOKEN subagent work token PASS, R-RC-2 honest-limit due low context threshold. R-CW-4 intentionally not touched; treated as Silas-occupied unless blocked."
+  "status": "in_progress_rcw_multi_collapse_honest_limit_added",
+  "notes": "Cael clean /new additions: R-CD-SILENT tool silent PASS, R-CD-3 post-compaction registration PASS, R-CD-TOKEN bracket subagent fallback PASS, R-CW-TOKEN subagent work token PASS, R-RC-2 honest-limit due low context threshold. R-CW-4 intentionally not touched; treated as Silas-occupied unless blocked. Elliott added R-CW-MULTI-COLLAPSE HONEST-LIMIT: source/test green at 2723dbee; live stale-fold needs >48h overdue backlog under current maxDelayMs=86400000 or config mutation, so no live PASS claimed."
 }


### PR DESCRIPTION
## Summary

Adds a 2723dbee proof-corpus entry for `R-CW-MULTI-COLLAPSE` as an **HONEST_LIMIT**, not a PASS.

## Byte state

- Exact ship SHA: `2723dbee783c113cae70e4fb63a4cff9f55402e3`
- Added `PROOFS/2723dbee.../R-CW-MULTI-COLLAPSE/elliott-legion/HONEST_LIMIT.md`
- Captures source/test bytes for:
  - `src/auto-reply/continuation/work-dispatch.ts`
  - `src/auto-reply/continuation/work-dispatch.test.ts`
  - `src/agents/command/attempt-execution.continue-work-opts.test.ts`
- Captures current continuation config excerpt: `maxDelayMs=86400000`, so `supersededGraceMs=maxDelayMs*2=172800000` (48h).

## Verification

Ran on elliott at source checkout HEAD `2723dbee783c113cae70e4fb63a4cff9f55402e3`:

```bash
cd /home/figs/flesh_beast_tmp/openclaw
node scripts/run-vitest.mjs run \
  src/auto-reply/continuation/work-dispatch.test.ts \
  src/agents/command/attempt-execution.continue-work-opts.test.ts
```

Result:

```text
PASS — 2 Vitest project shards passed in 25.48s
auto-reply: work-dispatch.test.ts — 71 tests passed
agents: attempt-execution.continue-work-opts.test.ts — 15 tests passed
```

## Why honest-limit

Issue #118 asks for live behavior. I’m not claiming live PASS here.

The stale-fold condition is strict `now - work.dueAt > graceMs`; on current elliott config, grace is 48h. A live stale-fold proof therefore needs either:

1. a 48h+ overdue queued backlog before co-drain, or
2. an explicitly authorized temporary production config mutation to shrink `agents.defaults.continuation.maxDelayMs`, then restore it.

Neither was appropriate from this clean worker channel. This PR preserves the exact byte-grounded blocker while pinning the green source/test substrate.

Refs #118.
