### PR TITLE
docs(project-81): seed k6 proof runbooks

### DIFF
--- a/RUNBOOKS/project-81/README.md
+++ b/RUNBOOKS/project-81/README.md
@@ -1,0 +1,102 @@
+# Project 81 k6 proof runbooks
+
+Durable runbook surface for Project 81: turn manually executed proof-row methods into repeatable k6/direct-tool flows.
+
+This directory is intentionally operational. Each row runbook should answer:
+
+- what row is runnable today
+- exact runner/k6 command
+- required env and seat constraints
+- what k6 directly proves
+- what still needs manual collection before a PASS can be folded
+- where to write candidate artifacts
+- known honest-limit / review caveats
+
+Current automation substrate:
+
+```bash
+cd tools/k6-proofs
+./scripts/run-proofs.sh --dry-run all <candidate-sha>
+```
+
+As of docs `main@f99f2ea`, `all` expands to:
+
+```text
+preflight,R-CD-2,R-CD-4,R-CD-CHAINED-DEPTH-2,R-OBS-status
+```
+
+Use this directory as the accumulator. When a scaffold row becomes runnable, add or update `RUNBOOKS/project-81/rows/<ROW>.md` in the same PR as the scenario/manifest change.
+
+## Current runnable row runbooks
+
+- [preflight](rows/preflight.md)
+- [R-CD-2](rows/R-CD-2.md)
+- [R-CD-4](rows/R-CD-4.md)
+- [R-CD-CHAINED-DEPTH-2](rows/R-CD-CHAINED-DEPTH-2.md)
+- [R-OBS-status](rows/R-OBS-status.md)
+
+## Shared execution pattern
+
+1. Confirm the current proof corpus is mechanically clean:
+
+   ```bash
+   node tools/k6-proofs/scripts/validate-corpus.mjs --index --json
+   node tools/k6-proofs/scripts/check-manifest-scenarios.mjs
+   node tools/k6-proofs/scripts/check-scenario-alignment.mjs
+   ```
+
+2. Run seat readiness before any live fold candidate:
+
+   ```bash
+   OPENCLAW_CANDIDATE_SHA=<40-char-sha> \
+   OPENCLAW_SEAT_NAME=<seat> \
+   OPENCLAW_SESSION_KEY=<target-session-key> \
+   OPENCLAW_GATEWAY_TOKEN=*** \
+     node tools/k6-proofs/scripts/seat-readiness-preflight.mjs --json \
+       > /tmp/seat-readiness.json
+   ```
+
+3. Dry-run row selection:
+
+   ```bash
+   cd tools/k6-proofs
+   OPENCLAW_GATEWAY_TOKEN=*** \
+     ./scripts/run-proofs.sh --dry-run <ROW-or-comma-list-or-all> <candidate-sha>
+   ```
+
+4. Live-run only when the row runbook says it is safe:
+
+   ```bash
+   cd tools/k6-proofs
+   OPENCLAW_GATEWAY_TOKEN=*** \
+   OPENCLAW_SESSION_KEY=<target-session-key> \
+     ./scripts/run-proofs.sh --live <ROW> <candidate-sha>
+   ```
+
+5. Preserve candidate output. A k6 PASS-candidate is not a folded proof by itself. Gather the row-specific manual receipts listed in the row runbook.
+
+## Shared manual receipts
+
+Most continuation rows still need one or more of these after k6 runs:
+
+- `seat-readiness.json`
+- raw k6 stdout and generated summary JSON
+- exact row manifest used
+- session transcript excerpts or JSONL for parent/child/target sessions
+- TaskFlow / flow rows when the behavior persists there
+- gateway journal lines for continuation dispatch / queue drain / fanout / wake
+- Tempo trace JSON, not just a trace URL:
+
+  ```bash
+  curl -fsS "http://tempo.dandelion.cult/api/traces/<trace-id>" \
+    -o PROOFS/<sha>/<row>/<seat>/tempo/trace-<trace-id>.json
+  ```
+
+Trace JSON should be committed with the candidate proof artifacts whenever available because internal Tempo URLs are not public maintainer receipts.
+
+## What not to do
+
+- Do not fold generated k6 artifacts as final proof verdicts without review.
+- Do not treat `tasks.list` absence as a continue_delegate failure by itself; delegate rows use pending-delegate/subagent/session-delivery surfaces.
+- Do not run same-session-unsafe continuation rows concurrently against the same target session.
+- Do not use `validate-corpus --all` as the current-board gate until #271 is resolved; use `--index` for point-in-time current corpus validation.

--- a/RUNBOOKS/project-81/rows/R-CD-2.md
+++ b/RUNBOOKS/project-81/rows/R-CD-2.md
@@ -1,0 +1,65 @@
+# R-CD-2 row runbook
+
+## Status
+
+Runnable live continuation row.
+
+- Manifest: `tools/k6-proofs/manifests/r-cd-2.json`
+- Scenario: `tools/k6-proofs/scenarios/r-cd-2-silent-wake.js`
+- Workflow choice: `r-cd-2-silent-wake`
+- Live safety: `k6-runnable`, same-session concurrency unsafe
+
+## Purpose
+
+Exercise `continue_delegate(mode="silent-wake")`: a dispatching session asks the agent to fire a silent-wake delegate; the delegate returns silently and wakes/enriches the parent without channel delivery.
+
+## Commands
+
+Dry path:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=*** \
+  ./scripts/run-proofs.sh --dry-run R-CD-2 <candidate-sha>
+```
+
+Live candidate run:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=*** \
+OPENCLAW_SESSION_KEY=<target-session-key> \
+  ./scripts/run-proofs.sh --live R-CD-2 <candidate-sha> \
+  2>&1 | tee /tmp/r-cd-2-k6.log
+```
+
+Direct k6 form:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=*** \
+OPENCLAW_SESSION_KEY=<target-session-key> \
+OPENCLAW_ROW_MANIFEST="$PWD/manifests/r-cd-2.json" \
+OPENCLAW_CANDIDATE_SHA=<candidate-sha> \
+  k6 run scenarios/r-cd-2-silent-wake.js 2>&1 | tee /tmp/r-cd-2-k6.log
+```
+
+## k6 covers
+
+- Dispatch request accepted via gateway/session path.
+- Parent/session events are watched for nonce-correlated wake/return.
+- No-channel-delivery expectation is tracked as part of the candidate evidence.
+- Optional `tasks.list` context may be captured, but absence is not a failure by itself.
+
+## Manual collection still needed
+
+- Save raw k6 stdout and generated summary.
+- Save exact manifest used.
+- Save parent session transcript/events showing wake/enrichment.
+- Save child/delegate transcript if available.
+- Fetch and commit Tempo trace JSON for any emitted trace id.
+- Preserve gateway journal lines for `continuation.delegate.dispatch`, child spawn, queue drain, and return/wake when available.
+
+## Fold guidance
+
+PASS requires dispatch accepted, parent wake/return observed, no visible channel delivery from the silent delegate, and trace/session receipts reviewed. Run serially per target session.

--- a/RUNBOOKS/project-81/rows/R-CD-4.md
+++ b/RUNBOOKS/project-81/rows/R-CD-4.md
@@ -1,0 +1,54 @@
+# R-CD-4 row runbook
+
+## Status
+
+Runnable scenario exists, but live safety metadata still needs tightening before unattended live use.
+
+- Manifest: `tools/k6-proofs/manifests/r-cd-4.json`
+- Scenario: `tools/k6-proofs/scenarios/r-cd-4-target-session-key.js`
+- Workflow choice: `r-cd-4-target-session-key`
+- Live safety: not yet declared in manifest
+
+## Purpose
+
+Exercise `continue_delegate` with `targetSessionKey`: the delegate return should land in the specified target session, not the dispatching parent.
+
+## Commands
+
+Dry path:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=*** \
+  ./scripts/run-proofs.sh --dry-run R-CD-4 <candidate-sha>
+```
+
+Live candidate run only after target session is explicitly chosen:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=*** \
+OPENCLAW_SESSION_KEY=<dispatching-session-key> \
+OPENCLAW_TARGET_SESSION_KEY=<target-session-key> \
+OPENCLAW_ROW_MANIFEST="$PWD/manifests/r-cd-4.json" \
+OPENCLAW_CANDIDATE_SHA=<candidate-sha> \
+  k6 run scenarios/r-cd-4-target-session-key.js 2>&1 | tee /tmp/r-cd-4-k6.log
+```
+
+## k6 covers
+
+- Dispatch request includes target session configuration.
+- Target and parent session streams are monitored for nonce-correlated delivery.
+- Candidate evidence distinguishes target delivery from parent delivery.
+
+## Manual collection still needed
+
+- Save raw k6 stdout and summary.
+- Save target and parent session event receipts.
+- Save child transcript if available.
+- Fetch Tempo trace JSON for emitted trace id.
+- Capture TaskFlow/session rows only as supporting context; do not require `tasks.list` as the primary proof surface.
+
+## Fold guidance
+
+PASS requires target receipt and no parent receipt for the return. Before unattended runner use, add `liveRunSafety` to the manifest with `requiresTargetSessionKey=true` and `sameSessionConcurrencySafe=false`.

--- a/RUNBOOKS/project-81/rows/R-CD-CHAINED-DEPTH-2.md
+++ b/RUNBOOKS/project-81/rows/R-CD-CHAINED-DEPTH-2.md
@@ -1,0 +1,56 @@
+# R-CD-CHAINED-DEPTH-2 row runbook
+
+## Status
+
+Runnable scenario exists, but live safety metadata still needs tightening before unattended live use.
+
+- Manifest: `tools/k6-proofs/manifests/r-cd-chained-depth-2.json`
+- Scenario: `tools/k6-proofs/scenarios/r-cd-chained-depth-2.js`
+- Workflow choice: `r-cd-chained-depth-2`
+- Live safety: not yet declared in manifest
+
+## Purpose
+
+Exercise a depth-2 delegate chain: parent → child → grandchild → return path. This corresponds to the manual proof rows where a child fires its own delegate and the root observes the nonce-correlated chain result.
+
+## Commands
+
+Dry path:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=*** \
+  ./scripts/run-proofs.sh --dry-run R-CD-CHAINED-DEPTH-2 <candidate-sha>
+```
+
+Live candidate run:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=*** \
+OPENCLAW_SESSION_KEY=<target-session-key> \
+OPENCLAW_ROW_MANIFEST="$PWD/manifests/r-cd-chained-depth-2.json" \
+OPENCLAW_CANDIDATE_SHA=<candidate-sha> \
+  k6 run scenarios/r-cd-chained-depth-2.js 2>&1 | tee /tmp/r-cd-chained-depth-2-k6.log
+```
+
+## k6 covers
+
+- Parent dispatch accepted.
+- Child session/turn observed.
+- Grandchild spawn/return path is nonce-correlated where events expose it.
+- Candidate evidence looks for parent receipt of the chained return.
+
+## Manual collection still needed
+
+- Save raw k6 stdout and summary.
+- Save parent, child, and grandchild session transcripts/events.
+- Save gateway journal lines for delegate dispatch/spawn/fanout/drain.
+- Fetch Tempo trace JSON and preserve trace summary for the chain.
+- Preserve any flow/task rows showing chain state and child session keys.
+
+## Fold guidance
+
+PASS requires parent→child→grandchild correlation and root/parent receipt of the final return. If the scenario observes only spawn but not final root receipt, fold as PARTIAL with exact missing surface.
+
+Before unattended runner use, add `liveRunSafety` with external tool invocation required and same-session concurrency unsafe.

--- a/RUNBOOKS/project-81/rows/R-OBS-status.md
+++ b/RUNBOOKS/project-81/rows/R-OBS-status.md
@@ -1,0 +1,63 @@
+# R-OBS-status row runbook
+
+## Status
+
+Runnable. Read-only gateway observer/status receipt row.
+
+- Manifest: `tools/k6-proofs/manifests/r-obs-status.json`
+- Scenario: `tools/k6-proofs/scenarios/r-obs-status.js`
+- Workflow choice: `r-obs-status`
+- Live safety: `k6-runnable`
+
+## Purpose
+
+Prove the proof harness can collect an observer/status receipt from the target gateway without firing continuation tools or mutating state.
+
+## Commands
+
+Runner dry path:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=*** \
+  ./scripts/run-proofs.sh --dry-run R-OBS-status <candidate-sha>
+```
+
+Live read-only smoke:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=*** \
+OPENCLAW_SESSION_KEY=<target-session-key> \
+  ./scripts/run-proofs.sh --live R-OBS-status <candidate-sha> \
+  2>&1 | tee /tmp/r-obs-status-k6.log
+```
+
+Direct k6 form:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=*** \
+OPENCLAW_SESSION_KEY=<target-session-key> \
+OPENCLAW_ROW_MANIFEST="$PWD/manifests/r-obs-status.json" \
+OPENCLAW_CANDIDATE_SHA=<candidate-sha> \
+  k6 run scenarios/r-obs-status.js 2>&1 | tee /tmp/r-obs-status-k6.log
+```
+
+## k6 covers
+
+- WebSocket connect/auth accepted.
+- Gateway `status` request accepted.
+- Redacted observer receipt printed as `R_OBS_STATUS_EVIDENCE`.
+- Summary JSON verdict is `PASS-candidate` when `proof_failures=0`.
+
+## Manual collection still needed
+
+- Save `/tmp/r-obs-status-k6.log`.
+- Save `tools/k6-proofs/r-obs-status-summary.json` if generated; move it into the candidate artifact directory, do not leave it untracked at repo root.
+- If the status payload includes a traceparent/trace id, fetch Tempo JSON and store it under `PROOFS/<sha>/R-OBS-status/<seat>/tempo/`.
+- If no trace id is emitted, record that explicitly; for status-only rows this is a receipt limitation, not automatically a product failure.
+
+## Fold guidance
+
+This row is read-only. It can support observability/readiness claims, not continuation behavior claims.

--- a/RUNBOOKS/project-81/rows/preflight.md
+++ b/RUNBOOKS/project-81/rows/preflight.md
@@ -1,0 +1,63 @@
+# preflight row runbook
+
+## Status
+
+Runnable. Non-mutating readiness/inventory row.
+
+- Manifest: `tools/k6-proofs/manifests/preflight.example.json`
+- Scenario: `tools/k6-proofs/scenarios/preflight.js`
+- Workflow choice: `preflight`
+- Live safety: `static-preflight-only`
+
+## Purpose
+
+Verify the k6 harness can authenticate to the target gateway and collect basic inventory before live proof rows run.
+
+## Commands
+
+Dry/offline golden path:
+
+```bash
+rm -rf /tmp/p81-k6-golden-path
+node tools/k6-proofs/scripts/postprocess-k6-summary.mjs \
+  --manifest tools/k6-proofs/manifests/preflight.example.json \
+  --summary tools/k6-proofs/examples/k6-summary.preflight.example.json \
+  --out-root /tmp/p81-k6-golden-path
+```
+
+Runner dry path:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=*** \
+  ./scripts/run-proofs.sh --dry-run preflight <candidate-sha>
+```
+
+Live k6 path when a gateway inventory receipt is desired:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=*** \
+OPENCLAW_SESSION_KEY=<target-session-key> \
+OPENCLAW_ROW_MANIFEST="$PWD/manifests/preflight.example.json" \
+OPENCLAW_CANDIDATE_SHA=<candidate-sha> \
+  k6 run scenarios/preflight.js 2>&1 | tee /tmp/preflight-k6.log
+```
+
+## k6 covers
+
+- WebSocket connect/auth succeeds.
+- `sessions.list` accepted.
+- `tools.effective` accepted for the target session.
+- Redacted inventory evidence is printed as `PREFLIGHT_EVIDENCE`.
+
+## Manual collection still needed
+
+- Save raw k6 stdout.
+- Save generated summary JSON if using `handleSummary`/postprocess path.
+- Save `seat-readiness.json` for live fold candidates.
+- If folded into corpus, keep it as candidate evidence; preflight alone is not a product behavior proof.
+
+## Fold guidance
+
+Use as setup/readiness evidence. Failures are usually `HONEST-LIMIT` / environment setup candidates, not product failures.


### PR DESCRIPTION
## Summary

Seed `RUNBOOKS/project-81/` as the durable tracker figs requested for turning manual proof rows into reusable k6/direct-tool method.

Adds:

- `RUNBOOKS/project-81/README.md` with shared execution pattern, current runnable row set, required manual receipts, and guardrails
- row runbooks for currently runnable rows:
  - `preflight`
  - `R-CD-2`
  - `R-CD-4`
  - `R-CD-CHAINED-DEPTH-2`
  - `R-OBS-status`

Each row runbook records command shape, what k6 covers, what still needs manual collection (trace JSON/session rows/journal/etc.), and fold guidance.

## Validation

- `node tools/k6-proofs/scripts/validate-corpus.mjs --index --json` → `failed=false`
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs` → `Manifest scenario registry check passed: 22 manifests; 8 scenario files.`
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs` → `ok=true`

Refs #178 / #270.
