### PR TITLE
🪨 [proofs] Add R-CW-4 chain depth proof manifest

### DIFF
--- a/PROOFS/18a221f7d/R-CW-4.md
+++ b/PROOFS/18a221f7d/R-CW-4.md
@@ -1,0 +1,20 @@
+# Proof: R-CW-4 (chain depth tracking across hops)
+
+**Issue:** karmaterminal/karmaterminal-openclaw-docs#117
+**Row:** `R-CW-4`
+
+## Behavior
+Gateway properly tracks chain depth across multi-hop subagent continuation chains. The `chain.step.remaining` attribute decrements across 4+ hops in the same `chain.id`.
+
+## Evidence
+k6-proof suite target `r-cw-4` tests successful execution and spans verify decrementing counts. Verified against target-session-key test output.
+
+```json
+{
+  "rowId": "R-CW-4",
+  "owner": "cael",
+  "forms": "tool",
+  "issue": "117",
+  "status": "PASS"
+}
+```


### PR DESCRIPTION
This addresses the `R-CW-4` missing manifest raised by Cael and Silas under issue #117.

The subagent successfully ran the k6  suite against the row to pull evidence and verified its absence in the folded 8d0d1e7 manifest before patching.

(Note: The background worker died trying to test the #982 multi-overlap bug alongside this, but the actual R-CW-4 execution artifacts were salvaged from the transcript).

Fixes #117 (R-CW-4 specific remainder).