### PR TITLE
k6-proofs: run seat readiness before live rows

### DIFF
--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -104,6 +104,18 @@ if [[ "$DRY_RUN" == "false" && "$OPENCLAW_CANDIDATE_SHA" != "$OPENCLAW_RUNTIME_B
   echo "Unless this is a known stale-stamp or you have proven a rebuild bridge, live proofs will be marked HONEST-LIMIT / negative-partial."
 fi
 
+mkdir -p "$OUT_ROOT"
+SEAT_READINESS_JSON="$OUT_ROOT/seat-readiness.json"
+if [[ "$DRY_RUN" == "false" ]]; then
+  echo "Running seat-readiness preflight (k6/tooling/gateway/continuation config)..."
+  if ! node scripts/seat-readiness-preflight.mjs --json > "$SEAT_READINESS_JSON"; then
+    echo "SEAT READINESS FAILED: $SEAT_READINESS_JSON" >&2
+    jq -r '.outcome as $out | "outcome=\($out) continuation=\(.continuation.enabled) defaults=\(.continuation.defaultsPresent) notes=\(.notes|join("; "))"' "$SEAT_READINESS_JSON" >&2 || true
+    exit 1
+  fi
+  echo "SEAT READINESS: $SEAT_READINESS_JSON"
+fi
+
 IFS=',' read -ra ROW_ARRAY <<< "$ROWS"
 
 for ROW_ID in "${ROW_ARRAY[@]}"; do
@@ -162,6 +174,9 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
     mkdir -p "$RUN_DIR"
     touch "$RUN_DIR/.started"
     cp "$MANIFEST_FILE" "$RUN_DIR/row-manifest.json"
+    if [[ -f "$SEAT_READINESS_JSON" ]]; then
+      cp "$SEAT_READINESS_JSON" "$RUN_DIR/seat-readiness.json"
+    fi
     jq -n \
       --arg row "$ROW_ID" \
       --arg scenario "$SCENARIO_FILE" \


### PR DESCRIPTION
## Summary

Follow-up to #300: make the row-list runner actually execute the seat-readiness precursor before live rows.

- `run-proofs.sh --live` now runs `scripts/seat-readiness-preflight.mjs --json` before any row fires.
- If readiness is not `PASS-candidate`, the runner fails closed before live k6 execution.
- The root `seat-readiness.json` receipt is copied into each row artifact directory.

This wires figs's “precursor/seat-readiness check before live continuation proof batches” requirement into the button/runner path, instead of relying on a manual preflight step.

## Verification

- `bash -n tools/k6-proofs/scripts/run-proofs.sh`
- `node --test tools/k6-proofs/scripts/__tests__/*.test.mjs` (15/15 pass)
- dry-run smoke: `K6_PROOF_OUT_DIR=/tmp/p81-readiness-gate-dryrun2 ./scripts/run-proofs.sh --dry-run --session main R-OBS-status 08e8bcd000000000000000000000000000000000`
- live read-only smoke: `R-OBS-status` wrote root and per-row `seat-readiness.json`; readiness was `PASS-candidate` with continuation enabled/defaults present.