### PR TITLE
tools(k6-proofs): gate live rows on continuation readiness

### DIFF
--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -69,11 +69,12 @@ The helper emits `openclaw.k6.seat-readiness.v1` JSON and never prints secret va
 - k6 binary path and version, compared to the centralized policy expectation (`tools/k6-proofs/seat-readiness.policy.json`; override with `OPENCLAW_EXPECTED_K6_VERSION` or `--expected-k6-version` only when the row issue says so)
 - every binary candidate checked (`/home/figs/bin/k6`, common system paths, and `K6_BIN` when set)
 - gateway health/status reachability shape
+- continuation config readiness from `openclaw config get agents.defaults.continuation --json`, including `enabled=true` and presence of `maxChainLength`, `maxDelegatesPerTurn`, and `costCapTokens`
 - candidate SHA validity, seat name/class, and coarse session scope
 - required env-var presence as booleans only, plus public-safe purpose strings from the policy
 - whether the check is safe to run concurrently
 
-If k6 is missing, the version differs, required env is absent, or gateway health/status is unreachable, treat row output as `HONEST-LIMIT-candidate` / setup failure until the seat is fixed. Do not fold it as product behavior evidence. Use `--no-gateway` only for offline docs/schema checks; live proof rows need a checked gateway.
+If k6 is missing, the version differs, continuation is disabled/missing, required env is absent, or gateway health/status is unreachable, treat row output as `HONEST-LIMIT-candidate` / setup failure until the seat is fixed. Do not fold it as product behavior evidence. Use `--no-gateway` only for offline docs/schema checks; live proof rows need a checked gateway and live continuation rows need continuation enabled.
 
 ### 2. Preflight check
 
@@ -216,6 +217,27 @@ node tools/k6-proofs/scripts/render-run-report.mjs \
 
 The HTML report is a review aid only. It does not promote candidate artifacts into
 canonical `PROOFS/**` folds.
+
+## Config-mutating rows and restart containment
+
+Rows that lower continuation limits or restart the gateway must stay `orchestration-required` until their fixture emits the full receipt chain:
+
+1. capture the original config value;
+2. apply the row-local low test value;
+3. reload/restart through the configured command;
+4. fire the proof;
+5. restore the original value;
+6. reload/restart again and record the restore receipt.
+
+The default restart command for fixtures is:
+
+```bash
+openclaw gateway restart --safe --wait 10s
+```
+
+Override it with `OPENCLAW_GATEWAY_RESTART_CMD` for nonstandard deployments. The command must be self-contained for the target seat; do not bake frond-specific SSH, service, or workflow names into public row logic.
+
+Cost-cap boundary rows should take their low test value from `OPENCLAW_K6_COST_CAP_TEST_VALUE` when set, with a documented default in the row fixture. They must restore the original cap before emitting a fold-reviewable candidate artifact.
 
 ## Design principles
 

--- a/tools/k6-proofs/k6-proofs-pipeline.xml
+++ b/tools/k6-proofs/k6-proofs-pipeline.xml
@@ -228,7 +228,13 @@
     </Mandate>
     <Mandate id="caps-test">
       <Rule>Cap-exhaustion rows MUST be proven by actually hitting the cap</Rule>
-      <Procedure>Lower caps → reload gateway → fire → verify reject → restore → reload</Procedure>
+      <Procedure>Backup original config → lower caps (env-overridable row test value) → reload/restart gateway → fire → verify reject → restore original config → reload/restart gateway</Procedure>
+      <RestartCommand>Use OPENCLAW_GATEWAY_RESTART_CMD when set; default fixture command is `openclaw gateway restart --safe --wait 10s`.</RestartCommand>
+      <Constraint>Rows that mutate config or restart remain orchestration-required until backup/lower/fire/restore/restart receipts are emitted.</Constraint>
+    </Mandate>
+    <Mandate id="continuation-readiness">
+      <Rule>Live continuation proof batches MUST include a precursor seat-readiness receipt proving agents.defaults.continuation.enabled=true.</Rule>
+      <Reason>A disabled continuation subsystem is setup state/HONEST-LIMIT, not product behavior evidence.</Reason>
     </Mandate>
     <Mandate id="corpus-fold">
       <Rule>Proof artifacts fold only after review/coordination; docs and harness changes use normal PR review</Rule>

--- a/tools/k6-proofs/manifests/r-cw-5.json
+++ b/tools/k6-proofs/manifests/r-cw-5.json
@@ -33,10 +33,17 @@
     "configOverride": {
       "path": "agents.defaults.continuation.costCapTokens",
       "testValue": 1,
-      "restoreAfter": true
+      "restoreAfter": true,
+      "testValueEnv": "OPENCLAW_K6_COST_CAP_TEST_VALUE",
+      "defaultTestValue": "1"
     }
   },
   "expectedReceipts": [
+    {
+      "name": "seat-readiness-continuation-enabled",
+      "required": true,
+      "description": "Precursor seat-readiness report proves agents.defaults.continuation.enabled=true before config-mutating continuation proof"
+    },
     {
       "name": "config-lowered",
       "required": true,
@@ -63,7 +70,7 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Cost-cap boundary. PASS when rejection is delivered at the cap boundary. MUTATES config temporarily (costCapTokens\u21921 then restore). The reject IS the proof."
+    "notes": "Cost-cap boundary. PASS when rejection is delivered at the cap boundary. MUTATES config temporarily (costCapTokens\u21921 then restore). The reject IS the proof. Low cap value must be env-overridable via OPENCLAW_K6_COST_CAP_TEST_VALUE and restored after proof."
   },
   "liveRunSafety": {
     "classification": "orchestration-required",
@@ -75,11 +82,12 @@
     "sameSessionConcurrencySafe": false,
     "expectedArtifactClass": "PARTIAL-candidate",
     "requiredReceipts": [
+      "seat-readiness-continuation-enabled",
       "config-lowered",
       "tool-invoke-rejected",
       "config-restored"
     ],
     "foldRequiresReview": true,
-    "notes": "Config-mutating cost-cap boundary row. Do not expose as unattended k6-runnable on a live prince. Requires explicit mutation fixture or isolated gateway plus backup/restore."
+    "notes": "Config-mutating cost-cap boundary row. Do not expose as unattended k6-runnable on a live prince. Requires explicit mutation fixture or isolated gateway plus backup/restore. Restart/reload command must come from OPENCLAW_GATEWAY_RESTART_CMD when set; default fixture command is `openclaw gateway restart --safe --wait 10s`. Requires a precursor seat-readiness receipt proving continuation.enabled=true."
   }
 }

--- a/tools/k6-proofs/manifests/r-cw-6.json
+++ b/tools/k6-proofs/manifests/r-cw-6.json
@@ -40,6 +40,11 @@
   },
   "expectedReceipts": [
     {
+      "name": "seat-readiness-continuation-enabled",
+      "required": true,
+      "description": "Precursor seat-readiness report proves agents.defaults.continuation.enabled=true before config-mutating continuation proof"
+    },
+    {
       "name": "config-set-to-1",
       "required": true,
       "description": "maxChainLength set to 1 + gateway restart"
@@ -82,12 +87,13 @@
     "sameSessionConcurrencySafe": false,
     "expectedArtifactClass": "PARTIAL-candidate",
     "requiredReceipts": [
+      "seat-readiness-continuation-enabled",
       "config-set-to-1",
       "hop-1-accepted",
       "hop-2-rejected",
       "config-restored"
     ],
     "foldRequiresReview": true,
-    "notes": "Config + restart mutating maxChainLength boundary row. Only run against an isolated/fixture gateway or explicit human-approved live maintenance window."
+    "notes": "Config + restart mutating maxChainLength boundary row. Only run against an isolated/fixture gateway or explicit human-approved live maintenance window. Restart/reload command must come from OPENCLAW_GATEWAY_RESTART_CMD when set; default fixture command is `openclaw gateway restart --safe --wait 10s`. Requires a precursor seat-readiness receipt proving continuation.enabled=true."
   }
 }

--- a/tools/k6-proofs/scripts/__tests__/seat-readiness.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/seat-readiness.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { readFile, mkdtemp, rm, writeFile, chmod } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { mkdir } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 
 const repoRoot = new URL('../../../..', import.meta.url).pathname;
@@ -33,13 +34,20 @@ test('seat readiness policy keeps the k6 proof-standard version in one place', a
   assert.equal(parsed.k6.expectedVersion, 'v2.0.0');
   assert.ok(parsed.env.some((entry) => entry.name === 'OPENCLAW_GATEWAY_TOKEN' && entry.secret === true));
   assert.ok(parsed.env.some((entry) => entry.name === 'OPENCLAW_CANDIDATE_SHA' && entry.required === true));
+  assert.ok(parsed.env.some((entry) => entry.name === 'OPENCLAW_GATEWAY_RESTART_CMD' && entry.required === false));
+  assert.ok(parsed.env.some((entry) => entry.name === 'OPENCLAW_K6_COST_CAP_TEST_VALUE' && entry.required === false));
 });
 
 test('seat readiness JSON contains no env secret values and reports booleans only', async () => {
   await withTmp(async (dir) => {
     const fakeK6 = join(dir, 'k6');
+    const fakeOpenClawDir = join(dir, 'bin');
+    const fakeOpenClaw = join(fakeOpenClawDir, 'openclaw');
+    await mkdir(fakeOpenClawDir, { recursive: true });
     await writeFile(fakeK6, '#!/bin/sh\necho "k6 v2.0.0 (commit/test)"\n');
+    await writeFile(fakeOpenClaw, '#!/bin/sh\necho \'{"enabled":true,"maxChainLength":200,"maxDelegesPerTurn":500,"costCapTokens":500000}\' | sed s/Deleges/Delegates/\n');
     await chmod(fakeK6, 0o755);
+    await chmod(fakeOpenClaw, 0o755);
 
     const token = 'CANARY-TOKEN-VALUE-DO-NOT-PRINT';
     const run = runPreflight(['--json', '--no-gateway', '--expected-k6-version', 'v2.0.0'], {
@@ -49,6 +57,7 @@ test('seat readiness JSON contains no env secret values and reports booleans onl
       OPENCLAW_SEAT_NAME: 'unit-seat',
       OPENCLAW_SESSION_KEY: 'agent:main:discord:channel:test',
       OPENCLAW_GATEWAY_WS: 'ws://127.0.0.1:18789',
+      PATH: `${fakeOpenClawDir}:${process.env.PATH}`,
     });
 
     assert.equal(run.status, 0, run.stderr || run.stdout);
@@ -60,6 +69,9 @@ test('seat readiness JSON contains no env secret values and reports booleans onl
     assert.equal(report.k6.path, fakeK6);
     assert.equal(report.k6.version, 'v2.0.0');
     assert.equal(report.gateway.mode, 'skipped-by-flag');
+    assert.equal(report.continuation.mode, 'checked');
+    assert.equal(report.continuation.enabled, true);
+    assert.equal(report.continuation.defaultsPresent, true);
     const tokenEnv = report.env.find((entry) => entry.name === 'OPENCLAW_GATEWAY_TOKEN');
     assert.deepEqual(
       { present: tokenEnv.present, secret: tokenEnv.secret, value: tokenEnv.value },
@@ -69,9 +81,12 @@ test('seat readiness JSON contains no env secret values and reports booleans onl
   });
 });
 
-test('seat readiness schema tracks policy, checked k6 candidates, and env purposes', async () => {
+test('seat readiness schema tracks policy, continuation readiness, checked k6 candidates, and env purposes', async () => {
   const parsed = JSON.parse(await readFile(schema, 'utf8'));
   assert.ok(parsed.required.includes('policy'));
+  assert.ok(parsed.required.includes('continuation'));
+  assert.ok(parsed.properties.continuation.required.includes('enabled'));
+  assert.ok(parsed.properties.continuation.required.includes('defaultsPresent'));
   assert.ok(parsed.properties.k6.required.includes('checked'));
   assert.ok(parsed.properties.env.items.required.includes('purpose'));
 });

--- a/tools/k6-proofs/scripts/seat-readiness-preflight.mjs
+++ b/tools/k6-proofs/scripts/seat-readiness-preflight.mjs
@@ -6,7 +6,7 @@
  * so a bad seat/tooling environment becomes HONEST-LIMIT-candidate instead of
  * being confused with product behavior.
  */
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -44,6 +44,16 @@ function commandOrNull(cmd, args) {
     return execFileSync(cmd, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
   } catch {
     return null;
+  }
+}
+
+function jsonCommandOrNull(cmd, args) {
+  const run = spawnSync(cmd, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  if (run.status !== 0) return { ok: false, data: null, error: 'command-failed' };
+  try {
+    return { ok: true, data: JSON.parse(run.stdout), error: null };
+  } catch {
+    return { ok: false, data: null, error: 'json-parse-failed' };
   }
 }
 
@@ -128,11 +138,25 @@ function redactRawVersion(rawVersion) {
   return rawVersion.replace(/(token|secret|password|authorization|bearer)=[^\s]+/gi, '$1=<redacted>');
 }
 
+function readContinuationConfig() {
+  const out = jsonCommandOrNull('openclaw', ['config', 'get', 'agents.defaults.continuation', '--json']);
+  const config = out.data && typeof out.data === 'object' ? out.data : null;
+  return {
+    mode: out.ok ? 'checked' : 'unavailable',
+    enabled: typeof config?.enabled === 'boolean' ? config.enabled : null,
+    maxChainLengthPresent: config && Object.prototype.hasOwnProperty.call(config, 'maxChainLength'),
+    maxDelegatesPerTurnPresent: config && Object.prototype.hasOwnProperty.call(config, 'maxDelegatesPerTurn'),
+    costCapTokensPresent: config && Object.prototype.hasOwnProperty.call(config, 'costCapTokens'),
+    error: out.error,
+  };
+}
+
 function printText(report) {
   console.log(`seat readiness: ${report.outcome}`);
   console.log(`policy: ${report.policy.name} ${report.policy.version}`);
   console.log(`k6: ${report.k6.version || 'missing'} at ${report.k6.path || '(not found)'} (expected ${report.expectedK6Version})`);
   console.log(`gateway: ${report.gateway.mode}; health=${report.gateway.healthReachable}; status=${report.gateway.statusReachable}; url=${report.gateway.url}`);
+  console.log(`continuation: ${report.continuation.mode}; enabled=${report.continuation.enabled}; defaults=${report.continuation.defaultsPresent}`);
   console.log(`candidate sha: ${report.candidate.valid40Hex ? 'valid' : 'missing/invalid'}`);
   console.log(`seat: ${report.seat.name}; session scope: ${report.session.scope}`);
   console.log(`concurrency: ${report.concurrency.safeToRunConcurrently ? 'safe' : 'serialized'} — ${report.concurrency.reason}`);
@@ -170,6 +194,9 @@ async function main() {
     };
   }
 
+  const continuation = readContinuationConfig();
+  continuation.defaultsPresent = Boolean(continuation.maxChainLengthPresent && continuation.maxDelegatesPerTurnPresent && continuation.costCapTokensPresent);
+
   const candidateSha = process.env.OPENCLAW_CANDIDATE_SHA || null;
   const env = envReport(policy);
   const requiredMissing = env.filter((e) => e.required && !e.present).map((e) => e.name);
@@ -178,12 +205,16 @@ async function main() {
   else if (!k6.matchesExpected) notes.push(`k6 version mismatch: expected ${expectedK6Version}, got ${k6.version}.`);
   if (gateway.mode === 'checked' && (!gateway.healthReachable || !gateway.statusReachable)) notes.push('gateway health/status not reachable from this seat.');
   if (gateway.mode === 'skipped-no-token') notes.push('gateway reachability skipped because OPENCLAW_GATEWAY_TOKEN is absent; token value was not printed.');
+  if (continuation.mode !== 'checked') notes.push('continuation config could not be read with openclaw config get agents.defaults.continuation --json.');
+  else if (continuation.enabled !== true) notes.push('agents.defaults.continuation.enabled is not true; live continuation proof rows must not run.');
+  else if (!continuation.defaultsPresent) notes.push('continuation config is missing one or more required default fields.');
   if (requiredMissing.length) notes.push(`missing required env: ${requiredMissing.join(', ')}.`);
 
   const valid40Hex = typeof candidateSha === 'string' && /^[0-9a-f]{40}$/.test(candidateSha);
   if (!valid40Hex) notes.push('OPENCLAW_CANDIDATE_SHA is missing or not a 40-char lowercase hex SHA.');
 
-  const pass = k6.ok && k6.matchesExpected && valid40Hex && requiredMissing.length === 0 && (gateway.mode !== 'checked' || (gateway.healthReachable && gateway.statusReachable));
+  const continuationReady = continuation.mode === 'checked' && continuation.enabled === true && continuation.defaultsPresent;
+  const pass = k6.ok && k6.matchesExpected && continuationReady && valid40Hex && requiredMissing.length === 0 && (gateway.mode !== 'checked' || (gateway.healthReachable && gateway.statusReachable));
 
   const report = {
     schema: 'openclaw.k6.seat-readiness.v1',
@@ -197,6 +228,7 @@ async function main() {
     expectedK6Version,
     k6,
     gateway,
+    continuation,
     candidate: { sha: candidateSha, valid40Hex },
     seat: {
       name: process.env.OPENCLAW_SEAT_NAME || policy.seat?.defaultName || 'unknown-seat',

--- a/tools/k6-proofs/seat-readiness.policy.json
+++ b/tools/k6-proofs/seat-readiness.policy.json
@@ -1,7 +1,7 @@
 {
   "schema": "openclaw.k6.seat-readiness-policy.v1",
   "name": "k6 PROOFS seat readiness policy",
-  "version": "2026-06-27",
+  "version": "2026-07-07",
   "k6": {
     "expectedVersion": "v2.0.0",
     "binaryCandidates": [
@@ -59,6 +59,18 @@
       "required": false,
       "secret": false,
       "purpose": "manifest path for a specific row run"
+    },
+    {
+      "name": "OPENCLAW_GATEWAY_RESTART_CMD",
+      "required": false,
+      "secret": false,
+      "purpose": "optional self-contained restart command for config-mutating proof fixtures; default is documented as openclaw gateway restart --safe --wait 10s"
+    },
+    {
+      "name": "OPENCLAW_K6_COST_CAP_TEST_VALUE",
+      "required": false,
+      "secret": false,
+      "purpose": "optional low costCapTokens value for cost-cap boundary rows; default must be row-local and restored"
     }
   ],
   "concurrency": {

--- a/tools/k6-proofs/seat-readiness.schema.json
+++ b/tools/k6-proofs/seat-readiness.schema.json
@@ -12,6 +12,7 @@
     "expectedK6Version",
     "k6",
     "gateway",
+    "continuation",
     "candidate",
     "seat",
     "session",
@@ -257,6 +258,60 @@
         },
         "source": {
           "type": "string"
+        }
+      }
+    },
+    "continuation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "enabled",
+        "defaultsPresent",
+        "maxChainLengthPresent",
+        "maxDelegatesPerTurnPresent",
+        "costCapTokensPresent",
+        "error"
+      ],
+      "properties": {
+        "mode": {
+          "enum": [
+            "checked",
+            "unavailable"
+          ]
+        },
+        "enabled": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "defaultsPresent": {
+          "type": "boolean"
+        },
+        "maxChainLengthPresent": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "maxDelegatesPerTurnPresent": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "costCapTokensPresent": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "error": {
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     }


### PR DESCRIPTION
## Summary
- add continuation config readiness to `seat-readiness-preflight.mjs`
- require `agents.defaults.continuation.enabled=true` plus default fields before readiness can be `PASS-candidate`
- document config-mutating row containment: backup → lower → restart/reload → fire → restore → restart/reload
- document/env-surface `OPENCLAW_GATEWAY_RESTART_CMD` and `OPENCLAW_K6_COST_CAP_TEST_VALUE`
- add precursor continuation-enabled receipt requirements to R-CW-5/R-CW-6 manifests

## Why
figs flagged three requirements before widening Project 81 live proof batches:

- low cost-cap tests must explicitly lower caps and contain restore paths
- restart command must be self-contained and env-overridable for funky setups
- live continuation proofs need a precursor check that continuation is enabled

This keeps disabled/misconfigured continuation seats as `HONEST-LIMIT-candidate` setup state, not product behavior evidence.

## Verification
- `node --test tools/k6-proofs/scripts/__tests__/*.test.mjs` → 15/15 pass
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs`
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs`
- live Cael readiness smoke: `PASS-candidate`, `continuation.enabled=true`, defaults present
