### PR TITLE
proofs: add bca2b0b R-CW-5 cost cap evidence

### DIFF
--- a/PROOFS/INDEX.json
+++ b/PROOFS/INDEX.json
@@ -9,16 +9,16 @@
   "readme_path": "PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/README.md",
   "rollup": {
     "total_rows": 28,
-    "pass": 14,
+    "pass": 15,
     "partial": 0,
     "thin": 0,
     "fail": 0,
     "honest_limit": 1,
-    "missing": 13
+    "missing": 12
   },
-  "disposition_note": "IN-PROGRESS corpus after exact-SHA Cael deploy and smoke; R-CW-2 recorded as PASS; R-RC-2 honest_limit; multiple live rows added by cael-dgx.",
+  "disposition_note": "IN-PROGRESS corpus after exact-SHA Cael deploy and smoke; R-CW-5 recorded as PASS via source/test evidence; R-RC-2 honest_limit; multiple live rows added by cael-dgx.",
   "navigation": "clawsweeper: read INDEX.json -> current_sha -> manifest_path -> rows[]",
-  "generated": "2026-07-04T17:18:00Z",
+  "generated": "2026-07-04T17:27:00Z",
   "generated_by": "frond-scribe (copilot, corpus-manager)",
   "capture_sha": "bca2b0b89ab886bf23a10e4983926f6b374b3188",
   "carried_from": null

--- a/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/EVIDENCE.md
+++ b/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/EVIDENCE.md
@@ -1,0 +1,103 @@
+# R-CW-5 — cost-cap exhaustion static/source + test proof (cael-dgx)
+
+Issue: https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/234
+
+Candidate SHA: `bca2b0b89ab886bf23a10e4983926f6b374b3188`  
+Source checkout: `bca2b0b89ab886bf23a10e4983926f6b374b3188`  
+Seat: Cael / `cael-dgx`  
+Runtime receipt: `OpenClaw 2026.6.11 (bca2b0b)`  
+Verdict: ✅ PASS
+
+## Expected byte lock
+
+This row is a source/test proof. It does not mutate live config and does not fire a live over-budget continuation. It proves cost-cap exhaustion through the scheduler source, delegate dispatcher source, and the dedicated cost-cap exhaustion test suite.
+
+Expected semantics:
+
+- accumulated chain tokens below cap: dispatch allowed;
+- accumulated chain tokens exactly equal to cap: allowed (`>` not `>=`);
+- accumulated chain tokens greater than cap: dispatch rejected/cost-capped;
+- once cap is crossed, remaining queued delegates are rejected and TaskFlow records are marked failed.
+
+## Source receipts
+
+`scheduler-source.txt` shows the shared scheduler guard:
+
+```ts
+if (config.costCapTokens > 0 && chainState.accumulatedChainTokens > config.costCapTokens) {
+  return "cost-capped";
+}
+```
+
+`delegate-dispatch-cost-cap-source.txt` shows delegate dispatch surfacing the cap rejection, including the `cost cap exceeded` summary.
+
+`subagent-announce-bracket-cost-cap-source.txt` and `subagent-announce-tool-cost-cap-source.txt` show the announce-side bracket/tool delegate cost-cap guards. These paths compare stored/folded parent chain tokens against `costCapTokens` and reject bracket/tool continuation when the cap is exceeded.
+
+## Dedicated test receipt
+
+`vitest-delegate-dispatch-cost-cap-exhaustion.log` was run at `bca2b0b89ab886bf23a10e4983926f6b374b3188` with:
+
+```bash
+pnpm vitest run --config test/vitest/vitest.auto-reply.config.ts \
+  src/auto-reply/continuation/delegate-dispatch.cost-cap-exhaustion.test.ts \\n  src/auto-reply/continuation/scheduler.test.ts \
+  --reporter=verbose
+```
+
+Result:
+
+```text
+✓ cost-cap exhaustion mid-chain > allows dispatch when accumulatedChainTokens is 1 below costCapTokens
+✓ cost-cap exhaustion mid-chain > rejects dispatch when accumulatedChainTokens exceeds costCapTokens by 1
+✓ cost-cap exhaustion mid-chain > rejects all remaining queued delegates once cost cap is crossed
+✓ cost-cap exhaustion mid-chain > marks TaskFlow records as failed for cost-cap-rejected delegates
+✓ cost-cap exhaustion mid-chain > rejects at exact boundary (accumulatedChainTokens === costCapTokens is NOT over)
+
+Test Files  1 passed (1)
+Tests       5 passed (5)
+```
+
+The filename is the dedicated cost-cap exhaustion suite; it pins the five cost-cap boundary/handling cases named above.
+
+## Announce-side guard receipt
+
+`vitest-chain-guard-cost-cap.log` was run with:
+
+```bash
+pnpm vitest run --config test/vitest/vitest.agents-support.config.ts \
+  src/agents/subagent-announce.chain-guard.test.ts \
+  --testNamePattern 'costCapTokens|cost cap|Cost cap' \
+  --reporter=verbose
+```
+
+Result:
+
+```text
+✓ allows continuation when accumulated tokens equal costCapTokens exactly (> not >=)
+✓ rejects continuation when accumulated tokens exceed costCapTokens by one
+
+Test Files  1 passed (1)
+Tests       2 passed | 21 skipped (23)
+```
+
+This confirms announce-side chain-hop cost-cap boundary behavior independently from delegate dispatch.
+
+## Supporting receipts
+
+- `source-git-status.txt` — source checkout SHA/status for `bca2b0b89ab886bf23a10e4983926f6b374b3188`.
+- `runtime-version.txt` — deployed runtime version receipt.
+- `scheduler-source.txt` — shared scheduler source excerpt.
+- `scheduler-test.txt` — shared scheduler boundary test excerpt.
+- `delegate-dispatch-cost-cap-source.txt` — delegate dispatch source excerpt.
+- `delegate-dispatch-cost-cap-exhaustion-test.txt` — dedicated cost-cap exhaustion suite source excerpt.
+- `subagent-announce-bracket-cost-cap-source.txt` — announce bracket cost-cap guard source excerpt.
+- `subagent-announce-tool-cost-cap-source.txt` — announce tool-delegate cost-cap guard source excerpt.
+- `vitest-delegate-dispatch-cost-cap-exhaustion.log` — dedicated cost-cap exhaustion suite, 5/5 pass.
+- `vitest-chain-guard-cost-cap.log` — announce-side cost-cap boundary tests, 2/2 selected pass.
+
+## Tempo / live-fire note
+
+No Tempo trace is included because this row is intentionally static/source + unit-test evidence. It does not dispatch a live over-budget delegate and does not mutate live continuation config.
+
+## Verdict
+
+✅ PASS — at `bca2b0b89ab886bf23a10e4983926f6b374b3188`, the cost-cap code paths are present and the dedicated cost-cap exhaustion suite passes 5/5, with announce-side chain-guard cost-cap boundary coverage passing 2/2 selected tests.

--- a/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/delegate-dispatch-cost-cap-exhaustion-test.txt
+++ b/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/delegate-dispatch-cost-cap-exhaustion-test.txt
@@ -1,0 +1,431 @@
+     1	// ─────────────────────────────────────────────────────────────────────────────
+     2	// delegate-dispatch — cost-cap exhaustion mid-chain
+     3	//
+     4	// SEAM GUARDED: This file traps the cost-cap invariant — the second of
+     5	// the two bounded-continuation guards (the first
+     6	// being chain-depth, covered in the sibling test file). Where chain-depth
+     7	// counts HOPS, cost-cap counts TOKENS. A long chain of cheap delegates
+     8	// might never hit chain-depth but could still burn through the user's
+     9	// token budget; the cost-cap is the financial-pressure brake.
+    10	//
+    11	// ARCHITECTURAL CANON (from delegate-dispatch.ts):
+    12	//   1. EVERY chain carries an accumulatedChainTokens running total.
+    13	//   2. The dispatcher compares it to config.costCapTokens using
+    14	//      STRICT-GREATER-THAN. accumulated > cap → reject; accumulated <=
+    15	//      cap → allow. This means an exact equality at the cap is ALLOWED,
+    16	//      not rejected — a deliberate "one more allowed at the line" choice
+    17	//      that this test file pins down.
+    18	//   3. Once the cap is crossed, EVERY remaining queued delegate in the
+    19	//      same dispatch call is rejected as a CASCADE — the dispatcher
+    20	//      doesn't re-check each one independently because the accumulated
+    21	//      total can only grow.
+    22	//   4. Cap-rejected delegates transition their TaskFlow record from
+    23	//      `queued` to `failed`, identical to chain-depth rejections.
+    24	//   5. Cap rejections emit a system event with "cost-capped" text.
+    25	//
+    26	// Tests guard distinct corners of the
+    27	// cost-cap contract:
+    28	//   - just-under   → ALLOW (proves the gate isn't over-eager)
+    29	//   - just-over    → REJECT (proves the gate fires)
+    30	//   - exact        → ALLOW (proves strict-greater-than, not >=)
+    31	//   - cascade      → all-remaining-rejected (proves the loop short-circuits)
+    32	//   - taskflow     → failed-state recorded (proves side-effect persists)
+    33	//
+    34	// If a future refactor changes the comparison operator (`>` → `>=`),
+    35	// removes the cascade short-circuit, or skips the failFlow call on
+    36	// cost-rejection, exactly one of these tests will fire and route the
+    37	// reviewer to the budget block in delegate-dispatch.ts. The five-point
+    38	// coverage is intentional — collapsing any two would leave a blind spot.
+    39	// ─────────────────────────────────────────────────────────────────────────────
+    40	
+    41	import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+    42	
+    43	// ─── Mock setup ──────────────────────────────────────────────────────────
+    44	// Mock TaskFlow registry — same pattern as delegate-dispatch.test.ts.
+    45	// All side-effect surfaces (spawn, system-events, task-flow-registry) are
+    46	// mocked so we can assert on dispatcher INTENT rather than downstream
+    47	// production state.
+    48	const mockFlows = new Map<string, Record<string, unknown>>();
+    49	const enqueueSystemEventMock = vi.fn();
+    50	const loggerRecords: Array<{ level: string; message: string }> = [];
+    51	const spawnSubagentDirectMock = vi.fn();
+    52	let flowIdCounter = 0;
+    53	
+    54	vi.mock("../../agents/subagent-spawn.js", () => ({
+    55	  spawnSubagentDirect: (...args: unknown[]) => spawnSubagentDirectMock(...args),
+    56	}));
+    57	
+    58	vi.mock("../../infra/system-events.js", () => ({
+    59	  enqueueSystemEvent: (text: string, options: unknown) => enqueueSystemEventMock(text, options),
+    60	}));
+    61	
+    62	vi.mock("../../logging/subsystem.js", () => {
+    63	  const record =
+    64	    (level: string) =>
+    65	    (message: string): void => {
+    66	      loggerRecords.push({ level, message });
+    67	    };
+    68	  const logger = {
+    69	    subsystem: "test",
+    70	    isEnabled: () => true,
+    71	    trace: record("trace"),
+    72	    debug: record("debug"),
+    73	    info: record("info"),
+    74	    warn: record("warn"),
+    75	    error: record("error"),
+    76	    fatal: record("fatal"),
+    77	    raw: record("raw"),
+    78	    child: () => logger,
+    79	  };
+    80	  return {
+    81	    createSubsystemLogger: () => logger,
+    82	  };
+    83	});
+    84	
+    85	vi.mock("../../tasks/task-flow-registry.js", () => ({
+    86	  createManagedTaskFlow: vi.fn((params: Record<string, unknown>) => {
+    87	    const flowId = `flow-${++flowIdCounter}`;
+    88	    mockFlows.set(flowId, {
+    89	      flowId,
+    90	      syncMode: "managed",
+    91	      ownerKey: params.ownerKey,
+    92	      controllerId: params.controllerId,
+    93	      status: "queued",
+    94	      stateJson: params.stateJson,
+    95	      goal: params.goal,
+    96	      currentStep: params.currentStep,
+    97	      revision: 0,
+    98	      createdAt: Date.now(),
+    99	      updatedAt: Date.now(),
+   100	    });
+   101	    return mockFlows.get(flowId);
+   102	  }),
+   103	  listTaskFlowsForOwnerKey: vi.fn((ownerKey: string) => {
+   104	    return [...mockFlows.values()].filter((f) => f.ownerKey === ownerKey);
+   105	  }),
+   106	  getTaskFlowById: vi.fn((flowId: string) => mockFlows.get(flowId)),
+   107	  updateFlowRecordByIdExpectedRevision: vi.fn(
+   108	    (params: { flowId: string; expectedRevision: number; patch: Record<string, unknown> }) => {
+   109	      const flow = mockFlows.get(params.flowId);
+   110	      if (!flow || flow.revision !== params.expectedRevision) {
+   111	        return {
+   112	          applied: false,
+   113	          reason: flow ? "revision_conflict" : "not_found",
+   114	          current: flow ? { ...flow } : undefined,
+   115	        };
+   116	      }
+   117	      Object.assign(flow, params.patch);
+   118	      flow.revision = flow.revision + 1;
+   119	      return { applied: true, flow: { ...flow } };
+   120	    },
+   121	  ),
+   122	  finishFlow: vi.fn((params: { flowId: string; expectedRevision: number }) => {
+   123	    const flow = mockFlows.get(params.flowId);
+   124	    if (!flow || flow.revision !== params.expectedRevision) {
+   125	      return { applied: false, reason: flow ? "revision_conflict" : "not_found" };
+   126	    }
+   127	    flow.status = "succeeded";
+   128	    flow.revision = flow.revision + 1;
+   129	    return { applied: true, flow: { ...flow } };
+   130	  }),
+   131	  failFlow: vi.fn((params: { flowId: string }) => {
+   132	    const flow = mockFlows.get(params.flowId);
+   133	    if (flow) {
+   134	      flow.status = "failed";
+   135	    }
+   136	    return { applied: Boolean(flow) };
+   137	  }),
+   138	  deleteTaskFlowRecordById: vi.fn((flowId: string) => {
+   139	    mockFlows.delete(flowId);
+   140	  }),
+   141	}));
+   142	
+   143	import { clearRuntimeConfigSnapshot } from "../../config/config.js";
+   144	import { resetContinuationTracer } from "../../infra/continuation-tracer.js";
+   145	import { dispatchToolDelegates, resetDelegateDispatchHedgesForTests } from "./delegate-dispatch.js";
+   146	import { enqueuePendingDelegate } from "./delegate-store.js";
+   147	import { resetContinuationStateForTests } from "./state.js";
+   148	
+   149	beforeEach(() => {
+   150	  // Fresh mock state per test — chain-state contamination between tests
+   151	  // could mask a real budget-check regression by carrying tokens forward.
+   152	  mockFlows.clear();
+   153	  enqueueSystemEventMock.mockClear();
+   154	  loggerRecords.length = 0;
+   155	  spawnSubagentDirectMock.mockReset().mockResolvedValue({ status: "accepted" });
+   156	  flowIdCounter = 0;
+   157	  vi.useFakeTimers();
+   158	});
+   159	
+   160	afterEach(() => {
+   161	  resetDelegateDispatchHedgesForTests();
+   162	  resetContinuationStateForTests();
+   163	  resetContinuationTracer();
+   164	  clearRuntimeConfigSnapshot();
+   165	  mockFlows.clear();
+   166	  vi.useRealTimers();
+   167	});
+   168	
+   169	describe("cost-cap exhaustion mid-chain", () => {
+   170	  // COST-CAP AXIS: tests below pin five points relative to costCapTokens:
+   171	  //   accumulated = cap - 1   → ALLOW   (sanity: gate isn't over-eager)
+   172	  //   accumulated = cap + 1   → REJECT  (sanity: gate fires)
+   173	  //   accumulated = cap       → ALLOW   (canon: strict-greater-than, not >=)
+   174	  //   cascade (3 queued, all over) → 3 rejected (canon: short-circuit loop)
+   175	  //   side-effect (TaskFlow)       → failed-state (canon: persistent record)
+   176	
+   177	  // ───────────────────────────────────────────────────────────────────────
+   178	  // JUST-UNDER case: accumulated = 499_999, cap = 500_000.
+   179	  //
+   180	  // CANON GUARDED: the gate is not over-eager. Being 1 token below the
+   181	  // cap is still under the cap; dispatch should succeed.
+   182	  //
+   183	  // Regression indicator: if this test starts asserting rejection, the
+   184	  // gate operator went from `>` to `>=` or got an off-by-one; reviewer
+   185	  // should look at the cost-cap comparison in delegate-dispatch.ts.
+   186	  // ───────────────────────────────────────────────────────────────────────
+   187	  it("allows dispatch when accumulatedChainTokens is 1 below costCapTokens", async () => {
+   188	    const sessionKey = "session-cost-cap-just-under";
+   189	    enqueuePendingDelegate(sessionKey, { task: "squeaks under the cap" });
+   190	
+   191	    const result = await dispatchToolDelegates({
+   192	      sessionKey,
+   193	      chainState: {
+   194	        currentChainCount: 0,
+   195	        chainStartedAt: Date.now(),
+   196	        accumulatedChainTokens: 499_999,
+   197	      },
+   198	      ctx: { sessionKey },
+   199	      maxChainLength: 10,
+   200	      config: {
+   201	        enabled: true,
+   202	        defaultDelayMs: 15_000,
+   203	        minDelayMs: 5_000,
+   204	        maxDelayMs: 300_000,
+   205	        maxChainLength: 10,
+   206	        costCapTokens: 500_000,
+   207	        maxDelegatesPerTurn: 5,
+   208	        maxPendingWork: 32,
+   209	        crossSessionTargeting: "disabled",
+   210	        earlyWarningBand: 0.3125,
+   211	      },
+   212	    });
+   213	
+   214	    // 499_999 < 500_000 → not cost-capped, should spawn.
+   215	    expect(result.dispatched).toBe(1);
+   216	    expect(result.rejected).toBe(0);
+   217	    expect(spawnSubagentDirectMock).toHaveBeenCalledTimes(1);
+   218	    expect(spawnSubagentDirectMock).toHaveBeenCalledWith(
+   219	      expect.objectContaining({
+   220	        task: expect.stringContaining("squeaks under the cap"),
+   221	      }),
+   222	      expect.objectContaining({ agentSessionKey: sessionKey }),
+   223	    );
+   224	  });
+   225	
+   226	  // ───────────────────────────────────────────────────────────────────────
+   227	  // JUST-OVER case: accumulated = 500_001, cap = 500_000.
+   228	  //
+   229	  // CANON GUARDED: the gate fires on over-cap, emitting the cost-capped
+   230	  // system event so the model can see why its delegate didn't dispatch.
+   231	  //
+   232	  // Regression indicator: if this test starts asserting "dispatched: 1",
+   233	  // the cost-cap check has been removed or bypassed; reviewer should
+   234	  // grep delegate-dispatch.ts for costCapTokens comparisons.
+   235	  // ───────────────────────────────────────────────────────────────────────
+   236	  it("rejects dispatch when accumulatedChainTokens exceeds costCapTokens by 1", async () => {
+   237	    const sessionKey = "session-cost-cap-just-over";
+   238	    enqueuePendingDelegate(sessionKey, { task: "over the budget" });
+   239	
+   240	    const result = await dispatchToolDelegates({
+   241	      sessionKey,
+   242	      chainState: {
+   243	        currentChainCount: 0,
+   244	        chainStartedAt: Date.now(),
+   245	        accumulatedChainTokens: 500_001,
+   246	      },
+   247	      ctx: { sessionKey },
+   248	      maxChainLength: 10,
+   249	      config: {
+   250	        enabled: true,
+   251	        defaultDelayMs: 15_000,
+   252	        minDelayMs: 5_000,
+   253	        maxDelayMs: 300_000,
+   254	        maxChainLength: 10,
+   255	        costCapTokens: 500_000,
+   256	        maxDelegatesPerTurn: 5,
+   257	        maxPendingWork: 32,
+   258	        crossSessionTargeting: "disabled",
+   259	        earlyWarningBand: 0.3125,
+   260	      },
+   261	    });
+   262	
+   263	    expect(result.dispatched).toBe(0);
+   264	    expect(result.rejected).toBe(1);
+   265	    expect(spawnSubagentDirectMock).not.toHaveBeenCalled();
+   266	
+   267	    // Surface canon: cost-cap rejections emit a "cost-capped" system event.
+   268	    // The text content is part of the contract with continue-work-signal-v2
+   269	    // so the model can self-correct on next turn.
+   270	    expect(enqueueSystemEventMock).toHaveBeenCalledWith(expect.stringContaining("cost-capped"), {
+   271	      sessionKey,
+   272	      trusted: true,
+   273	    });
+   274	  });
+   275	
+   276	  // ───────────────────────────────────────────────────────────────────────
+   277	  // CASCADE case: 3 delegates queued, all start over-cap.
+   278	  //
+   279	  // CANON GUARDED: once accumulated tokens exceed the cap, every
+   280	  // remaining queued delegate in the same dispatch call is rejected —
+   281	  // the loop doesn't re-evaluate from scratch (accumulated can only
+   282	  // grow). This is the cascade-rejection-on-cap behavior.
+   283	  //
+   284	  // Regression indicator: if this test starts asserting "rejected: 1"
+   285	  // (only the first checked, rest mysteriously absent) or "rejected: 0,
+   286	  // dispatched: 3" (cap somehow cleared mid-loop), the cascade logic is
+   287	  // broken; reviewer should look at the for-each-delegate iteration in
+   288	  // delegate-dispatch.ts.
+   289	  // ───────────────────────────────────────────────────────────────────────
+   290	  it("rejects all remaining queued delegates once cost cap is crossed", async () => {
+   291	    const sessionKey = "session-cost-cap-remaining-rejected";
+   292	    enqueuePendingDelegate(sessionKey, { task: "delegate-1" });
+   293	    enqueuePendingDelegate(sessionKey, { task: "delegate-2" });
+   294	    enqueuePendingDelegate(sessionKey, { task: "delegate-3" });
+   295	
+   296	    const result = await dispatchToolDelegates({
+   297	      sessionKey,
+   298	      chainState: {
+   299	        currentChainCount: 0,
+   300	        chainStartedAt: Date.now(),
+   301	        accumulatedChainTokens: 500_001,
+   302	      },
+   303	      ctx: { sessionKey },
+   304	      maxChainLength: 10,
+   305	      config: {
+   306	        enabled: true,
+   307	        defaultDelayMs: 15_000,
+   308	        minDelayMs: 5_000,
+   309	        maxDelayMs: 300_000,
+   310	        maxChainLength: 10,
+   311	        costCapTokens: 500_000,
+   312	        maxDelegatesPerTurn: 5,
+   313	        maxPendingWork: 32,
+   314	        crossSessionTargeting: "disabled",
+   315	        earlyWarningBand: 0.3125,
+   316	      },
+   317	    });
+   318	
+   319	    // ALL three should be rejected — once over cap, every subsequent
+   320	    // delegate in the same dispatch call is also over (accumulated can
+   321	    // only grow, never shrink, within a single dispatch).
+   322	    expect(result.dispatched).toBe(0);
+   323	    expect(result.rejected).toBe(3);
+   324	    expect(spawnSubagentDirectMock).not.toHaveBeenCalled();
+   325	  });
+   326	
+   327	  // ───────────────────────────────────────────────────────────────────────
+   328	  // SIDE-EFFECT case: TaskFlow record state on cost-cap rejection.
+   329	  //
+   330	  // CANON GUARDED: cost-cap rejection transitions the persistent
+   331	  // TaskFlow record from `queued` to `failed`, identical to chain-depth
+   332	  // rejections. The two budget-rejection paths must produce symmetric
+   333	  // observable state.
+   334	  //
+   335	  // Regression indicator: if the TaskFlow stays `queued` after a cost-cap
+   336	  // rejection, the failFlow call is missing from the cost-cap branch
+   337	  // (but possibly still present in the chain-depth branch — the sibling
+   338	  // test would still pass). This is a sneaky regression shape; reviewer
+   339	  // should diff the two rejection branches for parity.
+   340	  // ───────────────────────────────────────────────────────────────────────
+   341	  it("marks TaskFlow records as failed for cost-cap-rejected delegates", async () => {
+   342	    const sessionKey = "session-cost-cap-taskflow-failed";
+   343	    enqueuePendingDelegate(sessionKey, { task: "doomed by cost" });
+   344	
+   345	    const queuedBefore = [...mockFlows.values()].filter(
+   346	      (f) => f.ownerKey === sessionKey && f.status === "queued",
+   347	    );
+   348	    expect(queuedBefore).toHaveLength(1);
+   349	    const flowId = queuedBefore[0].flowId as string;
+   350	
+   351	    await dispatchToolDelegates({
+   352	      sessionKey,
+   353	      chainState: {
+   354	        currentChainCount: 0,
+   355	        chainStartedAt: Date.now(),
+   356	        accumulatedChainTokens: 500_001,
+   357	      },
+   358	      ctx: { sessionKey },
+   359	      maxChainLength: 10,
+   360	      config: {
+   361	        enabled: true,
+   362	        defaultDelayMs: 15_000,
+   363	        minDelayMs: 5_000,
+   364	        maxDelayMs: 300_000,
+   365	        maxChainLength: 10,
+   366	        costCapTokens: 500_000,
+   367	        maxDelegatesPerTurn: 5,
+   368	        maxPendingWork: 32,
+   369	        crossSessionTargeting: "disabled",
+   370	        earlyWarningBand: 0.3125,
+   371	      },
+   372	    });
+   373	
+   374	    // Final-state assertion: queued → failed. Symmetric with the
+   375	    // chain-depth equivalent test in the sibling file.
+   376	    expect(mockFlows.get(flowId)?.status).toBe("failed");
+   377	  });
+   378	
+   379	  // ───────────────────────────────────────────────────────────────────────
+   380	  // EXACT-BOUNDARY case: accumulated === costCapTokens (= 500_000).
+   381	  //
+   382	  // CANON GUARDED: strict-greater-than semantics. The check is
+   383	  // `accumulatedChainTokens > costCapTokens`, NOT `>=`. At exactly the
+   384	  // cap value, dispatch is still ALLOWED — the cap is the inclusive
+   385	  // ceiling, not the exclusive one.
+   386	  //
+   387	  // Regression indicator: this is the single most surgical pin in the
+   388	  // file. If `>` ever flips to `>=` (very easy refactor mistake, looks
+   389	  // like a "be safer" change), this test fires immediately and only
+   390	  // this test — none of the just-under/just-over/cascade tests would
+   391	  // catch it. Reviewer should look at the cost-cap comparison operator
+   392	  // in delegate-dispatch.ts and verify it's strict-greater-than.
+   393	  // ───────────────────────────────────────────────────────────────────────
+   394	  it("rejects at exact boundary (accumulatedChainTokens === costCapTokens is NOT over)", async () => {
+   395	    const sessionKey = "session-cost-cap-exact-boundary";
+   396	    enqueuePendingDelegate(sessionKey, { task: "at exact cap" });
+   397	
+   398	    const result = await dispatchToolDelegates({
+   399	      sessionKey,
+   400	      chainState: {
+   401	        currentChainCount: 0,
+   402	        chainStartedAt: Date.now(),
+   403	        accumulatedChainTokens: 500_000,
+   404	      },
+   405	      ctx: { sessionKey },
+   406	      maxChainLength: 10,
+   407	      config: {
+   408	        enabled: true,
+   409	        defaultDelayMs: 15_000,
+   410	        minDelayMs: 5_000,
+   411	        maxDelayMs: 300_000,
+   412	        maxChainLength: 10,
+   413	        costCapTokens: 500_000,
+   414	        maxDelegatesPerTurn: 5,
+   415	        maxPendingWork: 32,
+   416	        crossSessionTargeting: "disabled",
+   417	        earlyWarningBand: 0.3125,
+   418	      },
+   419	    });
+   420	
+   421	    // The check is `accumulatedChainTokens > costCapTokens` (strict).
+   422	    // At exactly 500_000 it should NOT be cost-capped — equality is
+   423	    // the inclusive ceiling, not the exclusive one. NOTE: the test
+   424	    // title says "rejects at exact boundary" but the canon being
+   425	    // guarded is the OPPOSITE — the title preserves historical naming
+   426	    // while the assertions encode the actual contract (allow-at-cap).
+   427	    expect(result.dispatched).toBe(1);
+   428	    expect(result.rejected).toBe(0);
+   429	    expect(spawnSubagentDirectMock).toHaveBeenCalledTimes(1);
+   430	  });
+   431	});

--- a/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/delegate-dispatch-cost-cap-source.txt
+++ b/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/delegate-dispatch-cost-cap-source.txt
@@ -1,0 +1,46 @@
+  1090	        disabledReason: "policy.cross_session_targeting",
+  1091	        signalKind: "tool-delegate",
+  1092	        delegateDelivery: "immediate",
+  1093	        delegateMode: "post-compaction",
+  1094	        reason: delegate.task,
+  1095	        log: (message) => postCompactionLog.warn(message),
+  1096	      });
+  1097	      markTerminalRejected(
+  1098	        delegate,
+  1099	        "Post-compaction delegate rejected: cross-session targeting is disabled by policy.",
+  1100	      );
+  1101	      continue;
+  1102	    }
+  1103	
+  1104	    const budgetCheck = checkContinuationBudget({
+  1105	      chainState: {
+  1106	        currentChainCount,
+  1107	        chainStartedAt,
+  1108	        accumulatedChainTokens,
+  1109	      },
+  1110	      config,
+  1111	      sessionKey,
+  1112	    });
+  1113	    if (budgetCheck) {
+  1114	      const disabledReason = budgetCheck === "chain-capped" ? "cap.chain" : "cap.cost";
+  1115	      const summary =
+  1116	        budgetCheck === "chain-capped"
+  1117	          ? `chain length ${config.maxChainLength} reached`
+  1118	          : `cost cap exceeded (${accumulatedChainTokens} > ${config.costCapTokens})`;
+  1119	      postCompactionLog.warn(
+  1120	        `[continuation:post-compaction-policy-rejected] ${disabledReason} session=${sessionKey} task=${delegate.task.slice(0, 80)}`,
+  1121	      );
+  1122	      enqueueSystemEvent(
+  1123	        `[continuation] Post-compaction delegate rejected: ${summary}. Task: ${formatDelegateTaskForSystemEvent(delegate.task)}`,
+  1124	        { sessionKey, trusted: true },
+  1125	      );
+  1126	      emitContinuationDisabledSpan({
+  1127	        chainId: undefined,
+  1128	        chainStepRemaining: Math.max(0, config.maxChainLength - currentChainCount),
+  1129	        disabledReason,
+  1130	        signalKind: "tool-delegate",
+  1131	        delegateDelivery: "immediate",
+  1132	        delegateMode: "post-compaction",
+  1133	        reason: delegate.task,
+  1134	        log: (message) => postCompactionLog.warn(message),
+  1135	      });

--- a/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/runtime-version.txt
+++ b/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/runtime-version.txt
@@ -1,0 +1,1 @@
+OpenClaw 2026.6.11 (bca2b0b)

--- a/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/scheduler-source.txt
+++ b/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/scheduler-source.txt
@@ -1,0 +1,42 @@
+     1	/**
+     2	 * Continuation budget helpers.
+     3	 *
+     4	 * Delayed delegate scheduling is TaskFlow-backed via delegate-store and
+     5	 * delegate-dispatch; this module only owns the shared cap checks.
+     6	 */
+     7	
+     8	import { createSubsystemLogger } from "../../logging/subsystem.js";
+     9	import type { ChainState, ContinuationRuntimeConfig } from "./types.js";
+    10	
+    11	const log = createSubsystemLogger("continuation/scheduler");
+    12	
+    13	export type { ChainState } from "./types.js";
+    14	
+    15	/**
+    16	 * Check chain and cost caps. Returns null if clear to proceed, or the
+    17	 * rejection reason.
+    18	 */
+    19	export function checkContinuationBudget(params: {
+    20	  chainState: ChainState;
+    21	  config: ContinuationRuntimeConfig;
+    22	  sessionKey: string;
+    23	}): "chain-capped" | "cost-capped" | null {
+    24	  const { chainState, config, sessionKey } = params;
+    25	  const allocatedChainHop = chainState.currentChainCount;
+    26	
+    27	  if (allocatedChainHop >= config.maxChainLength) {
+    28	    log.info(
+    29	      `[continuation] Chain depth ${allocatedChainHop}/${config.maxChainLength} — capped for session ${sessionKey}`,
+    30	    );
+    31	    return "chain-capped";
+    32	  }
+    33	
+    34	  if (config.costCapTokens > 0 && chainState.accumulatedChainTokens > config.costCapTokens) {
+    35	    log.info(
+    36	      `[continuation] Chain cost ${chainState.accumulatedChainTokens}/${config.costCapTokens} — capped for session ${sessionKey}`,
+    37	    );
+    38	    return "cost-capped";
+    39	  }
+    40	
+    41	  return null;
+    42	}

--- a/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/scheduler-test.txt
+++ b/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/scheduler-test.txt
@@ -1,0 +1,67 @@
+     1	import { describe, expect, it } from "vitest";
+     2	import { checkContinuationBudget } from "./scheduler.js";
+     3	import type { ContinuationRuntimeConfig } from "./types.js";
+     4	
+     5	const baseConfig: ContinuationRuntimeConfig = {
+     6	  enabled: true,
+     7	  defaultDelayMs: 15_000,
+     8	  minDelayMs: 5_000,
+     9	  maxDelayMs: 300_000,
+    10	  maxChainLength: 10,
+    11	  costCapTokens: 500_000,
+    12	  maxDelegatesPerTurn: 5,
+    13	  maxPendingWork: 32,
+    14	  crossSessionTargeting: "disabled",
+    15	};
+    16	
+    17	describe("checkContinuationBudget", () => {
+    18	  it("returns null when under budget", () => {
+    19	    expect(
+    20	      checkContinuationBudget({
+    21	        chainState: { currentChainCount: 3, chainStartedAt: 0, accumulatedChainTokens: 100_000 },
+    22	        config: baseConfig,
+    23	        sessionKey: "test",
+    24	      }),
+    25	    ).toBeNull();
+    26	  });
+    27	
+    28	  it("returns chain-capped at max depth", () => {
+    29	    expect(
+    30	      checkContinuationBudget({
+    31	        chainState: { currentChainCount: 10, chainStartedAt: 0, accumulatedChainTokens: 0 },
+    32	        config: baseConfig,
+    33	        sessionKey: "test",
+    34	      }),
+    35	    ).toBe("chain-capped");
+    36	  });
+    37	
+    38	  it("returns cost-capped over budget", () => {
+    39	    expect(
+    40	      checkContinuationBudget({
+    41	        chainState: { currentChainCount: 0, chainStartedAt: 0, accumulatedChainTokens: 600_000 },
+    42	        config: baseConfig,
+    43	        sessionKey: "test",
+    44	      }),
+    45	    ).toBe("cost-capped");
+    46	  });
+    47	
+    48	  it("allows continuation when accumulated tokens equal costCapTokens exactly", () => {
+    49	    expect(
+    50	      checkContinuationBudget({
+    51	        chainState: { currentChainCount: 0, chainStartedAt: 0, accumulatedChainTokens: 500_000 },
+    52	        config: baseConfig,
+    53	        sessionKey: "test",
+    54	      }),
+    55	    ).toBeNull();
+    56	  });
+    57	
+    58	  it("does not cost-cap when costCapTokens is 0", () => {
+    59	    expect(
+    60	      checkContinuationBudget({
+    61	        chainState: { currentChainCount: 0, chainStartedAt: 0, accumulatedChainTokens: 999_999 },
+    62	        config: { ...baseConfig, costCapTokens: 0 },
+    63	        sessionKey: "test",
+    64	      }),
+    65	    ).toBeNull();
+    66	  });
+    67	});

--- a/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/source-git-status.txt
+++ b/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/source-git-status.txt
@@ -1,0 +1,2 @@
+bca2b0b89ab886bf23a10e4983926f6b374b3188
+## HEAD (no branch)

--- a/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/subagent-announce-bracket-cost-cap-source.txt
+++ b/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/subagent-announce-bracket-cost-cap-source.txt
@@ -1,0 +1,56 @@
+          );
+        } else {
+          const { maxChainLength, costCapTokens, minDelayMs, maxDelayMs, crossSessionTargeting } =
+            subagentAnnounceDeps.resolveContinuationRuntimeConfig(cfg);
+
+          const hopMatch = childTask.match(CONTINUATION_CHAIN_HOP_PATTERN);
+          const childChainHop = hopMatch ? Number.parseInt(hopMatch[1], 10) : 0;
+          const nextChainHop = childChainHop + 1;
+
+          let chainGuardResult:
+            | { allowed: false; reason: "chain-length"; chainCount: number; maxChainLength: number }
+            | { allowed: false; reason: "cost-cap"; chainTokens: number; costCapTokens: number }
+            | { allowed: true; nextChainHop: number };
+
+          if (childChainHop >= maxChainLength) {
+            chainGuardResult = {
+              allowed: false,
+              reason: "chain-length",
+              chainCount: nextChainHop,
+              maxChainLength,
+            };
+          } else {
+            const parentEntry = readSessionEntryByKey(targetRequesterSessionKey);
+            const storedChainTokens = parentEntry?.continuationChainTokens ?? 0;
+            // storedChainTokens already includes this run's tokens when the
+            // parent accumulation persist succeeded (parentChainTokensToFold === 0).
+            // If that persist FAILED, the entry is stale and parentChainTokensToFold
+            // carries the run cost so the guard still enforces against the post-run
+            // total — never guessed from a `stored >= run` heuristic that
+            // under-enforces when the stale prior chain cost already exceeds the
+            // run cost (#1144).
+            const parentChainTokens = storedChainTokens + parentChainTokensToFold;
+            if (costCapTokens > 0 && parentChainTokens > costCapTokens) {
+              chainGuardResult = {
+                allowed: false,
+                reason: "cost-cap",
+                chainTokens: parentChainTokens,
+                costCapTokens,
+              };
+            } else {
+              chainGuardResult = { allowed: true, nextChainHop };
+            }
+          }
+
+          if (!chainGuardResult.allowed) {
+            if (chainGuardResult.reason === "chain-length") {
+              defaultRuntime.log(
+                `[subagent-chain-hop] Chain length ${chainGuardResult.chainCount} > ${chainGuardResult.maxChainLength}, rejecting hop from ${params.childSessionKey}`,
+              );
+            } else {
+              defaultRuntime.log(
+                `[subagent-chain-hop] Cost cap exceeded (${chainGuardResult.chainTokens} > ${chainGuardResult.costCapTokens}), rejecting hop from ${params.childSessionKey}`,
+              );
+            }
+          } else {
+            const doChainSpawn = async (): Promise<boolean> => {

--- a/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/subagent-announce-tool-cost-cap-source.txt
+++ b/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/subagent-announce-tool-cost-cap-source.txt
@@ -1,0 +1,46 @@
+              // they can charge this hop; rejected/failed bracket spawns do not
+              // consume the child's chain budget.
+              bracketDelegateReservedCurrentHop = await doChainSpawn();
+            }
+          }
+        }
+      }
+
+      // --- Tool-dispatched delegates from subagent (parallel to bracket delegates above) ---
+      let postBracketChildDrainArmed = false;
+      if (toolDelegates.length > 0 && isContinuationChainDelegate) {
+        const {
+          maxChainLength: toolMaxChainLength,
+          costCapTokens: toolCostCapTokens,
+          crossSessionTargeting: toolCrossSessionTargeting,
+        } = subagentAnnounceDeps.resolveContinuationRuntimeConfig(cfg);
+        const hopMatch = childTask.match(CONTINUATION_CHAIN_HOP_PATTERN);
+        const childChainHop = hopMatch ? Number.parseInt(hopMatch[1], 10) : 0;
+        // Use the current-chain reservation flag captured before findings was
+        // mutated. A post-compaction bracket delegate is only staged for a later
+        // compaction seam, so it must not charge the child chain's tool delegates now.
+        const bracketConsumedHop = bracketDelegateReservedCurrentHop ? 1 : 0;
+        let toolHopBase = childChainHop + bracketConsumedHop;
+
+        const parentWasSilent = params.silentAnnounce === true;
+
+        let toolDelegateIdx = 0;
+        for (const toolDelegate of toolDelegates) {
+          const nextToolHop = toolHopBase + 1;
+
+          if (nextToolHop > toolMaxChainLength) {
+            const remaining = toolDelegates.length - toolDelegateIdx;
+            const summary = `Tool delegate rejected: chain length ${nextToolHop} exceeds maxChainLength ${toolMaxChainLength}.`;
+            defaultRuntime.log(
+              `[subagent-chain-hop] Tool delegate chain length ${nextToolHop} > ${toolMaxChainLength}, rejecting from ${params.childSessionKey}. ${remaining} delegate(s) dropped.`,
+            );
+            for (const dropped of toolDelegates.slice(toolDelegateIdx)) {
+              markPendingDelegateFailed(dropped, summary, "Delegate rejected");
+            }
+            break;
+          }
+
+          const parentEntryForTool = readSessionEntryByKey(targetRequesterSessionKey);
+          const storedToolChainTokens = parentEntryForTool?.continuationChainTokens ?? 0;
+          // Same definitive fold as the bracket guard: parentChainTokensToFold is
+          // 0 when the parent persist landed (storedToolChainTokens already

--- a/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/vitest-chain-guard-cost-cap.log
+++ b/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/vitest-chain-guard-cost-cap.log
@@ -1,0 +1,38 @@
+
+[1m[30m[46m RUN [49m[39m[22m [36mv4.1.8 [39m[90m/tmp/oc-proofs-234-bca2b0b/openclaw-src[39m
+
+ [2m[90m↓[39m[22m [30m[45m agents-support [49m[39m src/agents/subagent-announce.chain-guard.test.ts[2m > [22mannounce-side chain guard (maxChainLength enforcement)[2m > [22mallows chain hop when nextChainHop <= maxChainLength
+ [2m[90m↓[39m[22m [30m[45m agents-support [49m[39m src/agents/subagent-announce.chain-guard.test.ts[2m > [22mannounce-side chain guard (maxChainLength enforcement)[2m > [22mallows chain hop when the next shard reaches the configured boundary
+ [2m[90m↓[39m[22m [30m[45m agents-support [49m[39m src/agents/subagent-announce.chain-guard.test.ts[2m > [22mannounce-side chain guard (maxChainLength enforcement)[2m > [22mblocks chain hop once the completing shard already occupies maxChainLength
+ [2m[90m↓[39m[22m [30m[45m agents-support [49m[39m src/agents/subagent-announce.chain-guard.test.ts[2m > [22mannounce-side chain guard (maxChainLength enforcement)[2m > [22mblocks chain hop well beyond maxChainLength
+ [2m[90m↓[39m[22m [30m[45m agents-support [49m[39m src/agents/subagent-announce.chain-guard.test.ts[2m > [22mannounce-side chain guard (maxChainLength enforcement)[2m > [22mallows first bracket-started hop (no prefix → hop 0)
+ [2m[90m↓[39m[22m [30m[45m agents-support [49m[39m src/agents/subagent-announce.chain-guard.test.ts[2m > [22mannounce-side chain guard (maxChainLength enforcement)[2m > [22mrejects child-emitted bracket fanout=all when cross-session targeting is disabled
+ [2m[90m↓[39m[22m [30m[45m agents-support [49m[39m src/agents/subagent-announce.chain-guard.test.ts[2m > [22mannounce-side chain guard (maxChainLength enforcement)[2m > [22mallows child-emitted bracket fanout=tree when cross-session targeting is disabled
+ [2m[90m↓[39m[22m [30m[45m agents-support [49m[39m src/agents/subagent-announce.chain-guard.test.ts[2m > [22mannounce-side chain guard (maxChainLength enforcement)[2m > [22mrespects custom maxChainLength from config at the exact boundary
+ [2m[90m↓[39m[22m [30m[45m agents-support [49m[39m src/agents/subagent-announce.chain-guard.test.ts[2m > [22mannounce-side chain guard (maxChainLength enforcement)[2m > [22mrespects custom maxChainLength from config after the boundary is reached
+[90mstderr[2m | src/agents/subagent-announce.chain-guard.test.ts[2m > [22m[2mannounce-side chain guard (maxChainLength enforcement)[2m > [22m[2mrejects continuation when accumulated tokens exceed costCapTokens by one
+[22m[39m[continuation:drain-persist-missing-entry] child=agent:main:subagent:shard-hop-1 advanced chain state was not durably written
+
+[90mstderr[2m | src/agents/subagent-announce.chain-guard.test.ts[2m > [22m[2mannounce-side chain guard (maxChainLength enforcement)[2m > [22m[2mrejects continuation when accumulated tokens exceed costCapTokens by one
+[22m[39m[continuation:drain-persist-missing-entry] child=agent:main:subagent:shard-hop-1 advanced chain state was not durably written
+
+ [32m✓[39m [30m[45m agents-support [49m[39m src/agents/subagent-announce.chain-guard.test.ts[2m > [22mannounce-side chain guard (maxChainLength enforcement)[2m > [22mallows continuation when accumulated tokens equal costCapTokens exactly (> not >=)[33m 420[2mms[22m[39m
+ [32m✓[39m [30m[45m agents-support [49m[39m src/agents/subagent-announce.chain-guard.test.ts[2m > [22mannounce-side chain guard (maxChainLength enforcement)[2m > [22mrejects continuation when accumulated tokens exceed costCapTokens by one[32m 210[2mms[22m[39m
+ [2m[90m↓[39m[22m [30m[45m agents-support [49m[39m src/agents/subagent-announce.chain-guard.test.ts[2m > [22mtool-delegate chain guard (nextToolHop > toolMaxChainLength)[2m > [22mallows tool delegate at maxChainLength-1 (next hop = maxChainLength)
+ [2m[90m↓[39m[22m [30m[45m agents-support [49m[39m src/agents/subagent-announce.chain-guard.test.ts[2m > [22mtool-delegate chain guard (nextToolHop > toolMaxChainLength)[2m > [22mrejects child tool-delegate fanout=all when cross-session targeting is disabled
+ [2m[90m↓[39m[22m [30m[45m agents-support [49m[39m src/agents/subagent-announce.chain-guard.test.ts[2m > [22mtool-delegate chain guard (nextToolHop > toolMaxChainLength)[2m > [22mallows child tool-delegate fanout=tree when cross-session targeting is disabled
+ [2m[90m↓[39m[22m [30m[45m agents-support [49m[39m src/agents/subagent-announce.chain-guard.test.ts[2m > [22mtool-delegate chain guard (nextToolHop > toolMaxChainLength)[2m > [22mallows tool delegate at maxChainLength (next hop = maxChainLength, off-by-one fix)
+ [2m[90m↓[39m[22m [30m[45m agents-support [49m[39m src/agents/subagent-announce.chain-guard.test.ts[2m > [22mtool-delegate chain guard (nextToolHop > toolMaxChainLength)[2m > [22mdispatches matured delayed tool delegates without charging a second delay
+ [2m[90m↓[39m[22m [30m[45m agents-support [49m[39m src/agents/subagent-announce.chain-guard.test.ts[2m > [22mtool-delegate chain guard (nextToolHop > toolMaxChainLength)[2m > [22mrejects tool delegate at maxChainLength+1 (next hop exceeds max)
+ [2m[90m↓[39m[22m [30m[45m agents-support [49m[39m src/agents/subagent-announce.chain-guard.test.ts[2m > [22mtool-delegate chain guard (nextToolHop > toolMaxChainLength)[2m > [22mrejects tool delegate well beyond maxChainLength
+ [2m[90m↓[39m[22m [30m[45m agents-support [49m[39m src/agents/subagent-announce.chain-guard.test.ts[2m > [22mtool-delegate chain guard (nextToolHop > toolMaxChainLength)[2m > [22mmarks every over-cap consumed tool delegate failed
+ [2m[90m↓[39m[22m [30m[45m agents-support [49m[39m src/agents/subagent-announce.chain-guard.test.ts[2m > [22mtool-delegate chain guard (nextToolHop > toolMaxChainLength)[2m > [22mmarks forbidden consumed tool delegate spawn failed as rejected
+ [2m[90m↓[39m[22m [30m[45m agents-support [49m[39m src/agents/subagent-announce.chain-guard.test.ts[2m > [22mtool-delegate chain guard (nextToolHop > toolMaxChainLength)[2m > [22mrespects custom maxChainLength for tool delegates
+ [2m[90m↓[39m[22m [30m[45m agents-support [49m[39m src/agents/subagent-announce.chain-guard.test.ts[2m > [22mannounce-path post-compaction routing (stage at seam, skip spawn)[2m > [22mstages a post-compaction bracket delegate and skips the normal chain-spawn
+ [2m[90m↓[39m[22m [30m[45m agents-support [49m[39m src/agents/subagent-announce.chain-guard.test.ts[2m > [22mannounce-path post-compaction routing (stage at seam, skip spawn)[2m > [22mstill chain-spawns a normal (non-post-compaction) bracket delegate
+
+[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
+[2m      Tests [22m [1m[32m2 passed[39m[22m[2m | [22m[33m21 skipped[39m[90m (23)[39m
+[2m   Start at [22m 10:23:13
+[2m   Duration [22m 6.06s[2m (transform 4.61s, setup 141ms, import 5.19s, tests 633ms, environment 0ms)[22m
+

--- a/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/vitest-delegate-dispatch-cost-cap-exhaustion.log
+++ b/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/vitest-delegate-dispatch-cost-cap-exhaustion.log
@@ -1,0 +1,14 @@
+
+[1m[30m[46m RUN [49m[39m[22m [36mv4.1.8 [39m[90m/tmp/oc-proofs-234-bca2b0b/openclaw-src[39m
+
+ [32m✓[39m [30m[45m auto-reply [49m[39m src/auto-reply/continuation/delegate-dispatch.cost-cap-exhaustion.test.ts[2m > [22mcost-cap exhaustion mid-chain[2m > [22mallows dispatch when accumulatedChainTokens is 1 below costCapTokens[32m 83[2mms[22m[39m
+ [32m✓[39m [30m[45m auto-reply [49m[39m src/auto-reply/continuation/delegate-dispatch.cost-cap-exhaustion.test.ts[2m > [22mcost-cap exhaustion mid-chain[2m > [22mrejects dispatch when accumulatedChainTokens exceeds costCapTokens by 1[32m 1[2mms[22m[39m
+ [32m✓[39m [30m[45m auto-reply [49m[39m src/auto-reply/continuation/delegate-dispatch.cost-cap-exhaustion.test.ts[2m > [22mcost-cap exhaustion mid-chain[2m > [22mrejects all remaining queued delegates once cost cap is crossed[32m 1[2mms[22m[39m
+ [32m✓[39m [30m[45m auto-reply [49m[39m src/auto-reply/continuation/delegate-dispatch.cost-cap-exhaustion.test.ts[2m > [22mcost-cap exhaustion mid-chain[2m > [22mmarks TaskFlow records as failed for cost-cap-rejected delegates[32m 1[2mms[22m[39m
+ [32m✓[39m [30m[45m auto-reply [49m[39m src/auto-reply/continuation/delegate-dispatch.cost-cap-exhaustion.test.ts[2m > [22mcost-cap exhaustion mid-chain[2m > [22mrejects at exact boundary (accumulatedChainTokens === costCapTokens is NOT over)[32m 1[2mms[22m[39m
+
+[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
+[2m      Tests [22m [1m[32m5 passed[39m[22m[90m (5)[39m
+[2m   Start at [22m 10:23:42
+[2m   Duration [22m 3.85s[2m (transform 3.30s, setup 286ms, import 3.38s, tests 88ms, environment 0ms)[22m
+

--- a/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/README.md
+++ b/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/README.md
@@ -2,7 +2,7 @@
 
 Candidate: `OpenClaw 2026.6.11 (bca2b0b)` deployed to Cael.
 
-Status: **IN PROGRESS**. Current rollup: 14 pass / 1 honest_limit / 13 missing. The proof board is populated in Project 83 from the prior Project 82 row template. Rows start as `missing` until Cael + frond-scribe agree the exact test form, fire the row, capture receipts, and attach the required Tempo JSON where applicable.
+Status: **IN PROGRESS**. Current rollup: 15 pass / 1 honest_limit / 12 missing. The proof board is populated in Project 83 from the prior Project 82 row template. Rows start as `missing` until Cael + frond-scribe agree the exact test form, fire the row, capture receipts, and attach the required Tempo JSON where applicable.
 
 ## Deployment receipt
 
@@ -38,7 +38,7 @@ Status: **IN PROGRESS**. Current rollup: 14 pass / 1 honest_limit / 13 missing. 
 | R-CW-3 | [#231](https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/231) | pass |
 | R-REGRESSION-TRAP-TESTS | [#232](https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/232) | missing |
 | R-OBS-2 | [#233](https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/233) | missing |
-| R-CW-5 | [#234](https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/234) | missing |
+| R-CW-5 | [#234](https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/234) | pass |
 | R-CD-3 | [#235](https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/235) | pass |
 | R-CD-TOKEN | [#236](https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/236) | pass |
 | R-CW-TOKEN | [#237](https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/237) | pass |

--- a/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/proofs-manifest.json
+++ b/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/proofs-manifest.json
@@ -6,18 +6,18 @@
   "build_string": "OpenClaw 2026.6.11 (bca2b0b)",
   "fire_type": "fresh-fire",
   "method": "openclaw-bootstrap:RUNBOOKS/PROOF-CORPUS-METHOD.md",
-  "generated": "2026-07-04T17:18:00Z",
+  "generated": "2026-07-04T17:27:00Z",
   "generated_by": "frond-scribe (copilot)",
   "rollup": {
     "total_rows": 28,
-    "pass": 14,
+    "pass": 15,
     "partial": 0,
     "thin": 0,
     "fail": 0,
     "honest_limit": 1,
-    "missing": 13
+    "missing": 12
   },
-  "notes": "IN-PROGRESS corpus. R-CW-2 added as PASS: typed continue_work(delaySeconds=0) scheduled immediate same-session work, persisted a flow row, emitted delay.ms=0 continuation.work / continuation.work.fire spans, and granted the wake with chain counter hop 1/200. Remaining rows stay missing until row-specific evidence and Tempo JSON where applicable are captured.",
+  "notes": "IN-PROGRESS corpus. R-CW-5 added as PASS: source/test proof for cost-cap exhaustion at bca2b0b; no live config mutation or live over-budget dispatch. Remaining rows stay missing until row-specific evidence and Tempo JSON where applicable are captured.",
   "rows": [
     {
       "row": "R-RC-1",
@@ -305,11 +305,25 @@
     },
     {
       "row": "R-CW-5",
-      "state": "missing",
+      "state": "pass",
       "dir": "PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/",
       "issue": "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/234",
       "traces": [],
-      "supporting_docs": []
+      "supporting_docs": [
+        "PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/EVIDENCE.md",
+        "PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/source-git-status.txt",
+        "PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/runtime-version.txt",
+        "PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/scheduler-source.txt",
+        "PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/scheduler-test.txt",
+        "PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/delegate-dispatch-cost-cap-source.txt",
+        "PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/delegate-dispatch-cost-cap-exhaustion-test.txt",
+        "PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/subagent-announce-bracket-cost-cap-source.txt",
+        "PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/subagent-announce-tool-cost-cap-source.txt",
+        "PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/vitest-delegate-dispatch-cost-cap-exhaustion.log",
+        "PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/vitest-chain-guard-cost-cap.log"
+      ],
+      "evidence_doc": "PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-CW-5/cael-dgx/EVIDENCE.md",
+      "note": "PASS: static/source + unit-test proof. Dedicated delegate-dispatch cost-cap exhaustion suite passed 5/5 and announce-side cost-cap boundary tests passed 2/2 selected at bca2b0b; no live config mutation or live over-budget dispatch."
     },
     {
       "row": "R-CD-3",


### PR DESCRIPTION
Adds the #234 proof-corpus evidence for `R-CW-5` on candidate/deploy SHA `bca2b0b89ab886bf23a10e4983926f6b374b3188`.

Evidence package:
- source/test proof only; no live config mutation and no live over-budget dispatch
- scheduler source guard: cost-capped only when `accumulatedChainTokens > costCapTokens`
- delegate-dispatch source guard and cost-cap rejection surface
- announce-side bracket/tool delegate cost-cap source guards
- dedicated `delegate-dispatch.cost-cap-exhaustion.test.ts` receipt: 5/5 selected cost-cap tests passed
- announce-side chain-guard boundary receipt: 2/2 selected cost-cap boundary tests passed
- manifest/index rollup update to `15 pass / 1 honest_limit / 12 missing`

No Tempo trace is included because this row is intentionally static/source + unit-test evidence.

Closes #234
