### PR TITLE
tools(k6-proofs): promote R-OBS-status runnable

### DIFF
--- a/.github/workflows/k6-proof.yml
+++ b/.github/workflows/k6-proof.yml
@@ -29,6 +29,7 @@ on:
           - r-cd-2-silent-wake
           - r-cd-4-target-session-key
           - r-cd-chained-depth-2
+          - r-obs-status
           - r-cw-1
           - r-cw
       row:

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -207,6 +207,7 @@ This is **declared in the manifest before the run**, not a post-hoc excuse. The 
 | R-CD-MODEL-TOKEN | planned `r-cd-model-token` | bracket-token | Scaffold; bracket `model=` modifier parse + observed child model byte |
 | R-CD-MODEL-CHAINED-ALT | planned `r-cd-model-chained-alt` | typed-tool | Scaffold; depth-2 delegate observes explicit alternate model |
 | R-CW-1 | `r-cw-1` | typed-tool | Candidate; continue_work schedule + wake |
+| R-OBS-status | `r-obs-status` | read-only | Candidate; gateway status/observer receipt check |
 | R-CW overview | `r-cw` | read-only/infrastructure | Candidate; combined continue_work infrastructure check |
 
 Other manifests may be `scaffold` or `construct-only`: they are tracked rows,

--- a/tools/k6-proofs/manifests/r-obs-status.json
+++ b/tools/k6-proofs/manifests/r-obs-status.json
@@ -4,19 +4,28 @@
   "issue": 104,
   "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
   "seat": "${OPENCLAW_SEAT_NAME:-emeric-nuc}",
-  "sessionKey": "${OPENCLAW_SESSION_KEY:***-obs}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
   "transport": "ws-status-probe",
   "toolSurface": "read-only",
   "mutates": false,
   "timeoutSeconds": 60,
   "scenario": {
-    "status": "scaffold",
-    "expectedFile": "r-obs-status.js",
-    "registryNotes": "No runnable observer/status scenario exists yet; this read-only manifest is scaffolded until a dedicated runner lands."
+    "status": "runnable",
+    "file": "r-obs-status.js",
+    "name": "r-obs-status",
+    "description": "Read-only gateway status/observer receipt check."
   },
   "expectedReceipts": [
-    { "name": "tempo-trace-id", "required": true, "description": "Tempo trace ID generated and resolvable" },
-    { "name": "observer-receipt", "required": true, "description": "Observer/status receipt intact" }
+    {
+      "name": "tempo-trace-id",
+      "required": true,
+      "description": "Tempo trace ID generated and resolvable"
+    },
+    {
+      "name": "observer-receipt",
+      "required": true,
+      "description": "Observer/status receipt intact"
+    }
   ],
   "artifactDestination": {
     "root": "PROOFS",
@@ -29,5 +38,18 @@
     "candidateOnly": true,
     "foldRequiresReview": true,
     "notes": "Observer status row. Read-only."
+  },
+  "liveRunSafety": {
+    "classification": "k6-runnable",
+    "requiresLiveGatewayToken": true,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "PASS-candidate",
+    "requiredReceipts": [
+      "observer-receipt"
+    ],
+    "foldRequiresReview": true
   }
 }

--- a/tools/k6-proofs/scenarios/r-obs-status.js
+++ b/tools/k6-proofs/scenarios/r-obs-status.js
@@ -1,110 +1,147 @@
-import { buildRequest, connectFrame, RequestTracker } from '../lib/gateway-ws.js';
-import { check, sleep } from 'k6';
+/**
+ * Scenario: R-OBS-status — read-only gateway status/observer receipt.
+ *
+ * Converts the historical scaffold into a manifest-driven k6 row. It only
+ * authenticates to the gateway and requests operator status; it does not fire
+ * continuation tools, mutate files, or dispatch agents.
+ */
 import ws from 'k6/ws';
+import { check } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+import { connectFrame, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
+import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
 
-const ROW_ID = 'R-OBS-status';
+export const options = {
+  scenarios: {
+    r_obs_status: {
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 1,
+      maxDuration: '30s',
+    },
+  },
+  thresholds: {
+    proof_failures: ['count==0'],
+    r_obs_status_duration: ['p(95)<20000'],
+  },
+};
 
-export function setup() {
-  const wsUrl = __ENV.GATEWAY_URL || 'ws://127.0.0.1:4000/api/v1/gateway';
-  return { wsUrl, token: __ENV.GATEWAY_TOKEN || 'openclaw-local-testing-token' };
-}
+const failures = new Counter('proof_failures');
+const duration = new Trend('r_obs_status_duration');
+const manifest = loadManifestFromEnv();
 
-export default function(data) {
-  let statusOk = false;
-  let statusResponse = null;
-  let wsError = null;
-  let connectAck = null;
-  let rawConnectAck = null;
-  let connectionFrames = [];
+export default function () {
+  const url = __ENV.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
+  const token = __ENV.OPENCLAW_GATEWAY_TOKEN;
+  const seat = (manifest && manifest.seat) || __ENV.OPENCLAW_SEAT_NAME || 'ci-runner';
+  const candidateSha = (manifest && manifest.candidateSha) || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset';
+  const started = Date.now();
 
-  const res = ws.connect(data.wsUrl, {}, function(socket) {
+  if (!token) {
+    console.error('OPENCLAW_GATEWAY_TOKEN is required');
+    failures.add(1);
+    return;
+  }
+
+  if (manifest) {
+    const errors = validateManifest(manifest);
+    if (errors.length > 0) {
+      console.warn(`Manifest validation warnings: ${errors.join('; ')}`);
+    }
+  }
+
+  const evidence = {
+    row: 'R-OBS-status',
+    manifest_loaded: !!manifest,
+    seat,
+    candidateSha,
+    started: new Date().toISOString(),
+    connected: false,
+    connect_ok: false,
+    status_ok: false,
+    status_payload: null,
+    trace_id: null,
+    redacted_events: [],
+  };
+
+  const res = ws.connect(url, {}, (socket) => {
     const tracker = new RequestTracker();
-    
+
     socket.on('open', () => {
-      // Send the connect frame explicitly including the target scopes since 
-      // lib/gateway-ws.js connectFrame hardcodes the older structure
-      const connectPayload = {
-        type: 'req',
-        id: 'conn-1',
-        method: 'connect',
-        params: {
-          minProtocol: 3,
-          maxProtocol: 4,
-          client: {
-            id: 'gateway-client',
-            version: '0.2.0',
-            platform: 'linux',
-            mode: 'backend'
-          },
-          role: 'operator',
-          scopes: ['operator.read', 'operator.write', 'session.control'],
-          caps: [],
-          commands: [],
-          permissions: {},
-          auth: { token: data.token },
-          userAgent: 'k6-proof-harness/0.2.0'
-        }
-      };
-      socket.send(JSON.stringify(connectPayload));
+      evidence.connected = true;
+      socket.send(connectFrame(token));
+      socket.setTimeout(() => tracker.send(socket, 'status', {}), 500);
+      socket.setTimeout(() => socket.close(), 10000);
     });
-    
-    socket.on('message', (msg) => {
-      let parsed;
-      try { parsed = JSON.parse(msg); } catch (e) { return; }
-      
-      const classified = tracker.classify(parsed);
-      connectionFrames.push(parsed);
-      
-      if (parsed.id === 'conn-1') {
-        connectAck = parsed;
-        rawConnectAck = msg;
-        if (!parsed.error) {
-           tracker.send(socket, 'status', {});
-        } else {
-           socket.close();
+
+    socket.on('message', (raw) => {
+      try {
+        const msg = JSON.parse(raw);
+        const classified = tracker.classify(msg);
+        evidence.redacted_events.push({
+          ts: Date.now(),
+          kind: classified.kind,
+          method: classified.method || null,
+          event: classified.event || null,
+          ok: classified.ok !== undefined ? classified.ok : null,
+          data: classified.payload ? redactEvent(classified.payload) : null,
+        });
+
+        if (classified.kind === 'other' && msg.type === 'res' && !msg.error) {
+          evidence.connect_ok = true;
         }
-      } else if (classified.kind === 'response' && classified.method === 'status') {
-        statusResponse = classified.payload || parsed;
-        statusOk = classified.ok;
-        socket.close();
+
+        if (classified.kind === 'response' && classified.method === 'status') {
+          evidence.status_ok = classified.ok;
+          evidence.status_payload = classified.payload ? redactEvent(classified.payload) : null;
+          if (classified.payload && classified.payload.traceparent) {
+            const parts = String(classified.payload.traceparent).split('-');
+            evidence.trace_id = parts.length > 1 ? parts[1] : null;
+          }
+          if (!classified.ok) {
+            console.error(`status failed: ${JSON.stringify(classified.error)}`);
+            failures.add(1);
+          }
+          socket.close();
+        }
+      } catch (err) {
+        console.warn(`parse error: ${err}`);
       }
     });
-    
-    socket.on('error', (e) => {
-      wsError = e.error();
-      console.log('WS error observed:', wsError);
+
+    socket.on('error', (err) => {
+      console.error(`ws error: ${err && err.error ? err.error() : err}`);
+      failures.add(1);
     });
-    
-    socket.setTimeout(function() {
-      socket.close();
-    }, 10000);
   });
-  
-  check(res, { 'status is 101': (r) => r && r.status === 101 });
-  check(connectAck, { 'connect ack received and ok': (r) => r && !r.error });
-  check(statusResponse, { 'status response received': (r) => r !== null });
-  check(statusOk, { 'status ok': (r) => r === true });
-  
-  const statusEvidence = statusOk ? "PASS-CANDIDATE" : "FAIL";
-  
-  const out = {
-    rowId: ROW_ID,
-    capture_sha: __ENV.TARGET_COMMIT_SHA || 'unknown',
-    seat: __ENV.K6_SEAT || 'emeric',
-    transport: 'ws',
-    mutates: false,
-    observed: {
-      wsError: wsError,
-      connectAck: connectAck,
-      rawConnectAck: rawConnectAck,
-      statusResponse: statusResponse,
-      status_call_ok: statusOk,
-      allFrames: connectionFrames,
-      tempoTraceId: statusResponse && statusResponse.traceparent ? statusResponse.traceparent.split('-')[1] : null
-    },
-    redacted_events: [],
-    status: statusEvidence
+
+  evidence.ended = new Date().toISOString();
+  evidence.duration_ms = Date.now() - started;
+  duration.add(evidence.duration_ms);
+
+  check(res, { 'websocket connected': (r) => r && r.status === 101 });
+  check(null, {
+    'connect accepted': () => evidence.connect_ok,
+    'status accepted': () => evidence.status_ok,
+  });
+
+  if (!evidence.connect_ok || !evidence.status_ok) failures.add(1);
+
+  console.log(`R_OBS_STATUS_EVIDENCE ${JSON.stringify(evidence)}`);
+}
+
+export function handleSummary(data) {
+  const failureMetric = data.metrics.proof_failures && data.metrics.proof_failures.values;
+  const failuresCount = failureMetric ? failureMetric.count : 0;
+  return {
+    'r-obs-status-summary.json': JSON.stringify({
+      row: 'R-OBS-status',
+      sha: __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
+      verdict: failuresCount === 0 ? 'PASS-candidate' : 'FAIL-candidate',
+      metrics: {
+        failures: failuresCount,
+        duration_ms: data.metrics.r_obs_status_duration ? data.metrics.r_obs_status_duration.values : null,
+      },
+    }, null, 2),
   };
-  
-  console.log(`\n=== K6-PROOF-EVIDENCE ===\n${JSON.stringify(out, null, 2)}\n=== END-EVIDENCE ===\n`);
 }


### PR DESCRIPTION
## Summary

Promote `R-OBS-status` from scaffold to a runnable read-only k6 row:

- rewrites `scenarios/r-obs-status.js` to use the shared Gateway WS helpers, manifest loader, redaction, metrics, and k6 summary output
- updates `manifests/r-obs-status.json` to `scenario.status=runnable` with live-run safety metadata
- exposes `r-obs-status` in `.github/workflows/k6-proof.yml`
- documents the row in `tools/k6-proofs/README.md`

This is deliberately a low-risk automation target: it authenticates and requests gateway `status`; it does not fire continuation tools or mutate proof corpus files.

## Validation

- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs` → `Manifest scenario registry check passed: 22 manifests; 8 scenario files.`
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs` → `ok=true`
- `node tools/k6-proofs/scripts/validate-corpus.mjs --index --json` → `failed=false`
- `./tools/k6-proofs/scripts/run-proofs.sh --dry-run all 71a1dfff040000ce8862d30d0587ebee044a23b3` includes `R-OBS-status`
- local read-only smoke: `./tools/k6-proofs/scripts/run-proofs.sh --live R-OBS-status 71a1dfff040000ce8862d30d0587ebee044a23b3` → `PASS-candidate`, `proof_failures=0`

Refs #270 / #178.
