### PR TITLE
tools(k6-proofs): make all-corpus validation archival

### DIFF
--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -281,11 +281,15 @@ The corpus invariants enforced at fold time live in
 # Validate a single corpus dir (manifest + rollup tally + evidence + dirs)
 node tools/k6-proofs/scripts/validate-corpus.mjs --sha <40-char-sha>
 
-# Validate every PROOFS/<sha>/ that has a manifest; legacy short-SHA dirs are skipped
+# Archival sweep across PROOFS/<sha>/; reports skipped/legacy/failed historical dirs but exits 0 by default
 node tools/k6-proofs/scripts/validate-corpus.mjs --all
 
-# Validate PROOFS/INDEX.json consistency vs the manifest it points to
+# Strict archival sweep; exits non-zero if any historical manifest fails current invariants
+node tools/k6-proofs/scripts/validate-corpus.mjs --all --strict
+
+# Validate PROOFS/INDEX.json consistency vs the manifest it points to (current-board gate)
 node tools/k6-proofs/scripts/validate-corpus.mjs --index
+node tools/k6-proofs/scripts/validate-corpus.mjs --current
 
 # Machine-readable
 node tools/k6-proofs/scripts/validate-corpus.mjs --index --json
@@ -304,8 +308,11 @@ Checks: JSON parse, schema sanity (`openclaw.proofs.index.v1` /
 `openclaw.proofs.manifest.v1`), every declared `evidence_doc` and `rows[].dir`
 exists, no orphan row dirs, INDEX `rollup` tallies match the manifest `rows[].state`
 counts, manifest `capture_sha` matches its directory name, and no stale
-`pending_push` / `upload-blame` / `TODO-UPLOAD` wording. Exit code is non-zero
-on any failure; the script never mutates corpus data.
+`pending_push` / `upload-blame` / `TODO-UPLOAD` wording. `--index` / `--current`
+are the current-board gates and exit non-zero on failure. `--all` is archival by
+default: its JSON includes `archivalFailed` and `archivalSummary` for skipped,
+legacy-schema, and failed historical dirs, but it exits 0 unless `--strict` is
+supplied. The script never mutates corpus data.
 
 `check-manifest-scenarios.mjs` is the row-harness registry check: runnable
 manifests must point at an existing `tools/k6-proofs/scenarios/*.js`; rows with

--- a/tools/k6-proofs/scripts/validate-corpus.mjs
+++ b/tools/k6-proofs/scripts/validate-corpus.mjs
@@ -10,13 +10,17 @@
  *   node tools/k6-proofs/scripts/validate-corpus.mjs --sha <40-char-sha>
  *   node tools/k6-proofs/scripts/validate-corpus.mjs --all
  *   node tools/k6-proofs/scripts/validate-corpus.mjs --index
+ *   node tools/k6-proofs/scripts/validate-corpus.mjs --current
  *   node tools/k6-proofs/scripts/validate-corpus.mjs --index --json
  *
  * Optional:
  *   --root <path>   PROOFS parent (defaults to CWD, matching sibling scripts).
  *   --json          Emit a machine-readable JSON result on stdout.
+ *   --strict        Make archival --all failures fatal. By default --all is
+ *                   informational; use --index/--current for current-board gating.
  *
- * Exit code is non-zero on any check failure; 0 on clean validation.
+ * Exit code is non-zero on current-board check failure; --all exits 0 unless
+ * --strict is supplied.
  */
 
 import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
@@ -59,7 +63,8 @@ function usage() {
       `  node tools/k6-proofs/scripts/validate-corpus.mjs --sha <40-char-sha>\n` +
       `  node tools/k6-proofs/scripts/validate-corpus.mjs --all\n` +
       `  node tools/k6-proofs/scripts/validate-corpus.mjs --index\n` +
-      `Options: --root <path>  --json`,
+      `  node tools/k6-proofs/scripts/validate-corpus.mjs --current\n` +
+      `Options: --root <path>  --json  --strict`,
   );
 }
 
@@ -339,6 +344,13 @@ function validateIndex(root) {
   return report;
 }
 
+function isLegacySchemaReport(report) {
+  if (!report || report.skipped) return false;
+  return (report.checks || []).some((c) =>
+    c.ok === false && (c.name === 'schema-manifest' || c.name === 'schema-manifest-capture-sha'),
+  );
+}
+
 function validateAll(root) {
   const proofsDir = join(root, 'PROOFS');
   const subs = listSubdirs(proofsDir) || [];
@@ -393,6 +405,7 @@ function main() {
   const wantJson = Boolean(args.json);
 
   let modeCount = 0;
+  if (args.current) args.index = true;
   if (args.sha) modeCount += 1;
   if (args.all) modeCount += 1;
   if (args.index) modeCount += 1;
@@ -418,17 +431,35 @@ function main() {
     if (!wantJson) console.log(renderReport(report));
   } else if (args.all) {
     const reports = validateAll(root);
+    let archivalFailed = false;
     for (const r of reports) {
       if (r.skipped) skipped += 1;
-      if (reportFailed(r)) failed = true;
+      if (reportFailed(r)) archivalFailed = true;
       if (!wantJson) console.log(renderReport(r));
     }
+    const validated = reports.length - skipped;
+    const okCount = reports.filter((r) => !r.skipped && !reportFailed(r)).length;
+    const failedReports = reports.filter((r) => !r.skipped && reportFailed(r)).length;
+    const legacySchemaReports = reports.filter(isLegacySchemaReport).length;
+    const archivalSummary = {
+      archival: true,
+      fatalOnlyWithStrict: true,
+      reportCount: reports.length,
+      validated,
+      ok: okCount,
+      skippedNoManifest: skipped,
+      failedReports,
+      legacySchemaReports,
+    };
+    failed = Boolean(args.strict) && archivalFailed;
     if (!wantJson) {
-      const validated = reports.length - skipped;
-      const okCount = reports.filter((r) => !r.skipped && !reportFailed(r)).length;
-      console.log(`\n--all summary: ${validated} validated (${okCount} OK), ${skipped} skipped (no manifest)`);
+      console.log(
+        `\n--all archival summary: ${validated} validated (${okCount} OK), ` +
+          `${failedReports} failed historical reports, ${legacySchemaReports} legacy-schema reports, ` +
+          `${skipped} skipped (no manifest). Use --index/--current for current-board gating; add --strict to make archival failures fatal.`,
+      );
     }
-    payload = { mode: 'all', root, reports };
+    payload = { mode: 'all', root, archivalSummary, archivalFailed, reports };
   } else {
     const report = validateIndex(root);
     failed = reportFailed(report);


### PR DESCRIPTION
## Summary
- make `validate-corpus.mjs --all` explicitly archival and non-fatal by default
- add `--strict` for callers that really want historical `--all` failures to fail the process
- add `--current` as an alias for the current-board `--index` gate
- add JSON `archivalSummary` / `archivalFailed` fields to distinguish skipped, failed, and legacy-schema historical dirs
- document the current-board gate vs archival sweep in the k6-proofs README

## Why
Project 81 automation needs one unambiguous green current-board gate. That gate is `--index` / `--current`. Historical `PROOFS/<sha>` directories include skipped/no-manifest dirs and legacy schema artifacts, so `--all` should be useful for archive maintenance without being mistaken for current-board health.

Closes #271.

## Verification
- `node --check tools/k6-proofs/scripts/validate-corpus.mjs`
- `node tools/k6-proofs/scripts/validate-corpus.mjs --index --json` exits 0
- `node tools/k6-proofs/scripts/validate-corpus.mjs --current --json` exits 0
- `node tools/k6-proofs/scripts/validate-corpus.mjs --all --json` exits 0 and reports `archivalFailed=true` / `failed=false`
- `node tools/k6-proofs/scripts/validate-corpus.mjs --all --strict --json` exits 1
- `node --test tools/k6-proofs/scripts/__tests__/*.test.mjs`
