### PR TITLE
k6-proofs: create R-CW-4 disposable subagent sessions

### DIFF
--- a/tools/k6-proofs/manifests/r-cw-4.json
+++ b/tools/k6-proofs/manifests/r-cw-4.json
@@ -69,7 +69,7 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Chain depth counter. PASS when 3 sequential hops show incrementing chain.step. Requires a session that can accept 3 sequential continue_work invocations."
+    "notes": "Chain depth counter. PASS when 3 sequential hops show incrementing chain.step. Use OPENCLAW_CREATE_DISPOSABLE_SESSION=true for an automatic proof subagent session, or supply an explicit reviewed session key."
   },
   "liveRunSafety": {
     "classification": "k6-runnable",
@@ -87,6 +87,6 @@
       "final-done"
     ],
     "foldRequiresReview": true,
-    "notes": "Sequential continue_work chain row. Prefer disposable session and serialize; do not run alongside other same-session continuation rows."
+    "notes": "Sequential continue_work chain row. Prefer OPENCLAW_CREATE_DISPOSABLE_SESSION=true; when enabled the scenario creates an agent:main:subagent:continuation-r-cw-4-* proof session so broad runs do not depend on a hand-supplied session_selector. Serialize per target session; do not run alongside other same-session continuation rows."
   }
 }

--- a/tools/k6-proofs/scenarios/r-cw-4-chain-depth.js
+++ b/tools/k6-proofs/scenarios/r-cw-4-chain-depth.js
@@ -16,6 +16,7 @@ const DEFAULTS = { sessionKey: 'main', seat: 'cael-dgx', delaySeconds: 5, idempo
 const HARNESS_MARKER = '[k6-proof-harness]';
 function boolEnv(name) { return (__ENV[name] || '').toLowerCase() === 'true'; }
 function isRunnerProvisionedSession(key) { return String(key || '').includes(':subagent:continuation-'); }
+function disposableSubagentKey(rowNonce) { return `agent:main:subagent:continuation-r-cw-4-${rowNonce}`.toLowerCase().replace(/[^a-z0-9:._-]/g, '-'); }
 function invocationCfg() { const inv = manifest?.invocation || {}; return { delaySeconds: Number(inv.delaySeconds ?? __ENV.OPENCLAW_DELAY_SECONDS ?? DEFAULTS.delaySeconds), idempotencyKeyPrefix: inv.idempotencyKeyPrefix || DEFAULTS.idempotencyKeyPrefix }; }
 
 export default function () {
@@ -41,7 +42,7 @@ export default function () {
       }, 500);
       socket.setTimeout(() => socket.close(), Math.max(600000, (inv.delaySeconds * 4 + 360) * 1000));
     }
-    socket.on('open', () => { socket.send(connectFrame(token)); if (createDisposableSession) { socket.setTimeout(() => { const disposableKey = `r-cw-4-${rowNonce}`.toLowerCase().replace(/[^a-z0-9-]/g, '-'); tracker.send(socket, 'sessions.create', { key: disposableKey, label: `k6 R-CW-4 ${rowNonce}` }); }, 250); } else socket.setTimeout(() => startProofFlow(socket), 500); });
+    socket.on('open', () => { socket.send(connectFrame(token)); if (createDisposableSession) { socket.setTimeout(() => { const disposableKey = disposableSubagentKey(rowNonce); tracker.send(socket, 'sessions.create', { key: disposableKey, label: `k6 R-CW-4 ${rowNonce}` }); }, 250); } else socket.setTimeout(() => startProofFlow(socket), 500); });
     socket.on('message', (raw) => {
       try {
         const msg = JSON.parse(raw); const classified = tracker.classify(msg);

--- a/tools/k6-proofs/scripts/__tests__/r-cw-4-session-selection.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cw-4-session-selection.test.mjs
@@ -11,6 +11,8 @@ test('R-CW-4 uses runner-provisioned subagent sessions instead of custom main-la
   const source = await readFile(scenarioPath, 'utf8');
   assert.match(source, /function isRunnerProvisionedSession\(key\)/);
   assert.match(source, /includes\(':subagent:continuation-'\)/);
+  assert.match(source, /function disposableSubagentKey\(rowNonce\)/);
+  assert.match(source, /agent:main:subagent:continuation-r-cw-4-/);
   assert.match(
     source,
     /&& !isRunnerProvisionedSession\(requestedSessionKey\)/,
@@ -18,7 +20,8 @@ test('R-CW-4 uses runner-provisioned subagent sessions instead of custom main-la
   );
 });
 
-test('R-CW-4 manifest documents supplied-session preference', async () => {
+test('R-CW-4 manifest documents supplied-session and disposable-subagent preference', async () => {
   const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
   assert.match(manifest.scenario.registryNotes, /supplied runner-provisioned session/);
+  assert.match(manifest.liveRunSafety.notes, /agent:main:subagent:continuation-r-cw-4-/);
 });


### PR DESCRIPTION
## Summary
- make R-CW-4's disposable-session mode create an explicit `agent:main:subagent:continuation-r-cw-4-*` proof session
- keep supplied runner-provisioned continuation subagent sessions authoritative when provided
- document the automatic proof-subagent path in the row manifest and extend the source guard test

## Validation
- `git diff --check`
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs`
- `node --test tools/k6-proofs/scripts/__tests__/r-cw-4-session-selection.test.mjs tools/k6-proofs/scripts/__tests__/r-cw-4-observation-window.test.mjs`
