### PR TITLE
fix(k6-proofs): validate current corpus index

### DIFF
--- a/PROOFS/71a1dfff040000ce8862d30d0587ebee044a23b3/proofs-manifest.json
+++ b/PROOFS/71a1dfff040000ce8862d30d0587ebee044a23b3/proofs-manifest.json
@@ -164,7 +164,8 @@
       ],
       "traces": [
         "PROOFS/71a1dfff040000ce8862d30d0587ebee044a23b3/R-CD-COLLECTION-ON-COLLAPSE/cael-dgx/tempo/trace-ecda443e0038fb9a38fc33a8b98d7d02.json"
-      ]
+      ],
+      "evidence_doc": "PROOFS/71a1dfff040000ce8862d30d0587ebee044a23b3/R-CD-COLLECTION-ON-COLLAPSE/cael-dgx/EVIDENCE.md"
     },
     {
       "dir": "PROOFS/71a1dfff040000ce8862d30d0587ebee044a23b3/R-CD-1/",

--- a/tools/k6-proofs/scripts/validate-corpus.mjs
+++ b/tools/k6-proofs/scripts/validate-corpus.mjs
@@ -234,8 +234,14 @@ function validateSha(root, sha, { manifestRequired = true } = {}) {
   );
 
   const onDiskRowDirs = listSubdirs(shaDir) || [];
+  const supportDirs = new Set(['gates']);
+  const ignoredSupportDirs = [];
   const orphanDirs = [];
   for (const sub of onDiskRowDirs) {
+    if (supportDirs.has(sub)) {
+      ignoredSupportDirs.push(`PROOFS/${sha}/${sub}/`);
+      continue;
+    }
     const candidate = join('PROOFS', sha, sub);
     if (!declaredDirs.has(candidate)) {
       orphanDirs.push(`PROOFS/${sha}/${sub}/`);
@@ -246,7 +252,7 @@ function validateSha(root, sha, { manifestRequired = true } = {}) {
     'no-orphan-row-dirs',
     orphanDirs.length === 0,
     orphanDirs.length === 0
-      ? `${onDiskRowDirs.length} on-disk row dirs all referenced`
+      ? `${onDiskRowDirs.length - ignoredSupportDirs.length} on-disk row dirs all referenced; ignored support dirs: ${ignoredSupportDirs.length ? ignoredSupportDirs.join(', ') : 'none'}`
       : `orphans: ${orphanDirs.join(', ')}`,
   );
 


### PR DESCRIPTION
## Summary

Bring the current Project 81 proof corpus to a validator-clean point-in-time:

- adds the missing `evidence_doc` pointer for `R-CD-COLLECTION-ON-COLLAPSE` in the current `71a1dff` corpus manifest
- teaches `validate-corpus.mjs` that per-SHA `gates/` is support evidence, not a proof row directory orphan

This is intentionally narrow: it does not change proof verdicts or live-fire evidence.

## Validation

- `node tools/k6-proofs/scripts/validate-corpus.mjs --index --json` → `failed=false`
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs` → `Manifest scenario registry check passed: 22 manifests; 8 scenario files.`
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs` → `ok=true`

## Notes

This supports #178 by making the current corpus mechanically checkable before the next automation/golden-path layer.
