### PR TITLE
k6-proofs: prefer supplied session for R-CW-4

### DIFF
--- a/tools/k6-proofs/manifests/r-cw-4.json
+++ b/tools/k6-proofs/manifests/r-cw-4.json
@@ -22,7 +22,7 @@
     ],
     "status": "runnable",
     "expectedFile": "r-cw-4-chain-depth.js",
-    "registryNotes": "Local scratch conversion: runnable k6 scenario drives a disposable session through three sequential continue_work hops and final CW4-DONE sentinel.",
+    "registryNotes": "Runnable k6 scenario drives a supplied runner-provisioned session, or a disposable fallback session, through three sequential continue_work hops and final CW4-DONE sentinel.",
     "file": "r-cw-4-chain-depth.js"
   },
   "invocation": {

--- a/tools/k6-proofs/scenarios/r-cw-4-chain-depth.js
+++ b/tools/k6-proofs/scenarios/r-cw-4-chain-depth.js
@@ -15,6 +15,7 @@ const manifest = loadManifestFromEnv();
 const DEFAULTS = { sessionKey: 'main', seat: 'cael-dgx', delaySeconds: 5, idempotencyKeyPrefix: 'R-CW-4' };
 const HARNESS_MARKER = '[k6-proof-harness]';
 function boolEnv(name) { return (__ENV[name] || '').toLowerCase() === 'true'; }
+function isRunnerProvisionedSession(key) { return String(key || '').includes(':subagent:continuation-'); }
 function invocationCfg() { const inv = manifest?.invocation || {}; return { delaySeconds: Number(inv.delaySeconds ?? __ENV.OPENCLAW_DELAY_SECONDS ?? DEFAULTS.delaySeconds), idempotencyKeyPrefix: inv.idempotencyKeyPrefix || DEFAULTS.idempotencyKeyPrefix }; }
 
 export default function () {
@@ -22,7 +23,7 @@ export default function () {
   const token = __ENV.OPENCLAW_GATEWAY_TOKEN;
   const requestedSessionKey = manifest?.sessionKey || __ENV.OPENCLAW_SESSION_KEY || DEFAULTS.sessionKey;
   let sessionKey = requestedSessionKey;
-  const createDisposableSession = boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSION') || boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSIONS');
+  const createDisposableSession = (boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSION') || boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSIONS')) && !isRunnerProvisionedSession(requestedSessionKey);
   const seat = manifest?.seat || __ENV.OPENCLAW_SEAT_NAME || DEFAULTS.seat;
   const rowNonce = nonce('R-CW-4');
   if (!token) { console.error('OPENCLAW_GATEWAY_TOKEN is required'); failures.add(1); return; }

--- a/tools/k6-proofs/scripts/__tests__/r-cw-4-session-selection.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cw-4-session-selection.test.mjs
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const repoRoot = new URL('../../../..', import.meta.url).pathname;
+const scenarioPath = join(repoRoot, 'tools/k6-proofs/scenarios/r-cw-4-chain-depth.js');
+const manifestPath = join(repoRoot, 'tools/k6-proofs/manifests/r-cw-4.json');
+
+test('R-CW-4 uses runner-provisioned subagent sessions instead of custom main-lane sessions', async () => {
+  const source = await readFile(scenarioPath, 'utf8');
+  assert.match(source, /function isRunnerProvisionedSession\(key\)/);
+  assert.match(source, /includes\(':subagent:continuation-'\)/);
+  assert.match(
+    source,
+    /&& !isRunnerProvisionedSession\(requestedSessionKey\)/,
+    'global disposable-session env must not override the runner-provisioned continuation subagent session',
+  );
+});
+
+test('R-CW-4 manifest documents supplied-session preference', async () => {
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+  assert.match(manifest.scenario.registryNotes, /supplied runner-provisioned session/);
+});


### PR DESCRIPTION
## Summary

R-CW-4 should use the proof runner provisioned session when one is supplied instead of creating its own custom disposable session. The custom key is not parsed as a subagent session key, so continuation wakes can fall back to the shared main command lane and park behind `command-queue-busy` after hop 1.

- keep disposable-session fallback for local/manual runs
- bypass custom `sessions.create` when `OPENCLAW_SESSION_KEY` is the runner-provisioned continuation subagent session
- document the supplied-session preference in the manifest
- add a unit test pinning the session-selection behavior

## Verification

- `node --test tools/k6-proofs/scripts/__tests__/r-cw-4-session-selection.test.mjs`
- `node --test tools/k6-proofs/scripts/__tests__/*.test.mjs`
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs`

## Evidence

After #304 widened the R-CW-4 observation window, run `28883055128` still observed only hop1 in the custom `agent:main:r-cw-4-...` session. The durable flow row for hop1 stayed queued after `work-drive-skipped reason=command-queue-busy`, which points at the custom key taking the main command lane rather than the runner-provisioned subagent lane.