### PR TITLE
tools(k6-proofs): count R-CD-2 agent lifecycle events

### DIFF
--- a/RUNBOOKS/project-81/rows/R-CD-2.md
+++ b/RUNBOOKS/project-81/rows/R-CD-2.md
@@ -79,3 +79,15 @@ Manual work still remaining for a folded PASS:
 - Prefer a throwaway/non-Discord target session for repeated live runs so harness injection does not surprise the coordination room.
 - Fetch/commit Tempo trace JSON when a trace id is emitted.
 - Confirm the delayed parent wake corresponds to the delegate return, not only the dispatching agent's initial turn.
+
+## Repeatability note — 2026-07-05 non-Discord `main` test
+
+After the first detector chop, a live run against `OPENCLAW_SESSION_KEY=main` produced a cleaner artifact but still `PARTIAL-candidate`:
+
+- `sessions.send` accepted.
+- delayed `session.message` after the 5s wake gate was observed.
+- no delegate-return channel delivery was observed (`channel_message_observed=false`).
+- `dispatch_channel_message_observed=true` was tracked separately and did not fail the row.
+- `agent_turn_observed=false` only because this target session emitted generic `agent` events rather than an early `session.message` before the delayed wake.
+
+Chop applied after that test: generic `agent` lifecycle events after `sessions.send` now count as dispatch-agent activity, and a delayed parent wake candidate also implies the agent turn occurred. This should make the row's remaining PASS/partial boundary about the delegate return evidence, not about which event flavor the target session emits.

--- a/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
+++ b/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
@@ -188,11 +188,18 @@ export default function () {
           }
         }
 
-        // Detect parent wake via session.message + agent events
+        // Detect dispatch progress and parent wake via session/agent events.
         if (classified.kind === 'event') {
           const eventName = classified.event || '';
           const eventData = classified.data || {};
           const eventStr = JSON.stringify(eventData);
+
+          // Some target sessions emit generic agent lifecycle events rather than
+          // an early session.message before the delayed wake. Count these as the
+          // dispatching agent turn, not as the silent-wake return.
+          if (eventName === 'agent' && evidence.tool_accepted) {
+            evidence.agent_turn_observed = true;
+          }
 
           // session.message events immediately after sessions.send are the dispatching
           // agent turn, not the silent-wake return.  The delegate delay is clamped
@@ -201,6 +208,7 @@ export default function () {
             const elapsed = evidence.dispatch_accepted_at_ms ? Date.now() - evidence.dispatch_accepted_at_ms : 0;
             if (elapsed >= evidence.wake_gate_ms) {
               evidence.parent_wake_observed = true;
+              evidence.agent_turn_observed = true;
               console.log('✓ delayed session.message event observed (silent-wake return candidate)');
             } else {
               evidence.agent_turn_observed = true;


### PR DESCRIPTION
## Summary

Second `R-CD-2` repeatability chop after running the tightened scenario against a non-Discord `main` session.

Observed live artifact from `/tmp/p81-rcd2-main-test1/.../R-CD-2/...`:

- `sessions.send` accepted
- delayed `session.message` after the 5s gate was observed
- no delegate-return channel delivery was observed (`channel_message_observed=false`)
- dispatch channel event was tracked separately (`dispatch_channel_message_observed=true`)
- row still returned `PARTIAL-candidate` because `agent_turn_observed=false`; that target session emitted generic `agent` lifecycle events, not an early `session.message`

Patch:

- count generic `agent` events after `sessions.send` as dispatch-agent activity
- delayed wake candidate also implies dispatch-agent activity occurred
- update `R-CD-2` runbook with the second live partial and exact remaining boundary

## Validation

- `bash -n tools/k6-proofs/scripts/run-proofs.sh`
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs` → passed
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs` → `ok=true`
- `node tools/k6-proofs/scripts/validate-corpus.mjs --index --json` → `failed=false`

Refs #178.
