### PR TITLE
k6-proofs: fail closed R-CW-5/R-CW-6 config rows

### DIFF
--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -223,11 +223,13 @@ canonical `PROOFS/**` folds.
 Rows that lower continuation limits or restart the gateway must stay `orchestration-required` until their fixture emits the full receipt chain:
 
 1. capture the original config value;
-2. apply the row-local low test value;
+2. apply only the row-local low test value named by the manifest;
 3. reload/restart through the configured command;
 4. fire the proof;
-5. restore the original value;
+5. restore the original value even when the proof fails or aborts;
 6. reload/restart again and record the restore receipt.
+
+`run-proof.sh` fails closed for `orchestration-required` and `construct-only` manifests when `OPENCLAW_ROW_MANIFEST` is set. A config-mutating row must not become directly k6-runnable until a promotion PR changes the manifest to `scenario.status="runnable"` and `liveRunSafety.classification="k6-runnable"` with the receipt chain above implemented and tested.
 
 The default restart command for fixtures is:
 
@@ -235,9 +237,9 @@ The default restart command for fixtures is:
 openclaw gateway restart --safe --wait 10s
 ```
 
-Override it with `OPENCLAW_GATEWAY_RESTART_CMD` for nonstandard deployments. The command must be self-contained for the target seat; do not bake frond-specific SSH, service, or workflow names into public row logic.
+Override it with `OPENCLAW_GATEWAY_RESTART_CMD` for nonstandard deployments. The command must be self-contained for the target seat; do not bake frond-specific SSH, service, or workflow names into public row logic. If a fixture cannot safely restart/reload through that configured command, it must emit a blocked candidate artifact instead of mutating config.
 
-Cost-cap boundary rows should take their low test value from `OPENCLAW_K6_COST_CAP_TEST_VALUE` when set, with a documented default in the row fixture. They must restore the original cap before emitting a fold-reviewable candidate artifact.
+Cost-cap boundary rows should take their low test value from `OPENCLAW_K6_COST_CAP_TEST_VALUE` when set, with a documented row-local default. They must restore the original cap before emitting a fold-reviewable candidate artifact.
 
 ## Design principles
 

--- a/tools/k6-proofs/manifests/r-cw-5.json
+++ b/tools/k6-proofs/manifests/r-cw-5.json
@@ -23,7 +23,7 @@
     ],
     "status": "scaffold",
     "expectedFile": "r-cw-5-cost-cap-reject.js",
-    "registryNotes": "No runnable row scenario file exists yet; config mutation/restoration semantics need a dedicated scenario before this becomes runnable."
+    "registryNotes": "A scaffold scenario file exists and intentionally throws. Keep non-runnable until a promotion PR implements config backup/lower/restore receipts and updates liveRunSafety.classification to k6-runnable."
   },
   "invocation": {
     "tool": "continue_work",
@@ -43,6 +43,16 @@
       "name": "seat-readiness-continuation-enabled",
       "required": true,
       "description": "Precursor seat-readiness report proves agents.defaults.continuation.enabled=true before config-mutating continuation proof"
+    },
+    {
+      "name": "original-config-captured",
+      "required": true,
+      "description": "Original agents.defaults.continuation.costCapTokens value captured verbatim before mutation and used as the restore source"
+    },
+    {
+      "name": "failure-safe-restore-armed",
+      "required": true,
+      "description": "Fixture records a finally/trap-style restore guard before mutation so the original costCapTokens value is restored even if the proof fails or aborts"
     },
     {
       "name": "config-lowered",
@@ -83,11 +93,13 @@
     "expectedArtifactClass": "PARTIAL-candidate",
     "requiredReceipts": [
       "seat-readiness-continuation-enabled",
+      "original-config-captured",
+      "failure-safe-restore-armed",
       "config-lowered",
       "tool-invoke-rejected",
       "config-restored"
     ],
     "foldRequiresReview": true,
-    "notes": "Config-mutating cost-cap boundary row. Do not expose as unattended k6-runnable on a live prince. Requires explicit mutation fixture or isolated gateway plus backup/restore. Restart/reload command must come from OPENCLAW_GATEWAY_RESTART_CMD when set; default fixture command is `openclaw gateway restart --safe --wait 10s`. Requires a precursor seat-readiness receipt proving continuation.enabled=true."
+    "notes": "Config-mutating cost-cap boundary row. Do not expose as unattended k6-runnable on a live prince. Current scaffold is blocked by live-run-guard because classification=orchestration-required. Requires explicit mutation fixture or isolated gateway plus backup/restore, restore-on-failure, and only the row-local costCapTokens override from OPENCLAW_K6_COST_CAP_TEST_VALUE (default 1). Restart/reload command must come from OPENCLAW_GATEWAY_RESTART_CMD when set; default fixture command is `openclaw gateway restart --safe --wait 10s`. Requires a precursor seat-readiness receipt proving continuation.enabled=true/defaults present."
   }
 }

--- a/tools/k6-proofs/manifests/r-cw-6.json
+++ b/tools/k6-proofs/manifests/r-cw-6.json
@@ -24,7 +24,7 @@
     ],
     "status": "scaffold",
     "expectedFile": "r-cw-6-max-chain-length.js",
-    "registryNotes": "No runnable row scenario file exists yet; restart/restoration semantics need a dedicated scenario before this becomes runnable."
+    "registryNotes": "A scaffold scenario file exists and intentionally throws. Keep non-runnable until a promotion PR implements config backup/lower/restart/proof/restore/restart receipts and updates liveRunSafety.classification to k6-runnable."
   },
   "invocation": {
     "tool": "continue_work",
@@ -43,6 +43,16 @@
       "name": "seat-readiness-continuation-enabled",
       "required": true,
       "description": "Precursor seat-readiness report proves agents.defaults.continuation.enabled=true before config-mutating continuation proof"
+    },
+    {
+      "name": "original-config-captured",
+      "required": true,
+      "description": "Original agents.defaults.continuation.maxChainLength value captured verbatim before mutation and used as the restore source"
+    },
+    {
+      "name": "failure-safe-restore-armed",
+      "required": true,
+      "description": "Fixture records a finally/trap-style restore guard before mutation so the original maxChainLength value is restored and the gateway is restarted even if the proof fails or aborts"
     },
     {
       "name": "config-set-to-1",
@@ -88,12 +98,14 @@
     "expectedArtifactClass": "PARTIAL-candidate",
     "requiredReceipts": [
       "seat-readiness-continuation-enabled",
+      "original-config-captured",
+      "failure-safe-restore-armed",
       "config-set-to-1",
       "hop-1-accepted",
       "hop-2-rejected",
       "config-restored"
     ],
     "foldRequiresReview": true,
-    "notes": "Config + restart mutating maxChainLength boundary row. Only run against an isolated/fixture gateway or explicit human-approved live maintenance window. Restart/reload command must come from OPENCLAW_GATEWAY_RESTART_CMD when set; default fixture command is `openclaw gateway restart --safe --wait 10s`. Requires a precursor seat-readiness receipt proving continuation.enabled=true."
+    "notes": "Config + restart mutating maxChainLength boundary row. Current scaffold is blocked by live-run-guard because classification=orchestration-required. Only run against an isolated/fixture gateway or explicit human-approved live maintenance window. Fixture must capture original maxChainLength, set only the row-local maxChainLength=1 override, restore on failure, and record both restart receipts. Restart/reload command must come from OPENCLAW_GATEWAY_RESTART_CMD when set; default fixture command is `openclaw gateway restart --safe --wait 10s`. Requires a precursor seat-readiness receipt proving continuation.enabled=true/defaults present."
   }
 }

--- a/tools/k6-proofs/row-manifest.schema.json
+++ b/tools/k6-proofs/row-manifest.schema.json
@@ -79,7 +79,7 @@
       "properties": {
         "classification": {
           "enum": ["static-preflight-only", "k6-runnable", "orchestration-required", "construct-only"],
-          "description": "Static/preflight-only rows never fire the live gateway; k6-runnable rows may be started by run-proof.sh; orchestration-required rows need an external agent/tool/human step; construct-only rows document planned/non-runnable proof contracts."
+          "description": "Static/preflight-only rows never fire the live gateway; k6-runnable rows may be started by run-proof.sh; orchestration-required rows need an external agent/tool/human step and are rejected by the live-run guard; construct-only rows document planned/non-runnable proof contracts and are also rejected by the live-run guard."
         },
         "requiresLiveGatewayToken": { "type": "boolean" },
         "requiresTargetSessionKey": { "type": "boolean" },

--- a/tools/k6-proofs/scripts/__tests__/live-run-guard.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/live-run-guard.test.mjs
@@ -1,0 +1,87 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const repoRoot = new URL('../../../..', import.meta.url).pathname;
+const script = join(repoRoot, 'tools/k6-proofs/scripts/live-run-guard.mjs');
+const validEnv = {
+  ...process.env,
+  OPENCLAW_GATEWAY_TOKEN: 'unit-token-not-printed',
+  OPENCLAW_CANDIDATE_SHA: '2723dbee783c113cae70e4fb63a4cff9f55402e3',
+  OPENCLAW_SESSION_KEY: 'agent:main:discord:channel:test',
+};
+
+function runGuard(manifest, extraEnv = {}) {
+  return spawnSync(process.execPath, [script, '--manifest', manifest, '--json'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: { ...validEnv, ...extraEnv },
+  });
+}
+
+test('live-run guard fails closed for orchestration-required config-mutating rows', async () => {
+  for (const manifestName of ['r-cw-5.json', 'r-cw-6.json']) {
+    const manifest = join(repoRoot, 'tools/k6-proofs/manifests', manifestName);
+    const run = runGuard(manifest);
+    assert.equal(run.status, 1, `${manifestName} unexpectedly passed: ${run.stdout}`);
+    const parsed = JSON.parse(run.stdout);
+    assert.equal(parsed.ok, false);
+    assert.ok(
+      parsed.errors.some((error) => error.includes('orchestration-required is not directly runnable')),
+      `${manifestName} errors did not include orchestration-required fail-closed guard: ${run.stdout}`,
+    );
+    assert.doesNotMatch(run.stdout, /unit-token-not-printed/);
+  }
+});
+
+test('live-run guard still permits ordinary k6-runnable manifests with required env present', async () => {
+  const manifest = join(repoRoot, 'tools/k6-proofs/manifests/r-config-defaults.json');
+  const run = runGuard(manifest);
+  assert.equal(run.status, 0, run.stderr || run.stdout);
+  const parsed = JSON.parse(run.stdout);
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.rowId, 'R-CONFIG-defaults');
+  assert.equal(parsed.classification, 'k6-runnable');
+});
+
+test('live-run guard still permits static preflight manifests without live candidate env', async () => {
+  const manifest = join(repoRoot, 'tools/k6-proofs/manifests/preflight.example.json');
+  const run = runGuard(manifest, {
+    OPENCLAW_GATEWAY_TOKEN: '',
+    OPENCLAW_CANDIDATE_SHA: '',
+    OPENCLAW_SESSION_KEY: '',
+  });
+  assert.equal(run.status, 0, run.stderr || run.stdout);
+  const parsed = JSON.parse(run.stdout);
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.rowId, 'preflight');
+  assert.equal(parsed.classification, 'static-preflight-only');
+});
+
+test('config-mutating row manifests keep restore/review receipts declared', async () => {
+  for (const manifestName of ['r-cw-5.json', 'r-cw-6.json']) {
+    const manifestPath = join(repoRoot, 'tools/k6-proofs/manifests', manifestName);
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+    assert.equal(manifest.mutates, true);
+    assert.equal(manifest.scenario.status, 'scaffold');
+    assert.equal(manifest.liveRunSafety.classification, 'orchestration-required');
+    assert.equal(manifest.liveRunSafety.foldRequiresReview, true);
+    for (const receiptName of [
+      'seat-readiness-continuation-enabled',
+      'original-config-captured',
+      'failure-safe-restore-armed',
+      'config-restored',
+    ]) {
+      assert.ok(
+        manifest.expectedReceipts.some((receipt) => receipt.name === receiptName && receipt.required === true),
+        `${manifestName} missing expected receipt ${receiptName}`,
+      );
+      assert.ok(
+        manifest.liveRunSafety.requiredReceipts.includes(receiptName),
+        `${manifestName} liveRunSafety.requiredReceipts missing ${receiptName}`,
+      );
+    }
+  }
+});

--- a/tools/k6-proofs/scripts/live-run-guard.mjs
+++ b/tools/k6-proofs/scripts/live-run-guard.mjs
@@ -4,7 +4,8 @@
  *
  * This script is intentionally dependency-free so run-proof.sh and CI can call it
  * before k6 starts. It validates only the safety contract that affects live runs:
- * required env presence and same-session concurrency lock metadata.
+ * required env presence, direct-runnability classification, and same-session
+ * concurrency lock metadata.
  */
 import { readFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
@@ -79,8 +80,16 @@ function safetyErrors(manifest, env = process.env) {
     errors.push('liveRunSafety.classification=k6-runnable requires scenario.status=runnable');
   }
 
+  if (safety.classification === 'orchestration-required') {
+    errors.push('liveRunSafety.classification=orchestration-required is not directly runnable by run-proof.sh; use an explicit orchestration fixture/maintenance window');
+  }
+
   if (safety.classification === 'construct-only' && manifest.scenario?.status === 'runnable') {
     errors.push('liveRunSafety.classification=construct-only cannot be paired with scenario.status=runnable');
+  }
+
+  if (safety.classification === 'construct-only') {
+    errors.push('liveRunSafety.classification=construct-only is not directly runnable by run-proof.sh');
   }
 
   if (safety.requiresExternalAgentOrToolInvocation && manifest.toolSurface === 'read-only') {


### PR DESCRIPTION
## Summary

R-CW-5/R-CW-6 are still scaffold/config-mutating rows, so this hardens the lane before any live fire:

- fail closed in `live-run-guard.mjs` for `orchestration-required` and `construct-only` manifests when called through `run-proof.sh`
- document the config-mutating receipt chain: capture original config, lower only row-local value, restart/reload through configured command, restore even on failure, restart/reload again
- add explicit required receipts for `original-config-captured` and `failure-safe-restore-armed` in both R-CW-5/R-CW-6 manifests
- clarify R-CW-5/R-CW-6 manifest notes: scaffold scenario files exist and intentionally throw; promotion requires a fixture PR plus `k6-runnable` classification
- add tests proving the fail-closed guard catches R-CW-5/R-CW-6 while ordinary `k6-runnable` and static preflight manifests still pass

## Current disposition

Blocked from live-fire by design: R-CW-5/R-CW-6 remain `scenario.status="scaffold"` + `liveRunSafety.classification="orchestration-required"`. This PR makes a direct `run-proof.sh` invocation with those manifests fail closed even if token/SHA env is present.

## Verification

- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs`
- `node --test tools/k6-proofs/scripts/__tests__/*.test.mjs` → 20/20 pass
- explicit guard checks for R-CW-5/R-CW-6 with token + candidate env return only the orchestration-required blocked error

No live gateway/config mutation was run.