### PR TITLE
tools: summarize Project 81 review-marker debt

### DIFF
--- a/RUNBOOKS/project-81/README.md
+++ b/RUNBOOKS/project-81/README.md
@@ -119,7 +119,14 @@ Most continuation rows still need one or more of these after k6 runs:
     -o PROOFS/<sha>/<row>/<seat>/tempo/trace-<trace-id>.json
   ```
 
-Trace JSON should be committed with the candidate proof artifacts whenever available because internal Tempo URLs are not public maintainer receipts.
+Trace JSON should be committed with the candidate proof artifacts whenever available because internal Tempo URLs are not public maintainer receipts. Before fetching traces from a candidate bundle, summarize review debt so null trace ids are not mistaken for fetchable receipts:
+
+```bash
+node tools/k6-proofs/scripts/summarize-review-debt.mjs \
+  --run-root RUNBOOKS/project-81/candidate-runs/<sha>/<run-id>
+```
+
+If `tempo-trace-json` debt is reported as `tempo-trace-unfetchable`, the bundle emitted `traceId: null`; rerun with trace emission or explicitly accept trace-missing as an honest review limit before a canonical fold.
 
 ## What not to do
 

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -199,6 +199,19 @@ node tools/k6-proofs/scripts/fetch-tempo-trace.mjs \
   --run-dir /tmp/k6-proof-runs/<sha>/<row>/<seat>/<run-id>
 ```
 
+When reviewing an existing candidate-run bundle, summarize pending review receipts
+before attempting Tempo fetches:
+
+```bash
+node tools/k6-proofs/scripts/summarize-review-debt.mjs \
+  --run-root RUNBOOKS/project-81/candidate-runs/<sha>/<run-id>
+```
+
+For `tempo-trace-json`, the summary distinguishes rows with a fetchable `traceId`
+from rows where `traceId` is null. Null trace ids cannot be fetched from Tempo;
+those rows need either a rerun with trace emission or an explicit fold decision
+accepting trace-missing as an honest review limit.
+
 ## HTML run report
 
 `run-proofs.sh` writes a public-safe `report.html` at the selected run output root.

--- a/tools/k6-proofs/scripts/__tests__/review-debt.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/review-debt.test.mjs
@@ -1,0 +1,65 @@
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const script = path.resolve('tools/k6-proofs/scripts/summarize-review-debt.mjs');
+const runNode = promisify(execFile);
+
+async function writeResult(root, row, body) {
+  const dir = path.join(root, 'candidate-sha', row, 'seat', `run-${row}`);
+  await mkdir(dir, { recursive: true });
+  await writeFile(path.join(dir, 'run-result.json'), `${JSON.stringify(body, null, 2)}\n`);
+}
+
+test('summarizes trace-missing debt as unfetchable when no trace id exists', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'review-debt-'));
+  try {
+    await writeResult(root, 'R-CD-2', {
+      observability: { traceStatus: 'missing', traceId: null, tempoTraceJson: null },
+      review: { status: 'review-pending', pendingReceipts: ['tempo-trace-json'] },
+    });
+    await writeResult(root, 'R-CD-4', {
+      observability: { traceStatus: 'present', traceId: 'abcdef0123456789', tempoTraceJson: null },
+      review: { status: 'review-pending', pendingReceipts: ['tempo-trace-json'] },
+    });
+    await writeResult(root, 'R-CW-1', {
+      observability: { traceStatus: 'unknown', traceId: null, tempoTraceJson: null },
+      review: { status: 'ready-for-human-review', pendingReceipts: [] },
+    });
+
+    const run = await runNode(process.execPath, [script, '--run-root', root, '--json'], { encoding: 'utf8' });
+    const summary = JSON.parse(run.stdout);
+    assert.equal(summary.totalRows, 3);
+    assert.equal(summary.pendingRows, 2);
+    assert.equal(summary.byClass['tempo-trace-unfetchable'], 1);
+    assert.equal(summary.byClass['tempo-trace-fetchable'], 1);
+    const unfetchable = summary.pending.find((row) => row.rowId === 'R-CD-2').pending[0];
+    assert.equal(unfetchable.fetchable, false);
+    assert.match(unfetchable.action, /rerun with trace emission/);
+    const fetchable = summary.pending.find((row) => row.rowId === 'R-CD-4').pending[0];
+    assert.equal(fetchable.fetchable, true);
+    assert.equal(fetchable.traceId, 'abcdef0123456789');
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('renders human-readable review debt table', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'review-debt-text-'));
+  try {
+    await writeResult(root, 'R-OBS-STATUS', {
+      observability: { traceStatus: 'missing', traceId: null, tempoTraceJson: null },
+      review: { status: 'review-pending', pendingReceipts: ['tempo-trace-json'] },
+    });
+    const run = await runNode(process.execPath, [script, '--run-root', root], { encoding: 'utf8' });
+    assert.match(run.stdout, /review-pending rows: 1/);
+    assert.match(run.stdout, /tempo-trace-unfetchable: 1/);
+    assert.match(run.stdout, /R-OBS-STATUS/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/tools/k6-proofs/scripts/summarize-review-debt.mjs
+++ b/tools/k6-proofs/scripts/summarize-review-debt.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+import { readdir, readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+
+function usage() {
+  return `Usage: node tools/k6-proofs/scripts/summarize-review-debt.mjs --run-root <candidate-run-dir> [--json]\n\nScans row run-result.json files and summarizes review-pending receipts.\nFor tempo-trace-json debt, distinguishes fetchable trace ids from trace-missing rows where no Tempo fetch can be attempted.\n`;
+}
+
+function parseArgs(argv) {
+  const args = { json: false, runRoot: '' };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--json') args.json = true;
+    else if (arg === '--run-root') args.runRoot = argv[++i] || '';
+    else if (arg === '--help' || arg === '-h') args.help = true;
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  return args;
+}
+
+async function walk(dir, out = []) {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) await walk(p, out);
+    else if (entry.isFile() && entry.name === 'run-result.json') out.push(p);
+  }
+  return out;
+}
+
+function rowFromPath(file) {
+  const parts = file.split(path.sep);
+  for (const part of parts) {
+    if (/^R-[A-Z0-9-]+$/.test(part)) return part;
+  }
+  return null;
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function classifyPending(row, receipt) {
+  if (receipt !== 'tempo-trace-json') return { receipt, class: 'manual-review', fetchable: null, action: 'supply-or-accept-review-receipt' };
+  const traceId = row.traceId || null;
+  if (traceId) {
+    return { receipt, class: 'tempo-trace-fetchable', fetchable: true, traceId, action: 'run fetch-tempo-trace.mjs --trace-id and commit trace JSON' };
+  }
+  return {
+    receipt,
+    class: 'tempo-trace-unfetchable',
+    fetchable: false,
+    traceId: null,
+    action: 'rerun with trace emission or explicitly accept trace-missing as an honest review limit',
+  };
+}
+
+async function loadRows(root) {
+  const files = await walk(root);
+  const rows = [];
+  for (const file of files.sort()) {
+    const raw = JSON.parse(await readFile(file, 'utf8'));
+    const pendingReceipts = asArray(raw.review?.pendingReceipts);
+    const rowId = raw.rowId || raw.row || rowFromPath(file) || 'unknown-row';
+    const traceId = raw.observability?.traceId || raw.traceId || null;
+    rows.push({
+      rowId,
+      file: path.relative(root, file),
+      reviewStatus: raw.review?.status || (pendingReceipts.length ? 'review-pending' : 'ready-for-human-review'),
+      pendingReceipts,
+      traceId,
+      pending: pendingReceipts.map((receipt) => classifyPending({ traceId }, receipt)),
+    });
+  }
+  return rows;
+}
+
+function summarize(rows) {
+  const pendingRows = rows.filter((row) => row.pendingReceipts.length > 0 || row.reviewStatus === 'review-pending');
+  const byClass = {};
+  for (const row of pendingRows) {
+    for (const item of row.pending) byClass[item.class] = (byClass[item.class] || 0) + 1;
+  }
+  return {
+    totalRows: rows.length,
+    pendingRows: pendingRows.length,
+    byClass,
+    pending: pendingRows,
+  };
+}
+
+function renderText(summary) {
+  const lines = [];
+  lines.push(`rows: ${summary.totalRows}`);
+  lines.push(`review-pending rows: ${summary.pendingRows}`);
+  for (const [klass, count] of Object.entries(summary.byClass).sort()) lines.push(`${klass}: ${count}`);
+  if (summary.pending.length) {
+    lines.push('');
+    for (const row of summary.pending) {
+      lines.push(`- ${row.rowId}: ${row.pendingReceipts.join(', ') || row.reviewStatus}`);
+      for (const item of row.pending) lines.push(`  - ${item.class}: ${item.action}${item.traceId ? ` (${item.traceId})` : ''}`);
+      lines.push(`  - ${row.file}`);
+    }
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(usage());
+    return;
+  }
+  if (!args.runRoot) throw new Error('missing --run-root');
+  const root = path.resolve(args.runRoot);
+  const st = await stat(root).catch(() => null);
+  if (!st?.isDirectory()) throw new Error(`run root is not a directory: ${root}`);
+  const rows = await loadRows(root);
+  const summary = summarize(rows);
+  if (args.json) process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  else process.stdout.write(renderText(summary));
+}
+
+main().catch((error) => {
+  console.error(error.message || error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a small Project 81 review-helper script for candidate bundles:

- scan row `run-result.json` files under a candidate-run root
- summarize review-pending receipts
- classify `tempo-trace-json` debt as either fetchable (trace id present) or unfetchable (`traceId: null`)
- document the command in both the k6 proof README and Project 81 runbook README

This follows the #307 review-marker finding: three pending rows had `tempo-trace-json` debt with `traceId: null`, so there was no Tempo trace to fetch. The helper makes that distinction mechanical instead of relying on issue archaeology.

## Verification

```bash
node --test tools/k6-proofs/scripts/__tests__/review-debt.test.mjs
node tools/k6-proofs/scripts/summarize-review-debt.mjs \
  --run-root RUNBOOKS/project-81/candidate-runs/1cc8f4e3d617ef6f173283ef83d7b739a4995734/20260707T194227Z-cael-dgx-2026911
```

Observed on the merged #307 bundle:

```text
rows: 16
review-pending rows: 3
tempo-trace-unfetchable: 3
```
