### PR TITLE
tools: promote Project 81 static proof validators

### DIFF
--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -106,6 +106,8 @@ GitHub Actions workflow choices. Current workflow-runnable basenames are:
 - `r-cw-delegate-self-continuation`
 - `r-cw-token-bracket`
 - `r-obs-status`
+- `r-regression-trap-tests`
+- `r-trace-redaction-1121`
 - `r-obs-2`
 - `r-rc-1`
 - `r-cw`

--- a/tools/k6-proofs/manifests/r-regression-trap-tests.json
+++ b/tools/k6-proofs/manifests/r-regression-trap-tests.json
@@ -8,21 +8,27 @@
   "transport": "offline",
   "toolSurface": "read-only",
   "mutates": false,
-  "timeoutSeconds": 0,
+  "timeoutSeconds": 15,
   "scenario": {
     "name": "r-regression-trap-tests",
-    "description": "regression trap source/test manual proof row. Registered to keep the executable-suite manifest catalog aligned with the 29-row manual proof corpus; not an unattended k6 scenario yet.",
+    "description": "Offline/static validator for committed continuation sibling-surface regression-trap test receipts in the current PROOFS corpus.",
     "methods": [
-      "manual-corpus-review"
+      "manual-corpus-review",
+      "static-artifact-parse"
     ],
-    "status": "construct-only",
-    "notes": "Construct-only registry entry. The current PROOFS corpus carries manual evidence for this row; promote to scaffold/runnable only after a reviewed k6 fixture exists."
+    "status": "runnable",
+    "file": "r-regression-trap-tests.js"
   },
   "expectedReceipts": [
     {
-      "name": "manual-row-corpus-receipt",
+      "name": "regression-trap-artifacts",
       "required": true,
-      "description": "Current PROOFS/<sha> corpus contains reviewed manual evidence for this row."
+      "description": "regression-trap evidence/log/source/test inventory artifacts parse from current PROOFS corpus"
+    },
+    {
+      "name": "regression-tests-passed",
+      "required": true,
+      "description": "Committed evidence records 31/31 continuation sibling-surface trap tests passing"
     }
   ],
   "artifactDestination": {
@@ -35,21 +41,22 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Catalog coverage entry only. Does not make the row runnable and does not change the canonical PROOFS corpus."
+    "notes": "Static artifact validator for source/test proof row. It validates committed corpus receipts, not a fresh Vitest execution."
   },
   "liveRunSafety": {
-    "classification": "construct-only",
+    "classification": "k6-runnable",
     "requiresLiveGatewayToken": false,
     "requiresTargetSessionKey": false,
-    "requiresCandidateSha": false,
+    "requiresCandidateSha": true,
     "requiresExternalAgentOrToolInvocation": false,
     "requiresHumanConfirmation": false,
     "sameSessionConcurrencySafe": true,
-    "expectedArtifactClass": "construct-only",
+    "expectedArtifactClass": "PASS-candidate",
     "requiredReceipts": [
-      "manual-row-corpus-receipt"
+      "regression-trap-artifacts",
+      "regression-tests-passed"
     ],
     "foldRequiresReview": true,
-    "notes": "Not included in --live-suite. This entry exists so every current manual proof row has an explicit manifest record."
+    "notes": "Offline/static current-corpus validator; safe in broad suite because it does not connect to or mutate gateway state."
   }
 }

--- a/tools/k6-proofs/manifests/r-trace-redaction-1121.json
+++ b/tools/k6-proofs/manifests/r-trace-redaction-1121.json
@@ -8,21 +8,27 @@
   "transport": "offline",
   "toolSurface": "read-only",
   "mutates": false,
-  "timeoutSeconds": 0,
+  "timeoutSeconds": 10,
   "scenario": {
     "name": "r-trace-redaction-1121",
-    "description": "trace redaction regression manual proof row. Registered to keep the executable-suite manifest catalog aligned with the 29-row manual proof corpus; not an unattended k6 scenario yet.",
+    "description": "Offline/static validator for committed #1121 trace-redaction contract evidence in the current PROOFS corpus.",
     "methods": [
-      "manual-corpus-review"
+      "manual-corpus-review",
+      "static-artifact-parse"
     ],
-    "status": "construct-only",
-    "notes": "Construct-only registry entry. The current PROOFS corpus carries manual evidence for this row; promote to scaffold/runnable only after a reviewed k6 fixture exists."
+    "status": "runnable",
+    "file": "r-trace-redaction-1121.js"
   },
   "expectedReceipts": [
     {
-      "name": "manual-row-corpus-receipt",
+      "name": "trace-redaction-contract",
       "required": true,
-      "description": "Current PROOFS/<sha> corpus contains reviewed manual evidence for this row."
+      "description": "Evidence records safe reason attrs and absence of raw reason.preview export"
+    },
+    {
+      "name": "trace-redaction-tests-passed",
+      "required": true,
+      "description": "Evidence records continuation-tracer redaction tests passing"
     }
   ],
   "artifactDestination": {
@@ -35,21 +41,22 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Catalog coverage entry only. Does not make the row runnable and does not change the canonical PROOFS corpus."
+    "notes": "Static artifact validator for source/unit proof row. It validates committed corpus receipts, not fresh source tests."
   },
   "liveRunSafety": {
-    "classification": "construct-only",
+    "classification": "k6-runnable",
     "requiresLiveGatewayToken": false,
     "requiresTargetSessionKey": false,
-    "requiresCandidateSha": false,
+    "requiresCandidateSha": true,
     "requiresExternalAgentOrToolInvocation": false,
     "requiresHumanConfirmation": false,
     "sameSessionConcurrencySafe": true,
-    "expectedArtifactClass": "construct-only",
+    "expectedArtifactClass": "PASS-candidate",
     "requiredReceipts": [
-      "manual-row-corpus-receipt"
+      "trace-redaction-contract",
+      "trace-redaction-tests-passed"
     ],
     "foldRequiresReview": true,
-    "notes": "Not included in --live-suite. This entry exists so every current manual proof row has an explicit manifest record."
+    "notes": "Offline/static current-corpus validator; safe in broad suite because it does not connect to or mutate gateway state."
   }
 }

--- a/tools/k6-proofs/scenarios/r-regression-trap-tests.js
+++ b/tools/k6-proofs/scenarios/r-regression-trap-tests.js
@@ -1,0 +1,80 @@
+/**
+ * Scenario: R-REGRESSION-TRAP-TESTS — offline/static regression-trap evidence validator.
+ *
+ * Validates the committed current PROOFS corpus contains the source/test receipts
+ * for the continuation sibling-surface regression traps. It does not run Vitest
+ * and does not connect to a gateway; it verifies the packaged proof artifacts
+ * are present and internally consistent enough for candidate review.
+ */
+import { check } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+
+export const options = {
+  scenarios: { r_regression_trap_tests_static: { executor: 'shared-iterations', vus: 1, iterations: 1, maxDuration: '15s' } },
+  thresholds: { proof_failures: ['count==0'], r_regression_trap_tests_duration: ['p(95)<10000'] },
+};
+
+const failures = new Counter('proof_failures');
+const duration = new Trend('r_regression_trap_tests_duration');
+const manifest = loadManifestFromEnv();
+const index = JSON.parse(open('../../../PROOFS/INDEX.json'));
+const currentSha = index.current_sha;
+const carriedFrom = index.carried_from || currentSha;
+const rowRoot = `../../../PROOFS/${currentSha}/R-REGRESSION-TRAP-TESTS/cael-dgx`;
+const evidenceMd = open(`${rowRoot}/EVIDENCE.md`);
+const regressionLog = open(`${rowRoot}/regression-trap.log`);
+const sourceStatus = open(`${rowRoot}/source-git-status.txt`);
+const testInventory = open(`${rowRoot}/test-inventory.txt`);
+
+export default function () {
+  const started = Date.now();
+  if (manifest) {
+    const errors = validateManifest(manifest);
+    if (errors.length > 0) console.warn(`Manifest validation warnings: ${errors.join('; ')}`);
+  }
+
+  const requiredTests = [
+    'src/agents/tools/continuation-inventory-opts.test.ts',
+    'src/agents/openclaw-tools.continuation-registration.test.ts',
+    'src/agents/tools/continuation-tools-registration.test.ts',
+    'src/agents/openclaw-tools.continuation-misconfig-warn.test.ts',
+  ];
+  const evidence = {
+    row: 'R-REGRESSION-TRAP-TESTS',
+    manifest_loaded: !!manifest,
+    candidateSha: manifest?.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
+    currentProofSha: currentSha,
+    started: new Date().toISOString(),
+    verdict_text_present: evidenceMd.includes('Verdict: ✅ PASS') || evidenceMd.includes('Verdict: PASS'),
+    shard_pass_text_present: regressionLog.includes('[test] passed 2 Vitest shards'),
+    test_count_text_present: evidenceMd.includes('31/31 PASS') || (regressionLog.includes('5 passed') && regressionLog.includes('26 passed')),
+    source_sha_present: sourceStatus.includes(currentSha) || evidenceMd.includes(currentSha) || sourceStatus.includes(carriedFrom) || evidenceMd.includes(carriedFrom),
+    required_tests_present: Object.fromEntries(requiredTests.map((name) => [name, evidenceMd.includes(name) || regressionLog.includes(name) || testInventory.includes(name)])),
+    source_files: {
+      evidence: `${rowRoot}/EVIDENCE.md`,
+      log: `${rowRoot}/regression-trap.log`,
+      sourceStatus: `${rowRoot}/source-git-status.txt`,
+      testInventory: `${rowRoot}/test-inventory.txt`,
+    },
+  };
+  const ok = evidence.verdict_text_present && evidence.shard_pass_text_present && evidence.test_count_text_present && evidence.source_sha_present && Object.values(evidence.required_tests_present).every(Boolean);
+  evidence.ended = new Date().toISOString();
+  evidence.duration_ms = Date.now() - started;
+  evidence.verdict = ok ? 'PASS-candidate' : 'FAIL-candidate';
+  duration.add(evidence.duration_ms);
+  check(null, {
+    'verdict pass text present': () => evidence.verdict_text_present,
+    'two vitest shards passed': () => evidence.shard_pass_text_present,
+    '31 tests passed text present': () => evidence.test_count_text_present,
+    'source sha present': () => evidence.source_sha_present,
+    'required tests named': () => Object.values(evidence.required_tests_present).every(Boolean),
+  });
+  if (!ok) failures.add(1);
+  console.log(`R_REGRESSION_TRAP_TESTS_EVIDENCE ${JSON.stringify(evidence)}`);
+}
+
+export function handleSummary(data) {
+  const failuresCount = data.metrics.proof_failures?.values?.count || 0;
+  return { 'r-regression-trap-tests-summary.json': JSON.stringify({ row: 'R-REGRESSION-TRAP-TESTS', sha: __ENV.OPENCLAW_CANDIDATE_SHA || 'unset', verdict: failuresCount === 0 ? 'PASS-candidate' : 'FAIL-candidate', metrics: { failures: failuresCount, duration_ms: data.metrics.r_regression_trap_tests_duration?.values || null } }, null, 2) };
+}

--- a/tools/k6-proofs/scenarios/r-trace-redaction-1121.js
+++ b/tools/k6-proofs/scenarios/r-trace-redaction-1121.js
@@ -1,0 +1,65 @@
+/**
+ * Scenario: R-TRACE-REDACTION-1121 — offline/static redaction-contract evidence validator.
+ *
+ * Validates the committed proof evidence for #1121 trace redaction. This is a
+ * static artifact check, not a live continuation fire and not a source checkout
+ * test runner.
+ */
+import { check } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+
+export const options = {
+  scenarios: { r_trace_redaction_1121_static: { executor: 'shared-iterations', vus: 1, iterations: 1, maxDuration: '10s' } },
+  thresholds: { proof_failures: ['count==0'], r_trace_redaction_1121_duration: ['p(95)<10000'] },
+};
+
+const failures = new Counter('proof_failures');
+const duration = new Trend('r_trace_redaction_1121_duration');
+const manifest = loadManifestFromEnv();
+const index = JSON.parse(open('../../../PROOFS/INDEX.json'));
+const currentSha = index.current_sha;
+const rowRoot = `../../../PROOFS/${currentSha}/R-TRACE-REDACTION-1121`;
+const evidenceMd = open(`${rowRoot}/EVIDENCE.md`);
+
+export default function () {
+  const started = Date.now();
+  if (manifest) {
+    const errors = validateManifest(manifest);
+    if (errors.length > 0) console.warn(`Manifest validation warnings: ${errors.join('; ')}`);
+  }
+  const evidence = {
+    row: 'R-TRACE-REDACTION-1121',
+    manifest_loaded: !!manifest,
+    candidateSha: manifest?.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
+    currentProofSha: currentSha,
+    started: new Date().toISOString(),
+    pass_heading_present: evidenceMd.includes('# R-TRACE-REDACTION-1121') && evidenceMd.includes('PASS'),
+    safe_attrs_present: ['reason.present', 'reason.length', 'reason.hash', 'reason.redacted'].every((needle) => evidenceMd.includes(needle)),
+    no_preview_contract_present: evidenceMd.includes('No `reason.preview` field exists') || evidenceMd.includes('asserts no `reason.preview`'),
+    raw_reason_guard_present: evidenceMd.includes('asserts no attribute value contains the raw reason'),
+    test_pass_present: evidenceMd.includes('src/infra/continuation-tracer.test.ts (88 tests) passed'),
+    source_surface_present: evidenceMd.includes('src/infra/continuation-tracer.ts') && evidenceMd.includes('src/infra/continuation-tracer.test.ts'),
+    source_files: { evidence: `${rowRoot}/EVIDENCE.md` },
+  };
+  const ok = evidence.pass_heading_present && evidence.safe_attrs_present && evidence.no_preview_contract_present && evidence.raw_reason_guard_present && evidence.test_pass_present && evidence.source_surface_present;
+  evidence.ended = new Date().toISOString();
+  evidence.duration_ms = Date.now() - started;
+  evidence.verdict = ok ? 'PASS-candidate' : 'FAIL-candidate';
+  duration.add(evidence.duration_ms);
+  check(null, {
+    'pass heading present': () => evidence.pass_heading_present,
+    'safe attrs present': () => evidence.safe_attrs_present,
+    'no preview contract present': () => evidence.no_preview_contract_present,
+    'raw reason guard present': () => evidence.raw_reason_guard_present,
+    'test pass present': () => evidence.test_pass_present,
+    'source/test surfaces present': () => evidence.source_surface_present,
+  });
+  if (!ok) failures.add(1);
+  console.log(`R_TRACE_REDACTION_1121_EVIDENCE ${JSON.stringify(evidence)}`);
+}
+
+export function handleSummary(data) {
+  const failuresCount = data.metrics.proof_failures?.values?.count || 0;
+  return { 'r-trace-redaction-1121-summary.json': JSON.stringify({ row: 'R-TRACE-REDACTION-1121', sha: __ENV.OPENCLAW_CANDIDATE_SHA || 'unset', verdict: failuresCount === 0 ? 'PASS-candidate' : 'FAIL-candidate', metrics: { failures: failuresCount, duration_ms: data.metrics.r_trace_redaction_1121_duration?.values || null } }, null, 2) };
+}


### PR DESCRIPTION
## Summary

Promotes two remaining source/static proof rows into safe runnable k6 validators:

- `R-REGRESSION-TRAP-TESTS` — validates committed regression-trap proof receipts/logs in the current PROOFS corpus
- `R-TRACE-REDACTION-1121` — validates committed #1121 redaction-contract proof evidence

These are offline/static artifact validators. They do not run Vitest, connect to a gateway, mutate config, restart anything, or fire continuation tools. They make the broad unattended suite able to verify the packaged proof evidence shape for these rows.

Current broad slice after this PR: 21 runnable rows.

## Validation

- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs` ✅
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs` ✅
- `node tools/k6-proofs/scripts/check-proof-row-manifests.mjs` ✅
- `node tools/k6-proofs/scripts/validate-corpus.mjs --current` ✅
- `k6 run scenarios/r-regression-trap-tests.js` ✅
- `k6 run scenarios/r-trace-redaction-1121.js` ✅
- workflow-equivalent `run-proofs.sh --dry-run live-suite` resolves 21 runnable rows ✅
- `git diff --check` ✅
