### PR TITLE
project81: refresh suite docs for 19 runnable rows

### DIFF
--- a/RUNBOOKS/project-81/EXECUTABLE-SUITE.md
+++ b/RUNBOOKS/project-81/EXECUTABLE-SUITE.md
@@ -45,10 +45,10 @@ ROWS="$(node scripts/list-runnable-rows.mjs --live-suite)"
 printf '%s\n' "$ROWS"
 ```
 
-This excludes static preflight and any `orchestration-required` rows. As of this catalog, it prints the 17-row broad live suite:
+This excludes static preflight and any `orchestration-required` rows. As of this catalog, it prints the 19-row broad live suite:
 
 ```text
-R-CD-1,R-CD-2,R-CD-4,R-CD-CHAINED-DEPTH-2,R-CD-MODEL-CHAINED-ALT,R-CD-MODEL-DEFAULT,R-CD-MODEL-TOKEN,R-CD-MODEL-TOOL,R-CD-TOKEN,R-CONFIG-defaults,R-CW-1,R-CW-4,R-CW-DELEGATE-SELF-CONTINUATION,R-CW-TOKEN,R-OBS-1,R-OBS-status,R-RC-1
+R-CD-1,R-CD-2,R-CD-4,R-CD-CHAINED-DEPTH-2,R-CD-MODEL-CHAINED-ALT,R-CD-MODEL-DEFAULT,R-CD-MODEL-TOKEN,R-CD-MODEL-TOOL,R-CD-TOKEN,R-CONFIG-defaults,R-CONFIG-INTERSESSION,R-CW-1,R-CW-4,R-CW-DELEGATE-SELF-CONTINUATION,R-CW-TOKEN,R-OBS-1,R-OBS-2,R-OBS-status,R-RC-1
 ```
 
 ## GitHub Actions option

--- a/RUNBOOKS/project-81/README.md
+++ b/RUNBOOKS/project-81/README.md
@@ -24,7 +24,7 @@ For an external/reviewer-facing path from “install k6” to “run the unatten
 As of the post-#306/#307 Project 81 surface, the broad live slice is:
 
 ```text
-R-CD-1,R-CD-2,R-CD-4,R-CD-CHAINED-DEPTH-2,R-CD-MODEL-CHAINED-ALT,R-CD-MODEL-DEFAULT,R-CD-MODEL-TOKEN,R-CD-MODEL-TOOL,R-CD-TOKEN,R-CONFIG-defaults,R-CW-1,R-CW-4,R-CW-DELEGATE-SELF-CONTINUATION,R-CW-TOKEN,R-OBS-1,R-OBS-status,R-RC-1
+R-CD-1,R-CD-2,R-CD-4,R-CD-CHAINED-DEPTH-2,R-CD-MODEL-CHAINED-ALT,R-CD-MODEL-DEFAULT,R-CD-MODEL-TOKEN,R-CD-MODEL-TOOL,R-CD-TOKEN,R-CONFIG-defaults,R-CONFIG-INTERSESSION,R-CW-1,R-CW-4,R-CW-DELEGATE-SELF-CONTINUATION,R-CW-TOKEN,R-OBS-1,R-OBS-2,R-OBS-status,R-RC-1
 ```
 
 `preflight` remains `static-preflight-only`: the runner performs seat-readiness preflight for live runs, but the preflight manifest row is intentionally skipped by live-run guard.
@@ -44,11 +44,13 @@ Use this directory as the accumulator. When a scaffold row becomes runnable, add
 - [R-CD-MODEL-TOOL](rows/R-CD-MODEL-TOOL.md)
 - [R-CD-TOKEN](rows/R-CD-TOKEN.md)
 - [R-CONFIG-defaults](rows/R-CONFIG-defaults.md)
+- [R-CONFIG-INTERSESSION](rows/R-CONFIG-INTERSESSION.md)
 - [R-CW-1](rows/R-CW-1.md)
 - [R-CW-4](rows/R-CW-4.md)
 - [R-CW-DELEGATE-SELF-CONTINUATION](rows/R-CW-DELEGATE-SELF-CONTINUATION.md)
 - [R-CW-TOKEN](rows/R-CW-TOKEN.md)
 - [R-OBS-1](rows/R-OBS-1.md)
+- [R-OBS-2](rows/R-OBS-2.md)
 - [R-OBS-status](rows/R-OBS-status.md)
 - [R-RC-1](rows/R-RC-1.md)
 

--- a/RUNBOOKS/project-81/rows/R-CONFIG-INTERSESSION.md
+++ b/RUNBOOKS/project-81/rows/R-CONFIG-INTERSESSION.md
@@ -1,0 +1,30 @@
+# R-CONFIG-INTERSESSION row runbook
+
+Read-only continuation config row. This row verifies that the deployed gateway exposes `agents.defaults.continuation.crossSessionTargeting` as `enabled` through the config receipt path required by cross-session delegate rows.
+
+## Safety
+
+- `mutates: false`
+- no continuation/delegate fire
+- no config mutation
+- no gateway restart
+- no compaction request
+- disposable session recommended
+
+## Dry run
+
+```bash
+cd tools/k6-proofs
+./scripts/run-proofs.sh --dry-run R-CONFIG-INTERSESSION <candidate-sha>
+```
+
+## Live candidate run
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_CREATE_DISPOSABLE_SESSION=true \
+OPENCLAW_GATEWAY_TOKEN=*** \
+  ./scripts/run-proofs.sh --live R-CONFIG-INTERSESSION <candidate-sha>
+```
+
+PASS-candidate requires the scenario to read continuation config and observe cross-session targeting as enabled. Candidate artifacts require review before canonical fold.

--- a/RUNBOOKS/project-81/rows/R-OBS-2.md
+++ b/RUNBOOKS/project-81/rows/R-OBS-2.md
@@ -1,0 +1,27 @@
+# R-OBS-2 row runbook
+
+Offline/static observability row for the committed current-corpus trace-tree/span-tree artifacts. This row does not connect to the gateway; it parses committed `PROOFS/<current_sha>/R-OBS-2` artifacts and verifies the trace-tree/lineage receipts expected by the manual proof.
+
+## Safety
+
+- `mutates: false`
+- no gateway token required
+- no live session required
+- no config mutation or restart
+- safe for unattended broad suite
+
+## Dry run
+
+```bash
+cd tools/k6-proofs
+./scripts/run-proofs.sh --dry-run R-OBS-2 <candidate-sha>
+```
+
+## Live/static candidate run
+
+```bash
+cd tools/k6-proofs
+./scripts/run-proofs.sh --live R-OBS-2 <candidate-sha>
+```
+
+Because this is an offline/static row, “live” means the runner emits candidate artifacts from committed corpus inspection; it does not touch a live OpenClaw gateway.


### PR DESCRIPTION
## What

Follow-up after #319: refreshes the Project 81 runbook/docs to match the now-19-row unattended live suite and adds row runbooks for the two rows #319 promoted:

- `R-CONFIG-INTERSESSION`
- `R-OBS-2`

No scenario behavior changes.

## Validation

- `node tools/k6-proofs/scripts/check-proof-row-manifests.mjs` — passed
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs` — passed (`36 manifests; 27 scenario files`)
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs` — `ok: true`
- `node tools/k6-proofs/scripts/validate-corpus.mjs --index --json` — `failed: false`
- `./scripts/run-proofs.sh --dry-run R-CONFIG-INTERSESSION,R-OBS-2 4fa0d9c4d4e2873a3d059c7ef5a0f90bfbd53b50` — passed