### PR TITLE
k6-proofs: add R-CD-MODEL-* scaffolds (#140)

### DIFF
--- a/tools/k6-proofs/scenarios/r-cd-3-post-compaction.js
+++ b/tools/k6-proofs/scenarios/r-cd-3-post-compaction.js
@@ -1,0 +1,27 @@
+/**
+ * Scenario scaffold: R-CD-3.
+ *
+ * This row proves the `continue_delegate(mode="post-compaction")` lifeboat.
+ * A session dispatches a post-compaction delegate with a working-state
+ * payload, then triggers a compaction. The delegate must fire exactly at
+ * the compaction seam and return the payload to the post-compaction
+ * session.
+ *
+ * Intentionally not runnable yet. Requires a deterministic compaction trigger
+ * (via artificial token filler or context threshold reduction) and a
+ * reliable way to observe the exact seam in tracing.
+ */
+export const options = {
+  scenarios: {
+    r_cd_3_post_compaction_scaffold: {
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 1,
+      maxDuration: '10s',
+    },
+  },
+};
+
+export default function () {
+  throw new Error('R-CD-3 is scaffold-only; deterministic compaction trigger not implemented.');
+}

--- a/tools/k6-proofs/scenarios/r-cd-model-chained-alt.js
+++ b/tools/k6-proofs/scenarios/r-cd-model-chained-alt.js
@@ -1,0 +1,22 @@
+/**
+ * Scenario scaffold: R-CD-MODEL-CHAINED-ALT.
+ *
+ * This row proves model overrides can be applied inside a chained delegate
+ * dispatch (A -> B(override) -> C(override)).
+ *
+ * Intentionally not runnable yet. Blocked on karmaterminal/openclaw#1103.
+ */
+export const options = {
+  scenarios: {
+    r_cd_model_chained_alt_scaffold: {
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 1,
+      maxDuration: '10s',
+    },
+  },
+};
+
+export default function () {
+  throw new Error('R-CD-MODEL-CHAINED-ALT is scaffold-only; blocked on karmaterminal/openclaw#1103.');
+}

--- a/tools/k6-proofs/scenarios/r-cd-model-default.js
+++ b/tools/k6-proofs/scenarios/r-cd-model-default.js
@@ -1,0 +1,22 @@
+/**
+ * Scenario scaffold: R-CD-MODEL-DEFAULT.
+ *
+ * This row proves omitting the model parameter preserves standard fallback/
+ * inheritance behavior (does not incorrectly apply an override).
+ *
+ * Intentionally not runnable yet. Blocked on karmaterminal/openclaw#1103.
+ */
+export const options = {
+  scenarios: {
+    r_cd_model_default_scaffold: {
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 1,
+      maxDuration: '10s',
+    },
+  },
+};
+
+export default function () {
+  throw new Error('R-CD-MODEL-DEFAULT is scaffold-only; blocked on karmaterminal/openclaw#1103.');
+}

--- a/tools/k6-proofs/scenarios/r-cd-model-token.js
+++ b/tools/k6-proofs/scenarios/r-cd-model-token.js
@@ -1,0 +1,22 @@
+/**
+ * Scenario scaffold: R-CD-MODEL-TOKEN.
+ *
+ * This row proves the `[[CONTINUE_DELEGATE: ... | model=<model>]]` token form
+ * forwards an explicit model override to the delegate child.
+ *
+ * Intentionally not runnable yet. Blocked on karmaterminal/openclaw#1103.
+ */
+export const options = {
+  scenarios: {
+    r_cd_model_token_scaffold: {
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 1,
+      maxDuration: '10s',
+    },
+  },
+};
+
+export default function () {
+  throw new Error('R-CD-MODEL-TOKEN is scaffold-only; blocked on karmaterminal/openclaw#1103.');
+}

--- a/tools/k6-proofs/scenarios/r-cd-model-tool.js
+++ b/tools/k6-proofs/scenarios/r-cd-model-tool.js
@@ -1,0 +1,22 @@
+/**
+ * Scenario scaffold: R-CD-MODEL-TOOL.
+ *
+ * This row proves the `continue_delegate` typed tool form forwards an explicit
+ * model override to the delegate child.
+ *
+ * Intentionally not runnable yet. Blocked on karmaterminal/openclaw#1103.
+ */
+export const options = {
+  scenarios: {
+    r_cd_model_tool_scaffold: {
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 1,
+      maxDuration: '10s',
+    },
+  },
+};
+
+export default function () {
+  throw new Error('R-CD-MODEL-TOOL is scaffold-only; blocked on karmaterminal/openclaw#1103.');
+}


### PR DESCRIPTION
Adds the missing scaffold scenarios for the `continue_delegate` model/provider override rows (R-CD-MODEL-TOOL, R-CD-MODEL-TOKEN, R-CD-MODEL-DEFAULT, R-CD-MODEL-CHAINED-ALT) to complete the R-CD extended rows coverage for issue #140.