### PR TITLE
k6-proofs: widen R-CW-4 observation window

### DIFF
--- a/tools/k6-proofs/scenarios/r-cw-4-chain-depth.js
+++ b/tools/k6-proofs/scenarios/r-cw-4-chain-depth.js
@@ -6,8 +6,8 @@ import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
 
 export const options = {
-  scenarios: { r_cw_4_chain_depth: { executor: 'shared-iterations', vus: 1, iterations: 1, maxDuration: '210s' } },
-  thresholds: { proof_failures: ['count==0'], r_cw_4_duration: ['p(95)<180000'] },
+  scenarios: { r_cw_4_chain_depth: { executor: 'shared-iterations', vus: 1, iterations: 1, maxDuration: '10m' } },
+  thresholds: { proof_failures: ['count==0'], r_cw_4_duration: ['p(95)<600000'] },
 };
 const failures = new Counter('proof_failures');
 const duration = new Trend('r_cw_4_duration');
@@ -38,7 +38,7 @@ export default function () {
         const instruction = `${HARNESS_MARKER} R-CW-4 proof nonce ${rowNonce}. This is a sequential continue_work proof. On this initial turn: call continue_work with delaySeconds=${inv.delaySeconds} and reason="R-CW-4 hop1 ${rowNonce}; on wake call hop2". After tool result scheduled, reply exactly CW4-HOP1-SCHEDULED ${rowNonce}. On the first continuation wake: call continue_work with delaySeconds=${inv.delaySeconds} and reason="R-CW-4 hop2 ${rowNonce}; on wake call hop3"; after scheduled, reply exactly CW4-HOP2-SCHEDULED ${rowNonce}. On the second continuation wake: call continue_work with delaySeconds=${inv.delaySeconds} and reason="R-CW-4 hop3 ${rowNonce}; on wake finish"; after scheduled, reply exactly CW4-HOP3-SCHEDULED ${rowNonce}. On the third continuation wake: reply exactly CW4-DONE ${rowNonce}. No file mutations, no external posts.`;
         tracker.send(socket, 'sessions.send', { key: sessionKey, message: instruction, idempotencyKey: `${inv.idempotencyKeyPrefix}-DISPATCH-${rowNonce}` });
       }, 500);
-      socket.setTimeout(() => socket.close(), Math.max(150000, (inv.delaySeconds * 4 + 80) * 1000));
+      socket.setTimeout(() => socket.close(), Math.max(600000, (inv.delaySeconds * 4 + 360) * 1000));
     }
     socket.on('open', () => { socket.send(connectFrame(token)); if (createDisposableSession) { socket.setTimeout(() => { const disposableKey = `r-cw-4-${rowNonce}`.toLowerCase().replace(/[^a-z0-9-]/g, '-'); tracker.send(socket, 'sessions.create', { key: disposableKey, label: `k6 R-CW-4 ${rowNonce}` }); }, 250); } else socket.setTimeout(() => startProofFlow(socket), 500); });
     socket.on('message', (raw) => {

--- a/tools/k6-proofs/scripts/__tests__/r-cw-4-observation-window.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cw-4-observation-window.test.mjs
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const repoRoot = new URL('../../../..', import.meta.url).pathname;
+const scenarioPath = join(repoRoot, 'tools/k6-proofs/scenarios/r-cw-4-chain-depth.js');
+
+test('R-CW-4 observation window tolerates delayed continuation delivery', async () => {
+  const source = await readFile(scenarioPath, 'utf8');
+  assert.match(source, /maxDuration:\s*'10m'/, 'scenario maxDuration should cover multi-minute idle-retry delays');
+  assert.match(source, /r_cw_4_duration:\s*\['p\(95\)<600000'\]/, 'duration threshold should match the 10m observation window');
+  assert.match(
+    source,
+    /socket\.setTimeout\(\(\) => socket\.close\(\), Math\.max\(600000, \(inv\.delaySeconds \* 4 \+ 360\) \* 1000\)\)/,
+    'websocket observer should remain open long enough to catch delayed hop receipts',
+  );
+});


### PR DESCRIPTION
## Summary

R-CW-4 proved the runtime eventually delivered all continuation hops, but the k6 observer closed too early during `command-queue-busy` idle-retry latency. This widens the R-CW-4 observation window so a durable but delayed continuation chain can be observed instead of being marked PARTIAL solely because the harness disconnected.

- raises R-CW-4 k6 `maxDuration` to 10m
- raises the duration threshold to match the longer window
- keeps the websocket observer open for at least 10m
- adds a unit test pinning the delayed-delivery observation window

## Verification

- `node --test tools/k6-proofs/scripts/__tests__/r-cw-4-observation-window.test.mjs`
- `node --test tools/k6-proofs/scripts/__tests__/*.test.mjs`
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs`

## Evidence

R-CW-4 run `28882170587` marked PARTIAL after observing hop1 only, but the disposable session later contained all required sentinels (`CW4-HOP1-SCHEDULED`, `CW4-HOP2-SCHEDULED`, `CW4-HOP3-SCHEDULED`, `CW4-DONE`). The delay was delivery latency under `command-queue-busy`, not a lost continuation or cost-cap failure.