### PR TITLE
fix(k6-proofs): require complete config sentinel

### DIFF
--- a/tools/k6-proofs/scenarios/r-config-defaults.js
+++ b/tools/k6-proofs/scenarios/r-config-defaults.js
@@ -35,11 +35,27 @@ function boolEnv(name) {
   return (__ENV[name] || '').toLowerCase() === 'true';
 }
 
-function valueAfterLabel(text, label) {
-  const idx = text.indexOf(label);
-  if (idx === -1) return null;
-  const tail = text.slice(idx + label.length);
-  return tail.match(/(null|\d+)/i)?.[1] || null;
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function parseConfigSentinel(text, rowNonce) {
+  const pattern = new RegExp(
+    `CONFIG-DEFAULTS\\s+${escapeRegExp(rowNonce)}[\\s\\S]*?` +
+    `ENABLED[^A-Za-z0-9]+(true|false)[\\s\\S]*?` +
+    `MAXCHAIN[^A-Za-z0-9]+(null|\\d+)[\\s\\S]*?` +
+    `MAXDELEGATES[^A-Za-z0-9]+(null|\\d+)[\\s\\S]*?` +
+    `COSTCAP[^A-Za-z0-9]+(null|\\d+)`,
+    'i',
+  );
+  const match = text.match(pattern);
+  if (!match) return null;
+  return {
+    enabled: match[1],
+    maxChain: match[2],
+    maxDelegates: match[3],
+    costCap: match[4],
+  };
 }
 
 export default function () {
@@ -163,20 +179,19 @@ export default function () {
             if (eventStr.includes(HARNESS_MARKER)) {
               console.log('ℹ Ignoring harness prompt echo event');
             } else if (eventStr.includes(`CONFIG-DEFAULTS ${rowNonce}`)) {
+              const parsed = parseConfigSentinel(eventStr, rowNonce);
+              if (!parsed) {
+                console.log('ℹ Ignoring incomplete CONFIG-DEFAULTS sentinel candidate');
+                return;
+              }
               evidence.config_read = true;
-              const sentinelIdx = eventStr.lastIndexOf(`CONFIG-DEFAULTS ${rowNonce}`);
-              const sentinelText = sentinelIdx === -1 ? eventStr : eventStr.slice(sentinelIdx);
-              const enabled = sentinelText.match(/ENABLED[^A-Za-z0-9]+(true|false)/)?.[1] || null;
-              const maxChain = sentinelText.match(/MAXCHAIN[^0-9]+(\d+)/)?.[1] || null;
-              const maxDelegates = valueAfterLabel(sentinelText, 'MAXDELEGATES');
-              const costCap = valueAfterLabel(sentinelText, 'COSTCAP');
-              evidence.enabled = enabled === null ? null : enabled === 'true';
-              evidence.max_chain_length = maxChain ? Number(maxChain) : null;
-              evidence.max_delegates_per_turn_observed = maxDelegates !== null;
-              evidence.max_delegates_per_turn = maxDelegates && maxDelegates.toLowerCase() !== 'null' ? Number(maxDelegates) : null;
-              evidence.cost_cap_tokens_observed = costCap !== null;
-              evidence.cost_cap_tokens = costCap && costCap.toLowerCase() !== 'null' ? Number(costCap) : null;
-              console.log(`✓ CONFIG-DEFAULTS sentinel observed: enabled=${enabled} maxChain=${maxChain} maxDelegates=${maxDelegates} costCap=${costCap}`);
+              evidence.enabled = parsed.enabled === 'true';
+              evidence.max_chain_length = parsed.maxChain.toLowerCase() !== 'null' ? Number(parsed.maxChain) : null;
+              evidence.max_delegates_per_turn_observed = true;
+              evidence.max_delegates_per_turn = parsed.maxDelegates.toLowerCase() !== 'null' ? Number(parsed.maxDelegates) : null;
+              evidence.cost_cap_tokens_observed = true;
+              evidence.cost_cap_tokens = parsed.costCap.toLowerCase() !== 'null' ? Number(parsed.costCap) : null;
+              console.log(`✓ CONFIG-DEFAULTS sentinel observed: enabled=${parsed.enabled} maxChain=${parsed.maxChain} maxDelegates=${parsed.maxDelegates} costCap=${parsed.costCap}`);
               socket.close();
             } else if (eventStr.includes(`CONFIG-DEFAULTS-FAIL ${rowNonce}`)) {
               console.error('✗ CONFIG-DEFAULTS-FAIL sentinel observed');


### PR DESCRIPTION
## Summary

Batch A exposed two parser edges in `R-CONFIG-defaults`:

1. null defaults are legitimate observed config values (#295/#296), and
2. scanning the whole serialized event text can pick up prompt/nonce digits instead of the actual agent sentinel (#298/green-but-tainted run `28874629386`).

This patch makes the row accept only a complete sentinel pattern:

```text
CONFIG-DEFAULTS <nonce> ENABLED <true|false> MAXCHAIN <null|digits> MAXDELEGATES <null|digits> COSTCAP <null|digits>
```

Incomplete prompt/history echoes are ignored instead of counted as config reads.

## Verification

- `node --test tools/k6-proofs/scripts/__tests__/observability-contract.test.mjs tools/k6-proofs/scripts/__tests__/metrics-export.test.mjs tools/k6-proofs/scripts/__tests__/report-render.test.mjs tools/k6-proofs/scripts/__tests__/dashboard-contract.test.mjs tools/k6-proofs/scripts/__tests__/tempo-fetch.test.mjs`
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs tools/k6-proofs/manifests tools/k6-proofs/scenarios`
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs --root tools/k6-proofs`
- `node tools/k6-proofs/scripts/validate-corpus.mjs --index`
- `node tools/k6-proofs/scripts/validate-corpus.mjs --current`

## Batch A context

- Original failure: `28874289469` (`maxDelegates=null`/`costCap=null` treated as missing)
- Follow-up failures: `28874495703`, `28874499112`
- Green-but-tainted run: `28874629386` (`maxDelegates=500 costCap=1783435034784` from prompt/nonce text)
- Honest post-#298 failure: `28874847944` avoided false digits but still matched incomplete sentinel text.
