### PR TITLE
runbooks: refresh Project 81 runnable row map

### DIFF
--- a/RUNBOOKS/project-81/README.md
+++ b/RUNBOOKS/project-81/README.md
@@ -19,21 +19,35 @@ cd tools/k6-proofs
 ./scripts/run-proofs.sh --dry-run all <candidate-sha>
 ```
 
-As of docs `main@f99f2ea`, `all` expands to:
+As of the post-#306/#307 Project 81 surface, the broad live slice is:
 
 ```text
-preflight,R-CD-2,R-CD-4,R-CD-CHAINED-DEPTH-2,R-OBS-status
+R-CD-1,R-CD-2,R-CD-4,R-CD-CHAINED-DEPTH-2,R-CD-MODEL-CHAINED-ALT,R-CD-MODEL-DEFAULT,R-CD-MODEL-TOKEN,R-CD-MODEL-TOOL,R-CD-TOKEN,R-CONFIG-defaults,R-CW-1,R-CW-4,R-CW-DELEGATE-SELF-CONTINUATION,R-CW-TOKEN,R-OBS-status,R-RC-1
 ```
+
+`preflight` remains `static-preflight-only`: the runner performs seat-readiness preflight for live runs, but the preflight manifest row is intentionally skipped by live-run guard.
 
 Use this directory as the accumulator. When a scaffold row becomes runnable, add or update `RUNBOOKS/project-81/rows/<ROW>.md` in the same PR as the scenario/manifest change.
 
 ## Current runnable row runbooks
 
-- [preflight](rows/preflight.md)
+- [preflight](rows/preflight.md) — static preflight / seat-readiness helper
+- [R-CD-1](rows/R-CD-1.md)
 - [R-CD-2](rows/R-CD-2.md)
 - [R-CD-4](rows/R-CD-4.md)
 - [R-CD-CHAINED-DEPTH-2](rows/R-CD-CHAINED-DEPTH-2.md)
+- [R-CD-MODEL-CHAINED-ALT](rows/R-CD-MODEL-CHAINED-ALT.md)
+- [R-CD-MODEL-DEFAULT](rows/R-CD-MODEL-DEFAULT.md)
+- [R-CD-MODEL-TOKEN](rows/R-CD-MODEL-TOKEN.md)
+- [R-CD-MODEL-TOOL](rows/R-CD-MODEL-TOOL.md)
+- [R-CD-TOKEN](rows/R-CD-TOKEN.md)
+- [R-CONFIG-defaults](rows/R-CONFIG-defaults.md)
+- [R-CW-1](rows/R-CW-1.md)
+- [R-CW-4](rows/R-CW-4.md)
+- [R-CW-DELEGATE-SELF-CONTINUATION](rows/R-CW-DELEGATE-SELF-CONTINUATION.md)
+- [R-CW-TOKEN](rows/R-CW-TOKEN.md)
 - [R-OBS-status](rows/R-OBS-status.md)
+- [R-RC-1](rows/R-RC-1.md)
 
 ## Shared execution pattern
 

--- a/RUNBOOKS/project-81/rows/R-CD-MODEL-CHAINED-ALT.md
+++ b/RUNBOOKS/project-81/rows/R-CD-MODEL-CHAINED-ALT.md
@@ -1,0 +1,59 @@
+# R-CD-MODEL-CHAINED-ALT row runbook
+
+## Status
+
+- Manifest: `tools/k6-proofs/manifests/r-cd-model-chained-alt.json`
+- Scenario: `tools/k6-proofs/scenarios/r-cd-model-chained-alt.js`
+- Live safety: `k6-runnable`
+- Same-session concurrency: unsafe unless the manifest explicitly says otherwise; prefer `OPENCLAW_CREATE_DISPOSABLE_SESSION=true`.
+
+## Purpose
+
+Depth-1 delegate schedules a depth-2 delegate with an explicit model override; depth-2 reports the observed model/provider.
+
+## Commands
+
+Dry-run selection:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=***   ./scripts/run-proofs.sh --dry-run R-CD-MODEL-CHAINED-ALT <candidate-sha>
+```
+
+Live candidate run:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=*** OPENCLAW_SESSION_KEY=<target-session-key> OPENCLAW_CREATE_DISPOSABLE_SESSION=true   ./scripts/run-proofs.sh --live R-CD-MODEL-CHAINED-ALT <candidate-sha>
+```
+
+When using the GitHub Actions wrapper, include `R-CD-MODEL-CHAINED-ALT` in the `rows` input and keep `create_disposable_sessions=true` for broad slices.
+
+## k6 covers
+
+- Seat readiness and manifest/live-run-guard receipts are preserved beside the row artifacts.
+- The scenario drives the row-specific continuation/config path through the gateway/session API.
+- The runner records raw `k6.log`, `evidence.jsonl`, `evidence-lines.log`, `run-result.json`, summary JSON, row manifest, and public-safe metrics artifacts.
+- PASS-candidate requires `proof_failures=0` plus the row-specific sentinel/receipt checks implemented in the scenario.
+
+## Manual collection still needed
+
+- Preserve the full candidate-run artifact directory, not only the summary JSON.
+- Review `run-result.json` for `review.status` and `pendingReceipts`; trace/receipt-marker gaps make the row review-pending, not failed.
+- Fetch and commit Tempo trace JSON when a trace id is emitted.
+- For model rows, record the requested model byte and observed child model byte in the fold note.
+- For token/bracket rows, record the surface class used (raw final text vs message-body) because scanner availability is the proof boundary.
+
+## Fold guidance
+
+A k6 `PASS-candidate` is review input, not a canonical proof fold. Fold only after checking:
+
+- artifact bundle is from the intended candidate SHA/runtime,
+- row manifest is the intended one,
+- nonce-correlated evidence is present,
+- any `review-pending` receipts are either supplied or explicitly accepted as honest limits,
+- no secret material is present in committed artifacts.
+
+## Nuance / caveat
+
+Use OPENCLAW_ALT_MODEL=<alias-or-provider/model> when intentionally testing a non-default model; otherwise scenario default currently requests gpt. PASS requires the depth-2 return to include the requested model byte.

--- a/RUNBOOKS/project-81/rows/R-CD-MODEL-DEFAULT.md
+++ b/RUNBOOKS/project-81/rows/R-CD-MODEL-DEFAULT.md
@@ -1,0 +1,59 @@
+# R-CD-MODEL-DEFAULT row runbook
+
+## Status
+
+- Manifest: `tools/k6-proofs/manifests/r-cd-model-default.json`
+- Scenario: `tools/k6-proofs/scenarios/r-cd-model-default.js`
+- Live safety: `k6-runnable`
+- Same-session concurrency: unsafe unless the manifest explicitly says otherwise; prefer `OPENCLAW_CREATE_DISPOSABLE_SESSION=true`.
+
+## Purpose
+
+Default provider/model inheritance for typed continue_delegate when no override is supplied.
+
+## Commands
+
+Dry-run selection:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=***   ./scripts/run-proofs.sh --dry-run R-CD-MODEL-DEFAULT <candidate-sha>
+```
+
+Live candidate run:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=*** OPENCLAW_SESSION_KEY=<target-session-key> OPENCLAW_CREATE_DISPOSABLE_SESSION=true   ./scripts/run-proofs.sh --live R-CD-MODEL-DEFAULT <candidate-sha>
+```
+
+When using the GitHub Actions wrapper, include `R-CD-MODEL-DEFAULT` in the `rows` input and keep `create_disposable_sessions=true` for broad slices.
+
+## k6 covers
+
+- Seat readiness and manifest/live-run-guard receipts are preserved beside the row artifacts.
+- The scenario drives the row-specific continuation/config path through the gateway/session API.
+- The runner records raw `k6.log`, `evidence.jsonl`, `evidence-lines.log`, `run-result.json`, summary JSON, row manifest, and public-safe metrics artifacts.
+- PASS-candidate requires `proof_failures=0` plus the row-specific sentinel/receipt checks implemented in the scenario.
+
+## Manual collection still needed
+
+- Preserve the full candidate-run artifact directory, not only the summary JSON.
+- Review `run-result.json` for `review.status` and `pendingReceipts`; trace/receipt-marker gaps make the row review-pending, not failed.
+- Fetch and commit Tempo trace JSON when a trace id is emitted.
+- For model rows, record the requested model byte and observed child model byte in the fold note.
+- For token/bracket rows, record the surface class used (raw final text vs message-body) because scanner availability is the proof boundary.
+
+## Fold guidance
+
+A k6 `PASS-candidate` is review input, not a canonical proof fold. Fold only after checking:
+
+- artifact bundle is from the intended candidate SHA/runtime,
+- row manifest is the intended one,
+- nonce-correlated evidence is present,
+- any `review-pending` receipts are either supplied or explicitly accepted as honest limits,
+- no secret material is present in committed artifacts.
+
+## Nuance / caveat
+
+Current scenario covers the typed-tool no-model path. Manifest notes say bracket/default inheritance may still need an explicit fold decision before treating it as the entire historical row.

--- a/RUNBOOKS/project-81/rows/R-CD-MODEL-TOKEN.md
+++ b/RUNBOOKS/project-81/rows/R-CD-MODEL-TOKEN.md
@@ -1,0 +1,59 @@
+# R-CD-MODEL-TOKEN row runbook
+
+## Status
+
+- Manifest: `tools/k6-proofs/manifests/r-cd-model-token.json`
+- Scenario: `tools/k6-proofs/scenarios/r-cd-model-token.js`
+- Live safety: `k6-runnable`
+- Same-session concurrency: unsafe unless the manifest explicitly says otherwise; prefer `OPENCLAW_CREATE_DISPOSABLE_SESSION=true`.
+
+## Purpose
+
+Bracket/token continue_delegate with model=<provider/model> emitted from a scanned final-text surface.
+
+## Commands
+
+Dry-run selection:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=***   ./scripts/run-proofs.sh --dry-run R-CD-MODEL-TOKEN <candidate-sha>
+```
+
+Live candidate run:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=*** OPENCLAW_SESSION_KEY=<target-session-key> OPENCLAW_CREATE_DISPOSABLE_SESSION=true   ./scripts/run-proofs.sh --live R-CD-MODEL-TOKEN <candidate-sha>
+```
+
+When using the GitHub Actions wrapper, include `R-CD-MODEL-TOKEN` in the `rows` input and keep `create_disposable_sessions=true` for broad slices.
+
+## k6 covers
+
+- Seat readiness and manifest/live-run-guard receipts are preserved beside the row artifacts.
+- The scenario drives the row-specific continuation/config path through the gateway/session API.
+- The runner records raw `k6.log`, `evidence.jsonl`, `evidence-lines.log`, `run-result.json`, summary JSON, row manifest, and public-safe metrics artifacts.
+- PASS-candidate requires `proof_failures=0` plus the row-specific sentinel/receipt checks implemented in the scenario.
+
+## Manual collection still needed
+
+- Preserve the full candidate-run artifact directory, not only the summary JSON.
+- Review `run-result.json` for `review.status` and `pendingReceipts`; trace/receipt-marker gaps make the row review-pending, not failed.
+- Fetch and commit Tempo trace JSON when a trace id is emitted.
+- For model rows, record the requested model byte and observed child model byte in the fold note.
+- For token/bracket rows, record the surface class used (raw final text vs message-body) because scanner availability is the proof boundary.
+
+## Fold guidance
+
+A k6 `PASS-candidate` is review input, not a canonical proof fold. Fold only after checking:
+
+- artifact bundle is from the intended candidate SHA/runtime,
+- row manifest is the intended one,
+- nonce-correlated evidence is present,
+- any `review-pending` receipts are either supplied or explicitly accepted as honest limits,
+- no secret material is present in committed artifacts.
+
+## Nuance / caveat
+
+Requires a surface where terminal bracket text is scanned. The scenario uses a lightContext subagent/raw final text path to avoid message-body scanner suppression.

--- a/RUNBOOKS/project-81/rows/R-CD-MODEL-TOOL.md
+++ b/RUNBOOKS/project-81/rows/R-CD-MODEL-TOOL.md
@@ -1,0 +1,59 @@
+# R-CD-MODEL-TOOL row runbook
+
+## Status
+
+- Manifest: `tools/k6-proofs/manifests/r-cd-model-tool.json`
+- Scenario: `tools/k6-proofs/scenarios/r-cd-model-tool.js`
+- Live safety: `k6-runnable`
+- Same-session concurrency: unsafe unless the manifest explicitly says otherwise; prefer `OPENCLAW_CREATE_DISPOSABLE_SESSION=true`.
+
+## Purpose
+
+Typed continue_delegate with explicit model override; child reports requested model byte.
+
+## Commands
+
+Dry-run selection:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=***   ./scripts/run-proofs.sh --dry-run R-CD-MODEL-TOOL <candidate-sha>
+```
+
+Live candidate run:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=*** OPENCLAW_SESSION_KEY=<target-session-key> OPENCLAW_CREATE_DISPOSABLE_SESSION=true   ./scripts/run-proofs.sh --live R-CD-MODEL-TOOL <candidate-sha>
+```
+
+When using the GitHub Actions wrapper, include `R-CD-MODEL-TOOL` in the `rows` input and keep `create_disposable_sessions=true` for broad slices.
+
+## k6 covers
+
+- Seat readiness and manifest/live-run-guard receipts are preserved beside the row artifacts.
+- The scenario drives the row-specific continuation/config path through the gateway/session API.
+- The runner records raw `k6.log`, `evidence.jsonl`, `evidence-lines.log`, `run-result.json`, summary JSON, row manifest, and public-safe metrics artifacts.
+- PASS-candidate requires `proof_failures=0` plus the row-specific sentinel/receipt checks implemented in the scenario.
+
+## Manual collection still needed
+
+- Preserve the full candidate-run artifact directory, not only the summary JSON.
+- Review `run-result.json` for `review.status` and `pendingReceipts`; trace/receipt-marker gaps make the row review-pending, not failed.
+- Fetch and commit Tempo trace JSON when a trace id is emitted.
+- For model rows, record the requested model byte and observed child model byte in the fold note.
+- For token/bracket rows, record the surface class used (raw final text vs message-body) because scanner availability is the proof boundary.
+
+## Fold guidance
+
+A k6 `PASS-candidate` is review input, not a canonical proof fold. Fold only after checking:
+
+- artifact bundle is from the intended candidate SHA/runtime,
+- row manifest is the intended one,
+- nonce-correlated evidence is present,
+- any `review-pending` receipts are either supplied or explicitly accepted as honest limits,
+- no secret material is present in committed artifacts.
+
+## Nuance / caveat
+
+If the child observes fallback/inherited model instead of the requested model, package as HONEST-LIMIT-candidate with mismatch evidence, not pass.

--- a/RUNBOOKS/project-81/rows/R-CD-TOKEN.md
+++ b/RUNBOOKS/project-81/rows/R-CD-TOKEN.md
@@ -1,0 +1,59 @@
+# R-CD-TOKEN row runbook
+
+## Status
+
+- Manifest: `tools/k6-proofs/manifests/r-cd-token.json`
+- Scenario: `tools/k6-proofs/scenarios/r-cd-token-bracket-delegate.js`
+- Live safety: `k6-runnable`
+- Same-session concurrency: unsafe unless the manifest explicitly says otherwise; prefer `OPENCLAW_CREATE_DISPOSABLE_SESSION=true`.
+
+## Purpose
+
+Bracket/token continue_delegate path for delegate scheduling and return.
+
+## Commands
+
+Dry-run selection:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=***   ./scripts/run-proofs.sh --dry-run R-CD-TOKEN <candidate-sha>
+```
+
+Live candidate run:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=*** OPENCLAW_SESSION_KEY=<target-session-key> OPENCLAW_CREATE_DISPOSABLE_SESSION=true   ./scripts/run-proofs.sh --live R-CD-TOKEN <candidate-sha>
+```
+
+When using the GitHub Actions wrapper, include `R-CD-TOKEN` in the `rows` input and keep `create_disposable_sessions=true` for broad slices.
+
+## k6 covers
+
+- Seat readiness and manifest/live-run-guard receipts are preserved beside the row artifacts.
+- The scenario drives the row-specific continuation/config path through the gateway/session API.
+- The runner records raw `k6.log`, `evidence.jsonl`, `evidence-lines.log`, `run-result.json`, summary JSON, row manifest, and public-safe metrics artifacts.
+- PASS-candidate requires `proof_failures=0` plus the row-specific sentinel/receipt checks implemented in the scenario.
+
+## Manual collection still needed
+
+- Preserve the full candidate-run artifact directory, not only the summary JSON.
+- Review `run-result.json` for `review.status` and `pendingReceipts`; trace/receipt-marker gaps make the row review-pending, not failed.
+- Fetch and commit Tempo trace JSON when a trace id is emitted.
+- For model rows, record the requested model byte and observed child model byte in the fold note.
+- For token/bracket rows, record the surface class used (raw final text vs message-body) because scanner availability is the proof boundary.
+
+## Fold guidance
+
+A k6 `PASS-candidate` is review input, not a canonical proof fold. Fold only after checking:
+
+- artifact bundle is from the intended candidate SHA/runtime,
+- row manifest is the intended one,
+- nonce-correlated evidence is present,
+- any `review-pending` receipts are either supplied or explicitly accepted as honest limits,
+- no secret material is present in committed artifacts.
+
+## Nuance / caveat
+
+Message-body Discord seats can suppress scanner fallback; use disposable/raw-final-text mode when proving PASS rather than honest-limit.

--- a/RUNBOOKS/project-81/rows/R-CONFIG-defaults.md
+++ b/RUNBOOKS/project-81/rows/R-CONFIG-defaults.md
@@ -1,0 +1,59 @@
+# R-CONFIG-defaults row runbook
+
+## Status
+
+- Manifest: `tools/k6-proofs/manifests/r-config-defaults.json`
+- Scenario: `tools/k6-proofs/scenarios/r-config-defaults.js`
+- Live safety: `k6-runnable`
+- Same-session concurrency: unsafe unless the manifest explicitly says otherwise; prefer `OPENCLAW_CREATE_DISPOSABLE_SESSION=true`.
+
+## Purpose
+
+Read continuation defaults/config surface and verify expected values are observable to proof automation.
+
+## Commands
+
+Dry-run selection:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=***   ./scripts/run-proofs.sh --dry-run R-CONFIG-defaults <candidate-sha>
+```
+
+Live candidate run:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=*** OPENCLAW_SESSION_KEY=<target-session-key> OPENCLAW_CREATE_DISPOSABLE_SESSION=true   ./scripts/run-proofs.sh --live R-CONFIG-defaults <candidate-sha>
+```
+
+When using the GitHub Actions wrapper, include `R-CONFIG-defaults` in the `rows` input and keep `create_disposable_sessions=true` for broad slices.
+
+## k6 covers
+
+- Seat readiness and manifest/live-run-guard receipts are preserved beside the row artifacts.
+- The scenario drives the row-specific continuation/config path through the gateway/session API.
+- The runner records raw `k6.log`, `evidence.jsonl`, `evidence-lines.log`, `run-result.json`, summary JSON, row manifest, and public-safe metrics artifacts.
+- PASS-candidate requires `proof_failures=0` plus the row-specific sentinel/receipt checks implemented in the scenario.
+
+## Manual collection still needed
+
+- Preserve the full candidate-run artifact directory, not only the summary JSON.
+- Review `run-result.json` for `review.status` and `pendingReceipts`; trace/receipt-marker gaps make the row review-pending, not failed.
+- Fetch and commit Tempo trace JSON when a trace id is emitted.
+- For model rows, record the requested model byte and observed child model byte in the fold note.
+- For token/bracket rows, record the surface class used (raw final text vs message-body) because scanner availability is the proof boundary.
+
+## Fold guidance
+
+A k6 `PASS-candidate` is review input, not a canonical proof fold. Fold only after checking:
+
+- artifact bundle is from the intended candidate SHA/runtime,
+- row manifest is the intended one,
+- nonce-correlated evidence is present,
+- any `review-pending` receipts are either supplied or explicitly accepted as honest limits,
+- no secret material is present in committed artifacts.
+
+## Nuance / caveat
+
+This is read-only; still save the exact config receipt and seat-readiness because per-seat divergence is expected.

--- a/RUNBOOKS/project-81/rows/R-CW-4.md
+++ b/RUNBOOKS/project-81/rows/R-CW-4.md
@@ -1,0 +1,59 @@
+# R-CW-4 row runbook
+
+## Status
+
+- Manifest: `tools/k6-proofs/manifests/r-cw-4.json`
+- Scenario: `tools/k6-proofs/scenarios/r-cw-4-chain-depth.js`
+- Live safety: `k6-runnable`
+- Same-session concurrency: unsafe unless the manifest explicitly says otherwise; prefer `OPENCLAW_CREATE_DISPOSABLE_SESSION=true`.
+
+## Purpose
+
+Chained continue_work depth/hop sequence through multiple wakes.
+
+## Commands
+
+Dry-run selection:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=***   ./scripts/run-proofs.sh --dry-run R-CW-4 <candidate-sha>
+```
+
+Live candidate run:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=*** OPENCLAW_SESSION_KEY=<target-session-key> OPENCLAW_CREATE_DISPOSABLE_SESSION=true   ./scripts/run-proofs.sh --live R-CW-4 <candidate-sha>
+```
+
+When using the GitHub Actions wrapper, include `R-CW-4` in the `rows` input and keep `create_disposable_sessions=true` for broad slices.
+
+## k6 covers
+
+- Seat readiness and manifest/live-run-guard receipts are preserved beside the row artifacts.
+- The scenario drives the row-specific continuation/config path through the gateway/session API.
+- The runner records raw `k6.log`, `evidence.jsonl`, `evidence-lines.log`, `run-result.json`, summary JSON, row manifest, and public-safe metrics artifacts.
+- PASS-candidate requires `proof_failures=0` plus the row-specific sentinel/receipt checks implemented in the scenario.
+
+## Manual collection still needed
+
+- Preserve the full candidate-run artifact directory, not only the summary JSON.
+- Review `run-result.json` for `review.status` and `pendingReceipts`; trace/receipt-marker gaps make the row review-pending, not failed.
+- Fetch and commit Tempo trace JSON when a trace id is emitted.
+- For model rows, record the requested model byte and observed child model byte in the fold note.
+- For token/bracket rows, record the surface class used (raw final text vs message-body) because scanner availability is the proof boundary.
+
+## Fold guidance
+
+A k6 `PASS-candidate` is review input, not a canonical proof fold. Fold only after checking:
+
+- artifact bundle is from the intended candidate SHA/runtime,
+- row manifest is the intended one,
+- nonce-correlated evidence is present,
+- any `review-pending` receipts are either supplied or explicitly accepted as honest limits,
+- no secret material is present in committed artifacts.
+
+## Nuance / caveat
+
+Use disposable subagent-style session keys after docs #306; older generic/main-ish sessions made cleanup and attribution harder.

--- a/RUNBOOKS/project-81/rows/R-CW-TOKEN.md
+++ b/RUNBOOKS/project-81/rows/R-CW-TOKEN.md
@@ -1,0 +1,59 @@
+# R-CW-TOKEN row runbook
+
+## Status
+
+- Manifest: `tools/k6-proofs/manifests/r-cw-token.json`
+- Scenario: `tools/k6-proofs/scenarios/r-cw-token-bracket.js`
+- Live safety: `k6-runnable`
+- Same-session concurrency: unsafe unless the manifest explicitly says otherwise; prefer `OPENCLAW_CREATE_DISPOSABLE_SESSION=true`.
+
+## Purpose
+
+Bracket/token continue_work fallback path schedules and observes hop-2 execution.
+
+## Commands
+
+Dry-run selection:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=***   ./scripts/run-proofs.sh --dry-run R-CW-TOKEN <candidate-sha>
+```
+
+Live candidate run:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=*** OPENCLAW_SESSION_KEY=<target-session-key> OPENCLAW_CREATE_DISPOSABLE_SESSION=true   ./scripts/run-proofs.sh --live R-CW-TOKEN <candidate-sha>
+```
+
+When using the GitHub Actions wrapper, include `R-CW-TOKEN` in the `rows` input and keep `create_disposable_sessions=true` for broad slices.
+
+## k6 covers
+
+- Seat readiness and manifest/live-run-guard receipts are preserved beside the row artifacts.
+- The scenario drives the row-specific continuation/config path through the gateway/session API.
+- The runner records raw `k6.log`, `evidence.jsonl`, `evidence-lines.log`, `run-result.json`, summary JSON, row manifest, and public-safe metrics artifacts.
+- PASS-candidate requires `proof_failures=0` plus the row-specific sentinel/receipt checks implemented in the scenario.
+
+## Manual collection still needed
+
+- Preserve the full candidate-run artifact directory, not only the summary JSON.
+- Review `run-result.json` for `review.status` and `pendingReceipts`; trace/receipt-marker gaps make the row review-pending, not failed.
+- Fetch and commit Tempo trace JSON when a trace id is emitted.
+- For model rows, record the requested model byte and observed child model byte in the fold note.
+- For token/bracket rows, record the surface class used (raw final text vs message-body) because scanner availability is the proof boundary.
+
+## Fold guidance
+
+A k6 `PASS-candidate` is review input, not a canonical proof fold. Fold only after checking:
+
+- artifact bundle is from the intended candidate SHA/runtime,
+- row manifest is the intended one,
+- nonce-correlated evidence is present,
+- any `review-pending` receipts are either supplied or explicitly accepted as honest limits,
+- no secret material is present in committed artifacts.
+
+## Nuance / caveat
+
+Message-body main sessions may honest-limit; use a scanned final-text subagent/raw surface when proving token fallback.


### PR DESCRIPTION
## Summary

Refreshes the Project 81 operational runbook surface after the broad live k6 slice and docs/bootstrap runner ergonomics work.

This keeps the maintenance path low-toil by making the runbook match the current automation surface instead of requiring readers to reconstruct runnable rows from issue comments and candidate bundles.

## Changes

- Updates `RUNBOOKS/project-81/README.md` from the stale 5-row `all` expansion to the current 16-row broad live slice.
- Calls out that `preflight` is `static-preflight-only`: seat-readiness still runs for live runs, but the preflight manifest row itself is skipped by live-run guard.
- Adds missing row runbooks for all currently `k6-runnable` manifests that did not yet have one:
  - `R-CD-MODEL-CHAINED-ALT`
  - `R-CD-MODEL-DEFAULT`
  - `R-CD-MODEL-TOKEN`
  - `R-CD-MODEL-TOOL`
  - `R-CD-TOKEN`
  - `R-CONFIG-defaults`
  - `R-CW-4`
  - `R-CW-TOKEN`

## Validation

```text
node tools/k6-proofs/scripts/check-manifest-scenarios.mjs
# passed: 22 manifests; 24 scenario files

node tools/k6-proofs/scripts/check-scenario-alignment.mjs
# ok: true

node tools/k6-proofs/scripts/validate-corpus.mjs --current
# OK: current corpus validates, rollup unchanged

comm -23 <runnable k6 manifests> <RUNBOOKS/project-81/rows/*.md>
# empty: every k6-runnable row now has a row runbook
```

## Non-goals

- Does not mutate canonical `PROOFS/INDEX.json` or `proofs-manifest.json`.
- Does not fold #307 candidate-run artifacts into canonical evidence.
- Does not touch the separate `karmaterminal/openclaw` splay/GATES lane.
