### PR TITLE
k6-proofs: make dashboard contract temporal

### DIFF
--- a/tools/k6-proofs/DASHBOARD.md
+++ b/tools/k6-proofs/DASHBOARD.md
@@ -2,6 +2,16 @@
 
 This dashboard tracks the execution outcomes of Project 81 candidate runs, providing visibility into the public-safe k6 PROOFS metrics contract in `METRICS.md`. The committed dashboard JSON is the Prometheus/metric-contract view; static `row-result.json` artifacts remain the source format that post-processing and future exporters derive from.
 
+## Temporal contract
+
+The dashboard has three distinct views, and panel names/descriptions should keep them separate:
+
+- **Provenance view:** all samples, including red/partial history. This is audit history and should not be hidden.
+- **Current-candidate view:** group by `row_id`, `seat`, `candidate_sha`, and `run_id`, then select the newest receipt while preserving `outcome` / `failure_class`. This answers latest-candidate state, not all-time health.
+- **Fold-readiness view:** latest `PASS-candidate` plus artifact/report receipt, no required receipt missing/unknown for that `run_id`, and explicit human review signoff. If `fold_requires_review="true"`, visual green means “ready for review,” never “canonical.”
+
+Prometheus is not the merge button for canonical `PROOFS/**`; it is the review queue and provenance surface.
+
 ## 1. Panel List
 
 The dashboard consists of 10 panels designed to monitor run outcomes, performance durations, required artifacts (receipts), and human-review bottlenecks. 
@@ -32,7 +42,7 @@ The dashboard consists of 10 panels designed to monitor run outcomes, performanc
 * **Viz Type:** State Timeline (or filtered Table)
 * **Fields Read:** `candidateOnly`, `foldRequiresReview`, `generatedAt`
 * **Group By:** `rowId`, `candidateSha`
-* **Purpose:** Highlights specific rows where `candidateOnly == true` and `foldRequiresReview == true` that require human sign-off before being folded into the corpus.
+* **Purpose:** Highlights specific rows where `candidateOnly == true` and `foldRequiresReview == true` that require human sign-off before being folded into the corpus. Visual green here means ready for review, not canonical.
 
 ### Panel 5: Proof Failures by Tool Surface
 * **Title:** Proof Failure Hotspots

--- a/tools/k6-proofs/METRICS.md
+++ b/tools/k6-proofs/METRICS.md
@@ -32,6 +32,7 @@ Allowed metric labels are low-cardinality and non-secret:
 - `tool_surface` — `typed-tool`, `bracket-token`, etc.
 - `transport` — `websocket`, etc.
 - `outcome` — `PASS-candidate`, `HONEST-LIMIT-candidate`, `FAIL-candidate`
+- `run_id` — proof-run artifact id; required for latest/current views and receipt joins
 - `candidate_only` — `true` / `false`
 - `fold_requires_review` — `true` / `false`
 - `receipt_name` — manifest receipt id, for example `tool-invoke-accepted`
@@ -52,6 +53,16 @@ Do **not** put these values in metric labels, logs intended for public artifacts
 - hostnames or IPs that are not already public-safe in the artifact corpus
 
 If a field is useful for debugging but not public-safe, store it only in private scratch, not in committed `PROOFS/` artifacts or exported metrics.
+
+## Temporal query contract
+
+Dashboards must keep three temporal meanings separate:
+
+1. **Provenance view** — show every emitted sample, including red, partial, and parser-history samples. This is audit history; do not collapse it into the latest verdict.
+2. **Current-candidate view** — group by `row_id`, `seat`, `candidate_sha`, and `run_id`, then select the most recent run sample while preserving its `outcome` / `failure_class` labels. This view answers “what is the latest candidate receipt for this row/seat/SHA?”
+3. **Fold-readiness view** — require all of: latest run `outcome="PASS-candidate"`, artifact/report receipt present, no required receipt missing/unknown for that `run_id`, and explicit human review signoff.
+
+`fold_requires_review="true"` overrides any visual green. A green panel means “ready for review,” not “canonical PROOFS fold.” Prometheus is an observability surface, not an accidental merge button.
 
 ## Artifact JSON fields
 
@@ -112,6 +123,7 @@ Labels:
 - `transport`
 - `outcome`
 - `candidate_only`
+- `run_id`
 - `fold_requires_review`
 - `failure_class`
 
@@ -126,6 +138,7 @@ Labels:
 - `row_id`
 - `seat`
 - `candidate_sha`
+- `run_id`
 - `scenario`
 - `failure_class`
 
@@ -140,6 +153,7 @@ Labels:
 - `row_id`
 - `seat`
 - `candidate_sha`
+- `run_id`
 - `scenario`
 - `outcome`
 
@@ -154,6 +168,7 @@ Labels:
 - `row_id`
 - `seat`
 - `candidate_sha`
+- `run_id`
 - `scenario`
 
 Value: 0..1.
@@ -177,7 +192,7 @@ Value:
 - `1` when `receipt_status="present"`
 - `0` when `receipt_status="missing"` or `"unknown"`
 
-Keep `run_id` only on receipt metrics where per-run drilling is useful; avoid adding it to high-volume counters.
+Keep `run_id` on per-run proof metrics so current-candidate and fold-readiness views can join outcomes to receipt state without treating historical red/partial samples as the current verdict.
 
 ### `openclaw_proofs_k6_candidate_pending_review`
 
@@ -188,7 +203,9 @@ Labels:
 - `row_id`
 - `seat`
 - `candidate_sha`
+- `run_id`
 - `outcome`
+- `fold_requires_review`
 
 Value:
 
@@ -212,9 +229,10 @@ Recommended panels:
 2. **Row × seat matrix** — latest outcome per row and seat.
 3. **Proof failures** — `proof_failures` by row / seat.
 4. **Duration / timeout watch** — p95 or latest `duration_ms` by row / seat.
-5. **Receipt completeness** — required receipt present/missing matrix.
-6. **Pending human review** — count of candidate-only runs not yet folded.
-7. **Recent runs table** — run id, generated time, SHA, row, seat, outcome, failure class.
+5. **Temporal current-candidate table** — latest run per `row_id` / `seat` / `candidate_sha` / `run_id`, preserving `outcome` semantics.
+6. **Receipt completeness** — required receipt present/missing matrix.
+7. **Pending human review** — count of candidate-only runs not yet folded.
+8. **Recent runs table** — run id, generated time, SHA, row, seat, outcome, failure class.
 
 ## Deployment surface
 

--- a/tools/k6-proofs/dashboards/k6-proofs.json
+++ b/tools/k6-proofs/dashboards/k6-proofs.json
@@ -15,7 +15,7 @@
   ],
   "panels": [
     {
-      "title": "Candidate outcomes",
+      "title": "Provenance outcomes (all samples)",
       "type": "stat",
       "gridPos": {
         "h": 4,
@@ -29,7 +29,7 @@
           "legendFormat": "{{outcome}}"
         }
       ],
-      "description": "Counts candidate proof runs by normalized outcome."
+      "description": "Provenance view: counts all candidate proof samples, including red/partial history. Not a latest verdict."
     },
     {
       "title": "Pending human review",
@@ -42,11 +42,11 @@
       },
       "targets": [
         {
-          "expr": "sum(openclaw_proofs_k6_candidate_pending_review{candidate_sha=~\"$candidate_sha\", row_id=~\"$row_id\", seat=~\"$seat\"})",
+          "expr": "sum(openclaw_proofs_k6_candidate_pending_review{candidate_sha=~\"$candidate_sha\", row_id=~\"$row_id\", seat=~\"$seat\", fold_requires_review=\"true\"})",
           "legendFormat": "pending review"
         }
       ],
-      "description": "Candidate-only runs that still require fold review."
+      "description": "Fold-readiness queue: visual green means ready for human review, not canonical PROOFS fold."
     },
     {
       "title": "Proof failures",
@@ -105,7 +105,7 @@
       "description": "Outcome distribution by seat."
     },
     {
-      "title": "Row \u00d7 outcome matrix",
+      "title": "Current candidate by row / seat / run",
       "type": "table",
       "gridPos": {
         "h": 8,
@@ -115,11 +115,11 @@
       },
       "targets": [
         {
-          "expr": "sum by (row_id, outcome) (openclaw_proofs_k6_run_total{candidate_sha=~\"$candidate_sha\", seat=~\"$seat\"})",
-          "legendFormat": "{{row_id}} {{outcome}}"
+          "expr": "topk by (row_id, seat, candidate_sha) (1, max by (row_id, seat, candidate_sha, run_id, outcome, failure_class, fold_requires_review) (timestamp(openclaw_proofs_k6_run_total{candidate_sha=~\"$candidate_sha\", row_id=~\"$row_id\", seat=~\"$seat\"})))",
+          "legendFormat": "{{row_id}} {{seat}} {{run_id}} {{outcome}}"
         }
       ],
-      "description": "Rows grouped by outcome for the selected candidate SHA / seat."
+      "description": "Current-candidate view: latest run sample per row/seat/SHA, preserving outcome/failure labels."
     },
     {
       "title": "Duration by row",
@@ -192,7 +192,7 @@
           "legendFormat": "{{outcome}}"
         }
       ],
-      "description": "Recent candidate run volume by outcome."
+      "description": "Recent provenance volume by outcome. Historical red/partial samples are useful audit history, not necessarily current state."
     }
   ],
   "schemaVersion": 39,
@@ -263,7 +263,7 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "k6 PROOFS \u2014 Candidate Row Health",
+  "title": "k6 PROOFS — Candidate Row Health",
   "uid": "k6-proofs-candidate-row-health",
   "version": 2
 }

--- a/tools/k6-proofs/scripts/__tests__/dashboard-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/dashboard-contract.test.mjs
@@ -47,6 +47,20 @@ test('committed Grafana dashboard uses the Project 81 public-safe metric contrac
   }
 });
 
+test('dashboard exposes temporal current-vs-provenance-vs-review semantics', async () => {
+  const dashboard = JSON.parse(await readFile(dashboardPath, 'utf8'));
+  const expressions = collectTargets(dashboard).map((target) => target.expr || '').join('\n');
+  const descriptions = dashboard.panels.map((panel) => `${panel.title}\n${panel.description || ''}`).join('\n');
+
+  assert.match(descriptions, /Provenance outcomes \(all samples\)/);
+  assert.match(descriptions, /Current-candidate view/);
+  assert.match(descriptions, /ready for human review, not canonical PROOFS fold/);
+  assert.match(expressions, /topk by \(row_id, seat, candidate_sha\)/);
+  assert.match(expressions, /timestamp\(openclaw_proofs_k6_run_total/);
+  assert.match(expressions, /run_id/);
+  assert.match(expressions, /fold_requires_review="true"/);
+});
+
 test('dashboard variables stay on public-safe proof labels', async () => {
   const dashboard = JSON.parse(await readFile(dashboardPath, 'utf8'));
   const variableNames = new Set((dashboard.templating?.list || []).map((item) => item.name));

--- a/tools/k6-proofs/scripts/__tests__/metrics-export.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/metrics-export.test.mjs
@@ -57,8 +57,9 @@ test('exports row-result.json to the public-safe Prometheus/OTLP contract', asyn
     ]));
 
     const promText = await readFile(prom, 'utf8');
-    assert.match(promText, /openclaw_proofs_k6_run_total\{/);
+    assert.match(promText, /openclaw_proofs_k6_run_total\{[^\n]*run_id="k6-run-unit"/);
     assert.match(promText, /row_id="R-CD-2"/);
+    assert.match(promText, /openclaw_proofs_k6_candidate_pending_review\{[^\n]*run_id="k6-run-unit"[^\n]*fold_requires_review="true"[^\n]*\} 1/);
     assert.match(promText, /receipt_name="tempo-trace-json"/);
     assert.match(promText, /receipt_status="missing"\} 0/);
     assert.doesNotMatch(promText, /agent:main|Proof nonce|Authorization|TOKEN|\/tmp\//);
@@ -117,7 +118,8 @@ test('exports row-list runner directory and marks trace-missing as pending recei
     const receipt = JSON.parse(run.stdout);
     assert.equal(receipt.outcome, 'PASS-candidate');
     const promText = await readFile(prom, 'utf8');
-    assert.match(promText, /openclaw_proofs_k6_candidate_pending_review\{[^\n]*\} 1/);
+    assert.match(promText, /openclaw_proofs_k6_run_total\{[^\n]*run_id="20260707T133429Z-r-cd-2"/);
+    assert.match(promText, /openclaw_proofs_k6_candidate_pending_review\{[^\n]*run_id="20260707T133429Z-r-cd-2"[^\n]*fold_requires_review="true"[^\n]*\} 1/);
     assert.match(promText, /receipt_name="tempo-trace-json"/);
     assert.match(promText, /receipt_status="missing"\} 0/);
     assert.match(promText, /receipt_name="dispatch-accepted"[^\n]*receipt_status="present"[^\n]*\} 1/);

--- a/tools/k6-proofs/scripts/export-prometheus-metrics.mjs
+++ b/tools/k6-proofs/scripts/export-prometheus-metrics.mjs
@@ -142,8 +142,12 @@ function normalizeRun(root, resultPath) {
     candidate_sha: candidateSha,
     scenario,
   };
-  const runLabels = {
+  const runScoped = {
     ...base,
+    run_id: runId,
+  };
+  const runLabels = {
+    ...runScoped,
     tool_surface: toolSurface,
     transport,
     outcome,
@@ -154,10 +158,10 @@ function normalizeRun(root, resultPath) {
 
   const lines = [];
   lines.push(metric('openclaw_proofs_k6_run_total', runLabels, 1));
-  lines.push(metric('openclaw_proofs_k6_proof_failures_total', { ...base, failure_class: failureClass }, proofFailures));
-  lines.push(metric('openclaw_proofs_k6_duration_ms', { ...base, outcome }, durationMs));
-  lines.push(metric('openclaw_proofs_k6_checks_rate', base, checksRate));
-  lines.push(metric('openclaw_proofs_k6_candidate_pending_review', { row_id: rowId, seat, candidate_sha: candidateSha, outcome }, candidateOnly && foldRequiresReview ? 1 : 0));
+  lines.push(metric('openclaw_proofs_k6_proof_failures_total', { ...runScoped, failure_class: failureClass }, proofFailures));
+  lines.push(metric('openclaw_proofs_k6_duration_ms', { ...runScoped, outcome }, durationMs));
+  lines.push(metric('openclaw_proofs_k6_checks_rate', runScoped, checksRate));
+  lines.push(metric('openclaw_proofs_k6_candidate_pending_review', { row_id: rowId, seat, candidate_sha: candidateSha, run_id: runId, outcome, fold_requires_review: boolLabel(foldRequiresReview) }, candidateOnly && foldRequiresReview ? 1 : 0));
 
   const receipts = Array.isArray(result.receipts) ? [...result.receipts] : [];
   const pending = result.review?.pendingReceipts || summary.review?.pendingReceipts || [];

--- a/tools/k6-proofs/scripts/export-row-metrics.mjs
+++ b/tools/k6-proofs/scripts/export-row-metrics.mjs
@@ -215,8 +215,12 @@ function buildMetricSamples(result) {
     candidate_sha: safeLabelValue(result.candidateSha),
     scenario: safeLabelValue(result.scenario),
   };
-  const full = {
+  const runScoped = {
     ...base,
+    run_id: safeLabelValue(result.runId),
+  };
+  const full = {
+    ...runScoped,
     tool_surface: safeLabelValue(result.toolSurface),
     transport: safeLabelValue(result.transport),
     outcome: safeLabelValue(result.outcome),
@@ -230,15 +234,15 @@ function buildMetricSamples(result) {
 
   const samples = [
     { name: `${METRIC_PREFIX}_run_total`, type: 'sum', labels: full, value: 1, int: true },
-    { name: `${METRIC_PREFIX}_proof_failures_total`, type: 'sum', labels: { ...base, scenario: full.scenario, failure_class: full.failure_class }, value: Number(result.metrics?.proofFailures ?? 0), int: true },
-    { name: `${METRIC_PREFIX}_candidate_pending_review`, type: 'gauge', labels: { row_id: base.row_id, seat: base.seat, candidate_sha: base.candidate_sha, outcome: full.outcome }, value: pendingReview ? 1 : 0, int: true },
+    { name: `${METRIC_PREFIX}_proof_failures_total`, type: 'sum', labels: { ...runScoped, scenario: full.scenario, failure_class: full.failure_class }, value: Number(result.metrics?.proofFailures ?? 0), int: true },
+    { name: `${METRIC_PREFIX}_candidate_pending_review`, type: 'gauge', labels: { row_id: base.row_id, seat: base.seat, candidate_sha: base.candidate_sha, run_id: runScoped.run_id, outcome: full.outcome, fold_requires_review: full.fold_requires_review }, value: pendingReview ? 1 : 0, int: true },
   ];
 
   if (result.metrics?.durationMs !== null && result.metrics?.durationMs !== undefined) {
-    samples.push({ name: `${METRIC_PREFIX}_duration_ms`, type: 'gauge', labels: { ...base, outcome: full.outcome }, value: Number(result.metrics.durationMs), int: false });
+    samples.push({ name: `${METRIC_PREFIX}_duration_ms`, type: 'gauge', labels: { ...runScoped, outcome: full.outcome }, value: Number(result.metrics.durationMs), int: false });
   }
   if (result.metrics?.checksRate !== null && result.metrics?.checksRate !== undefined) {
-    samples.push({ name: `${METRIC_PREFIX}_checks_rate`, type: 'gauge', labels: base, value: Number(result.metrics.checksRate), int: false });
+    samples.push({ name: `${METRIC_PREFIX}_checks_rate`, type: 'gauge', labels: runScoped, value: Number(result.metrics.checksRate), int: false });
   }
 
   for (const receipt of result.receipts || []) {


### PR DESCRIPTION
## Summary

Codifies Cael's dashboard/query invariant as an explicit temporal contract:

- provenance view: all samples remain visible, including red/partial history;
- current-candidate view: uses `run_id` and latest-sample semantics while preserving `outcome` / `failure_class`;
- fold-readiness view: visual green remains review-only; `fold_requires_review="true"` is not canonical.

Metric exporter changes:

- add `run_id` to per-run metrics (`run_total`, `proof_failures_total`, `duration_ms`, `checks_rate`);
- add `run_id` + `fold_requires_review` to `candidate_pending_review` so dashboard views can join candidate state to receipt state without collapsing historical samples.

Dashboard/docs changes:

- rename the all-samples panel to a provenance view;
- add a current-candidate table query using `timestamp(openclaw_proofs_k6_run_total)` + `topk by (row_id, seat, candidate_sha)`;
- make pending-review wording explicit that green means ready-for-review, not canonical fold.

## Verification

- `node --check tools/k6-proofs/scripts/export-prometheus-metrics.mjs`
- `node --check tools/k6-proofs/scripts/export-row-metrics.mjs`
- `node --test tools/k6-proofs/scripts/__tests__/*.test.mjs` (16/16 pass)
