### PR TITLE
project81: promote R-OBS-1 to runnable k6 row

### DIFF
--- a/RUNBOOKS/project-81/EXECUTABLE-SUITE.md
+++ b/RUNBOOKS/project-81/EXECUTABLE-SUITE.md
@@ -45,10 +45,10 @@ ROWS="$(node scripts/list-runnable-rows.mjs --live-suite)"
 printf '%s\n' "$ROWS"
 ```
 
-This excludes static preflight and any `orchestration-required` rows. As of this catalog, it prints the 16-row broad live suite:
+This excludes static preflight and any `orchestration-required` rows. As of this catalog, it prints the 17-row broad live suite:
 
 ```text
-R-CD-1,R-CD-2,R-CD-4,R-CD-CHAINED-DEPTH-2,R-CD-MODEL-CHAINED-ALT,R-CD-MODEL-DEFAULT,R-CD-MODEL-TOKEN,R-CD-MODEL-TOOL,R-CD-TOKEN,R-CONFIG-defaults,R-CW-1,R-CW-4,R-CW-DELEGATE-SELF-CONTINUATION,R-CW-TOKEN,R-OBS-status,R-RC-1
+R-CD-1,R-CD-2,R-CD-4,R-CD-CHAINED-DEPTH-2,R-CD-MODEL-CHAINED-ALT,R-CD-MODEL-DEFAULT,R-CD-MODEL-TOKEN,R-CD-MODEL-TOOL,R-CD-TOKEN,R-CONFIG-defaults,R-CW-1,R-CW-4,R-CW-DELEGATE-SELF-CONTINUATION,R-CW-TOKEN,R-OBS-1,R-OBS-status,R-RC-1
 ```
 
 ## GitHub Actions option

--- a/RUNBOOKS/project-81/README.md
+++ b/RUNBOOKS/project-81/README.md
@@ -24,7 +24,7 @@ For an external/reviewer-facing path from “install k6” to “run the unatten
 As of the post-#306/#307 Project 81 surface, the broad live slice is:
 
 ```text
-R-CD-1,R-CD-2,R-CD-4,R-CD-CHAINED-DEPTH-2,R-CD-MODEL-CHAINED-ALT,R-CD-MODEL-DEFAULT,R-CD-MODEL-TOKEN,R-CD-MODEL-TOOL,R-CD-TOKEN,R-CONFIG-defaults,R-CW-1,R-CW-4,R-CW-DELEGATE-SELF-CONTINUATION,R-CW-TOKEN,R-OBS-status,R-RC-1
+R-CD-1,R-CD-2,R-CD-4,R-CD-CHAINED-DEPTH-2,R-CD-MODEL-CHAINED-ALT,R-CD-MODEL-DEFAULT,R-CD-MODEL-TOKEN,R-CD-MODEL-TOOL,R-CD-TOKEN,R-CONFIG-defaults,R-CW-1,R-CW-4,R-CW-DELEGATE-SELF-CONTINUATION,R-CW-TOKEN,R-OBS-1,R-OBS-status,R-RC-1
 ```
 
 `preflight` remains `static-preflight-only`: the runner performs seat-readiness preflight for live runs, but the preflight manifest row is intentionally skipped by live-run guard.
@@ -48,6 +48,7 @@ Use this directory as the accumulator. When a scaffold row becomes runnable, add
 - [R-CW-4](rows/R-CW-4.md)
 - [R-CW-DELEGATE-SELF-CONTINUATION](rows/R-CW-DELEGATE-SELF-CONTINUATION.md)
 - [R-CW-TOKEN](rows/R-CW-TOKEN.md)
+- [R-OBS-1](rows/R-OBS-1.md)
 - [R-OBS-status](rows/R-OBS-status.md)
 - [R-RC-1](rows/R-RC-1.md)
 

--- a/RUNBOOKS/project-81/rows/R-OBS-1.md
+++ b/RUNBOOKS/project-81/rows/R-OBS-1.md
@@ -1,0 +1,49 @@
+# R-OBS-1 row runbook
+
+Status-card observability row. This row is read-only: it creates a disposable session by default, asks the agent to call `session_status`, and verifies that the resulting status card exposes build/version, context usage, continuation chain/queue visibility, and active route/delivery context.
+
+## Safety
+
+- `mutates: false`
+- no continuation/delegate fire
+- no config mutation
+- no gateway restart
+- no compaction request
+- same-session safe when using disposable sessions
+
+## Dry run
+
+```bash
+cd tools/k6-proofs
+./scripts/run-proofs.sh --dry-run R-OBS-1 <candidate-sha>
+```
+
+## Live candidate run
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_CREATE_DISPOSABLE_SESSION=true \
+OPENCLAW_GATEWAY_TOKEN=*** \
+  ./scripts/run-proofs.sh --live R-OBS-1 <candidate-sha>
+```
+
+The scenario writes candidate artifacts under the configured proof output root. Candidate artifacts are not canonical proof verdicts until reviewed/folded.
+
+## Required receipts
+
+- `seat-readiness.json`
+- `row-manifest.json`
+- `k6.log`
+- `evidence.jsonl`
+- `run-result.json`
+- `r-obs-1-summary.json`
+
+PASS-candidate requires the nonce-correlated `OBS1-STATUS` sentinel to report:
+
+```text
+BUILD yes CONTEXT yes CHAIN yes ROUTE yes
+```
+
+## Review notes
+
+The historical manual row also attached Tempo JSON for `session_status`. The k6 candidate row records trace id when the gateway exposes one, but a null trace id is review debt only if the manifest requires trace JSON; do not synthesize trace debt when no trace id was emitted.

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -347,6 +347,7 @@ This is **declared in the manifest before the run**, not a post-hoc excuse. The 
 | R-CW-4 | `r-cw-4-chain-depth` | typed-tool | Candidate; continue_work chain depth across multiple hops |
 | R-CW-DELEGATE-SELF-CONTINUATION | `r-cw-delegate-self-continuation` | typed-tool | Candidate; delegate child self-continuation path |
 | R-CW-TOKEN | `r-cw-token-bracket` | bracket-token | Candidate; bare `CONTINUE_WORK:N` from scanned final text drives hop-2 |
+| R-OBS-1 | `r-obs-1` | read-only | Candidate; status-card observability via session_status tool |
 | R-OBS-status | `r-obs-status` | read-only | Candidate; gateway status/observer receipt check |
 | R-RC-1 | `r-rc-1` | typed-tool | Candidate; request_compaction below-threshold structured rejection |
 | R-CW overview | `r-cw` | read-only/infrastructure | Candidate; combined continue_work infrastructure check |

--- a/tools/k6-proofs/manifests/r-obs-1.json
+++ b/tools/k6-proofs/manifests/r-obs-1.json
@@ -5,24 +5,47 @@
   "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
   "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
   "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
-  "transport": "offline",
-  "toolSurface": "read-only",
+  "transport": "websocket",
+  "toolSurface": "typed-tool",
   "mutates": false,
-  "timeoutSeconds": 0,
+  "timeoutSeconds": 90,
   "scenario": {
     "name": "r-obs-1",
-    "description": "session status observability manual proof row. Registered to keep the executable-suite manifest catalog aligned with the 29-row manual proof corpus; not an unattended k6 scenario yet.",
+    "description": "Session-status-card observability via the session_status tool. Creates a disposable session, asks the agent to call session_status, and verifies build/context/continuation-chain/route visibility by nonce-correlated sentinel.",
     "methods": [
-      "manual-corpus-review"
+      "sessions.create",
+      "sessions.send",
+      "sessions.messages.subscribe",
+      "session_status"
     ],
-    "status": "construct-only",
-    "notes": "Construct-only registry entry. The current PROOFS corpus carries manual evidence for this row; promote to scaffold/runnable only after a reviewed k6 fixture exists."
+    "status": "runnable",
+    "file": "r-obs-1.js"
   },
   "expectedReceipts": [
     {
-      "name": "manual-row-corpus-receipt",
+      "name": "session-created",
+      "required": false,
+      "description": "Disposable proof session was created for the status-card read."
+    },
+    {
+      "name": "dispatch-accepted",
       "required": true,
-      "description": "Current PROOFS/<sha> corpus contains reviewed manual evidence for this row."
+      "description": "sessions.send accepted the agent turn that calls session_status."
+    },
+    {
+      "name": "status-card-sentinel",
+      "required": true,
+      "description": "Agent reply included OBS1-STATUS sentinel for the nonce."
+    },
+    {
+      "name": "build-context-chain-route-visible",
+      "required": true,
+      "description": "Sentinel confirms build/version, context usage, continuation chain/queue, and route/delivery context were visible in the status card."
+    },
+    {
+      "name": "trace-id",
+      "required": false,
+      "description": "Trace ID from sessions.send or event payload when available."
     }
   ],
   "artifactDestination": {
@@ -35,21 +58,24 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Catalog coverage entry only. Does not make the row runnable and does not change the canonical PROOFS corpus."
+    "notes": "Read-only status-card observability row. PASS-candidate when dispatch is accepted and OBS1-STATUS sentinel reports build/context/chain/route visibility. Candidate artifacts require review before canonical fold."
   },
   "liveRunSafety": {
-    "classification": "construct-only",
-    "requiresLiveGatewayToken": false,
+    "classification": "k6-runnable",
+    "requiresLiveGatewayToken": true,
     "requiresTargetSessionKey": false,
-    "requiresCandidateSha": false,
-    "requiresExternalAgentOrToolInvocation": false,
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": true,
     "requiresHumanConfirmation": false,
     "sameSessionConcurrencySafe": true,
-    "expectedArtifactClass": "construct-only",
+    "expectedArtifactClass": "PASS-candidate",
     "requiredReceipts": [
-      "manual-row-corpus-receipt"
+      "seat-readiness",
+      "dispatch-accepted",
+      "status-card-sentinel",
+      "build-context-chain-route-visible"
     ],
     "foldRequiresReview": true,
-    "notes": "Not included in --live-suite. This entry exists so every current manual proof row has an explicit manifest record."
+    "notes": "Read-only session_status observability row. Uses a disposable session by default and does not fire continuation tools, delegates, config mutation, restart, or compaction."
   }
 }

--- a/tools/k6-proofs/scenarios/r-obs-1.js
+++ b/tools/k6-proofs/scenarios/r-obs-1.js
@@ -1,0 +1,236 @@
+/**
+ * Scenario: R-OBS-1 — status-card observability via session_status tool.
+ *
+ * This is the k6 candidate counterpart to the manual R-OBS-1 corpus row. It
+ * creates a disposable session, asks the agent to call the session_status tool,
+ * and requires a nonce-correlated sentinel confirming that the status card
+ * exposed the expected read-only observability fields. It does not fire
+ * continuation tools, mutate config, or dispatch delegates.
+ */
+import ws from 'k6/ws';
+import { check } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
+import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+
+export const options = {
+  scenarios: {
+    r_obs_1: {
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 1,
+      maxDuration: '90s',
+    },
+  },
+  thresholds: {
+    proof_failures: ['count==0'],
+    r_obs_1_duration: ['p(95)<75000'],
+  },
+};
+
+const failures = new Counter('proof_failures');
+const duration = new Trend('r_obs_1_duration');
+const manifest = loadManifestFromEnv();
+const HARNESS_MARKER = '[k6-proof-harness]';
+
+function boolEnv(name, defaultValue = false) {
+  const raw = __ENV[name];
+  if (raw === undefined || raw === '') return defaultValue;
+  return String(raw).toLowerCase() === 'true';
+}
+
+function parseObsSentinel(text, nonceValue) {
+  const idx = text.lastIndexOf(`OBS1-STATUS ${nonceValue}`);
+  if (idx === -1) return null;
+  const tail = text.slice(idx);
+  const build = tail.match(/BUILD\s+(yes|no)/i)?.[1]?.toLowerCase() || null;
+  const context = tail.match(/CONTEXT\s+(yes|no)/i)?.[1]?.toLowerCase() || null;
+  const chain = tail.match(/CHAIN\s+(yes|no)/i)?.[1]?.toLowerCase() || null;
+  const route = tail.match(/ROUTE\s+(yes|no)/i)?.[1]?.toLowerCase() || null;
+  if (!build || !context || !chain || !route) return null;
+  return { build, context, chain, route };
+}
+
+export default function () {
+  const url = __ENV.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
+  const token = __ENV.OPENCLAW_GATEWAY_TOKEN;
+  const requestedSessionKey = manifest?.sessionKey || __ENV.OPENCLAW_SESSION_KEY || 'main';
+  let sessionKey = requestedSessionKey;
+  const createDisposableSession = boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSION', true);
+  const seat = manifest?.seat || __ENV.OPENCLAW_SEAT_NAME || 'ci-runner';
+  const rowNonce = nonce('R-OBS-1');
+
+  if (!token) {
+    console.error('OPENCLAW_GATEWAY_TOKEN is required');
+    failures.add(1);
+    return;
+  }
+  if (manifest) {
+    const errors = validateManifest(manifest);
+    if (errors.length > 0) console.warn(`Manifest validation warnings: ${errors.join('; ')}`);
+  }
+
+  const evidence = {
+    row: 'R-OBS-1',
+    manifest_loaded: !!manifest,
+    nonce: rowNonce,
+    seat,
+    requestedSessionKey,
+    sessionKey,
+    session_created: false,
+    created_session_key: null,
+    candidateSha: manifest?.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
+    started: new Date().toISOString(),
+    dispatch_accepted: false,
+    status_card_observed: false,
+    build_visible: false,
+    context_visible: false,
+    continuation_chain_visible: false,
+    route_visible: false,
+    trace_id: null,
+    redacted_events: [],
+  };
+
+  const started = Date.now();
+  const nonceEventText = [];
+  let loggedPartialSentinel = false;
+
+  const res = ws.connect(url, {}, (socket) => {
+    const tracker = new RequestTracker();
+
+    function startProofFlow() {
+      tracker.send(socket, 'sessions.messages.subscribe', { key: sessionKey });
+      socket.setTimeout(() => {
+        const instruction =
+          `${HARNESS_MARKER} For Project 81 row R-OBS-1 nonce ${rowNonce}: ` +
+          `call the session_status tool for the current session. Inspect the returned status card. ` +
+          `Then reply exactly: OBS1-STATUS ${rowNonce} BUILD <yes|no> CONTEXT <yes|no> CHAIN <yes|no> ROUTE <yes|no>. ` +
+          `Use yes only if the status card exposes that field family: build/version, context usage, continuation chain/queue visibility, and active route/delivery context. No other action.`;
+        tracker.send(socket, 'sessions.send', {
+          key: sessionKey,
+          message: instruction,
+          idempotencyKey: `R-OBS-1-${rowNonce}`,
+        });
+      }, 500);
+      socket.setTimeout(() => socket.close(), 60000);
+    }
+
+    socket.on('open', () => {
+      socket.send(connectFrame(token));
+      if (createDisposableSession) {
+        socket.setTimeout(() => {
+          const disposableKey = `r-obs-1-${rowNonce}`.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+          tracker.send(socket, 'sessions.create', { key: disposableKey, label: `k6 R-OBS-1 ${rowNonce}` });
+        }, 250);
+      } else {
+        socket.setTimeout(startProofFlow, 500);
+      }
+    });
+
+    socket.on('message', (raw) => {
+      try {
+        const msg = JSON.parse(raw);
+        const classified = tracker.classify(msg);
+        evidence.redacted_events.push({
+          ts: Date.now(),
+          kind: classified.kind,
+          method: classified.method || null,
+          event: classified.event || null,
+          ok: classified.ok !== undefined ? classified.ok : null,
+          data: classified.payload ? redactEvent(classified.payload) : null,
+        });
+
+        if (classified.kind === 'response' && classified.method === 'sessions.create') {
+          if (classified.ok && classified.payload) {
+            sessionKey = classified.payload.key || sessionKey;
+            evidence.sessionKey = sessionKey;
+            evidence.session_created = true;
+            evidence.created_session_key = sessionKey;
+            console.log(`✓ disposable session created: ${sessionKey}`);
+            startProofFlow();
+          } else {
+            console.error(`✗ sessions.create rejected: ${JSON.stringify(classified.error)}`);
+            failures.add(1);
+            socket.close();
+          }
+        }
+
+        if (classified.kind === 'response' && classified.method === 'sessions.send') {
+          if (classified.ok) {
+            evidence.dispatch_accepted = true;
+            if (classified.payload?.traceId) evidence.trace_id = classified.payload.traceId;
+            console.log('✓ sessions.send accepted — agent turn triggered for R-OBS-1 status-card read');
+          } else {
+            console.error(`✗ sessions.send rejected: ${JSON.stringify(classified.error)}`);
+            failures.add(1);
+          }
+        }
+
+        if (classified.kind === 'event') {
+          const eventStr = JSON.stringify(classified.data || {});
+          if (eventStr.includes(rowNonce)) {
+            if (eventStr.includes(HARNESS_MARKER)) {
+              console.log('ℹ Ignoring harness prompt echo event');
+            } else {
+              nonceEventText.push(eventStr);
+              const observedText = nonceEventText.join(' ');
+              const sentinel = parseObsSentinel(observedText, rowNonce);
+              if (sentinel) {
+                evidence.status_card_observed = true;
+                evidence.build_visible = sentinel.build === 'yes';
+                evidence.context_visible = sentinel.context === 'yes';
+                evidence.continuation_chain_visible = sentinel.chain === 'yes';
+                evidence.route_visible = sentinel.route === 'yes';
+                console.log(`✓ OBS1-STATUS sentinel observed: ${JSON.stringify(sentinel)}`);
+                socket.close();
+              } else if (eventStr.includes(`OBS1-STATUS ${rowNonce}`) && !loggedPartialSentinel) {
+                loggedPartialSentinel = true;
+                console.log('ℹ OBS1-STATUS sentinel prefix observed; waiting for complete streamed sentinel');
+              }
+            }
+          }
+        }
+      } catch (e) {
+        console.warn(`parse error: ${e}`);
+      }
+    });
+
+    socket.on('error', (e) => {
+      console.error(`ws error: ${e && e.error ? e.error() : e}`);
+      failures.add(1);
+    });
+  });
+
+  evidence.ended = new Date().toISOString();
+  evidence.duration_ms = Date.now() - started;
+  duration.add(evidence.duration_ms);
+
+  check(res, { 'websocket connected': (r) => r && r.status === 101 });
+  check(null, {
+    'dispatch accepted': () => evidence.dispatch_accepted,
+    'status card sentinel observed': () => evidence.status_card_observed,
+    'build/context/chain/route visible': () => evidence.build_visible && evidence.context_visible && evidence.continuation_chain_visible && evidence.route_visible,
+  });
+
+  if (!evidence.dispatch_accepted || !evidence.status_card_observed || !evidence.build_visible || !evidence.context_visible || !evidence.continuation_chain_visible || !evidence.route_visible) {
+    failures.add(1);
+  }
+
+  console.log(`R_OBS_1_EVIDENCE ${JSON.stringify(evidence)}`);
+}
+
+export function handleSummary(data) {
+  const failureMetric = data.metrics.proof_failures && data.metrics.proof_failures.values;
+  const failuresCount = failureMetric ? failureMetric.count : 0;
+  return {
+    'r-obs-1-summary.json': JSON.stringify({
+      row: 'R-OBS-1',
+      sha: __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
+      verdict: failuresCount === 0 ? 'PASS-candidate' : 'FAIL-candidate',
+      metrics: {
+        failures: failuresCount,
+        duration_ms: data.metrics.r_obs_1_duration ? data.metrics.r_obs_1_duration.values : null,
+      },
+    }, null, 2),
+  };
+}


### PR DESCRIPTION
## What

Promotes `R-OBS-1` from construct-only manual-corpus coverage to an unattended `k6-runnable` row.

The new scenario creates a disposable session, asks the agent to call `session_status`, and requires a nonce-correlated `OBS1-STATUS` sentinel proving the status card exposes:

- build/version
- context usage
- continuation chain/queue visibility
- active route/delivery context

This is read-only: no continuation/delegate fire, no config mutation, no restart, no compaction.

## Result

The broad unattended live suite moves from 16 to 17 rows:

```text
R-CD-1,R-CD-2,R-CD-4,R-CD-CHAINED-DEPTH-2,R-CD-MODEL-CHAINED-ALT,R-CD-MODEL-DEFAULT,R-CD-MODEL-TOKEN,R-CD-MODEL-TOOL,R-CD-TOKEN,R-CONFIG-defaults,R-CW-1,R-CW-4,R-CW-DELEGATE-SELF-CONTINUATION,R-CW-TOKEN,R-OBS-1,R-OBS-status,R-RC-1
```

## Validation

- `node tools/k6-proofs/scripts/check-proof-row-manifests.mjs`
  - passed
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs`
  - passed: `36 manifests; 25 scenario files`
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs`
  - `ok: true`
- `node tools/k6-proofs/scripts/validate-corpus.mjs --index --json`
  - `failed: false`
- `./scripts/run-proofs.sh --dry-run R-OBS-1 c56399fc07d9d80c71cc09f054cd271f5c1111cd`
  - passed
- guarded live candidate run on disposable session:
  - `K6_PROOF_OUT_DIR=/tmp/p81-robs1-live OPENCLAW_CREATE_DISPOSABLE_SESSION=true ./scripts/run-proofs.sh --live R-OBS-1 c56399fc07d9d80c71cc09f054cd271f5c1111cd`
  - `k6ExitCode: 0`
  - `review.status: ready-for-human-review`
  - `pendingReceipts: []`
  - sentinel observed: `BUILD yes CONTEXT yes CHAIN yes ROUTE yes`
  - artifact root: `/tmp/p81-robs1-live/c56399fc07d9d80c71cc09f054cd271f5c1111cd/R-OBS-1/ronan/20260707T234004Z-r-obs-1`

Trace id was not emitted for the live candidate (`traceId: null`), but this manifest does not require Tempo trace JSON, so no trace debt is synthesized.