### PR TITLE
fix(k6-proofs): parse config values from sentinel segment

### DIFF
--- a/tools/k6-proofs/scenarios/r-config-defaults.js
+++ b/tools/k6-proofs/scenarios/r-config-defaults.js
@@ -164,10 +164,12 @@ export default function () {
               console.log('ℹ Ignoring harness prompt echo event');
             } else if (eventStr.includes(`CONFIG-DEFAULTS ${rowNonce}`)) {
               evidence.config_read = true;
-              const enabled = eventStr.match(/ENABLED[^A-Za-z0-9]+(true|false)/)?.[1] || null;
-              const maxChain = eventStr.match(/MAXCHAIN[^0-9]+(\d+)/)?.[1] || null;
-              const maxDelegates = valueAfterLabel(eventStr, 'MAXDELEGATES');
-              const costCap = valueAfterLabel(eventStr, 'COSTCAP');
+              const sentinelIdx = eventStr.lastIndexOf(`CONFIG-DEFAULTS ${rowNonce}`);
+              const sentinelText = sentinelIdx === -1 ? eventStr : eventStr.slice(sentinelIdx);
+              const enabled = sentinelText.match(/ENABLED[^A-Za-z0-9]+(true|false)/)?.[1] || null;
+              const maxChain = sentinelText.match(/MAXCHAIN[^0-9]+(\d+)/)?.[1] || null;
+              const maxDelegates = valueAfterLabel(sentinelText, 'MAXDELEGATES');
+              const costCap = valueAfterLabel(sentinelText, 'COSTCAP');
               evidence.enabled = enabled === null ? null : enabled === 'true';
               evidence.max_chain_length = maxChain ? Number(maxChain) : null;
               evidence.max_delegates_per_turn_observed = maxDelegates !== null;


### PR DESCRIPTION
## Summary

Follow-up to #296 after Batch A run `28874629386` went green but exposed a false-clean parser byte: `R-CONFIG-defaults` reported `maxDelegates=500 costCap=1783435034784`, which came from prompt/nonce text rather than the actual config sentinel.

This tightens parsing so config values are extracted from the last `CONFIG-DEFAULTS <nonce> ...` sentinel segment only, instead of scanning the whole serialized event text for labels.

## Verification

- `node --test tools/k6-proofs/scripts/__tests__/observability-contract.test.mjs tools/k6-proofs/scripts/__tests__/metrics-export.test.mjs tools/k6-proofs/scripts/__tests__/report-render.test.mjs tools/k6-proofs/scripts/__tests__/dashboard-contract.test.mjs tools/k6-proofs/scripts/__tests__/tempo-fetch.test.mjs`
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs tools/k6-proofs/manifests tools/k6-proofs/scenarios`
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs --root tools/k6-proofs`
- `node tools/k6-proofs/scripts/validate-corpus.mjs --index`
- `node tools/k6-proofs/scripts/validate-corpus.mjs --current`

## Batch A context

- Green-but-suspicious run: `28874629386`
- Bad parse: `maxDelegates=500 costCap=1783435034784`
- Cause: value extraction scanned the whole serialized event and matched prompt/nonce digits after labels.
