### PR TITLE
k6-proofs: add R-CD-3 post-compaction scaffold (#119)

### DIFF
--- a/tools/k6-proofs/scenarios/r-cd-3-post-compaction.js
+++ b/tools/k6-proofs/scenarios/r-cd-3-post-compaction.js
@@ -1,0 +1,27 @@
+/**
+ * Scenario scaffold: R-CD-3.
+ *
+ * This row proves the `continue_delegate(mode="post-compaction")` lifeboat.
+ * A session dispatches a post-compaction delegate with a working-state
+ * payload, then triggers a compaction. The delegate must fire exactly at
+ * the compaction seam and return the payload to the post-compaction
+ * session.
+ *
+ * Intentionally not runnable yet. Requires a deterministic compaction trigger
+ * (via artificial token filler or context threshold reduction) and a
+ * reliable way to observe the exact seam in tracing.
+ */
+export const options = {
+  scenarios: {
+    r_cd_3_post_compaction_scaffold: {
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 1,
+      maxDuration: '10s',
+    },
+  },
+};
+
+export default function () {
+  throw new Error('R-CD-3 is scaffold-only; deterministic compaction trigger not implemented.');
+}


### PR DESCRIPTION
Adds the missing scaffold scenario for R-CD-3 post-compaction to complete the R-CD extended rows coverage for issue #119.

The other rows (R-CD-2, R-CD-4, R-CD-CHAINED-DEPTH-2, R-CD-COLLECTION-ON-COLLAPSE) already exist in the `tools/k6-proofs/scenarios` directory.