### PR TITLE
tools: cover all Project 81 proof rows in manifest catalog

### DIFF
--- a/.github/workflows/project81-k6-proof.yml
+++ b/.github/workflows/project81-k6-proof.yml
@@ -112,6 +112,7 @@ jobs:
           node --check tools/k6-proofs/scripts/summarize-review-debt.mjs
           node tools/k6-proofs/scripts/check-manifest-scenarios.mjs
           node tools/k6-proofs/scripts/check-scenario-alignment.mjs
+          node tools/k6-proofs/scripts/check-proof-row-manifests.mjs
           if [[ "$ROWS_INPUT" == "live-suite" ]]; then
             rows="$(node tools/k6-proofs/scripts/list-runnable-rows.mjs --live-suite)"
           elif [[ "$ROWS_INPUT" == "all" ]]; then

--- a/RUNBOOKS/project-81/EXECUTABLE-SUITE.md
+++ b/RUNBOOKS/project-81/EXECUTABLE-SUITE.md
@@ -2,7 +2,7 @@
 
 Goal: give a reviewer or maintainer a small, repeatable path from a normal OpenClaw checkout to a candidate proof bundle.
 
-This quickstart intentionally covers only unattended `k6-runnable` rows. Rows marked `orchestration-required` stay out of the broad suite until a reviewed fixture exists.
+This quickstart intentionally covers only unattended `k6-runnable` rows. Rows marked `orchestration-required`, `scaffold`, or `construct-only` stay out of the broad suite until a reviewed fixture exists. The manifest catalog still records every current manual PROOFS row so the public surface explains the full 29-row corpus, not only the currently automated subset.
 
 ## 1. Install k6
 
@@ -98,6 +98,7 @@ node scripts/summarize-review-debt.mjs --run-root <run-root>
 node scripts/validate-corpus.mjs --current
 node scripts/check-manifest-scenarios.mjs
 node scripts/check-scenario-alignment.mjs
+node scripts/check-proof-row-manifests.mjs
 ```
 
 Fetch Tempo trace JSON when a row records a non-null trace id. If a row records `traceId: null`, treat trace JSON as unavailable review debt or an honest limit; do not invent a fetchable trace.

--- a/tools/k6-proofs/manifests/r-cd-return-overlap.json
+++ b/tools/k6-proofs/manifests/r-cd-return-overlap.json
@@ -1,0 +1,55 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CD-RETURN-OVERLAP",
+  "issue": 246,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-cd-return-overlap",
+    "description": "continue_delegate return overlap/collision behavior manual proof row. Registered to keep the executable-suite manifest catalog aligned with the 29-row manual proof corpus; not an unattended k6 scenario yet.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "notes": "Construct-only registry entry. The current PROOFS corpus carries manual evidence for this row; promote to scaffold/runnable only after a reviewed k6 fixture exists."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-row-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS/<sha> corpus contains reviewed manual evidence for this row."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CD-RETURN-OVERLAP",
+    "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "Catalog coverage entry only. Does not make the row runnable and does not change the canonical PROOFS corpus."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": false,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-row-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Not included in --live-suite. This entry exists so every current manual proof row has an explicit manifest record."
+  }
+}

--- a/tools/k6-proofs/manifests/r-cd-silent.json
+++ b/tools/k6-proofs/manifests/r-cd-silent.json
@@ -1,0 +1,55 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CD-SILENT",
+  "issue": 119,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-cd-silent",
+    "description": "silent delegate no-channel-output manual proof row. Registered to keep the executable-suite manifest catalog aligned with the 29-row manual proof corpus; not an unattended k6 scenario yet.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "notes": "Construct-only registry entry. The current PROOFS corpus carries manual evidence for this row; promote to scaffold/runnable only after a reviewed k6 fixture exists."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-row-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS/<sha> corpus contains reviewed manual evidence for this row."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CD-SILENT",
+    "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "Catalog coverage entry only. Does not make the row runnable and does not change the canonical PROOFS corpus."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": false,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-row-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Not included in --live-suite. This entry exists so every current manual proof row has an explicit manifest record."
+  }
+}

--- a/tools/k6-proofs/manifests/r-config-intersession.json
+++ b/tools/k6-proofs/manifests/r-config-intersession.json
@@ -1,0 +1,55 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CONFIG-INTERSESSION",
+  "issue": 121,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-config-intersession",
+    "description": "intersession configuration manual proof row. Registered to keep the executable-suite manifest catalog aligned with the 29-row manual proof corpus; not an unattended k6 scenario yet.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "notes": "Construct-only registry entry. The current PROOFS corpus carries manual evidence for this row; promote to scaffold/runnable only after a reviewed k6 fixture exists."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-row-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS/<sha> corpus contains reviewed manual evidence for this row."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CONFIG-INTERSESSION",
+    "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "Catalog coverage entry only. Does not make the row runnable and does not change the canonical PROOFS corpus."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": false,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-row-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Not included in --live-suite. This entry exists so every current manual proof row has an explicit manifest record."
+  }
+}

--- a/tools/k6-proofs/manifests/r-cw-2.json
+++ b/tools/k6-proofs/manifests/r-cw-2.json
@@ -1,0 +1,55 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CW-2",
+  "issue": 117,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-cw-2",
+    "description": "continue_work visible wake/receipt manual proof row. Registered to keep the executable-suite manifest catalog aligned with the 29-row manual proof corpus; not an unattended k6 scenario yet.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "notes": "Construct-only registry entry. The current PROOFS corpus carries manual evidence for this row; promote to scaffold/runnable only after a reviewed k6 fixture exists."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-row-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS/<sha> corpus contains reviewed manual evidence for this row."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CW-2",
+    "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "Catalog coverage entry only. Does not make the row runnable and does not change the canonical PROOFS corpus."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": false,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-row-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Not included in --live-suite. This entry exists so every current manual proof row has an explicit manifest record."
+  }
+}

--- a/tools/k6-proofs/manifests/r-cw-3.json
+++ b/tools/k6-proofs/manifests/r-cw-3.json
@@ -1,0 +1,55 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CW-3",
+  "issue": 117,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-cw-3",
+    "description": "continue_work trace/flow receipt manual proof row. Registered to keep the executable-suite manifest catalog aligned with the 29-row manual proof corpus; not an unattended k6 scenario yet.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "notes": "Construct-only registry entry. The current PROOFS corpus carries manual evidence for this row; promote to scaffold/runnable only after a reviewed k6 fixture exists."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-row-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS/<sha> corpus contains reviewed manual evidence for this row."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CW-3",
+    "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "Catalog coverage entry only. Does not make the row runnable and does not change the canonical PROOFS corpus."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": false,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-row-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Not included in --live-suite. This entry exists so every current manual proof row has an explicit manifest record."
+  }
+}

--- a/tools/k6-proofs/manifests/r-cw-7.json
+++ b/tools/k6-proofs/manifests/r-cw-7.json
@@ -1,0 +1,55 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CW-7",
+  "issue": 220,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-cw-7",
+    "description": "continue_work traceparent propagation source/test manual proof row. Registered to keep the executable-suite manifest catalog aligned with the 29-row manual proof corpus; not an unattended k6 scenario yet.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "notes": "Construct-only registry entry. The current PROOFS corpus carries manual evidence for this row; promote to scaffold/runnable only after a reviewed k6 fixture exists."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-row-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS/<sha> corpus contains reviewed manual evidence for this row."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CW-7",
+    "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "Catalog coverage entry only. Does not make the row runnable and does not change the canonical PROOFS corpus."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": false,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-row-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Not included in --live-suite. This entry exists so every current manual proof row has an explicit manifest record."
+  }
+}

--- a/tools/k6-proofs/manifests/r-cw-delegate-child-live.json
+++ b/tools/k6-proofs/manifests/r-cw-delegate-child-live.json
@@ -1,0 +1,55 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CW-DELEGATE-CHILD-LIVE",
+  "issue": 213,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-cw-delegate-child-live",
+    "description": "delegate child schedules its own continue_work manual proof row. Registered to keep the executable-suite manifest catalog aligned with the 29-row manual proof corpus; not an unattended k6 scenario yet.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "notes": "Construct-only registry entry. The current PROOFS corpus carries manual evidence for this row; promote to scaffold/runnable only after a reviewed k6 fixture exists."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-row-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS/<sha> corpus contains reviewed manual evidence for this row."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CW-DELEGATE-CHILD-LIVE",
+    "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "Catalog coverage entry only. Does not make the row runnable and does not change the canonical PROOFS corpus."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": false,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-row-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Not included in --live-suite. This entry exists so every current manual proof row has an explicit manifest record."
+  }
+}

--- a/tools/k6-proofs/manifests/r-cw-delegate-token.json
+++ b/tools/k6-proofs/manifests/r-cw-delegate-token.json
@@ -1,0 +1,55 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CW-DELEGATE-TOKEN",
+  "issue": 221,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-cw-delegate-token",
+    "description": "delegate child bare CONTINUE_WORK token manual proof row. Registered to keep the executable-suite manifest catalog aligned with the 29-row manual proof corpus; not an unattended k6 scenario yet.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "notes": "Construct-only registry entry. The current PROOFS corpus carries manual evidence for this row; promote to scaffold/runnable only after a reviewed k6 fixture exists."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-row-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS/<sha> corpus contains reviewed manual evidence for this row."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CW-DELEGATE-TOKEN",
+    "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "Catalog coverage entry only. Does not make the row runnable and does not change the canonical PROOFS corpus."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": false,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-row-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Not included in --live-suite. This entry exists so every current manual proof row has an explicit manifest record."
+  }
+}

--- a/tools/k6-proofs/manifests/r-cw-multi-collapse.json
+++ b/tools/k6-proofs/manifests/r-cw-multi-collapse.json
@@ -1,0 +1,55 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CW-MULTI-COLLAPSE",
+  "issue": 216,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-cw-multi-collapse",
+    "description": "stale/new same-session continuation collapse manual proof row. Registered to keep the executable-suite manifest catalog aligned with the 29-row manual proof corpus; not an unattended k6 scenario yet.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "notes": "Construct-only registry entry. The current PROOFS corpus carries manual evidence for this row; promote to scaffold/runnable only after a reviewed k6 fixture exists."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-row-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS/<sha> corpus contains reviewed manual evidence for this row."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CW-MULTI-COLLAPSE",
+    "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "Catalog coverage entry only. Does not make the row runnable and does not change the canonical PROOFS corpus."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": false,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-row-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Not included in --live-suite. This entry exists so every current manual proof row has an explicit manifest record."
+  }
+}

--- a/tools/k6-proofs/manifests/r-cw-multi.json
+++ b/tools/k6-proofs/manifests/r-cw-multi.json
@@ -1,0 +1,55 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CW-MULTI",
+  "issue": 117,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-cw-multi",
+    "description": "multiple continue_work same-turn manual proof row. Registered to keep the executable-suite manifest catalog aligned with the 29-row manual proof corpus; not an unattended k6 scenario yet.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "notes": "Construct-only registry entry. The current PROOFS corpus carries manual evidence for this row; promote to scaffold/runnable only after a reviewed k6 fixture exists."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-row-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS/<sha> corpus contains reviewed manual evidence for this row."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CW-MULTI",
+    "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "Catalog coverage entry only. Does not make the row runnable and does not change the canonical PROOFS corpus."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": false,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-row-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Not included in --live-suite. This entry exists so every current manual proof row has an explicit manifest record."
+  }
+}

--- a/tools/k6-proofs/manifests/r-obs-1.json
+++ b/tools/k6-proofs/manifests/r-obs-1.json
@@ -1,0 +1,55 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-OBS-1",
+  "issue": 1135,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-obs-1",
+    "description": "session status observability manual proof row. Registered to keep the executable-suite manifest catalog aligned with the 29-row manual proof corpus; not an unattended k6 scenario yet.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "notes": "Construct-only registry entry. The current PROOFS corpus carries manual evidence for this row; promote to scaffold/runnable only after a reviewed k6 fixture exists."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-row-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS/<sha> corpus contains reviewed manual evidence for this row."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-OBS-1",
+    "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "Catalog coverage entry only. Does not make the row runnable and does not change the canonical PROOFS corpus."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": false,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-row-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Not included in --live-suite. This entry exists so every current manual proof row has an explicit manifest record."
+  }
+}

--- a/tools/k6-proofs/manifests/r-obs-2.json
+++ b/tools/k6-proofs/manifests/r-obs-2.json
@@ -1,0 +1,55 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-OBS-2",
+  "issue": 233,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-obs-2",
+    "description": "trace/span observability manual proof row. Registered to keep the executable-suite manifest catalog aligned with the 29-row manual proof corpus; not an unattended k6 scenario yet.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "notes": "Construct-only registry entry. The current PROOFS corpus carries manual evidence for this row; promote to scaffold/runnable only after a reviewed k6 fixture exists."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-row-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS/<sha> corpus contains reviewed manual evidence for this row."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-OBS-2",
+    "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "Catalog coverage entry only. Does not make the row runnable and does not change the canonical PROOFS corpus."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": false,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-row-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Not included in --live-suite. This entry exists so every current manual proof row has an explicit manifest record."
+  }
+}

--- a/tools/k6-proofs/manifests/r-regression-trap-tests.json
+++ b/tools/k6-proofs/manifests/r-regression-trap-tests.json
@@ -1,0 +1,55 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-REGRESSION-TRAP-TESTS",
+  "issue": 121,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-regression-trap-tests",
+    "description": "regression trap source/test manual proof row. Registered to keep the executable-suite manifest catalog aligned with the 29-row manual proof corpus; not an unattended k6 scenario yet.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "notes": "Construct-only registry entry. The current PROOFS corpus carries manual evidence for this row; promote to scaffold/runnable only after a reviewed k6 fixture exists."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-row-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS/<sha> corpus contains reviewed manual evidence for this row."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-REGRESSION-TRAP-TESTS",
+    "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "Catalog coverage entry only. Does not make the row runnable and does not change the canonical PROOFS corpus."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": false,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-row-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Not included in --live-suite. This entry exists so every current manual proof row has an explicit manifest record."
+  }
+}

--- a/tools/k6-proofs/manifests/r-trace-redaction-1121.json
+++ b/tools/k6-proofs/manifests/r-trace-redaction-1121.json
@@ -1,0 +1,55 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-TRACE-REDACTION-1121",
+  "issue": 1121,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-trace-redaction-1121",
+    "description": "trace redaction regression manual proof row. Registered to keep the executable-suite manifest catalog aligned with the 29-row manual proof corpus; not an unattended k6 scenario yet.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "notes": "Construct-only registry entry. The current PROOFS corpus carries manual evidence for this row; promote to scaffold/runnable only after a reviewed k6 fixture exists."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-row-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS/<sha> corpus contains reviewed manual evidence for this row."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-TRACE-REDACTION-1121",
+    "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "Catalog coverage entry only. Does not make the row runnable and does not change the canonical PROOFS corpus."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": false,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-row-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Not included in --live-suite. This entry exists so every current manual proof row has an explicit manifest record."
+  }
+}

--- a/tools/k6-proofs/scripts/check-proof-row-manifests.mjs
+++ b/tools/k6-proofs/scripts/check-proof-row-manifests.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * check-proof-row-manifests.mjs — ensure every current PROOFS row has a k6 manifest entry.
+ *
+ * This does not require every proof row to be k6-runnable. Manual-only rows may be
+ * construct-only or scaffold, but they should still be explicit in the catalog so
+ * the public executable-suite surface can explain the full 29-row corpus.
+ */
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const indexPath = path.join(root, 'PROOFS', 'INDEX.json');
+const manifestsDir = path.join(root, 'tools', 'k6-proofs', 'manifests');
+const failures = [];
+
+if (!existsSync(indexPath)) failures.push(`missing ${indexPath}`);
+if (!existsSync(manifestsDir)) failures.push(`missing ${manifestsDir}`);
+
+let currentSha = '';
+let proofRows = [];
+if (!failures.length) {
+  const index = JSON.parse(readFileSync(indexPath, 'utf8'));
+  currentSha = index.current_sha;
+  const corpusDir = path.join(root, 'PROOFS', currentSha);
+  if (!currentSha || !existsSync(corpusDir)) {
+    failures.push(`current PROOFS corpus missing: ${corpusDir}`);
+  } else {
+    proofRows = readdirSync(corpusDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .filter((name) => name !== 'gates')
+      .sort();
+  }
+}
+
+const manifestRows = [];
+if (!failures.length) {
+  for (const file of readdirSync(manifestsDir).filter((name) => name.endsWith('.json')).sort()) {
+    const manifest = JSON.parse(readFileSync(path.join(manifestsDir, file), 'utf8'));
+    if (manifest.rowId) manifestRows.push({ rowId: manifest.rowId, file });
+  }
+}
+
+const manifestByUpper = new Map(manifestRows.map((row) => [row.rowId.toUpperCase(), row]));
+const missing = proofRows.filter((row) => !manifestByUpper.has(row.toUpperCase()));
+
+if (missing.length) {
+  failures.push(`proof rows missing manifest entries: ${missing.join(', ')}`);
+}
+
+console.log(`Current corpus: PROOFS/${currentSha}`);
+console.log(`Proof rows: ${proofRows.length}`);
+console.log(`Manifest entries: ${manifestRows.length}`);
+if (missing.length) console.log(`Missing manifests: ${missing.join(', ')}`);
+else console.log('Missing manifests: 0');
+
+if (failures.length) {
+  console.error('\nProof row manifest coverage check failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exitCode = 1;
+} else {
+  console.log('Proof row manifest coverage check passed.');
+}


### PR DESCRIPTION
## Summary

Closes the catalog gap figs flagged: the current `PROOFS/INDEX.json` corpus has 29 manual proof rows, but `tools/k6-proofs/manifests/` only described the runnable/scaffold subset.

This PR adds construct-only manifest entries for the current manual-only rows that did not yet have catalog records, without promoting them to unattended live k6 rows.

Added:

- 14 `construct-only` manifest entries for manual proof rows currently present under `PROOFS/<current_sha>/`
- `tools/k6-proofs/scripts/check-proof-row-manifests.mjs`, which verifies every current PROOFS row has a manifest entry
- workflow/runbook wiring so the public `project81-k6-proof` workflow checks the 29-row coverage invariant before resolving runnable rows

This keeps the portable suite honest:

- full manual corpus coverage: 29/29 proof rows have explicit manifest records
- live suite remains the safe unattended subset: 16 `k6-runnable` rows
- construct-only rows are not included in `--live-suite` and do not mutate canonical `PROOFS`

## Validation

- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs` ✅
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs` ✅
- `node tools/k6-proofs/scripts/check-proof-row-manifests.mjs` ✅ (`Proof rows: 29`, `Missing manifests: 0`)
- `node tools/k6-proofs/scripts/validate-corpus.mjs --current` ✅
- workflow-equivalent dry run from `tools/k6-proofs` using `rows=$(node scripts/list-runnable-rows.mjs --live-suite)` ✅
- `git diff --cached --check` ✅
