### PR TITLE
proofs: add bca2b0b regression trap test evidence

### DIFF
--- a/PROOFS/INDEX.json
+++ b/PROOFS/INDEX.json
@@ -9,16 +9,16 @@
   "readme_path": "PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/README.md",
   "rollup": {
     "total_rows": 28,
-    "pass": 16,
+    "pass": 17,
     "partial": 0,
     "thin": 0,
     "fail": 0,
     "honest_limit": 1,
-    "missing": 11
+    "missing": 10
   },
-  "disposition_note": "IN-PROGRESS corpus after exact-SHA Cael deploy and smoke; R-RC-1 recorded as PASS; R-RC-2 honest_limit; multiple live rows added by cael-dgx.",
+  "disposition_note": "IN-PROGRESS corpus after exact-SHA Cael deploy and smoke; R-REGRESSION-TRAP-TESTS recorded as PASS; R-RC-2 honest_limit; multiple live rows added by cael-dgx.",
   "navigation": "clawsweeper: read INDEX.json -> current_sha -> manifest_path -> rows[]",
-  "generated": "2026-07-04T17:31:00Z",
+  "generated": "2026-07-04T17:37:00Z",
   "generated_by": "frond-scribe (copilot, corpus-manager)",
   "capture_sha": "bca2b0b89ab886bf23a10e4983926f6b374b3188",
   "carried_from": null

--- a/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-REGRESSION-TRAP-TESTS/cael-dgx/EVIDENCE.md
+++ b/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-REGRESSION-TRAP-TESTS/cael-dgx/EVIDENCE.md
@@ -1,0 +1,62 @@
+# R-REGRESSION-TRAP-TESTS — continuation sibling-surface regression trap tests (cael-dgx)
+
+Issue: https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/232
+
+Candidate SHA: `bca2b0b89ab886bf23a10e4983926f6b374b3188`  
+Source checkout: `bca2b0b89ab886bf23a10e4983926f6b374b3188`  
+Seat: Cael / `cael-dgx`  
+Build receipt: `OpenClaw 2026.6.11 (bca2b0b)`  
+Verdict: ✅ PASS
+
+## Scenario
+
+Run the continuation sibling-surface regression trap tests on the exact deployed proof SHA. These tests lock the sibling continuation tool option/registration/misconfiguration surfaces together so a future cure cannot cover one sibling (`continue_work`, `continue_delegate`, `request_compaction`) while silently dropping another.
+
+This is the same trap shape as the prior #196 row, refreshed for `bca2b0b89ab886bf23a10e4983926f6b374b3188`.
+
+## Command
+
+```bash
+cd /tmp/oc-proofs-234-bca2b0b/openclaw-src
+node scripts/run-vitest.mjs run \
+  src/agents/tools/continuation-inventory-opts.test.ts \
+  src/agents/openclaw-tools.continuation-registration.test.ts \
+  src/agents/tools/continuation-tools-registration.test.ts \
+  src/agents/openclaw-tools.continuation-misconfig-warn.test.ts
+```
+
+## Observed
+
+Raw output is preserved in `regression-trap.log`. Summary:
+
+```text
+[test] starting test/vitest/vitest.unit-fast.config.ts
+✓ src/agents/tools/continuation-inventory-opts.test.ts (5 tests)
+Test Files 1 passed (1)\nTests      5 passed (5)
+
+[test] starting test/vitest/vitest.agents.config.ts
+✓ src/agents/openclaw-tools.continuation-misconfig-warn.test.ts (6 tests)
+✓ src/agents/openclaw-tools.continuation-registration.test.ts (7 tests)
+✓ src/agents/tools/continuation-tools-registration.test.ts (13 tests)
+Test Files 3 passed (3)
+Tests      26 passed (26)
+
+[test] passed 2 Vitest shards in 18.95s
+```
+
+Total: **31/31 PASS**, two Vitest shards, process exit code 0.
+
+## Supporting receipts
+
+- `source-git-status.txt` — source checkout SHA/status at `bca2b0b89ab886bf23a10e4983926f6b374b3188`.
+- `runtime-version.txt` — deployed runtime build receipt.
+- `test-inventory.txt` — test file existence and test inventory receipt.
+- `regression-trap.log` — raw command output showing 5/5 inventory opts plus 26/26 registration/misconfig trap tests.
+
+## Tempo / live-fire note
+
+No Tempo trace is included because this row is intentionally source/test evidence. It runs regression tests; it does not fire live continuation/delegate/compaction behavior.
+
+## Verdict
+
+✅ PASS. The deployed `bca2b0b` byte has continuation inventory/registration/misconfig warning coverage across sibling continuation tools. No half-symmetric regression is present in this trap set.

--- a/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-REGRESSION-TRAP-TESTS/cael-dgx/regression-trap.log
+++ b/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-REGRESSION-TRAP-TESTS/cael-dgx/regression-trap.log
@@ -1,0 +1,25 @@
+[test] starting test/vitest/vitest.unit-fast.config.ts
+
+[1m[30m[46m RUN [49m[39m[22m [36mv4.1.8 [39m[90m/tmp/oc-proofs-234-bca2b0b/openclaw-src[39m
+
+ [32m✓[39m [30m[45m unit-fast [49m[39m src/agents/tools/continuation-inventory-opts.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
+
+[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
+[2m      Tests [22m [1m[32m5 passed[39m[22m[90m (5)[39m
+[2m   Start at [22m 10:34:17
+[2m   Duration [22m 405ms[2m (transform 281ms, setup 0ms, import 334ms, tests 2ms, environment 0ms)[22m
+
+[test] starting test/vitest/vitest.agents.config.ts
+
+[1m[30m[46m RUN [49m[39m[22m [36mv4.1.8 [39m[90m/tmp/oc-proofs-234-bca2b0b/openclaw-src[39m
+
+ [32m✓[39m [30m[46m agents [49m[39m src/agents/openclaw-tools.continuation-misconfig-warn.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 273[2mms[22m[39m
+ [32m✓[39m [30m[46m agents [49m[39m src/agents/openclaw-tools.continuation-registration.test.ts [2m([22m[2m7 tests[22m[2m)[22m[33m 347[2mms[22m[39m
+ [32m✓[39m [30m[46m agents [49m[39m src/agents/tools/continuation-tools-registration.test.ts [2m([22m[2m13 tests[22m[2m)[22m[33m 958[2mms[22m[39m
+
+[2m Test Files [22m [1m[32m3 passed[39m[22m[90m (3)[39m
+[2m      Tests [22m [1m[32m26 passed[39m[22m[90m (26)[39m
+[2m   Start at [22m 10:34:19
+[2m   Duration [22m 13.82s[2m (transform 32.32s, setup 969ms, import 37.30s, tests 1.58s, environment 0ms)[22m
+
+[test] passed 2 Vitest shards in 18.95s

--- a/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-REGRESSION-TRAP-TESTS/cael-dgx/runtime-version.txt
+++ b/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-REGRESSION-TRAP-TESTS/cael-dgx/runtime-version.txt
@@ -1,0 +1,1 @@
+OpenClaw 2026.6.11 (bca2b0b)

--- a/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-REGRESSION-TRAP-TESTS/cael-dgx/source-git-status.txt
+++ b/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-REGRESSION-TRAP-TESTS/cael-dgx/source-git-status.txt
@@ -1,0 +1,1 @@
+## HEAD (no branch)

--- a/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-REGRESSION-TRAP-TESTS/cael-dgx/source-git-status.txt
+++ b/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-REGRESSION-TRAP-TESTS/cael-dgx/source-git-status.txt
@@ -1,1 +1,2 @@
+bca2b0b89ab886bf23a10e4983926f6b374b3188
 ## HEAD (no branch)

--- a/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-REGRESSION-TRAP-TESTS/cael-dgx/test-inventory.txt
+++ b/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-REGRESSION-TRAP-TESTS/cael-dgx/test-inventory.txt
@@ -1,0 +1,40 @@
+33 src/agents/tools/continuation-inventory-opts.test.ts
+4:describe("buildInventoryContinuationToolOpts", () => {
+5:  it("returns no opts when continuation is disabled", () => {
+9:  it("returns stub continueWorkOpts + requestCompactionOpts when enabled", () => {
+16:  it("stub getContextUsage returns null (no live usage on inventory paths)", () => {
+21:  it("stub requestContinuation throws a clear error (registered-but-not-runnable; no silent success)", () => {
+28:  it("stub triggerCompaction resolves to an inert rejection (no compaction fires)", async () => {
+161 src/agents/openclaw-tools.continuation-registration.test.ts
+54:describe("createOpenClawTools — continuation-tool registration visibility", () => {
+55:  it("registers no continuation tools when continuation.enabled is unset", () => {
+65:  it("registers no continuation tools when continuation.enabled is explicitly false", () => {
+78:  it("does not register request_compaction when continuation.enabled is true but requestCompactionOpts is missing", () => {
+95:  it("registers request_compaction when continuation.enabled is true AND requestCompactionOpts is provided", () => {
+113:  it("does not register request_compaction even with opts when continuation.enabled is unset", () => {
+124:  it("registers request_compaction with the expected tool surface (name + parameters present)", () => {
+141:  it("registers continuation tools at most once per createOpenClawTools call", () => {
+315 src/agents/tools/continuation-tools-registration.test.ts
+9:describe("continuation tool registration", { timeout: 240000 }, () => {
+21:  it("exposes continue_delegate on normal turns when continuation is enabled", () => {
+30:  it("exposes cross-session targeting fields on the continue_delegate schema descriptor", () => {
+47:  it("description documents the five continuation return targeting modes", () => {
+64:  it("hides continue_delegate when continuation is disabled", () => {
+76:  it("exposes continue_work when continuation is enabled and the runner wires it", () => {
+92:  it("exposes continue_delegate when drainsContinuationDelegateQueue is undefined (default normal turns)", () => {
+102:  it("exposes continue_delegate when drainsContinuationDelegateQueue is explicitly true (explicit drainers)", () => {
+112:  it("hides continue_delegate when drainsContinuationDelegateQueue is explicitly false (e.g. llm-slug-generator)", () => {
+148:  it("pins continue_delegate descriptor to mode enum and no boolean compatibility fields", () => {
+263:  describe("request_compaction registration truth-table", () => {
+270:    it("exposes request_compaction when continuation enabled AND requestCompactionOpts wired", () => {
+279:    it("hides request_compaction when continuation disabled (regardless of opts)", () => {
+291:    it("hides request_compaction when continuation enabled but opts omitted", () => {
+300:    it("descriptor name is stable across registrations", () => {
+181 src/agents/openclaw-tools.continuation-misconfig-warn.test.ts
+79:describe("createOpenClawTools — silent partial-registration guard", () => {
+84:  it("warns when continuation.enabled=true but neither continueWorkOpts nor requestCompactionOpts are supplied", () => {
+102:  it("does NOT warn when continuation is fully configured", () => {
+118:  it("does NOT warn when continuation.enabled is unset", () => {
+129:  it("does NOT warn when only continueWorkOpts is supplied (request_compaction will not register, but continue_work IS registered — partial-registration concern only fires when neither is supplied)", () => {
+149:  it("does NOT warn when continuation.enabled=true and stub inventory callbacks are supplied (register honestly, not suppress)", () => {
+164:  it("registers continue_work + request_compaction when stub inventory callbacks are supplied (catalog reflects full surface)", () => {

--- a/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/README.md
+++ b/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/README.md
@@ -2,7 +2,7 @@
 
 Candidate: `OpenClaw 2026.6.11 (bca2b0b)` deployed to Cael.
 
-Status: **IN PROGRESS**. Current rollup: 16 pass / 1 honest_limit / 11 missing. The proof board is populated in Project 83 from the prior Project 82 row template. Rows start as `missing` until Cael + frond-scribe agree the exact test form, fire the row, capture receipts, and attach the required Tempo JSON where applicable.
+Status: **IN PROGRESS**. Current rollup: 17 pass / 1 honest_limit / 10 missing. The proof board is populated in Project 83 from the prior Project 82 row template. Rows start as `missing` until Cael + frond-scribe agree the exact test form, fire the row, capture receipts, and attach the required Tempo JSON where applicable.
 
 ## Deployment receipt
 
@@ -36,7 +36,7 @@ Status: **IN PROGRESS**. Current rollup: 16 pass / 1 honest_limit / 11 missing. 
 | R-CW-1 | [#229](https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/229) | pass |
 | R-CW-2 | [#230](https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/230) | pass |
 | R-CW-3 | [#231](https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/231) | pass |
-| R-REGRESSION-TRAP-TESTS | [#232](https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/232) | missing |
+| R-REGRESSION-TRAP-TESTS | [#232](https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/232) | pass |
 | R-OBS-2 | [#233](https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/233) | missing |
 | R-CW-5 | [#234](https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/234) | pass |
 | R-CD-3 | [#235](https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/235) | pass |

--- a/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/proofs-manifest.json
+++ b/PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/proofs-manifest.json
@@ -6,18 +6,18 @@
   "build_string": "OpenClaw 2026.6.11 (bca2b0b)",
   "fire_type": "fresh-fire",
   "method": "openclaw-bootstrap:RUNBOOKS/PROOF-CORPUS-METHOD.md",
-  "generated": "2026-07-04T17:31:00Z",
+  "generated": "2026-07-04T17:37:00Z",
   "generated_by": "frond-scribe (copilot)",
   "rollup": {
     "total_rows": 28,
-    "pass": 16,
+    "pass": 17,
     "partial": 0,
     "thin": 0,
     "fail": 0,
     "honest_limit": 1,
-    "missing": 11
+    "missing": 10
   },
-  "notes": "IN-PROGRESS corpus. R-RC-1 added as PASS: request_compaction rejected below threshold with guard=context_threshold at 19% < 70%, with Tempo tool trace. Remaining rows stay missing until row-specific evidence and Tempo JSON where applicable are captured.",
+  "notes": "IN-PROGRESS corpus. R-REGRESSION-TRAP-TESTS added as PASS: continuation sibling-surface regression trap tests passed 31/31 at bca2b0b. Remaining rows stay missing until row-specific evidence and Tempo JSON where applicable are captured.",
   "rows": [
     {
       "row": "R-RC-1",
@@ -303,11 +303,19 @@
     },
     {
       "row": "R-REGRESSION-TRAP-TESTS",
-      "state": "missing",
+      "state": "pass",
       "dir": "PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-REGRESSION-TRAP-TESTS/",
       "issue": "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/232",
       "traces": [],
-      "supporting_docs": []
+      "supporting_docs": [
+        "PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-REGRESSION-TRAP-TESTS/cael-dgx/EVIDENCE.md",
+        "PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-REGRESSION-TRAP-TESTS/cael-dgx/source-git-status.txt",
+        "PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-REGRESSION-TRAP-TESTS/cael-dgx/runtime-version.txt",
+        "PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-REGRESSION-TRAP-TESTS/cael-dgx/test-inventory.txt",
+        "PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-REGRESSION-TRAP-TESTS/cael-dgx/regression-trap.log"
+      ],
+      "evidence_doc": "PROOFS/bca2b0b89ab886bf23a10e4983926f6b374b3188/R-REGRESSION-TRAP-TESTS/cael-dgx/EVIDENCE.md",
+      "note": "PASS: exact-SHA regression trap command passed 31/31 (continuation inventory opts 5/5 + registration/misconfig 26/26); no live behavior fired, so no Tempo trace by row design."
     },
     {
       "row": "R-OBS-2",


### PR DESCRIPTION
Adds the #232 proof-corpus evidence for `R-REGRESSION-TRAP-TESTS` on candidate/deploy SHA `bca2b0b89ab886bf23a10e4983926f6b374b3188`.

Evidence package:
- exact source checkout `bca2b0b89ab886bf23a10e4983926f6b374b3188`
- runtime receipt `OpenClaw 2026.6.11 (bca2b0b)`
- regression trap command:
  - `continuation-inventory-opts.test.ts`
  - `openclaw-tools.continuation-registration.test.ts`
  - `continuation-tools-registration.test.ts`
  - `openclaw-tools.continuation-misconfig-warn.test.ts`
- raw log showing 2 Vitest shards passed:
  - inventory opts `5/5`
  - registration/misconfig `26/26`
  - total `31/31`
- manifest/index rollup update to `17 pass / 1 honest_limit / 10 missing`
No Tempo trace is included because this row is intentionally source/test evidence and does not fire live continuation behavior.

Closes #232