### PR TITLE
tools(k6-proofs): isolate R-CD-2 repeat runs

### DIFF
--- a/RUNBOOKS/project-81/rows/R-CD-2.md
+++ b/RUNBOOKS/project-81/rows/R-CD-2.md
@@ -91,3 +91,36 @@ After the first detector chop, a live run against `OPENCLAW_SESSION_KEY=main` pr
 - `agent_turn_observed=false` only because this target session emitted generic `agent` events rather than an early `session.message` before the delayed wake.
 
 Chop applied after that test: generic `agent` lifecycle events after `sessions.send` now count as dispatch-agent activity, and a delayed parent wake candidate also implies the agent turn occurred. This should make the row's remaining PASS/partial boundary about the delegate return evidence, not about which event flavor the target session emits.
+
+## Disposable target-session mode
+
+For repeatability testing, prefer a disposable non-Discord session so the harness does not inject proof prompts into `#sprites` or depend on the active main lane's unrelated event traffic:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_CREATE_DISPOSABLE_SESSION=true \
+OPENCLAW_MIN_DELEGATE_DELAY_MS=5000 \
+  ./scripts/run-proofs.sh --live --out-dir /tmp/k6-proof-runs R-CD-2 <candidate-sha>
+```
+
+The scenario creates a session via `sessions.create`, subscribes to that created key, then runs the normal `sessions.send` / `continue_delegate(mode="silent-wake")` path against the disposable key. Artifact evidence includes `session_created`, `created_session_key`, and the final `sessionKey` actually used.
+
+## Repeatability note — 2026-07-05 disposable mode
+
+Disposable mode was validated with three consecutive live runs using:
+
+```bash
+OPENCLAW_CREATE_DISPOSABLE_SESSION=true \
+OPENCLAW_MIN_DELEGATE_DELAY_MS=5000 \
+  ./scripts/run-proofs.sh --live --out-dir /tmp/p81-rcd2-disposable-repeat R-CD-2 71a1dfff040000ce8862d30d0587ebee044a23b3
+```
+
+Results:
+
+```text
+run=1 rc=0 verdict=PASS-candidate failures=0 duration_avg=9084ms  evidence=session_created/tool_accepted/agent_turn/parent_wake true, channel_message false
+run=2 rc=0 verdict=PASS-candidate failures=0 duration_avg=7230ms  evidence=session_created/tool_accepted/agent_turn/parent_wake true, channel_message false
+run=3 rc=0 verdict=PASS-candidate failures=0 duration_avg=14359ms evidence=session_created/tool_accepted/agent_turn/parent_wake true, channel_message false
+```
+
+This makes the row mechanically repeatable as a `PASS-candidate` without touching the live Discord room. Remaining manual fold work is trace/session receipt review, not execution of the scenario itself.

--- a/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
+++ b/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
@@ -66,7 +66,9 @@ function invocationCfg() {
 export default function () {
   const url = __ENV.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
   const token = __ENV.OPENCLAW_GATEWAY_TOKEN;
-  const sessionKey = manifest && manifest.sessionKey || __ENV.OPENCLAW_SESSION_KEY || DEFAULTS.sessionKey;
+  const requestedSessionKey = manifest && manifest.sessionKey || __ENV.OPENCLAW_SESSION_KEY || DEFAULTS.sessionKey;
+  let sessionKey = requestedSessionKey;
+  const createDisposableSession = (__ENV.OPENCLAW_CREATE_DISPOSABLE_SESSION || '').toLowerCase() === 'true';
   const seat = manifest && manifest.seat || __ENV.OPENCLAW_SEAT_NAME || DEFAULTS.seat;
   const rowNonce = nonce('R-CD-2');
 
@@ -89,6 +91,9 @@ export default function () {
     nonce: rowNonce,
     seat,
     sessionKey,
+    requestedSessionKey,
+    session_created: false,
+    created_session_key: null,
     candidateSha: manifest && manifest.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
     started: new Date().toISOString(),
     // Required receipts
@@ -112,16 +117,12 @@ export default function () {
   const res = ws.connect(url, {}, (socket) => {
     const tracker = new RequestTracker();
 
-    socket.on('open', () => {
-      socket.send(connectFrame(token));
+    function startProofFlow(socket) {
+      // Subscribe to parent session messages to detect wake + verify no channel delivery.
+      // Protocol: sessions.messages.subscribe uses 'key' not 'sessionKey'.
+      tracker.send(socket, 'sessions.messages.subscribe', { key: sessionKey });
 
-      // Subscribe to parent session messages to detect wake + verify no channel delivery
-      // Protocol: sessions.messages.subscribe uses 'key' not 'sessionKey'
-      socket.setTimeout(() => {
-        tracker.send(socket, 'sessions.messages.subscribe', { key: sessionKey });
-      }, 500);
-
-      // Fire continue_delegate via sessions.send — instructs the agent to call the tool
+      // Fire continue_delegate via sessions.send — instructs the agent to call the tool.
       // NOTE: tools.invoke at the RPC layer accepts the call but continuation tools
       // are agent-side (execute inside an agent turn). sessions.send triggers an actual
       // agent turn that can call the tool, which is the E2E proof path.
@@ -134,15 +135,31 @@ export default function () {
           message: agentInstruction,
           idempotencyKey: `${inv.idempotencyKeyPrefix}-${rowNonce}`,
         });
-      }, 1000);
+      }, 500);
 
-      // Poll task ledger — check mode field
+      // Poll task ledger — check mode field.
       socket.setTimeout(() => tracker.send(socket, 'tasks.list', { limit: 10 }), 5000);
       socket.setTimeout(() => tracker.send(socket, 'tasks.list', { limit: 10 }), 15000);
       socket.setTimeout(() => tracker.send(socket, 'tasks.list', { limit: 10 }), 30000);
 
-      // Extended wait for silent-wake (child must complete + parent must wake)
+      // Extended wait for silent-wake (child must complete + parent must wake).
       socket.setTimeout(() => socket.close(), 90000);
+    }
+
+    socket.on('open', () => {
+      socket.send(connectFrame(token));
+
+      if (createDisposableSession) {
+        socket.setTimeout(() => {
+          const disposableKey = `r-cd-2-${rowNonce}`.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+          tracker.send(socket, 'sessions.create', {
+            key: disposableKey,
+            label: `k6 R-CD-2 ${rowNonce}`,
+          });
+        }, 250);
+      } else {
+        socket.setTimeout(() => startProofFlow(socket), 500);
+      }
     });
 
     socket.on('message', (raw) => {
@@ -158,6 +175,21 @@ export default function () {
           ok: classified.ok !== undefined ? classified.ok : null,
           data: classified.payload ? redactEvent(classified.payload) : null,
         });
+
+        if (classified.kind === 'response' && classified.method === 'sessions.create') {
+          if (classified.ok && classified.payload) {
+            sessionKey = classified.payload.key || sessionKey;
+            evidence.sessionKey = sessionKey;
+            evidence.session_created = true;
+            evidence.created_session_key = sessionKey;
+            console.log(`✓ disposable session created: ${sessionKey}`);
+            startProofFlow(socket);
+          } else {
+            console.error(`✗ sessions.create rejected: ${JSON.stringify(classified.error)}`);
+            failures.add(1);
+            socket.close();
+          }
+        }
 
         // Check sessions.send accepted (agent turn triggered)
         if (classified.kind === 'response' && classified.method === 'sessions.send') {
@@ -278,7 +310,8 @@ export default function () {
   }
 
   // Verdict — PASS when: turn triggered + events flowing + no channel delivery
-  const passed = evidence.tool_accepted && evidence.agent_turn_observed &&
+  const passed = (!createDisposableSession || evidence.session_created) &&
+    evidence.tool_accepted && evidence.agent_turn_observed &&
     evidence.parent_wake_observed && !evidence.channel_message_observed;
 
   console.log(`R_CD_2_EVIDENCE ${JSON.stringify(evidence)}`);


### PR DESCRIPTION
## Summary

Make `R-CD-2` mechanically repeatable without injecting proof prompts into `#sprites` or depending on the busy `main` lane.

Adds `OPENCLAW_CREATE_DISPOSABLE_SESSION=true` mode to the scenario:

- creates a disposable session via `sessions.create`
- subscribes to that created key
- runs the existing `sessions.send` → agent calls `continue_delegate(mode="silent-wake")` path against the disposable session
- records `session_created`, `created_session_key`, and final `sessionKey` in `R_CD_2_EVIDENCE`

Runbook updated with the new mode and repeatability receipts.

## Repeatability

Three consecutive disposable live runs:

```text
run=1 rc=0 verdict=PASS-candidate failures=0 duration_avg=9084ms
run=2 rc=0 verdict=PASS-candidate failures=0 duration_avg=7230ms
run=3 rc=0 verdict=PASS-candidate failures=0 duration_avg=14359ms
```

All three had:

```text
session_created=true
tool_accepted=true
agent_turn_observed=true
parent_wake_observed=true
channel_message_observed=false
dispatch_channel_message_observed=true
```

This moves `R-CD-2` from live-room-sensitive partial behavior to repeatable PASS-candidate execution. Remaining manual fold work is trace/session receipt review, not executing the scenario.

## Validation

- `bash -n tools/k6-proofs/scripts/run-proofs.sh`
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs` → passed
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs` → `ok=true`
- `node tools/k6-proofs/scripts/validate-corpus.mjs --index --json` → `failed=false`
- `./scripts/run-proofs.sh --dry-run R-CD-2 71a1dfff...` → row selection works

Refs #178.
