### PR TITLE
ci: fix Project 81 workflow catalog validation paths

### DIFF
--- a/.github/workflows/project81-k6-proof.yml
+++ b/.github/workflows/project81-k6-proof.yml
@@ -89,12 +89,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          cd tools/k6-proofs
-          node --check scripts/list-runnable-rows.mjs
-          node scripts/check-manifest-scenarios.mjs
-          node scripts/check-scenario-alignment.mjs
+          node --check tools/k6-proofs/scripts/list-runnable-rows.mjs
+          node tools/k6-proofs/scripts/check-manifest-scenarios.mjs
+          node tools/k6-proofs/scripts/check-scenario-alignment.mjs
           if [[ "${{ inputs.rows }}" == "live-suite" ]]; then
-            rows="$(node scripts/list-runnable-rows.mjs --live-suite)"
+            rows="$(node tools/k6-proofs/scripts/list-runnable-rows.mjs --live-suite)"
           else
             rows="${{ inputs.rows }}"
           fi


### PR DESCRIPTION
## Summary

Fixes the docs-local `project81-k6-proof` workflow validation step after the first public dry run. The manifest/scenario check scripts resolve paths from the repository root, so the workflow must call them as `tools/k6-proofs/scripts/...` instead of `cd tools/k6-proofs` first.

The live/dry run step still runs from `tools/k6-proofs`, where `run-proofs.sh` expects to be invoked.

## Validation

- `node --check tools/k6-proofs/scripts/list-runnable-rows.mjs` ✅
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs` ✅
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs` ✅
- `node tools/k6-proofs/scripts/validate-corpus.mjs --current` ✅
- workflow-equivalent row resolution from repo root ✅
- workflow-equivalent dry run from `tools/k6-proofs` ✅
- `git diff --check` ✅

Follow-up to the failed public dry run: https://github.com/karmaterminal/karmaterminal-openclaw-docs/actions/runs/28905153245
