### PR TITLE
k6-proofs: gate trace review markers by manifest

### DIFF
--- a/tools/k6-proofs/scripts/export-row-metrics.mjs
+++ b/tools/k6-proofs/scripts/export-row-metrics.mjs
@@ -108,17 +108,20 @@ function receiptRowsFrom({ result, manifest, runResult }) {
   // than row-result receipts. Expose that as the contract receipt the dashboard
   // knows how to show.
   const traceStatus = runResult?.observability?.traceStatus || result?.observability?.traceStatus;
-  if (traceStatus === 'missing' && !receipts.some((r) => r.name === 'tempo-trace-json')) {
-    receipts.push({ name: 'tempo-trace-json', required: true, status: 'missing' });
-  } else if (traceStatus === 'present' && !receipts.some((r) => r.name === 'tempo-trace-json')) {
-    receipts.push({ name: 'tempo-trace-json', required: true, status: 'present' });
-  }
 
   for (const name of manifest?.liveRunSafety?.requiredReceipts || []) {
     const safe = safeLabelValue(name);
     if (!receipts.some((r) => r.name === safe)) {
       receipts.push({ name: safe, required: true, status: 'unknown' });
     }
+  }
+
+  if (traceStatus === 'missing') {
+    const existing = receipts.find((r) => r.name === 'tempo-trace-json' || r.name === 'trace-id');
+    if (existing) existing.status = 'missing';
+  } else if (traceStatus === 'present') {
+    const existing = receipts.find((r) => r.name === 'tempo-trace-json' || r.name === 'trace-id');
+    if (existing) existing.status = 'present';
   }
 
   return receipts;

--- a/tools/k6-proofs/scripts/render-run-report.mjs
+++ b/tools/k6-proofs/scripts/render-run-report.mjs
@@ -93,7 +93,6 @@ function receiptSummary({ manifest, runResult, evidenceRows }) {
   if (traceStatus === 'missing') {
     const existing = receipts.find((r) => r.name === 'tempo-trace-json' || r.name === 'trace-id');
     if (existing) existing.status = 'missing';
-    else receipts.push({ name: 'tempo-trace-json', required: true, status: 'missing' });
   }
   const evidence = evidenceRows[0] || {};
   for (const receipt of receipts) {

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -220,6 +220,7 @@ PY_EVIDENCE_JSONL
     TRACE_ID=""
     TEMPO_TRACE_JSON=""
     REVIEW_PENDING_RECEIPTS='[]'
+    TRACE_REQUIRED="$(jq -r '((.liveRunSafety.requiredReceipts // []) | map(ascii_downcase) | any(. == "trace-id" or . == "tempo-trace-json"))' "$MANIFEST_FILE")"
     if [[ -s "$RUN_DIR/evidence.jsonl" ]]; then
       if jq -e 'select(has("trace_id"))' "$RUN_DIR/evidence.jsonl" >/dev/null; then
         TRACE_ID="$(jq -r 'select((.trace_id // "") != "") | .trace_id' "$RUN_DIR/evidence.jsonl" | head -n 1)"
@@ -230,7 +231,9 @@ PY_EVIDENCE_JSONL
             echo "[$ROW_ID] TEMPO TRACE: $TEMPO_TRACE_JSON"
           else
             TRACE_STATUS="missing"
-            REVIEW_PENDING_RECEIPTS='["tempo-trace-json"]'
+            if [[ "$TRACE_REQUIRED" == "true" ]]; then
+              REVIEW_PENDING_RECEIPTS='["tempo-trace-json"]'
+            fi
             echo "[$ROW_ID] TEMPO TRACE FETCH FAILED; see $RUN_DIR/tempo-trace-error.log" >&2
             if [[ "${OPENCLAW_PROOFS_K6_TEMPO_REQUIRED:-false}" == "true" ]]; then
               exit 1
@@ -238,7 +241,9 @@ PY_EVIDENCE_JSONL
           fi
         else
           TRACE_STATUS="missing"
-          REVIEW_PENDING_RECEIPTS='["tempo-trace-json"]'
+          if [[ "$TRACE_REQUIRED" == "true" ]]; then
+            REVIEW_PENDING_RECEIPTS='["tempo-trace-json"]'
+          fi
         fi
       fi
     fi


### PR DESCRIPTION
## Summary

Tightens Project 81 row-list runner review markers so missing Tempo trace JSON only marks a row `review-pending` when that row manifest actually requires trace receipts.

This came from reviewing the #307 broad candidate bundle: `R-OBS-status` was being marked `review-pending` for `tempo-trace-json` even though its manifest only requires `observer-receipt`. Rows that do require `trace-id` / `tempo-trace-json` still stay visibly review-pending when traces are missing.

## Changes

- `run-proofs.sh` now derives `TRACE_REQUIRED` from `liveRunSafety.requiredReceipts`.
- Missing/fetch-failed trace JSON only adds `tempo-trace-json` to `review.pendingReceipts` when the manifest requires trace evidence.
- Report rendering and row metrics no longer synthesize a new required `tempo-trace-json` receipt for rows whose manifests do not require trace receipts; they still mark existing `trace-id` / `tempo-trace-json` receipts missing/present.

## Validation

```text
node --test tools/k6-proofs/scripts/__tests__/report-render.test.mjs tools/k6-proofs/scripts/__tests__/metrics-export.test.mjs
# pass: 3

node tools/k6-proofs/scripts/check-manifest-scenarios.mjs
# passed: 22 manifests; 24 scenario files

node tools/k6-proofs/scripts/check-scenario-alignment.mjs
# ok: true

node tools/k6-proofs/scripts/validate-corpus.mjs --current
# OK: current corpus validates; rollup unchanged (29 rows / 28 pass / 1 honest_limit / 0 missing)

bash -n tools/k6-proofs/scripts/run-proofs.sh
# pass
```

## Non-goals

- Does not mutate canonical proof corpus or #307 candidate artifacts.
- Does not make Tempo mandatory/fatal; `OPENCLAW_PROOFS_K6_TEMPO_REQUIRED=true` remains the explicit hard-fail switch.
