### PR TITLE
tools(k6-proofs): fetch Tempo trace receipts for candidate runs

### DIFF
--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -181,6 +181,23 @@ outcome, duration, proof-failure count, checks rate when present, receipt status
 and review-pending signal. It does not export session keys, prompt bodies, nonces,
 raw websocket events, tokens, or local private paths.
 
+## Tempo trace receipts
+
+When a live row emits a `trace_id`, `run-proofs.sh` now attempts to fetch the
+matching Tempo JSON from `TEMPO_BASE_URL` (default `http://tempo.dandelion.cult`)
+and saves it beside the candidate run artifacts as `tempo-trace-<trace>.json`.
+The fetch receipt is stored in `tempo-trace-receipt.json`; fetch failures are
+kept non-fatal by default and leave `tempo-trace-json` review-pending. Set
+`OPENCLAW_PROOFS_K6_TEMPO_REQUIRED=true` only when a missing trace JSON should
+fail the run.
+
+Manual fetch:
+
+```bash
+node tools/k6-proofs/scripts/fetch-tempo-trace.mjs \
+  --run-dir /tmp/k6-proof-runs/<sha>/<row>/<seat>/<run-id>
+```
+
 ## HTML run report
 
 `run-proofs.sh` writes a public-safe `report.html` at the selected run output root.

--- a/tools/k6-proofs/scripts/__tests__/tempo-fetch.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/tempo-fetch.test.mjs
@@ -1,0 +1,66 @@
+import { createServer } from 'node:http';
+import { mkdtemp, mkdir, writeFile, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const script = path.resolve('tools/k6-proofs/scripts/fetch-tempo-trace.mjs');
+const runNode = promisify(execFile);
+
+async function withServer(handler, fn) {
+  const server = createServer(handler);
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address();
+  try {
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+test('fetches Tempo trace JSON by trace id and writes receipt', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'tempo-fetch-'));
+  try {
+    await withServer((req, res) => {
+      assert.equal(req.url, '/api/traces/0123456789abcdef');
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ batches: [{ scopeSpans: [{ spans: [{ traceId: '0123456789abcdef', spanId: 'abc' }] }] }] }));
+    }, async (baseUrl) => {
+      const out = path.join(root, 'trace.json');
+      const run = await runNode(process.execPath, [script, '--trace-id', '0123456789abcdef', '--tempo-url', baseUrl, '--out', out], { encoding: 'utf8' });
+      const receipt = JSON.parse(run.stdout);
+      assert.equal(receipt.fetched, true);
+      assert.equal(receipt.traceId, '0123456789abcdef');
+      assert.equal(receipt.spans, 1);
+      assert.equal(receipt.tempoUrl.includes('0123456789abcdef'), false);
+      const body = JSON.parse(await readFile(out, 'utf8'));
+      assert.equal(body.batches[0].scopeSpans[0].spans.length, 1);
+    });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('can discover trace id from run-dir evidence.jsonl', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'tempo-fetch-rundir-'));
+  try {
+    const runDir = path.join(root, 'run');
+    await mkdir(runDir, { recursive: true });
+    await writeFile(path.join(runDir, 'evidence.jsonl'), `${JSON.stringify({ trace_id: 'abcdef0123456789' })}\n`);
+    await withServer((req, res) => {
+      assert.equal(req.url, '/api/traces/abcdef0123456789');
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ trace: { spans: [{ spanId: 'abc' }] } }));
+    }, async (baseUrl) => {
+      const run = await runNode(process.execPath, [script, '--run-dir', runDir, '--tempo-url', baseUrl], { encoding: 'utf8' });
+      const receipt = JSON.parse(run.stdout);
+      assert.equal(receipt.traceId, 'abcdef0123456789');
+      assert.match(receipt.out, /tempo-trace-abcdef012345\.json$/);
+    });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/tools/k6-proofs/scripts/fetch-tempo-trace.mjs
+++ b/tools/k6-proofs/scripts/fetch-tempo-trace.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * Fetch a Tempo trace JSON receipt for a Project 81 k6 proof candidate run.
+ *
+ * The script accepts either --trace-id directly or --run-dir containing
+ * evidence.jsonl. It writes the raw Tempo JSON response to --out (or
+ * <run-dir>/tempo-trace-<trace-id>.json) and prints a compact public-safe
+ * receipt to stdout.
+ */
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+function usage() {
+  console.error('Usage: node fetch-tempo-trace.mjs (--trace-id <id> | --run-dir <dir>) [--tempo-url http://tempo.dandelion.cult] [--out trace.json]');
+}
+
+function parseArgs(argv) {
+  const out = { tempoUrl: process.env.TEMPO_BASE_URL || 'http://tempo.dandelion.cult' };
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--trace-id' || arg === '--run-dir' || arg === '--tempo-url' || arg === '--out') {
+      const value = argv[i + 1];
+      if (!value || value.startsWith('--')) throw new Error(`missing value for ${arg}`);
+      out[arg.slice(2).replace(/-([a-z])/g, (_, c) => c.toUpperCase())] = value;
+      i += 1;
+    } else if (arg === '--help' || arg === '-h') {
+      out.help = true;
+    } else {
+      throw new Error(`unexpected argument: ${arg}`);
+    }
+  }
+  return out;
+}
+
+function safeTraceId(value) {
+  const text = String(value ?? '').trim();
+  if (!/^[A-Fa-f0-9]{8,64}$/.test(text)) throw new Error(`invalid trace id: ${text || '(empty)'}`);
+  return text.toLowerCase();
+}
+
+async function traceIdFromRunDir(runDir) {
+  const evidencePath = path.join(runDir, 'evidence.jsonl');
+  const text = await readFile(evidencePath, 'utf8');
+  for (const line of text.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      const row = JSON.parse(line);
+      if (row.trace_id) return safeTraceId(row.trace_id);
+    } catch {
+      // Ignore malformed evidence lines; run-proofs already preserves raw logs.
+    }
+  }
+  throw new Error(`no trace_id found in ${evidencePath}`);
+}
+
+async function fetchTrace(baseUrl, traceId) {
+  const root = String(baseUrl).replace(/\/+$/, '');
+  const url = `${root}/api/traces/${encodeURIComponent(traceId)}`;
+  const response = await fetch(url, { headers: { accept: 'application/json' } });
+  const text = await response.text();
+  if (!response.ok) throw new Error(`Tempo trace fetch failed: HTTP ${response.status} ${response.statusText} ${text.slice(0, 240)}`.trim());
+  let json;
+  try { json = JSON.parse(text); }
+  catch { throw new Error(`Tempo trace fetch did not return JSON for ${traceId}`); }
+  return { url, json };
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) { usage(); return; }
+  if (args.traceId && args.runDir) throw new Error('choose --trace-id or --run-dir, not both');
+  const traceId = safeTraceId(args.traceId || await traceIdFromRunDir(args.runDir));
+  const out = args.out
+    ? path.resolve(args.out)
+    : path.join(path.resolve(args.runDir || process.cwd()), `tempo-trace-${traceId.slice(0, 12)}.json`);
+  const { url, json } = await fetchTrace(args.tempoUrl, traceId);
+  await mkdir(path.dirname(out), { recursive: true });
+  await writeFile(out, `${JSON.stringify(json, null, 2)}\n`);
+  const spans = Array.isArray(json?.batches)
+    ? json.batches.reduce((sum, batch) => sum + (batch?.scopeSpans || batch?.instrumentationLibrarySpans || []).reduce((s, scope) => s + (scope?.spans || []).length, 0), 0)
+    : Array.isArray(json?.trace?.spans) ? json.trace.spans.length : null;
+  console.log(JSON.stringify({
+    schema: 'openclaw.k6.tempo-trace-fetch.v1',
+    traceId,
+    out,
+    tempoUrl: url.replace(traceId, '<trace-id>'),
+    fetched: true,
+    spans,
+  }, null, 2));
+}
+
+main().catch((error) => {
+  usage();
+  console.error(error && error.stack ? error.stack : String(error));
+  process.exitCode = 1;
+});

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -202,11 +202,25 @@ if src.exists():
 dst.write_text(''.join(json.dumps(obj, sort_keys=True) + '\n' for obj in out))
 PY_EVIDENCE_JSONL
     TRACE_STATUS="unknown"
+    TRACE_ID=""
+    TEMPO_TRACE_JSON=""
     REVIEW_PENDING_RECEIPTS='[]'
     if [[ -s "$RUN_DIR/evidence.jsonl" ]]; then
       if jq -e 'select(has("trace_id"))' "$RUN_DIR/evidence.jsonl" >/dev/null; then
-        if jq -e 'select((.trace_id // "") != "")' "$RUN_DIR/evidence.jsonl" >/dev/null; then
-          TRACE_STATUS="present"
+        TRACE_ID="$(jq -r 'select((.trace_id // "") != "") | .trace_id' "$RUN_DIR/evidence.jsonl" | head -n 1)"
+        if [[ -n "$TRACE_ID" ]]; then
+          TEMPO_TRACE_JSON="$RUN_DIR/tempo-trace-${TRACE_ID:0:12}.json"
+          if node scripts/fetch-tempo-trace.mjs --trace-id "$TRACE_ID" --out "$TEMPO_TRACE_JSON" > "$RUN_DIR/tempo-trace-receipt.json" 2> "$RUN_DIR/tempo-trace-error.log"; then
+            TRACE_STATUS="present"
+            echo "[$ROW_ID] TEMPO TRACE: $TEMPO_TRACE_JSON"
+          else
+            TRACE_STATUS="missing"
+            REVIEW_PENDING_RECEIPTS='["tempo-trace-json"]'
+            echo "[$ROW_ID] TEMPO TRACE FETCH FAILED; see $RUN_DIR/tempo-trace-error.log" >&2
+            if [[ "${OPENCLAW_PROOFS_K6_TEMPO_REQUIRED:-false}" == "true" ]]; then
+              exit 1
+            fi
+          fi
         else
           TRACE_STATUS="missing"
           REVIEW_PENDING_RECEIPTS='["tempo-trace-json"]'
@@ -217,8 +231,10 @@ PY_EVIDENCE_JSONL
       --argjson rc "$k6_rc" \
       --arg ended "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
       --arg traceStatus "$TRACE_STATUS" \
+      --arg traceId "$TRACE_ID" \
+      --arg tempoTraceJson "$TEMPO_TRACE_JSON" \
       --argjson reviewPendingReceipts "$REVIEW_PENDING_RECEIPTS" \
-      '{k6ExitCode:$rc, endedAt:$ended, candidateOnly:true, foldRequiresReview:true, observability:{traceStatus:$traceStatus}, review:{status:(if ($reviewPendingReceipts|length)>0 then "review-pending" else "ready-for-human-review" end), pendingReceipts:$reviewPendingReceipts}}' \
+      '{k6ExitCode:$rc, endedAt:$ended, candidateOnly:true, foldRequiresReview:true, observability:{traceStatus:$traceStatus, traceId:(if $traceId == "" then null else $traceId end), tempoTraceJson:(if $tempoTraceJson == "" then null else $tempoTraceJson end)}, review:{status:(if ($reviewPendingReceipts|length)>0 then "review-pending" else "ready-for-human-review" end), pendingReceipts:$reviewPendingReceipts}}' \
       > "$RUN_DIR/run-result.json"
     METRICS_ARGS=(--run-dir "$RUN_DIR" --prometheus-out "$RUN_DIR/openclaw-proofs-k6.prom" --otlp-out "$RUN_DIR/openclaw-proofs-k6.otlp.json")
     if [[ -n "${OPENCLAW_PROOFS_K6_OTLP_ENDPOINT:-}" ]]; then


### PR DESCRIPTION
## Summary

- add `fetch-tempo-trace.mjs` to fetch Tempo trace JSON receipts from a trace id or candidate run dir
- have `run-proofs.sh` fetch and attach `tempo-trace-<trace>.json` when live rows emit `trace_id`
- keep Tempo fetch failures non-fatal by default and leave `tempo-trace-json` review-pending
- document the manual fetch path and add local HTTP-server tests

## Verification

- `node --test tools/k6-proofs/scripts/__tests__/*.mjs`
- `OPENCLAW_GATEWAY_TOKEN=redacted OPENCLAW_CANDIDATE_SHA=b40e59f08c7a8997e50a5c8a24b00bc68f653882 ./scripts/run-proofs.sh --dry-run --out-dir "$OUT" preflight` from `tools/k6-proofs`, verified `report.html` still renders

## Notes

Set `OPENCLAW_PROOFS_K6_TEMPO_REQUIRED=true` only when trace JSON fetch failure should fail a run. Default behavior preserves artifact generation and marks the row review-pending.
