### PR TITLE
tools: promote two Project 81 read-only rows

### DIFF
--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -100,11 +100,13 @@ GitHub Actions workflow choices. Current workflow-runnable basenames are:
 - `r-cd-model-token`
 - `r-cd-token-bracket-delegate`
 - `r-config-defaults`
+- `r-config-intersession`
 - `r-cw-1-tool-schedule-wake`
 - `r-cw-4-chain-depth`
 - `r-cw-delegate-self-continuation`
 - `r-cw-token-bracket`
 - `r-obs-status`
+- `r-obs-2`
 - `r-rc-1`
 - `r-cw`
 

--- a/tools/k6-proofs/manifests/r-config-intersession.json
+++ b/tools/k6-proofs/manifests/r-config-intersession.json
@@ -5,24 +5,31 @@
   "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
   "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
   "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
-  "transport": "offline",
+  "transport": "websocket",
   "toolSurface": "read-only",
   "mutates": false,
-  "timeoutSeconds": 0,
+  "timeoutSeconds": 60,
   "scenario": {
     "name": "r-config-intersession",
-    "description": "intersession configuration manual proof row. Registered to keep the executable-suite manifest catalog aligned with the 29-row manual proof corpus; not an unattended k6 scenario yet.",
+    "description": "Read-only continuation cross-session targeting config receipt via gateway config.get from a disposable session.",
     "methods": [
-      "manual-corpus-review"
+      "sessions.create",
+      "sessions.send",
+      "sessions.messages.subscribe"
     ],
-    "status": "construct-only",
-    "notes": "Construct-only registry entry. The current PROOFS corpus carries manual evidence for this row; promote to scaffold/runnable only after a reviewed k6 fixture exists."
+    "status": "runnable",
+    "file": "r-config-intersession.js"
   },
   "expectedReceipts": [
     {
-      "name": "manual-row-corpus-receipt",
+      "name": "config-read",
       "required": true,
-      "description": "Current PROOFS/<sha> corpus contains reviewed manual evidence for this row."
+      "description": "Configuration read successful"
+    },
+    {
+      "name": "cross-session-targeting",
+      "required": true,
+      "description": "agents.defaults.continuation.crossSessionTargeting byte observed"
     }
   ],
   "artifactDestination": {
@@ -35,21 +42,27 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Catalog coverage entry only. Does not make the row runnable and does not change the canonical PROOFS corpus."
+    "notes": "Config intersession row. Read-only; k6 path drives gateway config.get through an agent turn and records crossSessionTargeting."
   },
   "liveRunSafety": {
-    "classification": "construct-only",
-    "requiresLiveGatewayToken": false,
+    "classification": "k6-runnable",
+    "requiresLiveGatewayToken": true,
     "requiresTargetSessionKey": false,
-    "requiresCandidateSha": false,
+    "requiresCandidateSha": true,
     "requiresExternalAgentOrToolInvocation": false,
     "requiresHumanConfirmation": false,
     "sameSessionConcurrencySafe": true,
-    "expectedArtifactClass": "construct-only",
+    "expectedArtifactClass": "PASS-candidate",
     "requiredReceipts": [
-      "manual-row-corpus-receipt"
+      "seat-readiness",
+      "config-read",
+      "cross-session-targeting"
     ],
     "foldRequiresReview": true,
-    "notes": "Not included in --live-suite. This entry exists so every current manual proof row has an explicit manifest record."
+    "notes": "Read-only agent-mediated config.get row; disposable session recommended but no continuation scheduling or config mutation."
+  },
+  "gateway": {
+    "wsEnv": "OPENCLAW_GATEWAY_WS",
+    "tokenEnv": "OPENCLAW_GATEWAY_TOKEN"
   }
 }

--- a/tools/k6-proofs/manifests/r-obs-2.json
+++ b/tools/k6-proofs/manifests/r-obs-2.json
@@ -8,21 +8,27 @@
   "transport": "offline",
   "toolSurface": "read-only",
   "mutates": false,
-  "timeoutSeconds": 0,
+  "timeoutSeconds": 15,
   "scenario": {
     "name": "r-obs-2",
-    "description": "trace/span observability manual proof row. Registered to keep the executable-suite manifest catalog aligned with the 29-row manual proof corpus; not an unattended k6 scenario yet.",
+    "description": "Offline/static validator for committed R-OBS-2 trace-tree/span-tree/span-count artifacts in the current PROOFS corpus.",
     "methods": [
-      "manual-corpus-review"
+      "manual-corpus-review",
+      "static-artifact-parse"
     ],
-    "status": "construct-only",
-    "notes": "Construct-only registry entry. The current PROOFS corpus carries manual evidence for this row; promote to scaffold/runnable only after a reviewed k6 fixture exists."
+    "status": "runnable",
+    "file": "r-obs-2.js"
   },
   "expectedReceipts": [
     {
-      "name": "manual-row-corpus-receipt",
+      "name": "trace-tree-artifacts",
       "required": true,
-      "description": "Current PROOFS/<sha> corpus contains reviewed manual evidence for this row."
+      "description": "trace-tree/span-tree/span-count artifacts parse from current PROOFS corpus"
+    },
+    {
+      "name": "continuation-lineage",
+      "required": true,
+      "description": "Required continuation span names and zero-orphan tree shape observed"
     }
   ],
   "artifactDestination": {
@@ -35,21 +41,22 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Catalog coverage entry only. Does not make the row runnable and does not change the canonical PROOFS corpus."
+    "notes": "R-OBS-2 static artifact validator. It validates committed corpus artifact shape, not fresh live gateway behavior."
   },
   "liveRunSafety": {
-    "classification": "construct-only",
+    "classification": "k6-runnable",
     "requiresLiveGatewayToken": false,
     "requiresTargetSessionKey": false,
-    "requiresCandidateSha": false,
+    "requiresCandidateSha": true,
     "requiresExternalAgentOrToolInvocation": false,
     "requiresHumanConfirmation": false,
     "sameSessionConcurrencySafe": true,
-    "expectedArtifactClass": "construct-only",
+    "expectedArtifactClass": "PASS-candidate",
     "requiredReceipts": [
-      "manual-row-corpus-receipt"
+      "trace-tree-artifacts",
+      "continuation-lineage"
     ],
     "foldRequiresReview": true,
-    "notes": "Not included in --live-suite. This entry exists so every current manual proof row has an explicit manifest record."
+    "notes": "Offline/static current-corpus validator; safe in broad dry/live suite because it does not connect to or mutate gateway state."
   }
 }

--- a/tools/k6-proofs/scenarios/r-config-intersession.js
+++ b/tools/k6-proofs/scenarios/r-config-intersession.js
@@ -1,0 +1,127 @@
+/**
+ * Scenario: R-CONFIG-INTERSESSION — read-only cross-session continuation config receipt.
+ *
+ * Drives an agent turn in a disposable session that reads
+ * agents.defaults.continuation.crossSessionTargeting via config.get and emits a
+ * nonce-correlated sentinel. No config mutation, continuation fire, or channel
+ * delivery is required.
+ */
+import ws from 'k6/ws';
+import { check } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
+import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+
+export const options = {
+  scenarios: { r_config_intersession: { executor: 'shared-iterations', vus: 1, iterations: 1, maxDuration: '90s' } },
+  thresholds: { proof_failures: ['count==0'], r_config_intersession_duration: ['p(95)<75000'] },
+};
+
+const failures = new Counter('proof_failures');
+const duration = new Trend('r_config_intersession_duration');
+const manifest = loadManifestFromEnv();
+const HARNESS_MARKER = '[k6-proof-harness]';
+
+function boolEnv(name) { return (__ENV[name] || '').toLowerCase() === 'true'; }
+function parseSentinel(text, nonceValue) {
+  const idx = text.lastIndexOf(`CONFIG-INTERSESSION ${nonceValue}`);
+  if (idx === -1) return null;
+  const match = text.slice(idx).match(/CROSSSESSION[^A-Za-z0-9_-]+([A-Za-z0-9_-]+)/);
+  return match ? match[1] : null;
+}
+
+export default function () {
+  const url = __ENV.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
+  const token = __ENV.OPENCLAW_GATEWAY_TOKEN;
+  const requestedSessionKey = manifest?.sessionKey || __ENV.OPENCLAW_SESSION_KEY || 'main';
+  let sessionKey = requestedSessionKey;
+  const createDisposableSession = boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSION') || true;
+  const seat = manifest?.seat || __ENV.OPENCLAW_SEAT_NAME || 'cael-dgx';
+  const rowNonce = nonce('R-CONFIG-INTERSESSION');
+
+  if (!token) { console.error('OPENCLAW_GATEWAY_TOKEN is required'); failures.add(1); return; }
+  if (manifest) {
+    const errors = validateManifest(manifest);
+    if (errors.length > 0) console.warn(`Manifest validation warnings: ${errors.join('; ')}`);
+  }
+
+  const evidence = {
+    row: 'R-CONFIG-INTERSESSION', manifest_loaded: !!manifest, nonce: rowNonce, seat,
+    requestedSessionKey, sessionKey, session_created: false, created_session_key: null,
+    candidateSha: manifest?.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
+    started: new Date().toISOString(), dispatch_accepted: false, config_read: false,
+    cross_session_targeting: null, trace_id: null, redacted_events: [],
+  };
+  const started = Date.now();
+  const nonceEventText = [];
+  let loggedPartialSentinel = false;
+
+  const res = ws.connect(url, {}, (socket) => {
+    const tracker = new RequestTracker();
+    function startProofFlow() {
+      tracker.send(socket, 'sessions.messages.subscribe', { key: sessionKey });
+      socket.setTimeout(() => {
+        const instruction = `${HARNESS_MARKER} For Project 81 row R-CONFIG-INTERSESSION nonce ${rowNonce}: ` +
+          `call the gateway tool with action=config.get path=agents.defaults.continuation.crossSessionTargeting. ` +
+          `If the config read succeeds, reply exactly CONFIG-INTERSESSION ${rowNonce} CROSSSESSION <value>. ` +
+          `If the read fails, reply exactly CONFIG-INTERSESSION-FAIL ${rowNonce}. No other action.`;
+        tracker.send(socket, 'sessions.send', { key: sessionKey, message: instruction, idempotencyKey: `R-CONFIG-INTERSESSION-${rowNonce}` });
+      }, 500);
+      socket.setTimeout(() => socket.close(), 60000);
+    }
+
+    socket.on('open', () => {
+      socket.send(connectFrame(token));
+      if (createDisposableSession) {
+        socket.setTimeout(() => {
+          const disposableKey = `r-config-intersession-${rowNonce}`.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+          tracker.send(socket, 'sessions.create', { key: disposableKey, label: `k6 R-CONFIG-INTERSESSION ${rowNonce}` });
+        }, 250);
+      } else socket.setTimeout(startProofFlow, 500);
+    });
+
+    socket.on('message', (raw) => {
+      try {
+        const msg = JSON.parse(raw);
+        const classified = tracker.classify(msg);
+        evidence.redacted_events.push({ ts: Date.now(), kind: classified.kind, method: classified.method || null, event: classified.event || null, ok: classified.ok !== undefined ? classified.ok : null, data: classified.payload ? redactEvent(classified.payload) : null });
+        if (classified.kind === 'response' && classified.method === 'sessions.create') {
+          if (classified.ok && classified.payload) { sessionKey = classified.payload.key || sessionKey; evidence.sessionKey = sessionKey; evidence.session_created = true; evidence.created_session_key = sessionKey; console.log(`✓ disposable session created: ${sessionKey}`); startProofFlow(); }
+          else { console.error(`✗ sessions.create rejected: ${JSON.stringify(classified.error)}`); failures.add(1); socket.close(); }
+        }
+        if (classified.kind === 'response' && classified.method === 'sessions.send') {
+          if (classified.ok) { evidence.dispatch_accepted = true; if (classified.payload?.traceId) evidence.trace_id = classified.payload.traceId; console.log('✓ sessions.send accepted — agent turn triggered for intersession config read'); }
+          else { console.error(`✗ sessions.send rejected: ${JSON.stringify(classified.error)}`); failures.add(1); }
+        }
+        if (classified.kind === 'event') {
+          const eventStr = JSON.stringify(classified.data || {});
+          if (eventStr.includes(rowNonce)) {
+            if (eventStr.includes(HARNESS_MARKER)) console.log('ℹ Ignoring harness prompt echo event');
+            else if (eventStr.includes(`CONFIG-INTERSESSION-FAIL ${rowNonce}`)) { console.error('✗ CONFIG-INTERSESSION-FAIL sentinel observed'); failures.add(1); socket.close(); }
+            else {
+              nonceEventText.push(eventStr);
+              const observedText = nonceEventText.join(' ');
+              const crossSession = parseSentinel(observedText, rowNonce);
+              if (crossSession !== null) { evidence.config_read = true; evidence.cross_session_targeting = crossSession; console.log(`✓ CONFIG-INTERSESSION sentinel observed: crossSessionTargeting=${crossSession}`); socket.close(); }
+              else if (eventStr.includes(`CONFIG-INTERSESSION ${rowNonce}`) && !loggedPartialSentinel) { loggedPartialSentinel = true; console.log('ℹ CONFIG-INTERSESSION sentinel prefix observed; waiting for complete streamed sentinel'); }
+            }
+          }
+        }
+      } catch (e) { console.warn(`parse error: ${e}`); }
+    });
+    socket.on('error', (e) => { console.error(`ws error: ${e && e.error ? e.error() : e}`); failures.add(1); });
+  });
+
+  evidence.ended = new Date().toISOString(); evidence.duration_ms = Date.now() - started; duration.add(evidence.duration_ms);
+  check(res, { 'websocket connected': (r) => r && r.status === 101 });
+  check(null, { 'dispatch accepted': () => evidence.dispatch_accepted, 'config read succeeded': () => evidence.config_read, 'cross-session targeting observed': () => typeof evidence.cross_session_targeting === 'string' && evidence.cross_session_targeting.length > 0 });
+  if (!evidence.dispatch_accepted || !evidence.config_read || !evidence.cross_session_targeting) failures.add(1);
+  console.log('\n--- R-CONFIG-INTERSESSION EVIDENCE SUMMARY ---'); console.log(JSON.stringify(evidence, null, 2)); console.log('--- END EVIDENCE ---');
+  console.log(`\n[R-CONFIG-INTERSESSION] VERDICT: ${evidence.config_read ? 'PASS-candidate' : 'PARTIAL-candidate'}`);
+}
+
+export function handleSummary(data) {
+  const passRate = data.metrics.proof_failures?.values?.count === 0;
+  const summary = { row: 'R-CONFIG-INTERSESSION', sha: __ENV.OPENCLAW_CANDIDATE_SHA || 'unset', seat: __ENV.OPENCLAW_SEAT_NAME || 'cael-dgx', timestamp: new Date().toISOString(), verdict: passRate ? 'PASS-candidate' : 'PARTIAL-candidate', metrics: { duration_ms: data.metrics.r_config_intersession_duration?.values || null, failures: data.metrics.proof_failures?.values?.count || 0 } };
+  return { stdout: `\n[R-CONFIG-INTERSESSION] Summary: ${summary.verdict} | SHA: ${summary.sha} | Seat: ${summary.seat}\n`, 'r-config-intersession-summary.json': JSON.stringify(summary, null, 2) };
+}

--- a/tools/k6-proofs/scenarios/r-obs-2.js
+++ b/tools/k6-proofs/scenarios/r-obs-2.js
@@ -1,0 +1,51 @@
+/**
+ * Scenario: R-OBS-2 — offline/static trace-tree observability validator.
+ *
+ * Validates the committed current PROOFS corpus has normalized trace-tree,
+ * span-tree, and span-count receipts for R-OBS-2. This is intentionally offline:
+ * it validates the existing observability artifact shape, not fresh live gateway
+ * behavior.
+ */
+import { check } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+
+export const options = {
+  scenarios: { r_obs_2_static: { executor: 'shared-iterations', vus: 1, iterations: 1, maxDuration: '15s' } },
+  thresholds: { proof_failures: ['count==0'], r_obs_2_duration: ['p(95)<10000'] },
+};
+
+const failures = new Counter('proof_failures');
+const duration = new Trend('r_obs_2_duration');
+const manifest = loadManifestFromEnv();
+const index = JSON.parse(open('../../../PROOFS/INDEX.json'));
+const currentSha = index.current_sha;
+const rowRoot = `../../../PROOFS/${currentSha}/R-OBS-2/cael-dgx`;
+const traceTree = JSON.parse(open(`${rowRoot}/trace-tree.json`));
+const spanCounts = JSON.parse(open(`${rowRoot}/span-counts.json`));
+const spanTreeText = open(`${rowRoot}/span-tree.txt`);
+
+export default function () {
+  const started = Date.now();
+  if (manifest) {
+    const errors = validateManifest(manifest);
+    if (errors.length > 0) console.warn(`Manifest validation warnings: ${errors.join('; ')}`);
+  }
+  const requiredSpanNames = ['continuation.delegate.dispatch', 'openclaw.harness.run', 'openclaw.run', 'openclaw.tool.execution', 'continuation.queue.fanout', 'continuation.queue.drain'];
+  const evidence = {
+    row: 'R-OBS-2', manifest_loaded: !!manifest, candidateSha: manifest?.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset', currentProofSha: currentSha, started: new Date().toISOString(),
+    trace_ids_hex: spanCounts.traceIdsHex || traceTree.traceIdsHex || [], span_count: spanCounts.spanCount ?? traceTree.spanCount ?? null, root_count: spanCounts.rootCount ?? traceTree.rootCount ?? null, orphan_count: spanCounts.orphanCount ?? traceTree.orphanCount ?? null,
+    required_span_names_present: {}, source_files: { traceTree: `${rowRoot}/trace-tree.json`, spanTree: `${rowRoot}/span-tree.txt`, spanCounts: `${rowRoot}/span-counts.json` },
+  };
+  for (const name of requiredSpanNames) evidence.required_span_names_present[name] = spanTreeText.includes(name) || Boolean((spanCounts.spanNameCounts || {})[name]);
+  const ok = evidence.trace_ids_hex.length > 0 && evidence.span_count > 0 && evidence.root_count >= 1 && evidence.orphan_count === 0 && Object.values(evidence.required_span_names_present).every(Boolean);
+  evidence.ended = new Date().toISOString(); evidence.duration_ms = Date.now() - started; evidence.verdict = ok ? 'PASS-candidate' : 'FAIL-candidate'; duration.add(evidence.duration_ms);
+  check(null, { 'trace id present': () => evidence.trace_ids_hex.length > 0, 'span count positive': () => evidence.span_count > 0, 'root exists': () => evidence.root_count >= 1, 'zero orphan spans': () => evidence.orphan_count === 0, 'required lineage present': () => Object.values(evidence.required_span_names_present).every(Boolean) });
+  if (!ok) failures.add(1);
+  console.log(`R_OBS_2_EVIDENCE ${JSON.stringify(evidence)}`);
+}
+
+export function handleSummary(data) {
+  const failuresCount = data.metrics.proof_failures?.values?.count || 0;
+  return { 'r-obs-2-summary.json': JSON.stringify({ row: 'R-OBS-2', sha: __ENV.OPENCLAW_CANDIDATE_SHA || 'unset', verdict: failuresCount === 0 ? 'PASS-candidate' : 'FAIL-candidate', metrics: { failures: failuresCount, duration_ms: data.metrics.r_obs_2_duration?.values || null } }, null, 2) };
+}


### PR DESCRIPTION
## Summary

Promotes two safe/read-only Project 81 rows from catalog-only coverage into runnable k6 manifest entries:

- `R-CONFIG-INTERSESSION` — live, read-only agent-mediated `config.get` for `agents.defaults.continuation.crossSessionTargeting`
- `R-OBS-2` — offline/static validator for the committed current-corpus trace-tree/span-tree/span-count artifacts

This intentionally does **not** touch config-mutating rows or orchestration-heavy rows. It moves the unattended broad slice from 16 to 18 runnable rows while preserving the full 29-row manifest coverage added in #316.

## Safety

- no gateway config mutation
- no continuation config clipping
- no restart
- `R-CONFIG-INTERSESSION` uses a disposable session and read-only `config.get`
- `R-OBS-2` does not connect to a gateway; it validates committed corpus artifacts only

## Validation

- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs` ✅
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs` ✅
- `node tools/k6-proofs/scripts/check-proof-row-manifests.mjs` ✅
- `node tools/k6-proofs/scripts/validate-corpus.mjs --current` ✅
- `OPENCLAW_ROW_MANIFEST=.../r-obs-2.json k6 run scenarios/r-obs-2.js` ✅
- `R-CONFIG-INTERSESSION` k6 init/syntax smoke reaches expected missing-token guard without parse/import failure ✅
- workflow-equivalent `run-proofs.sh --dry-run live-suite` resolves 18 runnable rows ✅
- `git diff --cached --check` ✅
