### PR TITLE
tools(k6-proofs): mark trace-missing candidates review-pending

### DIFF
--- a/tools/k6-proofs/METRICS.md
+++ b/tools/k6-proofs/METRICS.md
@@ -71,6 +71,13 @@ Minimum v1 shape:
   "reason": "k6 checks passed and proof_failures is zero; receipts still need human review",
   "candidateOnly": true,
   "foldRequiresReview": true,
+  "observability": {
+    "traceStatus": "missing"
+  },
+  "review": {
+    "status": "review-pending",
+    "pendingReceipts": ["tempo-trace-json"]
+  },
   "metrics": {
     "proofFailures": 0,
     "checksRate": 1,
@@ -85,7 +92,7 @@ Minimum v1 shape:
 }
 ```
 
-Current post-processor output writes this v1 dashboard shape for manifest-driven runs: `scenario`, `toolSurface`, `transport`, `metrics`, `receipts`, and `failureClass` are normalized into `row-result.json` from the row manifest plus k6 summary / evidence summary. Dashboards may still ingest the minimal fields (`outcome`, `rowId`, `candidateSha`, `seat`, `runId`, `candidateOnly`, and `foldRequiresReview`) for older candidate runs, but new candidate artifacts should include the full v1 shape above.
+Current post-processor output writes this v1 dashboard shape for manifest-driven runs: `scenario`, `toolSurface`, `transport`, `metrics`, `receipts`, and `failureClass` are normalized into `row-result.json` from the row manifest plus k6 summary / evidence summary. Row-list runner artifacts may also include `observability.traceStatus` (`present`, `missing`, or `unknown`) plus `review.status` / `review.pendingReceipts` to keep trace-missing PASS candidates visibly review-pending instead of silently foldable. Dashboards may still ingest the minimal fields (`outcome`, `rowId`, `candidateSha`, `seat`, `runId`, `candidateOnly`, and `foldRequiresReview`) for older candidate runs, but new candidate artifacts should include the full v1 shape above.
 
 ## Prometheus metric names
 

--- a/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
+++ b/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
@@ -40,6 +40,7 @@ export const options = {
 
 const failures = new Counter('proof_failures');
 const duration = new Trend('r_cd_2_duration');
+let finalEvidence = null;
 
 // --- Manifest-driven config ---
 const manifest = loadManifestFromEnv();
@@ -285,6 +286,7 @@ export default function () {
 
   evidence.ended = new Date().toISOString();
   evidence.duration_ms = Date.now() - started;
+  finalEvidence = evidence;
   duration.add(evidence.duration_ms);
 
   // Checks — core evidence for silent-wake proof:
@@ -324,12 +326,26 @@ export default function () {
 export function handleSummary(data) {
   const timestamp = new Date().toISOString();
   const passRate = data.metrics.proof_failures && data.metrics.proof_failures.values && data.metrics.proof_failures.values.count === 0;
+  const traceId = finalEvidence && finalEvidence.trace_id || null;
   const summary = {
     row: 'R-CD-2',
     sha: __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
     seat: __ENV.OPENCLAW_SEAT_NAME || 'ronan-dgx',
     timestamp,
     verdict: passRate ? 'PASS-candidate' : 'PARTIAL-candidate',
+    candidateOnly: true,
+    foldRequiresReview: true,
+    observability: {
+      traceId,
+      traceJson: traceId ? 'pending-fetch' : 'missing',
+    },
+    review: {
+      status: traceId ? 'ready-for-human-review' : 'review-pending',
+      pendingReceipts: traceId ? [] : ['tempo-trace-json'],
+      notes: traceId
+        ? ['Trace id captured; fetch and attach Tempo trace JSON before canonical fold.']
+        : ['No trace_id was emitted by this candidate run; keep PASS-candidate as review-pending until trace JSON is fetched or the fold explicitly accepts trace-missing.'],
+    },
     metrics: {
       duration_ms: data.metrics.r_cd_2_duration && data.metrics.r_cd_2_duration.values || null,
       failures: data.metrics.proof_failures && data.metrics.proof_failures.values && data.metrics.proof_failures.values.count || 0,

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -201,7 +201,25 @@ if src.exists():
             pass
 dst.write_text(''.join(json.dumps(obj, sort_keys=True) + '\n' for obj in out))
 PY_EVIDENCE_JSONL
-    jq -n --argjson rc "$k6_rc" --arg ended "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '{k6ExitCode:$rc, endedAt:$ended}' > "$RUN_DIR/run-result.json"
+    TRACE_STATUS="unknown"
+    REVIEW_PENDING_RECEIPTS='[]'
+    if [[ -s "$RUN_DIR/evidence.jsonl" ]]; then
+      if jq -e 'select(has("trace_id"))' "$RUN_DIR/evidence.jsonl" >/dev/null; then
+        if jq -e 'select((.trace_id // "") != "")' "$RUN_DIR/evidence.jsonl" >/dev/null; then
+          TRACE_STATUS="present"
+        else
+          TRACE_STATUS="missing"
+          REVIEW_PENDING_RECEIPTS='["tempo-trace-json"]'
+        fi
+      fi
+    fi
+    jq -n \
+      --argjson rc "$k6_rc" \
+      --arg ended "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      --arg traceStatus "$TRACE_STATUS" \
+      --argjson reviewPendingReceipts "$REVIEW_PENDING_RECEIPTS" \
+      '{k6ExitCode:$rc, endedAt:$ended, candidateOnly:true, foldRequiresReview:true, observability:{traceStatus:$traceStatus}, review:{status:(if ($reviewPendingReceipts|length)>0 then "review-pending" else "ready-for-human-review" end), pendingReceipts:$reviewPendingReceipts}}' \
+      > "$RUN_DIR/run-result.json"
     rm -f "$RUN_DIR/.started"
 
     echo "[$ROW_ID] ARTIFACTS: $RUN_DIR"


### PR DESCRIPTION
## Summary
- mark row-list runner outputs as candidate-only/fold-review artifacts with an explicit trace observability status
- make R-CD-2 summaries keep `PASS-candidate` but mark `trace_id: null` runs as `review-pending` with pending receipt `tempo-trace-json`
- document the review-pending trace fields in the Project 81 metrics/artifact contract

## Why
The first Project 81 button runs now produce live `R-CD-2` PASS-candidates, but current runs can have `trace_id: null`. That should not silently look fold-ready. Until trace JSON is fetched/attached (or explicitly accepted as trace-missing by review), the candidate artifact should say so in machine-readable form.

## Verification
- `node --check tools/k6-proofs/scenarios/r-cd-2-silent-wake.js`
- `bash -n tools/k6-proofs/scripts/run-proofs.sh`
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs`
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs`
- `node --test tools/k6-proofs/scripts/__tests__/*.test.mjs`
- `node tools/k6-proofs/scripts/validate-corpus.mjs --index --json`
- live local R-CD-2 against scratch session `agent:main:dashboard:direct:project81-scratch-20260707133234` on candidate `b40e59f08c7a8997e50a5c8a24b00bc68f653882`: k6 exit 0, `PASS-candidate`, `run-result.json` now has `observability.traceStatus="missing"` and `review.pendingReceipts=["tempo-trace-json"]`
