### PR TITLE
tools/k6-proofs: Seat-aware row-list runner for Project 81 (#178)

### DIFF
--- a/tools/k6-proofs/lib/manifest-loader.js
+++ b/tools/k6-proofs/lib/manifest-loader.js
@@ -49,7 +49,7 @@ export function loadManifestFromEnv() {
     return null;
   }
   // k6 open() reads at init time
-  const raw = open(manifestPath);
+  const raw = open(manifestPath.startsWith('/') ? manifestPath : '../'+manifestPath);
   const parsed = JSON.parse(raw);
   return resolveManifest(parsed);
 }
@@ -83,7 +83,7 @@ export function validateManifest(manifest) {
     if (safety.requiresLiveGatewayToken && manifest.transport === 'offline') {
       errors.push('offline transport cannot require a live gateway token');
     }
-    if (safety.classification === 'k6-runnable' && manifest.scenario?.status !== 'runnable') {
+    if (safety.classification === 'k6-runnable' && manifest.scenario && manifest.scenario.status !== 'runnable') {
       errors.push('liveRunSafety.classification=k6-runnable requires scenario.status=runnable');
     }
     if (!Array.isArray(safety.requiredReceipts) || safety.requiredReceipts.length === 0) {

--- a/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
+++ b/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
@@ -53,11 +53,11 @@ const DEFAULTS = {
 };
 
 function invocationCfg() {
-  const inv = manifest?.invocation || {};
+  const inv = manifest && manifest.invocation || {};
   return {
     tool: inv.tool || 'continue_delegate',
     mode: inv.mode || __ENV.OPENCLAW_DELEGATE_MODE || DEFAULTS.mode,
-    delaySeconds: Number(inv.delaySeconds ?? __ENV.OPENCLAW_DELAY_SECONDS ?? DEFAULTS.delaySeconds),
+    delaySeconds: Number(inv.delaySeconds !== undefined ? inv.delaySeconds : (__ENV.OPENCLAW_DELAY_SECONDS !== undefined ? __ENV.OPENCLAW_DELAY_SECONDS : DEFAULTS.delaySeconds)),
     promptTemplate: inv.promptTemplate || DEFAULTS.promptTemplate,
     idempotencyKeyPrefix: inv.idempotencyKeyPrefix || DEFAULTS.idempotencyKeyPrefix,
   };
@@ -66,8 +66,8 @@ function invocationCfg() {
 export default function () {
   const url = __ENV.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
   const token = __ENV.OPENCLAW_GATEWAY_TOKEN;
-  const sessionKey = manifest?.sessionKey || __ENV.OPENCLAW_SESSION_KEY || DEFAULTS.sessionKey;
-  const seat = manifest?.seat || __ENV.OPENCLAW_SEAT_NAME || DEFAULTS.seat;
+  const sessionKey = manifest && manifest.sessionKey || __ENV.OPENCLAW_SESSION_KEY || DEFAULTS.sessionKey;
+  const seat = manifest && manifest.seat || __ENV.OPENCLAW_SEAT_NAME || DEFAULTS.seat;
   const rowNonce = nonce('R-CD-2');
 
   if (!token) {
@@ -89,7 +89,7 @@ export default function () {
     nonce: rowNonce,
     seat,
     sessionKey,
-    candidateSha: manifest?.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
+    candidateSha: manifest && manifest.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
     started: new Date().toISOString(),
     // Required receipts
     tool_accepted: false,
@@ -159,7 +159,7 @@ export default function () {
         if (classified.kind === 'response' && classified.method === 'sessions.send') {
           if (classified.ok) {
             evidence.tool_accepted = true;
-            if (classified.payload?.traceId) evidence.trace_id = classified.payload.traceId;
+            if (classified.payload && classified.payload.traceId) evidence.trace_id = classified.payload.traceId;
             console.log('✓ sessions.send accepted — agent turn triggered for R-CD-2 (mode=silent-wake)');
           } else if (classified.error) {
             console.error(`✗ sessions.send rejected: ${JSON.stringify(classified.error)}`);
@@ -170,7 +170,7 @@ export default function () {
         // Optional TaskFlow ledger context. Absence here is not a failure:
         // continue_delegate uses pending-delegate/subagent surfaces.
         if (classified.kind === 'response' && classified.method === 'tasks.list') {
-          const tasks = classified.payload?.tasks || [];
+          const tasks = classified.payload && classified.payload.tasks || [];
           for (const task of tasks) {
             const taskStr = JSON.stringify(task);
             if (taskStr.includes(rowNonce)) {
@@ -259,7 +259,7 @@ export default function () {
 
 export function handleSummary(data) {
   const timestamp = new Date().toISOString();
-  const passRate = data.metrics.proof_failures?.values?.count === 0;
+  const passRate = data.metrics.proof_failures && data.metrics.proof_failures.values && data.metrics.proof_failures.values.count === 0;
   const summary = {
     row: 'R-CD-2',
     sha: __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
@@ -267,8 +267,8 @@ export function handleSummary(data) {
     timestamp,
     verdict: passRate ? 'PASS-candidate' : 'PARTIAL-candidate',
     metrics: {
-      duration_ms: data.metrics.r_cd_2_duration?.values || null,
-      failures: data.metrics.proof_failures?.values?.count || 0,
+      duration_ms: data.metrics.r_cd_2_duration && data.metrics.r_cd_2_duration.values || null,
+      failures: data.metrics.proof_failures && data.metrics.proof_failures.values && data.metrics.proof_failures.values.count || 0,
     },
   };
 

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -47,7 +47,7 @@ export OPENCLAW_SEAT_NAME="$(hostname)"
 
 # Local Gateway Auth extraction (never logged/committed)
 if [[ -z "${OPENCLAW_GATEWAY_TOKEN:-}" && -f ~/.openclaw/openclaw.json ]]; then
-  export OPENCLAW_GATEWAY_TOKEN="$(jq -r '.auth.operatorToken // empty' ~/.openclaw/openclaw.json)"
+  export OPENCLAW_GATEWAY_TOKEN="$(jq -r '.gateway.auth.token // .auth.operatorToken // empty' ~/.openclaw/openclaw.json)"
 fi
 if [[ -z "${OPENCLAW_GATEWAY_TOKEN:-}" ]]; then
   echo "Warning: OPENCLAW_GATEWAY_TOKEN not found in local config."
@@ -77,6 +77,15 @@ echo "Seat: $OPENCLAW_SEAT_NAME"
 echo "Target Candidate SHA: $OPENCLAW_CANDIDATE_SHA"
 echo "Deployed Runtime SHA: $OPENCLAW_RUNTIME_BUILD_SHA"
 echo "Session: $OPENCLAW_SESSION_KEY"
+if [[ "$ROWS" == "all" ]]; then
+  ROWS="$(for f in manifests/*.json; do jq -r 'select(.scenario.status == "runnable") | .rowId' "$f"; done | paste -sd, -)"
+fi
+
+if [[ -z "$ROWS" ]]; then
+  echo "No runnable rows found."
+  exit 1
+fi
+
 echo "Rows: $ROWS"
 echo "Dry Run: $DRY_RUN"
 echo "=========================================================="
@@ -93,10 +102,10 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
   # Normalize row ID
   ROW_ID="$(echo "$ROW_ID" | tr '[:lower:]' '[:upper:]')"
   
-  # Find manifest
+  # Find manifest (case-insensitive so lowercase preflight still works)
   MANIFEST_FILE=""
   for f in manifests/*.json; do
-    if grep -q "\"rowId\": \"$ROW_ID\"" "$f"; then
+    if jq -e --arg row "$ROW_ID" '(.rowId | ascii_upcase) == $row' "$f" >/dev/null; then
       MANIFEST_FILE="$(pwd)/$f" # Absolute path
       break
     fi
@@ -107,7 +116,7 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
     continue
   fi
 
-  SCENARIO_FILE=$(jq -r '.scenario.file' "$MANIFEST_FILE")
+  SCENARIO_FILE=$(jq -r '.scenario.file // .scenario.name // empty' "$MANIFEST_FILE")
   SCENARIO_STATUS=$(jq -r '.scenario.status' "$MANIFEST_FILE")
   LIVE_SAFETY=$(jq -r '.liveRunSafety.classification // "unknown"' "$MANIFEST_FILE")
 
@@ -115,12 +124,17 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
   echo "----------------------------------------"
   echo "Row: $ROW_ID"
   echo "Manifest: $MANIFEST_FILE"
-  echo "Scenario: scenarios/$SCENARIO_FILE"
+  echo "Scenario: ${SCENARIO_FILE:+scenarios/$SCENARIO_FILE}"
   echo "Status: $SCENARIO_STATUS"
   echo "Live Safety: $LIVE_SAFETY"
 
   if [[ "$SCENARIO_STATUS" != "runnable" ]]; then
     echo "[$ROW_ID] SKIPPED: Scenario status is $SCENARIO_STATUS (not runnable)."
+    continue
+  fi
+
+  if [[ -z "$SCENARIO_FILE" || ! -f "scenarios/$SCENARIO_FILE" ]]; then
+    echo "[$ROW_ID] SKIPPED: runnable scenario file missing: scenarios/$SCENARIO_FILE"
     continue
   fi
 

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# Seat-aware row-list runner for Project 81 / k6-proofs
+# References: #178 / #106 / #119
+#
+# Usage:
+#   cd tools/k6-proofs
+#   ./scripts/run-proofs.sh [--dry-run] [R-CD-2,R-CD-4] [candidate_sha]
+
+set -euo pipefail
+
+DRY_RUN=true
+ROWS=""
+CANDIDATE_SHA=""
+SESSION_SELECTOR="discord-channel:1466192485440164011"
+
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    --dry-run) DRY_RUN=true; shift ;;
+    --live) DRY_RUN=false; shift ;;
+    --session) SESSION_SELECTOR="$2"; shift 2 ;;
+    *)
+      if [[ -z "$ROWS" ]]; then
+        ROWS="$1"
+      elif [[ -z "$CANDIDATE_SHA" ]]; then
+        CANDIDATE_SHA="$1"
+      else
+        echo "Unknown argument: $1"
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$ROWS" ]]; then
+  echo "Error: must specify comma-separated list of rows (e.g. R-CD-2,R-CD-4) or 'all'."
+  exit 1
+fi
+
+if [[ -z "$CANDIDATE_SHA" ]]; then
+  CANDIDATE_SHA="$(git rev-parse HEAD 2>/dev/null || echo 'unknown')"
+fi
+
+export OPENCLAW_CANDIDATE_SHA="${CANDIDATE_SHA}"
+export OPENCLAW_SEAT_NAME="$(hostname)"
+
+# Local Gateway Auth extraction (never logged/committed)
+if [[ -f ~/.openclaw/openclaw.json ]]; then
+  export OPENCLAW_GATEWAY_TOKEN="$(jq -r '.auth.operatorToken // empty' ~/.openclaw/openclaw.json)"
+fi
+if [[ -z "${OPENCLAW_GATEWAY_TOKEN:-}" ]]; then
+  echo "Warning: OPENCLAW_GATEWAY_TOKEN not found in local config."
+  if [[ "$DRY_RUN" == "false" ]]; then
+    exit 1
+  fi
+fi
+
+# Resolve Session Key
+if [[ -z "${OPENCLAW_SESSION_KEY:-}" ]]; then
+  echo "Resolving session key for selector: $SESSION_SELECTOR"
+  export OPENCLAW_SESSION_KEY="main" # Fallback/stub. In a full implementation this shells out to `openclaw sessions --json`
+fi
+
+echo "=========================================================="
+echo "Project 81: Seat-Aware k6 Proof Runner"
+echo "Seat: $OPENCLAW_SEAT_NAME"
+echo "Target SHA: $OPENCLAW_CANDIDATE_SHA"
+echo "Session: $OPENCLAW_SESSION_KEY"
+echo "Rows: $ROWS"
+echo "Dry Run: $DRY_RUN"
+echo "=========================================================="
+
+IFS=',' read -ra ROW_ARRAY <<< "$ROWS"
+
+for ROW_ID in "${ROW_ARRAY[@]}"; do
+  # Normalize row ID
+  ROW_ID="$(echo "$ROW_ID" | tr '[:lower:]' '[:upper:]')"
+  
+  # Find manifest
+  MANIFEST_FILE=""
+  for f in manifests/*.json; do
+    if grep -q "\"rowId\": \"$ROW_ID\"" "$f"; then
+      MANIFEST_FILE="$(pwd)/$f" # Absolute path
+      break
+    fi
+  done
+
+  if [[ -z "$MANIFEST_FILE" ]]; then
+    echo "[$ROW_ID] SKIPPED: Manifest not found."
+    continue
+  fi
+
+  SCENARIO_FILE=$(jq -r '.scenario.file' "$MANIFEST_FILE")
+  SCENARIO_STATUS=$(jq -r '.scenario.status' "$MANIFEST_FILE")
+  LIVE_SAFETY=$(jq -r '.liveRunSafety.classification // "unknown"' "$MANIFEST_FILE")
+
+  echo ""
+  echo "----------------------------------------"
+  echo "Row: $ROW_ID"
+  echo "Manifest: $MANIFEST_FILE"
+  echo "Scenario: scenarios/$SCENARIO_FILE"
+  echo "Status: $SCENARIO_STATUS"
+  echo "Live Safety: $LIVE_SAFETY"
+
+  if [[ "$SCENARIO_STATUS" != "runnable" ]]; then
+    echo "[$ROW_ID] SKIPPED: Scenario status is $SCENARIO_STATUS (not runnable)."
+    continue
+  fi
+
+  if [[ "$DRY_RUN" == "false" && "$LIVE_SAFETY" != "k6-runnable" ]]; then
+    echo "[$ROW_ID] SKIPPED: liveRunSafety classification ($LIVE_SAFETY) rejects unattended live fire."
+    continue
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo "[$ROW_ID] DRY RUN: Would execute k6 run scenarios/$SCENARIO_FILE"
+  else
+    echo "[$ROW_ID] RUNNING..."
+    export OPENCLAW_ROW_MANIFEST="$MANIFEST_FILE"
+    
+    # Actually run k6
+    k6 run "scenarios/$SCENARIO_FILE"
+    
+    echo "[$ROW_ID] COMPLETED."
+    
+    # Observability hints
+    echo "Observability check: query Grafana for run/nonce or review Tempo traces if trace ID was emitted."
+  fi
+done
+
+echo ""
+echo "=========================================================="
+echo "Runner execution finished."

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Seat-aware row-list runner for Project 81 / k6-proofs
-# References: #178 / #106 / #119
+# References: #178 / #106 / #119 / #179
 #
 # Usage:
 #   cd tools/k6-proofs
@@ -56,6 +56,15 @@ if [[ -z "${OPENCLAW_GATEWAY_TOKEN:-}" ]]; then
   fi
 fi
 
+# Fetch deployed runtime build stamp explicitly (do not collapse into CANDIDATE_SHA)
+DEPLOYED_BUILD_STAMP="unknown"
+if [[ -f ~/.openclaw/openclaw.json ]]; then
+  if openclaw version --json >/dev/null 2>&1; then
+    DEPLOYED_BUILD_STAMP="$(openclaw version --json | jq -r '.build.sha // empty')"
+  fi
+fi
+export OPENCLAW_RUNTIME_BUILD_SHA="$DEPLOYED_BUILD_STAMP"
+
 # Resolve Session Key
 if [[ -z "${OPENCLAW_SESSION_KEY:-}" ]]; then
   echo "Resolving session key for selector: $SESSION_SELECTOR"
@@ -65,11 +74,18 @@ fi
 echo "=========================================================="
 echo "Project 81: Seat-Aware k6 Proof Runner"
 echo "Seat: $OPENCLAW_SEAT_NAME"
-echo "Target SHA: $OPENCLAW_CANDIDATE_SHA"
+echo "Target Candidate SHA: $OPENCLAW_CANDIDATE_SHA"
+echo "Deployed Runtime SHA: $OPENCLAW_RUNTIME_BUILD_SHA"
 echo "Session: $OPENCLAW_SESSION_KEY"
 echo "Rows: $ROWS"
 echo "Dry Run: $DRY_RUN"
 echo "=========================================================="
+
+# Check for Live Bridge alignment (candidate vs deployed runtime)
+if [[ "$DRY_RUN" == "false" && "$OPENCLAW_CANDIDATE_SHA" != "$OPENCLAW_RUNTIME_BUILD_SHA" ]]; then
+  echo "WARNING: Candidate SHA ($OPENCLAW_CANDIDATE_SHA) does not match Deployed Runtime SHA ($OPENCLAW_RUNTIME_BUILD_SHA)."
+  echo "Unless this is a known stale-stamp or you have proven a rebuild bridge, live proofs will be marked HONEST-LIMIT / negative-partial."
+fi
 
 IFS=',' read -ra ROW_ARRAY <<< "$ROWS"
 

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -22,7 +22,7 @@ while [[ "$#" -gt 0 ]]; do
     *)
       if [[ -z "$ROWS" ]]; then
         ROWS="$1"
-      elif [[ -z "$CANDIDATE_SHA" ]]; then
+      elif [[ -z "$CANDIDATE_SHA" && -z "${OPENCLAW_CANDIDATE_SHA:-}" ]]; then
         CANDIDATE_SHA="$1"
       else
         echo "Unknown argument: $1"
@@ -38,15 +38,15 @@ if [[ -z "$ROWS" ]]; then
   exit 1
 fi
 
-if [[ -z "$CANDIDATE_SHA" ]]; then
+if [[ -z "$CANDIDATE_SHA" && -z "${OPENCLAW_CANDIDATE_SHA:-}" ]]; then
   CANDIDATE_SHA="$(git rev-parse HEAD 2>/dev/null || echo 'unknown')"
 fi
 
-export OPENCLAW_CANDIDATE_SHA="${CANDIDATE_SHA}"
+if [[ -n "$CANDIDATE_SHA" ]]; then export OPENCLAW_CANDIDATE_SHA="${CANDIDATE_SHA}"; fi
 export OPENCLAW_SEAT_NAME="$(hostname)"
 
 # Local Gateway Auth extraction (never logged/committed)
-if [[ -f ~/.openclaw/openclaw.json ]]; then
+if [[ -z "${OPENCLAW_GATEWAY_TOKEN:-}" && -f ~/.openclaw/openclaw.json ]]; then
   export OPENCLAW_GATEWAY_TOKEN="$(jq -r '.auth.operatorToken // empty' ~/.openclaw/openclaw.json)"
 fi
 if [[ -z "${OPENCLAW_GATEWAY_TOKEN:-}" ]]; then


### PR DESCRIPTION
Fixes #178

Harden the k6 proof harness into a seat-aware, row-list driven runner.
- Adds `run-proofs.sh` which resolves local gateway auth, seat name, and exact manifests.
- Normalizes manifest loading inside the k6 runtime (which doesn't support Node dynamic `fs` paths identically).
- Transpiles `??` and `?.` syntax out of the scenario templates because k6's internal compiler trips on them in some contexts.

Ready for review and live testing of R-CD-2.