### PR TITLE
project81: register manual corpus rows in k6 manifests

### DIFF
--- a/RUNBOOKS/project-81/EXECUTABLE-SUITE.md
+++ b/RUNBOOKS/project-81/EXECUTABLE-SUITE.md
@@ -4,6 +4,12 @@ Goal: give a reviewer or maintainer a small, repeatable path from a normal OpenC
 
 This quickstart intentionally covers only unattended `k6-runnable` rows. Rows marked `orchestration-required` stay out of the broad suite until a reviewed fixture exists.
 
+The proof catalog is broader than the unattended suite: it also carries construct-only manifests so every row in the current 29-row manual PROOFS corpus has an explicit manifest entry. To verify that row-map without running live proof traffic:
+
+```bash
+node tools/k6-proofs/scripts/check-current-corpus-manifest-coverage.mjs
+```
+
 ## 1. Install k6
 
 Install Grafana k6 using the upstream package for your OS:

--- a/RUNBOOKS/project-81/README.md
+++ b/RUNBOOKS/project-81/README.md
@@ -29,6 +29,14 @@ R-CD-1,R-CD-2,R-CD-4,R-CD-CHAINED-DEPTH-2,R-CD-MODEL-CHAINED-ALT,R-CD-MODEL-DEFA
 
 `preflight` remains `static-preflight-only`: the runner performs seat-readiness preflight for live runs, but the preflight manifest row is intentionally skipped by live-run guard.
 
+The current canonical manual corpus has 29 rows under `PROOFS/INDEX.json`. The k6 manifest registry covers all 29: runnable/scaffold manifests for rows with executable fixtures, and `construct-only` manifests for rows that are currently manual-corpus receipts only. Check the coverage map with:
+
+```bash
+node tools/k6-proofs/scripts/check-current-corpus-manifest-coverage.mjs
+```
+
+`extraNonCorpusRows` in that report are supplemental automation rows that are not entries in the current 29-row manual corpus.
+
 Use this directory as the accumulator. When a scaffold row becomes runnable, add or update `RUNBOOKS/project-81/rows/<ROW>.md` in the same PR as the scenario/manifest change.
 
 ## Current runnable row runbooks

--- a/tools/k6-proofs/manifests/r-cd-return-overlap.json
+++ b/tools/k6-proofs/manifests/r-cd-return-overlap.json
@@ -1,0 +1,58 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CD-RETURN-OVERLAP",
+  "issue": 119,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-manual-corpus}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-cd-return-overlap",
+    "description": "Manual corpus row for same-root silent + silent-wake delegate return overlap collection.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "registryNotes": "Construct-only registry entry for the current 29-row manual PROOFS corpus. It intentionally does not expose an unattended k6 scenario yet."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS corpus row entry and evidence_doc/supporting_docs are present under PROOFS current_sha."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CD-RETURN-OVERLAP",
+    "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": false,
+    "foldRequiresReview": true,
+    "canonicalEvidenceDoc": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-CD-RETURN-OVERLAP/cael-dgx/EVIDENCE.md",
+    "canonicalRowDir": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-CD-RETURN-OVERLAP/",
+    "canonicalState": "pass",
+    "notes": "This manifest closes catalog coverage for the manual 29-row corpus only. Promotion to scaffold/runnable requires a separate reviewed scenario/fixture PR."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Registry-only coverage for a manually folded PROOFS row; not included in dry-run/live k6 suites."
+  }
+}

--- a/tools/k6-proofs/manifests/r-cd-silent.json
+++ b/tools/k6-proofs/manifests/r-cd-silent.json
@@ -1,0 +1,58 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CD-SILENT",
+  "issue": 119,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-manual-corpus}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-cd-silent",
+    "description": "Manual corpus row for continue_delegate(mode=silent) delivery without immediate wake.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "registryNotes": "Construct-only registry entry for the current 29-row manual PROOFS corpus. It intentionally does not expose an unattended k6 scenario yet."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS corpus row entry and evidence_doc/supporting_docs are present under PROOFS current_sha."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CD-SILENT",
+    "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": false,
+    "foldRequiresReview": true,
+    "canonicalEvidenceDoc": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-CD-SILENT/cael-dgx/EVIDENCE.md",
+    "canonicalRowDir": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-CD-SILENT/",
+    "canonicalState": "pass",
+    "notes": "This manifest closes catalog coverage for the manual 29-row corpus only. Promotion to scaffold/runnable requires a separate reviewed scenario/fixture PR."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Registry-only coverage for a manually folded PROOFS row; not included in dry-run/live k6 suites."
+  }
+}

--- a/tools/k6-proofs/manifests/r-config-intersession.json
+++ b/tools/k6-proofs/manifests/r-config-intersession.json
@@ -1,0 +1,58 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CONFIG-INTERSESSION",
+  "issue": 104,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-manual-corpus}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-config-intersession",
+    "description": "Manual corpus row for continuation config persistence across session boundaries.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "registryNotes": "Construct-only registry entry for the current 29-row manual PROOFS corpus. It intentionally does not expose an unattended k6 scenario yet."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS corpus row entry and evidence_doc/supporting_docs are present under PROOFS current_sha."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CONFIG-INTERSESSION",
+    "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": false,
+    "foldRequiresReview": true,
+    "canonicalEvidenceDoc": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-CONFIG-INTERSESSION/EVIDENCE.md",
+    "canonicalRowDir": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-CONFIG-INTERSESSION/",
+    "canonicalState": "pass",
+    "notes": "This manifest closes catalog coverage for the manual 29-row corpus only. Promotion to scaffold/runnable requires a separate reviewed scenario/fixture PR."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Registry-only coverage for a manually folded PROOFS row; not included in dry-run/live k6 suites."
+  }
+}

--- a/tools/k6-proofs/manifests/r-cw-2.json
+++ b/tools/k6-proofs/manifests/r-cw-2.json
@@ -1,0 +1,58 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CW-2",
+  "issue": 117,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-manual-corpus}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-cw-2",
+    "description": "Manual corpus row for continue_work chain-counter accounting.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "registryNotes": "Construct-only registry entry for the current 29-row manual PROOFS corpus. It intentionally does not expose an unattended k6 scenario yet."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS corpus row entry and evidence_doc/supporting_docs are present under PROOFS current_sha."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CW-2",
+    "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": false,
+    "foldRequiresReview": true,
+    "canonicalEvidenceDoc": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-CW-2/cael-dgx/EVIDENCE.md",
+    "canonicalRowDir": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-CW-2/",
+    "canonicalState": "pass",
+    "notes": "This manifest closes catalog coverage for the manual 29-row corpus only. Promotion to scaffold/runnable requires a separate reviewed scenario/fixture PR."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Registry-only coverage for a manually folded PROOFS row; not included in dry-run/live k6 suites."
+  }
+}

--- a/tools/k6-proofs/manifests/r-cw-3.json
+++ b/tools/k6-proofs/manifests/r-cw-3.json
@@ -1,0 +1,58 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CW-3",
+  "issue": 117,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-manual-corpus}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-cw-3",
+    "description": "Manual corpus row for continue_work reason-field capture in telemetry/OTel spans.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "registryNotes": "Construct-only registry entry for the current 29-row manual PROOFS corpus. It intentionally does not expose an unattended k6 scenario yet."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS corpus row entry and evidence_doc/supporting_docs are present under PROOFS current_sha."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CW-3",
+    "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": false,
+    "foldRequiresReview": true,
+    "canonicalEvidenceDoc": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-CW-3/cael-dgx/EVIDENCE.md",
+    "canonicalRowDir": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-CW-3/",
+    "canonicalState": "pass",
+    "notes": "This manifest closes catalog coverage for the manual 29-row corpus only. Promotion to scaffold/runnable requires a separate reviewed scenario/fixture PR."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Registry-only coverage for a manually folded PROOFS row; not included in dry-run/live k6 suites."
+  }
+}

--- a/tools/k6-proofs/manifests/r-cw-7.json
+++ b/tools/k6-proofs/manifests/r-cw-7.json
@@ -1,0 +1,58 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CW-7",
+  "issue": 117,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-manual-corpus}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-cw-7",
+    "description": "Manual corpus row for traceparent E2E propagation across continuation spans.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "registryNotes": "Construct-only registry entry for the current 29-row manual PROOFS corpus. It intentionally does not expose an unattended k6 scenario yet."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS corpus row entry and evidence_doc/supporting_docs are present under PROOFS current_sha."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CW-7",
+    "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": false,
+    "foldRequiresReview": true,
+    "canonicalEvidenceDoc": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-CW-7/cael-dgx/EVIDENCE.md",
+    "canonicalRowDir": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-CW-7/",
+    "canonicalState": "pass",
+    "notes": "This manifest closes catalog coverage for the manual 29-row corpus only. Promotion to scaffold/runnable requires a separate reviewed scenario/fixture PR."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Registry-only coverage for a manually folded PROOFS row; not included in dry-run/live k6 suites."
+  }
+}

--- a/tools/k6-proofs/manifests/r-cw-delegate-child-live.json
+++ b/tools/k6-proofs/manifests/r-cw-delegate-child-live.json
@@ -1,0 +1,58 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CW-DELEGATE-CHILD-LIVE",
+  "issue": 117,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-manual-corpus}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-cw-delegate-child-live",
+    "description": "Manual corpus row for live delegate-child continue_work self-continuation.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "registryNotes": "Construct-only registry entry for the current 29-row manual PROOFS corpus. It intentionally does not expose an unattended k6 scenario yet."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS corpus row entry and evidence_doc/supporting_docs are present under PROOFS current_sha."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CW-DELEGATE-CHILD-LIVE",
+    "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": false,
+    "foldRequiresReview": true,
+    "canonicalEvidenceDoc": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-CW-DELEGATE-CHILD-LIVE/cael-dgx/EVIDENCE.md",
+    "canonicalRowDir": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-CW-DELEGATE-CHILD-LIVE/",
+    "canonicalState": "pass",
+    "notes": "This manifest closes catalog coverage for the manual 29-row corpus only. Promotion to scaffold/runnable requires a separate reviewed scenario/fixture PR."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Registry-only coverage for a manually folded PROOFS row; not included in dry-run/live k6 suites."
+  }
+}

--- a/tools/k6-proofs/manifests/r-cw-delegate-token.json
+++ b/tools/k6-proofs/manifests/r-cw-delegate-token.json
@@ -1,0 +1,58 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CW-DELEGATE-TOKEN",
+  "issue": 117,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-manual-corpus}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-cw-delegate-token",
+    "description": "Manual corpus row for delegate-child bracket/bare-token continue_work fallback.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "registryNotes": "Construct-only registry entry for the current 29-row manual PROOFS corpus. It intentionally does not expose an unattended k6 scenario yet."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS corpus row entry and evidence_doc/supporting_docs are present under PROOFS current_sha."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CW-DELEGATE-TOKEN",
+    "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": false,
+    "foldRequiresReview": true,
+    "canonicalEvidenceDoc": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-CW-DELEGATE-TOKEN/cael-dgx/EVIDENCE.md",
+    "canonicalRowDir": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-CW-DELEGATE-TOKEN/",
+    "canonicalState": "pass",
+    "notes": "This manifest closes catalog coverage for the manual 29-row corpus only. Promotion to scaffold/runnable requires a separate reviewed scenario/fixture PR."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Registry-only coverage for a manually folded PROOFS row; not included in dry-run/live k6 suites."
+  }
+}

--- a/tools/k6-proofs/manifests/r-cw-multi-collapse.json
+++ b/tools/k6-proofs/manifests/r-cw-multi-collapse.json
@@ -1,0 +1,58 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CW-MULTI-COLLAPSE",
+  "issue": 117,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-manual-corpus}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-cw-multi-collapse",
+    "description": "Manual corpus row for elapsed-overlap/stale continuation co-drain and supersession semantics.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "registryNotes": "Construct-only registry entry for the current 29-row manual PROOFS corpus. It intentionally does not expose an unattended k6 scenario yet."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS corpus row entry and evidence_doc/supporting_docs are present under PROOFS current_sha."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CW-MULTI-COLLAPSE",
+    "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": false,
+    "foldRequiresReview": true,
+    "canonicalEvidenceDoc": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-CW-MULTI-COLLAPSE/cael-dgx/EVIDENCE.md",
+    "canonicalRowDir": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-CW-MULTI-COLLAPSE/",
+    "canonicalState": "pass",
+    "notes": "This manifest closes catalog coverage for the manual 29-row corpus only. Promotion to scaffold/runnable requires a separate reviewed scenario/fixture PR."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Registry-only coverage for a manually folded PROOFS row; not included in dry-run/live k6 suites."
+  }
+}

--- a/tools/k6-proofs/manifests/r-cw-multi.json
+++ b/tools/k6-proofs/manifests/r-cw-multi.json
@@ -1,0 +1,58 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CW-MULTI",
+  "issue": 117,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-manual-corpus}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-cw-multi",
+    "description": "Manual corpus row for same-turn multi-continue_work fanout semantics.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "registryNotes": "Construct-only registry entry for the current 29-row manual PROOFS corpus. It intentionally does not expose an unattended k6 scenario yet."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS corpus row entry and evidence_doc/supporting_docs are present under PROOFS current_sha."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CW-MULTI",
+    "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": false,
+    "foldRequiresReview": true,
+    "canonicalEvidenceDoc": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-CW-MULTI/cael-dgx/EVIDENCE.md",
+    "canonicalRowDir": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-CW-MULTI/",
+    "canonicalState": "pass",
+    "notes": "This manifest closes catalog coverage for the manual 29-row corpus only. Promotion to scaffold/runnable requires a separate reviewed scenario/fixture PR."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Registry-only coverage for a manually folded PROOFS row; not included in dry-run/live k6 suites."
+  }
+}

--- a/tools/k6-proofs/manifests/r-obs-1.json
+++ b/tools/k6-proofs/manifests/r-obs-1.json
@@ -1,0 +1,58 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-OBS-1",
+  "issue": 104,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-manual-corpus}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-obs-1",
+    "description": "Manual corpus row for status/external observer receipt.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "registryNotes": "Construct-only registry entry for the current 29-row manual PROOFS corpus. It intentionally does not expose an unattended k6 scenario yet."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS corpus row entry and evidence_doc/supporting_docs are present under PROOFS current_sha."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-OBS-1",
+    "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": false,
+    "foldRequiresReview": true,
+    "canonicalEvidenceDoc": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-OBS-1/cael-dgx/EVIDENCE.md",
+    "canonicalRowDir": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-OBS-1/",
+    "canonicalState": "pass",
+    "notes": "This manifest closes catalog coverage for the manual 29-row corpus only. Promotion to scaffold/runnable requires a separate reviewed scenario/fixture PR."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Registry-only coverage for a manually folded PROOFS row; not included in dry-run/live k6 suites."
+  }
+}

--- a/tools/k6-proofs/manifests/r-obs-2.json
+++ b/tools/k6-proofs/manifests/r-obs-2.json
@@ -1,0 +1,58 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-OBS-2",
+  "issue": 104,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-manual-corpus}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-obs-2",
+    "description": "Manual corpus row for Tempo trace-tree visualization/export.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "registryNotes": "Construct-only registry entry for the current 29-row manual PROOFS corpus. It intentionally does not expose an unattended k6 scenario yet."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS corpus row entry and evidence_doc/supporting_docs are present under PROOFS current_sha."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-OBS-2",
+    "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": false,
+    "foldRequiresReview": true,
+    "canonicalEvidenceDoc": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-OBS-2/cael-dgx/EVIDENCE.md",
+    "canonicalRowDir": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-OBS-2/",
+    "canonicalState": "pass",
+    "notes": "This manifest closes catalog coverage for the manual 29-row corpus only. Promotion to scaffold/runnable requires a separate reviewed scenario/fixture PR."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Registry-only coverage for a manually folded PROOFS row; not included in dry-run/live k6 suites."
+  }
+}

--- a/tools/k6-proofs/manifests/r-regression-trap-tests.json
+++ b/tools/k6-proofs/manifests/r-regression-trap-tests.json
@@ -1,0 +1,58 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-REGRESSION-TRAP-TESTS",
+  "issue": 104,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-manual-corpus}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-regression-trap-tests",
+    "description": "Manual corpus row for regression trap tests covering continuation sibling surfaces.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "registryNotes": "Construct-only registry entry for the current 29-row manual PROOFS corpus. It intentionally does not expose an unattended k6 scenario yet."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS corpus row entry and evidence_doc/supporting_docs are present under PROOFS current_sha."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-REGRESSION-TRAP-TESTS",
+    "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": false,
+    "foldRequiresReview": true,
+    "canonicalEvidenceDoc": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-REGRESSION-TRAP-TESTS/cael-dgx/EVIDENCE.md",
+    "canonicalRowDir": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-REGRESSION-TRAP-TESTS/",
+    "canonicalState": "pass",
+    "notes": "This manifest closes catalog coverage for the manual 29-row corpus only. Promotion to scaffold/runnable requires a separate reviewed scenario/fixture PR."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Registry-only coverage for a manually folded PROOFS row; not included in dry-run/live k6 suites."
+  }
+}

--- a/tools/k6-proofs/manifests/r-trace-redaction-1121.json
+++ b/tools/k6-proofs/manifests/r-trace-redaction-1121.json
@@ -1,0 +1,58 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-TRACE-REDACTION-1121",
+  "issue": 121,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-manual-corpus}",
+  "transport": "offline",
+  "toolSurface": "read-only",
+  "mutates": false,
+  "timeoutSeconds": 0,
+  "scenario": {
+    "name": "r-trace-redaction-1121",
+    "description": "Manual corpus row for trace redaction proof receipts.",
+    "methods": [
+      "manual-corpus-review"
+    ],
+    "status": "construct-only",
+    "registryNotes": "Construct-only registry entry for the current 29-row manual PROOFS corpus. It intentionally does not expose an unattended k6 scenario yet."
+  },
+  "expectedReceipts": [
+    {
+      "name": "manual-corpus-receipt",
+      "required": true,
+      "description": "Current PROOFS corpus row entry and evidence_doc/supporting_docs are present under PROOFS current_sha."
+    }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-TRACE-REDACTION-1121",
+    "seat": "${OPENCLAW_SEAT_NAME:-manual-corpus}",
+    "runDirPrefix": "manual-corpus"
+  },
+  "review": {
+    "candidateOnly": false,
+    "foldRequiresReview": true,
+    "canonicalEvidenceDoc": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-TRACE-REDACTION-1121/EVIDENCE.md",
+    "canonicalRowDir": "PROOFS/1cc8f4e3d617ef6f173283ef83d7b739a4995734/R-TRACE-REDACTION-1121/",
+    "canonicalState": "pass",
+    "notes": "This manifest closes catalog coverage for the manual 29-row corpus only. Promotion to scaffold/runnable requires a separate reviewed scenario/fixture PR."
+  },
+  "liveRunSafety": {
+    "classification": "construct-only",
+    "requiresLiveGatewayToken": false,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
+    "sameSessionConcurrencySafe": true,
+    "expectedArtifactClass": "construct-only",
+    "requiredReceipts": [
+      "manual-corpus-receipt"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Registry-only coverage for a manually folded PROOFS row; not included in dry-run/live k6 suites."
+  }
+}

--- a/tools/k6-proofs/scripts/check-current-corpus-manifest-coverage.mjs
+++ b/tools/k6-proofs/scripts/check-current-corpus-manifest-coverage.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+/**
+ * Verify that every row in PROOFS/INDEX.json's current manual corpus has a
+ * tools/k6-proofs manifest entry. This is intentionally broader than the
+ * unattended k6 live suite: construct-only manifests count as catalog coverage.
+ */
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const root = process.cwd().endsWith('/tools/k6-proofs') ? join(process.cwd(), '..', '..') : process.cwd();
+const index = JSON.parse(readFileSync(join(root, 'PROOFS', 'INDEX.json'), 'utf8'));
+const corpus = JSON.parse(readFileSync(join(root, index.manifest_path), 'utf8'));
+const normalize = (row) => row === 'R-CONFIG-defaults' ? 'R-CONFIG-DEFAULTS' : row;
+const corpusRows = [...new Set(corpus.rows.map((row) => normalize(row.row)))].sort();
+const manifestRows = readdirSync(join(root, 'tools', 'k6-proofs', 'manifests'))
+  .filter((name) => name.endsWith('.json'))
+  .map((name) => JSON.parse(readFileSync(join(root, 'tools', 'k6-proofs', 'manifests', name), 'utf8')).rowId)
+  .map(normalize);
+const manifestSet = new Set(manifestRows);
+const missing = corpusRows.filter((row) => !manifestSet.has(row));
+const extra = [...new Set(manifestRows)].filter((row) => row !== 'preflight' && !corpusRows.includes(row)).sort();
+const result = {
+  currentSha: index.current_sha,
+  corpusRows: corpusRows.length,
+  manifestRows: manifestRows.length,
+  coveredCorpusRows: corpusRows.length - missing.length,
+  missing,
+  extraNonCorpusRows: extra,
+  ok: missing.length === 0,
+};
+console.log(JSON.stringify(result, null, 2));
+if (!result.ok) process.exit(1);


### PR DESCRIPTION
## What

Registers every row in the current 29-row manual `PROOFS/INDEX.json` corpus in the k6 proof manifest catalog.

This intentionally does **not** pretend all 29 are unattended k6 scenarios. The added rows are `construct-only` manifests for manually folded corpus rows that do not yet have a reviewed runnable fixture.

## Why

The executable suite had 16 unattended live rows (+ held/scaffold rows), but the current canonical manual corpus has 29 rows. This closes the row-map gap so the catalog can answer: 29 manual rows are represented; runnable promotion remains explicit.

## Validation

- `node tools/k6-proofs/scripts/check-current-corpus-manifest-coverage.mjs`
  - `corpusRows: 29`
  - `coveredCorpusRows: 29`
  - `missing: []`
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs`
  - passes: 36 manifests; 24 scenario files
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs`
  - `ok: true`
- `node tools/k6-proofs/scripts/validate-corpus.mjs --index --json`
  - failed=false
- dry-run of resolved live suite still resolves the same 16 unattended rows

## Notes

`extraNonCorpusRows` in the new coverage report are supplemental automation rows already present in the manifest catalog but not entries in the current 29-row manual corpus: model rows, `R-CW-4`, and `R-OBS-status`.