### PR TITLE
tools(k6-proofs): make R-CW-1 wake sentinel pass-capable

### DIFF
--- a/RUNBOOKS/project-81/rows/R-CW-1.md
+++ b/RUNBOOKS/project-81/rows/R-CW-1.md
@@ -1,0 +1,62 @@
+# R-CW-1 — typed `continue_work` schedule + wake
+
+## Purpose
+
+Prove the typed `continue_work` tool path can schedule a same-session follow-up
+turn and that the scheduled wake turn executes. The row uses a disposable
+session by default so repeatability runs do not touch the live coordination lane.
+
+## Runnable scenario
+
+- Manifest: `tools/k6-proofs/manifests/r-cw-1.json`
+- Scenario: `tools/k6-proofs/scenarios/r-cw-1-tool-schedule-wake.js`
+- Preferred mode: `OPENCLAW_CREATE_DISPOSABLE_SESSION=true`
+
+The scenario sends a proof-harness prompt into a disposable session. The agent
+must call `continue_work` with a nonce-bearing reason. The reason embeds the
+wake-turn instruction so the continuation turn can emit the required wake
+sentinel without relying on unstated context.
+
+Required post-dispatch receipts:
+
+1. `tool-invoke-accepted` — `sessions.send` accepted and triggered the agent
+   turn that calls `continue_work`.
+2. `continue-work-tool-result-scheduled` — explicit `CW-SCHEDULED <nonce>`
+   sentinel, emitted only after the `continue_work` tool result reports
+   scheduled.
+3. `work-woke-event` — explicit `CW-WOKE <nonce>` sentinel from the continuation
+   wake turn.
+
+Prompt echoes containing `[k6-proof-harness]` are ignored. Generic nonce-bearing
+events are not enough for PASS.
+
+## Live smoke — 2026-07-05
+
+Cael ran a disposable live smoke against candidate SHA
+`1cc8f4e3d617ef6f173283ef83d7b739a4995734`.
+
+Result: `PASS-candidate`, `rc=0`.
+
+Observed receipts:
+
+- disposable session created: `agent:main:r-cw-1-r-cw-1-1783310177004-q8wkl2w6`
+- `sessions.send` accepted
+- harness prompt echo ignored
+- `CW-SCHEDULED` observed via `session.message`
+- `CW-WOKE` observed via `session.message` `25265ms` after scheduled
+
+Summary line:
+
+```text
+[R-CW-1] Summary: PASS-candidate | SHA: 1cc8f4e3d617ef6f173283ef83d7b739a4995734 | Seat: cael-dgx
+```
+
+## Repeatability guidance
+
+Use the standard live-run guard and serialize per target session. For repeated
+runs, keep `OPENCLAW_CREATE_DISPOSABLE_SESSION=true`; do not use `#sprites` or a
+human-facing main lane as the target session.
+
+If `CW-SCHEDULED` appears but `CW-WOKE` does not, fold the run as
+`PARTIAL-candidate` unless session history independently proves the wake turn
+executed and emitted the exact sentinel.

--- a/tools/k6-proofs/manifests/r-cw-1.json
+++ b/tools/k6-proofs/manifests/r-cw-1.json
@@ -51,7 +51,7 @@
     "requiresCandidateSha": true,
     "requiresExternalAgentOrToolInvocation": true,
     "sameSessionConcurrencySafe": false,
-    "expectedArtifactClass": "PARTIAL-candidate",
+    "expectedArtifactClass": "PASS-candidate",
     "requiredReceipts": [
       "seat-readiness",
       "tool-invoke-accepted",
@@ -60,6 +60,6 @@
       "trace-id"
     ],
     "foldRequiresReview": true,
-    "notes": "Live continue_work schedule + wake row. Prefer OPENCLAW_CREATE_DISPOSABLE_SESSION=true for repeatability. Serialize per session (sameSessionConcurrencySafe=false). Ignore harness prompt echo; PASS requires explicit CW-SCHEDULED and CW-WOKE sentinels emitted after tool result/wake; current live smoke may be PARTIAL if the disposable session does not deliver the continuation wake turn."
+    "notes": "Live continue_work schedule + wake row. Prefer OPENCLAW_CREATE_DISPOSABLE_SESSION=true for repeatability. Serialize per session (sameSessionConcurrencySafe=false). Ignore harness prompt echo; PASS requires explicit CW-SCHEDULED and CW-WOKE sentinels; the scenario embeds the CW-WOKE instruction in the continue_work reason so the wake turn has the required sentinel instruction."
   }
 }

--- a/tools/k6-proofs/scenarios/r-cw-1-tool-schedule-wake.js
+++ b/tools/k6-proofs/scenarios/r-cw-1-tool-schedule-wake.js
@@ -112,6 +112,7 @@ export default function () {
     const tracker = new RequestTracker();
     const inv = invocationCfg();
     const reasonWithNonce = inv.reason.replace(/\{\{nonce\}\}/g, rowNonce) + `-${rowNonce}`;
+    const wakeReason = `${reasonWithNonce} -- on continuation wake reply exactly CW-WOKE ${rowNonce}`;
 
     function startProofFlow(socket) {
       // Subscribe to session events — scheduled result + wake surface.
@@ -120,7 +121,7 @@ export default function () {
       // Dispatch via sessions.send — triggers agent turn that calls continue_work.
       socket.setTimeout(() => {
         const agentInstruction =
-          `[k6-proof-harness] Call continue_work with reason="${reasonWithNonce}" and delaySeconds=${inv.delaySeconds}. ` +
+          `[k6-proof-harness] Call continue_work with reason="${wakeReason}" and delaySeconds=${inv.delaySeconds}. ` +
           `After the continue_work tool result reports scheduled, reply exactly CW-SCHEDULED ${rowNonce}. ` +
           `On the continuation wake, reply exactly CW-WOKE ${rowNonce}. ` +
           `This is a proof run — no other action needed.`;


### PR DESCRIPTION
## Summary

- make `R-CW-1` full PASS-capable by embedding the `CW-WOKE <nonce>` instruction into the `continue_work` reason
- promote `r-cw-1.json` expected artifact class back to `PASS-candidate`
- add `RUNBOOKS/project-81/rows/R-CW-1.md` with disposable live-smoke evidence and repeatability guidance

## Verification

- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs`
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs`
- `node tools/k6-proofs/scripts/validate-corpus.mjs --index --json`
- Disposable live smoke against `OPENCLAW_CANDIDATE_SHA=1cc8f4e3d617ef6f173283ef83d7b739a4995734`: `R-CW-1` returned `PASS-candidate`, `rc=0`, with `CW-SCHEDULED` and `CW-WOKE` observed.
