### PR TITLE
tools(k6-proofs): preserve live runner artifacts

### DIFF
--- a/RUNBOOKS/project-81/README.md
+++ b/RUNBOOKS/project-81/README.md
@@ -73,7 +73,20 @@ Use this directory as the accumulator. When a scaffold row becomes runnable, add
      ./scripts/run-proofs.sh --live <ROW> <candidate-sha>
    ```
 
-5. Preserve candidate output. A k6 PASS-candidate is not a folded proof by itself. Gather the row-specific manual receipts listed in the row runbook.
+5. Preserve candidate output. For live runs, `run-proofs.sh` writes artifacts under `--out-dir` (default `/tmp/k6-proof-runs`):
+
+   ```text
+   <out-dir>/<candidate-sha>/<ROW>/<seat>/<timestamp-row>/
+   ├── row-manifest.json
+   ├── runner-metadata.json
+   ├── k6.log
+   ├── evidence-lines.log
+   ├── evidence.jsonl
+   ├── run-result.json
+   └── *summary.json
+   ```
+
+   A k6 PASS-candidate is not a folded proof by itself. Gather the row-specific manual receipts listed in the row runbook.
 
 ## Shared manual receipts
 

--- a/RUNBOOKS/project-81/rows/R-CD-2.md
+++ b/RUNBOOKS/project-81/rows/R-CD-2.md
@@ -29,8 +29,7 @@ Live candidate run:
 cd tools/k6-proofs
 OPENCLAW_GATEWAY_TOKEN=*** \
 OPENCLAW_SESSION_KEY=<target-session-key> \
-  ./scripts/run-proofs.sh --live R-CD-2 <candidate-sha> \
-  2>&1 | tee /tmp/r-cd-2-k6.log
+  ./scripts/run-proofs.sh --live --out-dir /tmp/k6-proof-runs R-CD-2 <candidate-sha>
 ```
 
 Direct k6 form:

--- a/RUNBOOKS/project-81/rows/R-OBS-status.md
+++ b/RUNBOOKS/project-81/rows/R-OBS-status.md
@@ -29,8 +29,7 @@ Live read-only smoke:
 cd tools/k6-proofs
 OPENCLAW_GATEWAY_TOKEN=*** \
 OPENCLAW_SESSION_KEY=<target-session-key> \
-  ./scripts/run-proofs.sh --live R-OBS-status <candidate-sha> \
-  2>&1 | tee /tmp/r-obs-status-k6.log
+  ./scripts/run-proofs.sh --live --out-dir /tmp/k6-proof-runs R-OBS-status <candidate-sha>
 ```
 
 Direct k6 form:
@@ -53,8 +52,8 @@ OPENCLAW_CANDIDATE_SHA=<candidate-sha> \
 
 ## Manual collection still needed
 
-- Save `/tmp/r-obs-status-k6.log`.
-- Save `tools/k6-proofs/r-obs-status-summary.json` if generated; move it into the candidate artifact directory, do not leave it untracked at repo root.
+- Save the runner artifact directory; it contains `k6.log`, `row-manifest.json`, `runner-metadata.json`, `run-result.json`, `evidence-lines.log`, and generated summary JSON when present.
+- Summary JSON is moved into the runner artifact directory automatically for live runs.
 - If the status payload includes a traceparent/trace id, fetch Tempo JSON and store it under `PROOFS/<sha>/R-OBS-status/<seat>/tempo/`.
 - If no trace id is emitted, record that explicitly; for status-only rows this is a receipt limitation, not automatically a product failure.
 

--- a/RUNBOOKS/project-81/rows/preflight.md
+++ b/RUNBOOKS/project-81/rows/preflight.md
@@ -53,8 +53,8 @@ OPENCLAW_CANDIDATE_SHA=<candidate-sha> \
 
 ## Manual collection still needed
 
-- Save raw k6 stdout.
-- Save generated summary JSON if using `handleSummary`/postprocess path.
+- Save raw k6 stdout (`k6.log` under the runner artifact directory).
+- Save generated summary JSON; the runner now moves `*summary.json` into the artifact directory for live runs.
 - Save `seat-readiness.json` for live fold candidates.
 - If folded into corpus, keep it as candidate evidence; preflight alone is not a product behavior proof.
 

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -5,7 +5,7 @@
 #
 # Usage:
 #   cd tools/k6-proofs
-#   ./scripts/run-proofs.sh [--dry-run] [R-CD-2,R-CD-4] [candidate_sha]
+#   ./scripts/run-proofs.sh [--dry-run] [--out-dir /tmp/k6-proof-runs] [R-CD-2,R-CD-4] [candidate_sha]
 
 set -euo pipefail
 
@@ -13,12 +13,14 @@ DRY_RUN=true
 ROWS=""
 CANDIDATE_SHA=""
 SESSION_SELECTOR="discord-channel:1466192485440164011"
+OUT_ROOT="${K6_PROOF_OUT_DIR:-/tmp/k6-proof-runs}"
 
 while [[ "$#" -gt 0 ]]; do
   case $1 in
     --dry-run) DRY_RUN=true; shift ;;
     --live) DRY_RUN=false; shift ;;
     --session) SESSION_SELECTOR="$2"; shift 2 ;;
+    --out-dir) OUT_ROOT="$2"; shift 2 ;;
     *)
       if [[ -z "$ROWS" ]]; then
         ROWS="$1"
@@ -77,6 +79,7 @@ echo "Seat: $OPENCLAW_SEAT_NAME"
 echo "Target Candidate SHA: $OPENCLAW_CANDIDATE_SHA"
 echo "Deployed Runtime SHA: $OPENCLAW_RUNTIME_BUILD_SHA"
 echo "Session: $OPENCLAW_SESSION_KEY"
+echo "Artifact root: $OUT_ROOT"
 if [[ "$ROWS" == "all" ]]; then
   ROWS="$(for f in manifests/*.json; do jq -r 'select(.scenario.status == "runnable") | .rowId' "$f"; done | paste -sd, -)"
 fi
@@ -101,7 +104,7 @@ IFS=',' read -ra ROW_ARRAY <<< "$ROWS"
 for ROW_ID in "${ROW_ARRAY[@]}"; do
   # Normalize row ID
   ROW_ID="$(echo "$ROW_ID" | tr '[:lower:]' '[:upper:]')"
-  
+
   # Find manifest (case-insensitive so lowercase preflight still works)
   MANIFEST_FILE=""
   for f in manifests/*.json; do
@@ -148,12 +151,62 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
   else
     echo "[$ROW_ID] RUNNING..."
     export OPENCLAW_ROW_MANIFEST="$MANIFEST_FILE"
-    
-    # Actually run k6
-    k6 run "scenarios/$SCENARIO_FILE"
-    
+
+    RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%s' "$ROW_ID" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-')"
+    RUN_DIR="$OUT_ROOT/$OPENCLAW_CANDIDATE_SHA/$ROW_ID/$OPENCLAW_SEAT_NAME/$RUN_ID"
+    mkdir -p "$RUN_DIR"
+    touch "$RUN_DIR/.started"
+    cp "$MANIFEST_FILE" "$RUN_DIR/row-manifest.json"
+    jq -n \
+      --arg row "$ROW_ID" \
+      --arg scenario "$SCENARIO_FILE" \
+      --arg candidate "$OPENCLAW_CANDIDATE_SHA" \
+      --arg runtime "$OPENCLAW_RUNTIME_BUILD_SHA" \
+      --arg seat "$OPENCLAW_SEAT_NAME" \
+      --arg session "$OPENCLAW_SESSION_KEY" \
+      --arg started "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      '{row:$row, scenario:$scenario, candidateSha:$candidate, runtimeBuildSha:$runtime, seat:$seat, sessionKey:$session, startedAt:$started}' \
+      > "$RUN_DIR/runner-metadata.json"
+
+    set +e
+    k6 run "scenarios/$SCENARIO_FILE" 2>&1 | tee "$RUN_DIR/k6.log"
+    k6_rc=${PIPESTATUS[0]}
+    set -e
+
+    find . -maxdepth 1 -type f -name '*summary.json' -newer "$RUN_DIR/.started" -print -exec mv {} "$RUN_DIR" \;
+    grep -E '(_EVIDENCE|=== K6-PROOF-EVIDENCE ===)' "$RUN_DIR/k6.log" > "$RUN_DIR/evidence-lines.log" || true
+    python3 - "$RUN_DIR/evidence-lines.log" "$RUN_DIR/evidence.jsonl" <<'PY_EVIDENCE_JSONL'
+import json
+import re
+import sys
+from pathlib import Path
+
+src = Path(sys.argv[1])
+dst = Path(sys.argv[2])
+out = []
+if src.exists():
+    for line in src.read_text().splitlines():
+        match = re.search(r'msg="(?:[A-Z0-9_]+_EVIDENCE )?(\{.*\})"(?: source=|$)', line)
+        if not match:
+            continue
+        raw = match.group(1).replace(r'\"', '"')
+        try:
+            out.append(json.loads(raw))
+        except json.JSONDecodeError:
+            pass
+dst.write_text(''.join(json.dumps(obj, sort_keys=True) + '\n' for obj in out))
+PY_EVIDENCE_JSONL
+    jq -n --argjson rc "$k6_rc" --arg ended "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '{k6ExitCode:$rc, endedAt:$ended}' > "$RUN_DIR/run-result.json"
+    rm -f "$RUN_DIR/.started"
+
+    echo "[$ROW_ID] ARTIFACTS: $RUN_DIR"
+    if [[ "$k6_rc" -ne 0 ]]; then
+      echo "[$ROW_ID] FAILED with k6 exit code $k6_rc. Artifacts preserved."
+      exit "$k6_rc"
+    fi
+
     echo "[$ROW_ID] COMPLETED."
-    
+
     # Observability hints
     echo "Observability check: query Grafana for run/nonce or review Tempo traces if trace ID was emitted."
   fi


### PR DESCRIPTION
## Summary

Chop one manual step out of Project 81 proof execution: live `run-proofs.sh` now creates a durable artifact directory per row run.

For each live row it now writes:

- `row-manifest.json`
- `runner-metadata.json`
- `k6.log`
- `evidence-lines.log`
- `evidence.jsonl` (parsed JSON evidence when k6 emits `*_EVIDENCE`)
- `run-result.json`
- generated `*summary.json`

Runbooks updated for the new `--out-dir` behavior.

## Repeatability check

I ran converted `R-OBS-status` three times before this patch:

- run 1: rc=0, `PASS-candidate`, failures=0, duration avg=630ms
- run 2: rc=0, `PASS-candidate`, failures=0, duration avg=632ms
- run 3: rc=0, `PASS-candidate`, failures=0, duration avg=622ms

Then after this patch I ran:

```bash
cd tools/k6-proofs
./scripts/run-proofs.sh --live --out-dir /tmp/p81-runner-artifacts-test4 R-OBS-status 71a1dfff040000ce8862d30d0587ebee044a23b3
```

It produced the full artifact bundle with `k6ExitCode=0`, `r-obs-status-summary.json`, and one parsed `evidence.jsonl` row.

## Validation

- `bash -n tools/k6-proofs/scripts/run-proofs.sh`
- `node tools/k6-proofs/scripts/validate-corpus.mjs --index --json` → `failed=false`
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs` → passed, `22 manifests; 8 scenario files`
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs` → `ok=true`
- `./scripts/run-proofs.sh --dry-run all 71a1dfff...` still includes `R-OBS-status`

Refs #178 / #270.
