### PR TITLE
docs(project-81): add receipts for R-CD-1 and delegate self rows

### DIFF
--- a/RUNBOOKS/project-81/rows/R-CD-1.md
+++ b/RUNBOOKS/project-81/rows/R-CD-1.md
@@ -1,0 +1,64 @@
+# R-CD-1 — typed `continue_delegate` schedule + return
+
+## Purpose
+
+Prove the typed `continue_delegate` tool path can schedule a delegate and return
+a nonce-bound child result to the parent proof session. This row focuses on the
+tool-form delegate path, not bracket fallback.
+
+## Runnable scenario
+
+- Manifest: `tools/k6-proofs/manifests/r-cd-1.json`
+- Scenario: `tools/k6-proofs/scenarios/r-cd-1-typed-delegate.js`
+- Preferred mode: `OPENCLAW_CREATE_DISPOSABLE_SESSION=true`
+
+The scenario creates or targets a disposable session, sends a proof-harness
+prompt that asks the parent agent to call `continue_delegate(mode="normal")`,
+and subscribes to session events. The child task receives a nonce-only prompt and
+must return the exact `CD1-DONE <nonce>` sentinel.
+
+Prompt echoes containing `[k6-proof-harness]` are ignored. Task ledger rows are
+corroborative only; PASS depends on explicit post-dispatch sentinels/return
+evidence.
+
+Required post-dispatch receipts:
+
+1. `tool-invoke-accepted` — `sessions.send` accepted and triggered the parent
+   turn that calls `continue_delegate`.
+2. `delegate-scheduled-sentinel` — explicit `CD1-DELEGATE-SCHEDULED <nonce>`
+   sentinel from the parent after the `continue_delegate` tool result reports
+   scheduled.
+3. `parent-return-event` — explicit `CD1-DONE <nonce>` and/or delegate return
+   evidence observed after dispatch.
+
+## Live smoke — 2026-07-05
+
+Cael ran a disposable live smoke against candidate SHA
+`1cc8f4e3d617ef6f173283ef83d7b739a4995734`.
+
+Result: `PASS-candidate`, `rc=0`.
+
+Observed receipts:
+
+- disposable session created: `agent:main:r-cd-1-r-cd-1-1783311857795-rkx8pg6c`
+- `sessions.send` accepted
+- harness prompt echo ignored
+- `CD1-DONE` / delegate return evidence observed post-dispatch via
+  `session.message` and `agent` events
+- `CD1-DELEGATE-SCHEDULED` observed post-dispatch via `session.message`
+
+Summary line:
+
+```text
+[R-CD-1] Summary: PASS-candidate | SHA: 1cc8f4e3d617ef6f173283ef83d7b739a4995734 | Seat: ronan-dgx
+```
+
+## Repeatability guidance
+
+Use the standard live-run guard and serialize per target session. Prefer
+`OPENCLAW_CREATE_DISPOSABLE_SESSION=true`; do not use a human-facing main lane as
+the proof target.
+
+If `CD1-DELEGATE-SCHEDULED` appears without `CD1-DONE` / delegate return
+evidence, fold as `PARTIAL-candidate`. If only a task ledger row appears, do not
+fold as PASS; ledger rows are optional context for this row.

--- a/RUNBOOKS/project-81/rows/R-CW-DELEGATE-SELF-CONTINUATION.md
+++ b/RUNBOOKS/project-81/rows/R-CW-DELEGATE-SELF-CONTINUATION.md
@@ -1,0 +1,62 @@
+# R-CW-DELEGATE-SELF-CONTINUATION — delegate child self-continuation
+
+## Purpose
+
+Prove a delegate child can call `continue_work` for itself and execute the hop-2
+wake turn. This covers the interaction between typed `continue_delegate` and a
+child-owned typed `continue_work` election.
+
+## Runnable scenario
+
+- Manifest: `tools/k6-proofs/manifests/r-cw-delegate-self.json`
+- Scenario: `tools/k6-proofs/scenarios/r-cw-delegate-self-continuation.js`
+- Preferred mode: `OPENCLAW_CREATE_DISPOSABLE_SESSION=true`
+
+The scenario asks the parent proof session to call `continue_delegate`. The
+child delegate then calls `continue_work`, emits `CHILD-CW-SCHEDULED <nonce>`
+after the tool result reports scheduled, and must emit `CHILD-HOP2-DONE <nonce>`
+on the child hop-2 wake.
+
+Prompt echoes containing `[k6-proof-harness]` are ignored. Generic nonce-bearing
+events are not enough for PASS.
+
+Required post-dispatch receipts:
+
+1. `delegate-accepted` — `sessions.send` accepted and triggered the parent turn.
+2. `child-continue-work-accepted` — explicit `CHILD-CW-SCHEDULED <nonce>`
+   sentinel after the child `continue_work` tool result reports scheduled.
+3. `child-hop-2-woke` — explicit `CHILD-HOP2-DONE <nonce>` sentinel from the
+   child continuation wake turn.
+4. `parent-return` — delegate return observed after dispatch.
+
+## Live smoke — 2026-07-05
+
+Cael ran a disposable live smoke against candidate SHA
+`1cc8f4e3d617ef6f173283ef83d7b739a4995734`.
+
+Result: `PASS-candidate`, `rc=0`.
+
+Observed receipts:
+
+- disposable session created: `agent:main:r-cw-ds-r-cw-ds-1783311884772-vfqfu8ut`
+- `sessions.send` accepted
+- harness prompt echo ignored
+- `CHILD-CW-SCHEDULED` observed post-dispatch
+- `CHILD-HOP2-DONE` observed post-dispatch
+- parent return event from delegate observed post-dispatch
+
+Summary line:
+
+```text
+[R-CW-DELEGATE-SELF-CONTINUATION] Summary: PASS-candidate | SHA: 1cc8f4e3d617ef6f173283ef83d7b739a4995734 | Seat: cael-dgx
+```
+
+## Repeatability guidance
+
+Use the standard live-run guard and serialize per target session. Prefer
+`OPENCLAW_CREATE_DISPOSABLE_SESSION=true`; do not use a human-facing main lane as
+the proof target.
+
+If the child emits `CHILD-CW-SCHEDULED` but not `CHILD-HOP2-DONE`, fold as
+`PARTIAL-candidate`. If the parent return is missing, keep the artifact as
+review-pending even if the child sentinels appear.


### PR DESCRIPTION
## Summary

- add row runbooks for already-runnable `R-CD-1` and `R-CW-DELEGATE-SELF-CONTINUATION`
- record fresh disposable live-smoke receipts against exact PR #85651 head `1cc8f4e3d617ef6f173283ef83d7b739a4995734`
- document required post-dispatch sentinels and partial-fold rules so future runs are press-play/reviewable instead of bespoke

## Verification

- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs`
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs`
- `node tools/k6-proofs/scripts/validate-corpus.mjs --index --json`
- Disposable live smoke:
  - `R-CD-1`: `PASS-candidate`, `rc=0`, `CD1-DONE`/delegate return and `CD1-DELEGATE-SCHEDULED` observed post-dispatch
  - `R-CW-DELEGATE-SELF-CONTINUATION`: `PASS-candidate`, `rc=0`, `CHILD-CW-SCHEDULED`, `CHILD-HOP2-DONE`, and parent return observed post-dispatch
