### PR TITLE
tools: promote Project 81 non-config continuation rows

### DIFF
--- a/.github/workflows/k6-proof.yml
+++ b/.github/workflows/k6-proof.yml
@@ -30,6 +30,7 @@ on:
           - r-cd-2-silent-wake
           - r-cd-4-target-session-key
           - r-cd-chained-depth-2
+          - r-cd-silent
           - r-cd-model-default
           - r-cd-model-tool
           - r-cd-model-chained-alt
@@ -38,6 +39,8 @@ on:
           - r-config-defaults
           - r-cw-1
           - r-cw-1-tool-schedule-wake
+          - r-cw-2-immediate-wake
+          - r-cw-3-reason-telemetry
           - r-cw-4-chain-depth
           - r-cw-delegate-self-continuation
           - r-cw-token-bracket

--- a/RUNBOOKS/project-81/README.md
+++ b/RUNBOOKS/project-81/README.md
@@ -24,7 +24,7 @@ For an external/reviewer-facing path from “install k6” to “run the unatten
 As of the post-#306/#307 Project 81 surface, the broad live slice is:
 
 ```text
-R-CD-1,R-CD-2,R-CD-4,R-CD-CHAINED-DEPTH-2,R-CD-MODEL-CHAINED-ALT,R-CD-MODEL-DEFAULT,R-CD-MODEL-TOKEN,R-CD-MODEL-TOOL,R-CD-TOKEN,R-CONFIG-defaults,R-CONFIG-INTERSESSION,R-CW-1,R-CW-4,R-CW-DELEGATE-SELF-CONTINUATION,R-CW-TOKEN,R-OBS-1,R-OBS-2,R-OBS-status,R-RC-1
+R-CD-1,R-CD-2,R-CD-4,R-CD-CHAINED-DEPTH-2,R-CD-MODEL-CHAINED-ALT,R-CD-MODEL-DEFAULT,R-CD-MODEL-TOKEN,R-CD-MODEL-TOOL,R-CD-SILENT,R-CD-TOKEN,R-CONFIG-defaults,R-CONFIG-INTERSESSION,R-CW-1,R-CW-2,R-CW-3,R-CW-4,R-CW-DELEGATE-SELF-CONTINUATION,R-CW-TOKEN,R-OBS-1,R-OBS-2,R-OBS-status,R-RC-1
 ```
 
 `preflight` remains `static-preflight-only`: the runner performs seat-readiness preflight for live runs, but the preflight manifest row is intentionally skipped by live-run guard.
@@ -38,6 +38,7 @@ Use this directory as the accumulator. When a scaffold row becomes runnable, add
 - [R-CD-2](rows/R-CD-2.md)
 - [R-CD-4](rows/R-CD-4.md)
 - [R-CD-CHAINED-DEPTH-2](rows/R-CD-CHAINED-DEPTH-2.md)
+- [R-CD-SILENT](rows/R-CD-SILENT.md)
 - [R-CD-MODEL-CHAINED-ALT](rows/R-CD-MODEL-CHAINED-ALT.md)
 - [R-CD-MODEL-DEFAULT](rows/R-CD-MODEL-DEFAULT.md)
 - [R-CD-MODEL-TOKEN](rows/R-CD-MODEL-TOKEN.md)
@@ -46,6 +47,8 @@ Use this directory as the accumulator. When a scaffold row becomes runnable, add
 - [R-CONFIG-defaults](rows/R-CONFIG-defaults.md)
 - [R-CONFIG-INTERSESSION](rows/R-CONFIG-INTERSESSION.md)
 - [R-CW-1](rows/R-CW-1.md)
+- [R-CW-2](rows/R-CW-2.md)
+- [R-CW-3](rows/R-CW-3.md)
 - [R-CW-4](rows/R-CW-4.md)
 - [R-CW-DELEGATE-SELF-CONTINUATION](rows/R-CW-DELEGATE-SELF-CONTINUATION.md)
 - [R-CW-TOKEN](rows/R-CW-TOKEN.md)

--- a/RUNBOOKS/project-81/rows/R-CD-SILENT.md
+++ b/RUNBOOKS/project-81/rows/R-CD-SILENT.md
@@ -1,0 +1,53 @@
+# R-CD-SILENT row runbook
+
+## Status
+
+- Manifest: `tools/k6-proofs/manifests/r-cd-silent.json`
+- Scenario: `tools/k6-proofs/scenarios/r-cd-silent.js`
+- Live safety: `k6-runnable`
+- Same-session concurrency: unsafe; prefer `OPENCLAW_CREATE_DISPOSABLE_SESSION=true`.
+
+## Purpose
+
+Exercise `continue_delegate(mode="silent")`: the child return should land in the parent session's internal context without producing channel-visible child delivery.
+
+## Commands
+
+Dry path:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=*** \
+  ./scripts/run-proofs.sh --dry-run R-CD-SILENT <candidate-sha>
+```
+
+Live candidate run:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=*** \
+OPENCLAW_CREATE_DISPOSABLE_SESSION=true \
+  ./scripts/run-proofs.sh --live --out-dir /tmp/k6-proof-runs R-CD-SILENT <candidate-sha>
+```
+
+## k6 covers
+
+- Dispatching agent turn accepted.
+- Agent emits `RCDS-SCHEDULED <nonce>` only after `continue_delegate(mode="silent")` reports scheduled.
+- The child task receives a child-only `SILENTCHILD-*` token that is not included in the later follow-up prompt.
+- A delayed follow-up asks the parent to report the silent delegate return from internal context.
+- The row fails if the child-only token appears in channel-delivery evidence.
+
+## Manual collection still needed
+
+- Review the generated artifact directory and exact manifest.
+- Fetch/commit Tempo trace JSON when a trace id is emitted, or explicitly accept trace-missing as review debt.
+- Check transcript/session receipts if the candidate will be folded into canonical PROOFS.
+
+## Fold guidance
+
+A PASS-candidate requires dispatch accepted, scheduled sentinel, follow-up accepted, child-token readback from parent internal context, and no child-token channel delivery. Fold only after trace/session receipts are reviewed.
+
+## 2026-07-07 smoke note
+
+`/tmp/p81-rcd-silent-smoke2` produced `PASS-candidate` on `ronan` with `OPENCLAW_CREATE_DISPOSABLE_SESSION=true`: dispatch accepted, scheduled sentinel observed, child completion observed on the internal stream, follow-up accepted, parent read back the child-only token, and no child-token channel-delivery-shaped event fired. Trace id was null, so trace review remains debt.

--- a/RUNBOOKS/project-81/rows/R-CW-2.md
+++ b/RUNBOOKS/project-81/rows/R-CW-2.md
@@ -1,0 +1,41 @@
+# R-CW-2 row runbook
+
+## Status
+
+- Manifest: `tools/k6-proofs/manifests/r-cw-2.json`
+- Scenario: `tools/k6-proofs/scenarios/r-cw-2-immediate-wake.js`
+- Live safety: `k6-runnable`
+- Same-session concurrency: unsafe; prefer `OPENCLAW_CREATE_DISPOSABLE_SESSION=true`.
+
+## Purpose
+
+Exercise `continue_work(delaySeconds=0)`: the tool result must schedule an immediate continuation wake, and the detector must not count harness prompt echo as proof.
+
+## Commands
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=*** \
+OPENCLAW_CREATE_DISPOSABLE_SESSION=true \
+  ./scripts/run-proofs.sh --live --out-dir /tmp/k6-proof-runs R-CW-2 <candidate-sha>
+```
+
+## k6 covers
+
+- Dispatching `sessions.send` accepted.
+- Agent emits `CW2-SCHEDULED <nonce>` only after the `continue_work` tool result reports scheduled.
+- Continuation wake emits `CW2-WOKE <nonce>` after the scheduled sentinel.
+- Harness prompt echo is ignored and cannot satisfy the wake check by itself.
+
+## Manual collection still needed
+
+- Preserve `k6.log`, `evidence.jsonl`, summary JSON, and `run-result.json`.
+- Fetch/commit Tempo trace JSON when a trace id is emitted, or explicitly accept trace-missing as review debt.
+
+## Fold guidance
+
+Fold only after confirming the wake sentinel came from the continuation turn and not from the initial harness prompt. Run serially per target session.
+
+## 2026-07-07 smoke note
+
+Disposable-session smoke on `ronan` accepted dispatch and observed `CW2-SCHEDULED`, but did not observe `CW2-WOKE` within the k6 window. R-CW-1 showed the same disposable-session schedule-only shape. Treat this as a partial/diagnostic result, not a row-fixture failure and not a PASS. Canonical PASS still requires the wake sentinel from a target session that services self-elected continuation wakes.

--- a/RUNBOOKS/project-81/rows/R-CW-3.md
+++ b/RUNBOOKS/project-81/rows/R-CW-3.md
@@ -1,0 +1,42 @@
+# R-CW-3 row runbook
+
+## Status
+
+- Manifest: `tools/k6-proofs/manifests/r-cw-3.json`
+- Scenario: `tools/k6-proofs/scenarios/r-cw-3-reason-telemetry.js`
+- Live safety: `k6-runnable`
+- Expected artifact class: `HONEST-LIMIT-candidate` until Tempo trace JSON is fetched and reviewed.
+
+## Purpose
+
+Exercise `continue_work` reason telemetry/redaction. k6 proves the schedule/wake path and keeps the raw reason sentinel out of public artifacts; a reviewer must inspect Tempo JSON to assert that safe reason attrs are present and the raw reason is absent.
+
+## Commands
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN=*** \
+OPENCLAW_CREATE_DISPOSABLE_SESSION=true \
+  ./scripts/run-proofs.sh --live --out-dir /tmp/k6-proof-runs R-CW-3 <candidate-sha>
+```
+
+## k6 covers
+
+- Dispatching `sessions.send` accepted.
+- Agent emits `CW3-SCHEDULED <nonce>` only after `continue_work` reports scheduled.
+- Continuation wake emits `CW3-WOKE <nonce>`.
+- Public k6 evidence drops the raw reason field/sentinel rather than committing it.
+
+## Manual collection still needed
+
+- Fetch Tempo trace JSON for the emitted trace id when available.
+- Verify the trace has safe reason telemetry attributes and does not contain the raw reason sentinel.
+- If trace fetch/emission is unavailable, keep the run as `HONEST-LIMIT-candidate`; do not overclaim PASS.
+
+## Fold guidance
+
+R-CW-3 is not an unattended PASS row. The runner may execute it safely, but canonical fold requires explicit Tempo/redaction review.
+
+## 2026-07-07 smoke note
+
+Disposable-session smoke on `ronan` accepted dispatch and observed `CW3-SCHEDULED`, but did not observe `CW3-WOKE` within the k6 window. This is partial only. Even with a wake, R-CW-3 remains `HONEST-LIMIT-candidate` until Tempo trace JSON is fetched/reviewed for safe reason attrs present and raw reason absent.

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -94,6 +94,7 @@ GitHub Actions workflow choices. Current workflow-runnable basenames are:
 - `r-cd-2-silent-wake`
 - `r-cd-4-target-session-key`
 - `r-cd-chained-depth-2`
+- `r-cd-silent`
 - `r-cd-model-default`
 - `r-cd-model-tool`
 - `r-cd-model-chained-alt`
@@ -102,6 +103,8 @@ GitHub Actions workflow choices. Current workflow-runnable basenames are:
 - `r-config-defaults`
 - `r-config-intersession`
 - `r-cw-1-tool-schedule-wake`
+- `r-cw-2-immediate-wake`
+- `r-cw-3-reason-telemetry`
 - `r-cw-4-chain-depth`
 - `r-cw-delegate-self-continuation`
 - `r-cw-token-bracket`

--- a/tools/k6-proofs/manifests/r-cd-silent.json
+++ b/tools/k6-proofs/manifests/r-cd-silent.json
@@ -3,53 +3,100 @@
   "rowId": "R-CD-SILENT",
   "issue": 119,
   "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
-  "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
+  "seat": "${OPENCLAW_SEAT_NAME:-ronan-dgx}",
   "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
-  "transport": "offline",
-  "toolSurface": "read-only",
+  "transport": "websocket",
+  "toolSurface": "typed-tool",
   "mutates": false,
-  "timeoutSeconds": 0,
+  "timeoutSeconds": 180,
+  "gateway": {
+    "wsEnv": "OPENCLAW_GATEWAY_WS",
+    "tokenEnv": "OPENCLAW_GATEWAY_TOKEN"
+  },
   "scenario": {
     "name": "r-cd-silent",
-    "description": "silent delegate no-channel-output manual proof row. Registered to keep the executable-suite manifest catalog aligned with the 29-row manual proof corpus; not an unattended k6 scenario yet.",
+    "description": "Typed continue_delegate(mode='silent') proof. Fires a silent delegate, waits for child internal completion, then asks the parent to report the silent child token from internal context while checking no child channel delivery occurred.",
     "methods": [
-      "manual-corpus-review"
+      "sessions.create",
+      "sessions.send",
+      "sessions.messages.subscribe"
     ],
-    "status": "construct-only",
-    "notes": "Construct-only registry entry. The current PROOFS corpus carries manual evidence for this row; promote to scaffold/runnable only after a reviewed k6 fixture exists."
+    "status": "runnable",
+    "file": "r-cd-silent.js"
+  },
+  "invocation": {
+    "tool": "continue_delegate",
+    "mode": "silent",
+    "delaySeconds": 1,
+    "idempotencyKeyPrefix": "R-CD-SILENT"
   },
   "expectedReceipts": [
     {
-      "name": "manual-row-corpus-receipt",
+      "name": "dispatch-accepted",
       "required": true,
-      "description": "Current PROOFS/<sha> corpus contains reviewed manual evidence for this row."
+      "description": "Gateway accepted the dispatching sessions.send turn that asks the agent to call continue_delegate(mode=silent)."
+    },
+    {
+      "name": "delegate-scheduled-sentinel",
+      "required": true,
+      "description": "Parent emitted RCDS-SCHEDULED only after continue_delegate returned a scheduled result."
+    },
+    {
+      "name": "child-completion-observed",
+      "required": true,
+      "description": "The silent delegate child completed on the internal subagent stream before the follow-up turn was sent."
+    },
+    {
+      "name": "followup-accepted",
+      "required": true,
+      "description": "A later follow-up turn was accepted after the silent delegate had time to return."
+    },
+    {
+      "name": "parent-internal-context-observed",
+      "required": true,
+      "description": "Parent follow-up reported the child-only SILENTCHILD token that was not included in the follow-up prompt."
+    },
+    {
+      "name": "no-channel-delivery",
+      "required": true,
+      "description": "No channel-delivery event contained the child-only silent delegate token."
+    },
+    {
+      "name": "trace-id",
+      "required": false,
+      "description": "Trace ID from dispatch response or task metadata for Tempo fetch/review."
     }
   ],
   "artifactDestination": {
     "root": "PROOFS",
     "sha": "${OPENCLAW_CANDIDATE_SHA}",
     "row": "R-CD-SILENT",
-    "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
-    "runDirPrefix": "manual-corpus"
+    "seat": "${OPENCLAW_SEAT_NAME:-ronan-dgx}",
+    "runDirPrefix": "k6-run"
   },
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Catalog coverage entry only. Does not make the row runnable and does not change the canonical PROOFS corpus."
+    "notes": "PASS-candidate requires child internal completion, delayed child-token readback from parent internal context, and no child-token channel delivery. Prefer disposable sessions for repeated runs."
   },
   "liveRunSafety": {
-    "classification": "construct-only",
-    "requiresLiveGatewayToken": false,
+    "classification": "k6-runnable",
+    "requiresLiveGatewayToken": true,
     "requiresTargetSessionKey": false,
-    "requiresCandidateSha": false,
-    "requiresExternalAgentOrToolInvocation": false,
-    "requiresHumanConfirmation": false,
-    "sameSessionConcurrencySafe": true,
-    "expectedArtifactClass": "construct-only",
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": true,
+    "sameSessionConcurrencySafe": false,
+    "expectedArtifactClass": "PASS-candidate",
     "requiredReceipts": [
-      "manual-row-corpus-receipt"
+      "seat-readiness",
+      "dispatch-accepted",
+      "delegate-scheduled-sentinel",
+      "child-completion-observed",
+      "followup-accepted",
+      "parent-internal-context-observed",
+      "no-channel-delivery"
     ],
     "foldRequiresReview": true,
-    "notes": "Not included in --live-suite. This entry exists so every current manual proof row has an explicit manifest record."
+    "notes": "Live silent delegate row. Uses a child-only token plus follow-up readback to prove internal parent context without treating prompt echo as success. Serialize per target session."
   }
 }

--- a/tools/k6-proofs/manifests/r-cw-2.json
+++ b/tools/k6-proofs/manifests/r-cw-2.json
@@ -5,24 +5,56 @@
   "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
   "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
   "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
-  "transport": "offline",
-  "toolSurface": "read-only",
+  "transport": "websocket",
+  "toolSurface": "typed-tool",
   "mutates": false,
-  "timeoutSeconds": 0,
+  "timeoutSeconds": 120,
+  "gateway": {
+    "wsEnv": "OPENCLAW_GATEWAY_WS",
+    "tokenEnv": "OPENCLAW_GATEWAY_TOKEN"
+  },
   "scenario": {
-    "name": "r-cw-2",
-    "description": "continue_work visible wake/receipt manual proof row. Registered to keep the executable-suite manifest catalog aligned with the 29-row manual proof corpus; not an unattended k6 scenario yet.",
+    "name": "r-cw-2-immediate-wake",
+    "description": "Typed continue_work(delaySeconds=0) immediate wake proof. Requires an explicit scheduled sentinel and a continuation wake sentinel, while ignoring harness prompt echoes.",
     "methods": [
-      "manual-corpus-review"
+      "sessions.create",
+      "sessions.send",
+      "sessions.messages.subscribe"
     ],
-    "status": "construct-only",
-    "notes": "Construct-only registry entry. The current PROOFS corpus carries manual evidence for this row; promote to scaffold/runnable only after a reviewed k6 fixture exists."
+    "status": "runnable",
+    "file": "r-cw-2-immediate-wake.js"
+  },
+  "invocation": {
+    "tool": "continue_work",
+    "delaySeconds": 0,
+    "reason": "k6-proof-R-CW-2-immediate-{{nonce}}",
+    "idempotencyKeyPrefix": "R-CW-2"
   },
   "expectedReceipts": [
     {
-      "name": "manual-row-corpus-receipt",
+      "name": "dispatch-accepted",
       "required": true,
-      "description": "Current PROOFS/<sha> corpus contains reviewed manual evidence for this row."
+      "description": "Gateway accepted the sessions.send turn that asks the agent to call continue_work(delaySeconds=0)."
+    },
+    {
+      "name": "continue-work-tool-result-scheduled",
+      "required": true,
+      "description": "Agent emitted CW2-SCHEDULED only after the continue_work tool result reported scheduled."
+    },
+    {
+      "name": "immediate-wake-event",
+      "required": true,
+      "description": "Continuation wake turn emitted CW2-WOKE nonce sentinel."
+    },
+    {
+      "name": "prompt-echo-filtered",
+      "required": true,
+      "description": "Harness prompt echo was ignored; CW2-WOKE is only accepted after CW2-SCHEDULED."
+    },
+    {
+      "name": "trace-id",
+      "required": false,
+      "description": "Trace ID from dispatch response or optional task metadata for Tempo fetch."
     }
   ],
   "artifactDestination": {
@@ -30,26 +62,29 @@
     "sha": "${OPENCLAW_CANDIDATE_SHA}",
     "row": "R-CW-2",
     "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
-    "runDirPrefix": "manual-corpus"
+    "runDirPrefix": "k6-run"
   },
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Catalog coverage entry only. Does not make the row runnable and does not change the canonical PROOFS corpus."
+    "notes": "PASS-candidate requires dispatch accepted, explicit scheduled sentinel, explicit immediate wake sentinel, and prompt-echo filtering. Prefer disposable sessions."
   },
   "liveRunSafety": {
-    "classification": "construct-only",
-    "requiresLiveGatewayToken": false,
+    "classification": "k6-runnable",
+    "requiresLiveGatewayToken": true,
     "requiresTargetSessionKey": false,
-    "requiresCandidateSha": false,
-    "requiresExternalAgentOrToolInvocation": false,
-    "requiresHumanConfirmation": false,
-    "sameSessionConcurrencySafe": true,
-    "expectedArtifactClass": "construct-only",
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": true,
+    "sameSessionConcurrencySafe": false,
+    "expectedArtifactClass": "PASS-candidate",
     "requiredReceipts": [
-      "manual-row-corpus-receipt"
+      "seat-readiness",
+      "dispatch-accepted",
+      "continue-work-tool-result-scheduled",
+      "immediate-wake-event",
+      "prompt-echo-filtered"
     ],
     "foldRequiresReview": true,
-    "notes": "Not included in --live-suite. This entry exists so every current manual proof row has an explicit manifest record."
+    "notes": "Live continue_work delaySeconds=0 row. Serialize per target session. Disposable-session smoke may honestly stop at scheduled-only on runtimes where disposable sessions do not service self-elected continuation wakes; canonical PASS requires a CW2-WOKE receipt from the target session history or live websocket stream."
   }
 }

--- a/tools/k6-proofs/manifests/r-cw-3.json
+++ b/tools/k6-proofs/manifests/r-cw-3.json
@@ -5,24 +5,62 @@
   "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
   "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
   "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
-  "transport": "offline",
-  "toolSurface": "read-only",
+  "transport": "websocket",
+  "toolSurface": "typed-tool",
   "mutates": false,
-  "timeoutSeconds": 0,
+  "timeoutSeconds": 120,
+  "gateway": {
+    "wsEnv": "OPENCLAW_GATEWAY_WS",
+    "tokenEnv": "OPENCLAW_GATEWAY_TOKEN"
+  },
   "scenario": {
-    "name": "r-cw-3",
-    "description": "continue_work trace/flow receipt manual proof row. Registered to keep the executable-suite manifest catalog aligned with the 29-row manual proof corpus; not an unattended k6 scenario yet.",
+    "name": "r-cw-3-reason-telemetry",
+    "description": "continue_work reason telemetry/redaction honest-limit candidate. k6 proves schedule+wake and keeps the raw reason out of public artifacts; Tempo JSON review must verify safe reason attrs present and raw reason absent before a PASS fold.",
     "methods": [
-      "manual-corpus-review"
+      "sessions.create",
+      "sessions.send",
+      "sessions.messages.subscribe",
+      "tempo-trace-review"
     ],
-    "status": "construct-only",
-    "notes": "Construct-only registry entry. The current PROOFS corpus carries manual evidence for this row; promote to scaffold/runnable only after a reviewed k6 fixture exists."
+    "status": "runnable",
+    "file": "r-cw-3-reason-telemetry.js"
+  },
+  "invocation": {
+    "tool": "continue_work",
+    "delaySeconds": 5,
+    "reasonPrefix": "k6-proof-R-CW-3-redaction",
+    "idempotencyKeyPrefix": "R-CW-3"
   },
   "expectedReceipts": [
     {
-      "name": "manual-row-corpus-receipt",
+      "name": "dispatch-accepted",
       "required": true,
-      "description": "Current PROOFS/<sha> corpus contains reviewed manual evidence for this row."
+      "description": "Gateway accepted the sessions.send turn that asks the agent to call continue_work with a nonce-bearing reason."
+    },
+    {
+      "name": "continue-work-tool-result-scheduled",
+      "required": true,
+      "description": "Agent emitted CW3-SCHEDULED only after the continue_work tool result reported scheduled."
+    },
+    {
+      "name": "work-woke-event",
+      "required": true,
+      "description": "Continuation wake turn emitted CW3-WOKE nonce sentinel."
+    },
+    {
+      "name": "public-artifact-raw-reason-absent",
+      "required": true,
+      "description": "Scenario public evidence redacts the raw reason sentinel rather than committing it."
+    },
+    {
+      "name": "tempo-trace-json",
+      "required": true,
+      "description": "Fetched Tempo trace JSON for reviewer validation of reason telemetry/redaction."
+    },
+    {
+      "name": "reason-telemetry-redaction-review",
+      "required": true,
+      "description": "Reviewer confirms safe reason attrs are present and the raw reason sentinel is absent from Tempo JSON before folding PASS."
     }
   ],
   "artifactDestination": {
@@ -30,26 +68,31 @@
     "sha": "${OPENCLAW_CANDIDATE_SHA}",
     "row": "R-CW-3",
     "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
-    "runDirPrefix": "manual-corpus"
+    "runDirPrefix": "k6-run"
   },
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Catalog coverage entry only. Does not make the row runnable and does not change the canonical PROOFS corpus."
+    "notes": "This row intentionally tops out at HONEST-LIMIT-candidate until Tempo trace JSON is fetched and reviewed for safe reason attrs present / raw reason absent."
   },
   "liveRunSafety": {
-    "classification": "construct-only",
-    "requiresLiveGatewayToken": false,
+    "classification": "k6-runnable",
+    "requiresLiveGatewayToken": true,
     "requiresTargetSessionKey": false,
-    "requiresCandidateSha": false,
-    "requiresExternalAgentOrToolInvocation": false,
-    "requiresHumanConfirmation": false,
-    "sameSessionConcurrencySafe": true,
-    "expectedArtifactClass": "construct-only",
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": true,
+    "sameSessionConcurrencySafe": false,
+    "expectedArtifactClass": "HONEST-LIMIT-candidate",
     "requiredReceipts": [
-      "manual-row-corpus-receipt"
+      "seat-readiness",
+      "dispatch-accepted",
+      "continue-work-tool-result-scheduled",
+      "work-woke-event",
+      "public-artifact-raw-reason-absent",
+      "tempo-trace-json",
+      "reason-telemetry-redaction-review"
     ],
     "foldRequiresReview": true,
-    "notes": "Not included in --live-suite. This entry exists so every current manual proof row has an explicit manifest record."
+    "notes": "Safe unattended live fire, but not an unattended PASS proof: trace fetch/review decides whether the reason telemetry claim can be folded. Disposable-session smoke may honestly stop at scheduled-only on runtimes where disposable sessions do not service self-elected continuation wakes; canonical fold also requires a CW3-WOKE receipt."
   }
 }

--- a/tools/k6-proofs/scenarios/r-cd-silent.js
+++ b/tools/k6-proofs/scenarios/r-cd-silent.js
@@ -1,0 +1,143 @@
+/** Scenario: R-CD-SILENT — continue_delegate(mode="silent") no channel delivery + later internal context readback. */
+import ws from 'k6/ws';
+import { check } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
+import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+
+export const options = {
+  scenarios: { r_cd_silent: { executor: 'shared-iterations', vus: 1, iterations: 1, maxDuration: '210s' } },
+  thresholds: { proof_failures: ['count==0'], r_cd_silent_duration: ['p(95)<180000'] },
+};
+
+const failures = new Counter('proof_failures');
+const duration = new Trend('r_cd_silent_duration');
+const manifest = loadManifestFromEnv();
+const HARNESS_MARKER = '[k6-proof-harness]';
+const DEFAULTS = { sessionKey: 'main', seat: 'ronan-dgx', delaySeconds: 1, idempotencyKeyPrefix: 'R-CD-SILENT' };
+let finalEvidence = null;
+
+function boolEnv(name) { return (__ENV[name] || '').toLowerCase() === 'true'; }
+function invocationCfg() { const inv = manifest?.invocation || {}; return { mode: inv.mode || 'silent', delaySeconds: Number(inv.delaySeconds ?? __ENV.OPENCLAW_DELAY_SECONDS ?? DEFAULTS.delaySeconds), idempotencyKeyPrefix: inv.idempotencyKeyPrefix || DEFAULTS.idempotencyKeyPrefix }; }
+function safeRedact(classified) { return redactEvent(classified.payload || classified.data || {}); }
+function isChannelDeliveryEvent(eventName, eventData) {
+  const lowerName = String(eventName || '').toLowerCase();
+  if (lowerName.includes('channel') || lowerName.includes('delivery')) return true;
+  if (!eventData || typeof eventData !== 'object') return false;
+  const channelLike = eventData.channelId || eventData.channel_id || eventData.channel || eventData.targetChannel || eventData.deliveryChannel;
+  const surface = String(eventData.surface || eventData.provider || '').toLowerCase();
+  return Boolean(channelLike) || surface === 'discord' || surface === 'slack' || surface === 'telegram';
+}
+
+export default function () {
+  const url = __ENV.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
+  const token = __ENV.OPENCLAW_GATEWAY_TOKEN;
+  const requestedSessionKey = manifest?.sessionKey || __ENV.OPENCLAW_SESSION_KEY || DEFAULTS.sessionKey;
+  let sessionKey = requestedSessionKey;
+  const createDisposableSession = boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSION') || boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSIONS');
+  const seat = manifest?.seat || __ENV.OPENCLAW_SEAT_NAME || DEFAULTS.seat;
+  const rowNonce = nonce('R-CD-SILENT');
+  const childToken = `SILENTCHILD-${rowNonce}-${Math.random().toString(36).slice(2, 8)}`;
+
+  if (!token) { console.error('OPENCLAW_GATEWAY_TOKEN is required'); failures.add(1); return; }
+  if (manifest) { const errors = validateManifest(manifest); if (errors.length) console.warn('Manifest validation warnings: ' + errors.join('; ')); }
+
+  const inv = invocationCfg();
+  const evidence = {
+    row: 'R-CD-SILENT', manifest_loaded: !!manifest, nonce: rowNonce, seat,
+    requestedSessionKey, sessionKey, session_created: false, created_session_key: null,
+    candidateSha: manifest?.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset', started: new Date().toISOString(),
+    dispatch_accepted: false, scheduled_sentinel: false, child_completion_observed: false, followup_accepted: false,
+    parent_internal_context_observed: false, no_channel_delivery: true, child_channel_delivery_observed: false,
+    dispatch_accepted_at_ms: null, followup_sent_at_ms: null, trace_id: null, redacted_events: [],
+  };
+  const started = Date.now();
+
+  const res = ws.connect(url, {}, (socket) => {
+    const tracker = new RequestTracker();
+
+    function sendFollowup(socket) {
+      if (evidence.followup_sent_at_ms) return;
+      evidence.followup_sent_at_ms = Date.now();
+      const followup = `${HARNESS_MARKER} R-CD-SILENT follow-up nonce ${rowNonce}. If the previous silent delegate return is present in your internal context, reply exactly RCDS-PARENT-OBSERVED followed by that SILENTCHILD token. If it is absent, reply exactly RCDS-PARENT-MISSING ${rowNonce}. Do not call tools.`;
+      tracker.send(socket, 'sessions.send', { key: sessionKey, message: followup, idempotencyKey: `${inv.idempotencyKeyPrefix}-FOLLOWUP-${rowNonce}` });
+    }
+
+    function startProofFlow(socket) {
+      tracker.send(socket, 'sessions.messages.subscribe', { key: sessionKey });
+      socket.setTimeout(() => {
+        const task = `Proof ${rowNonce}: return exactly ${childToken}. Do not mutate files. Do not post to any channel.`;
+        const instruction = `${HARNESS_MARKER} R-CD-SILENT proof nonce ${rowNonce}. Call continue_delegate with task=${JSON.stringify(task)}, mode="${inv.mode}", delaySeconds=${inv.delaySeconds}. After the continue_delegate tool result reports scheduled, reply exactly RCDS-SCHEDULED ${rowNonce}. Do not say ${childToken} in your visible reply.`;
+        tracker.send(socket, 'sessions.send', { key: sessionKey, message: instruction, idempotencyKey: `${inv.idempotencyKeyPrefix}-DISPATCH-${rowNonce}` });
+      }, 500);
+      socket.setTimeout(() => socket.close(), Math.max(180000, (inv.delaySeconds + 150) * 1000));
+    }
+
+    socket.on('open', () => {
+      socket.send(connectFrame(token));
+      if (createDisposableSession) {
+        socket.setTimeout(() => {
+          const disposableKey = `r-cd-silent-${rowNonce}`.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+          tracker.send(socket, 'sessions.create', { key: disposableKey, label: `k6 R-CD-SILENT ${rowNonce}` });
+        }, 250);
+      } else socket.setTimeout(() => startProofFlow(socket), 500);
+    });
+
+    socket.on('message', (raw) => {
+      try {
+        const msg = JSON.parse(raw); const classified = tracker.classify(msg);
+        evidence.redacted_events.push({ ts: Date.now(), kind: classified.kind, method: classified.method || null, event: classified.event || null, ok: classified.ok !== undefined ? classified.ok : null, data: safeRedact(classified) });
+
+        if (classified.kind === 'response' && classified.method === 'sessions.create') {
+          if (classified.ok && classified.payload) { sessionKey = classified.payload.key || sessionKey; evidence.sessionKey = sessionKey; evidence.session_created = true; evidence.created_session_key = sessionKey; console.log('✓ disposable session created: ' + sessionKey); startProofFlow(socket); }
+          else { console.error('✗ sessions.create rejected: ' + JSON.stringify(classified.error)); failures.add(1); socket.close(); }
+        }
+        if (classified.kind === 'response' && classified.method === 'sessions.send') {
+          if (classified.ok) {
+            if (!evidence.dispatch_accepted) { evidence.dispatch_accepted = true; evidence.dispatch_accepted_at_ms = Date.now(); if (classified.payload?.traceId) evidence.trace_id = classified.payload.traceId; console.log('✓ dispatch sessions.send accepted for mode=silent'); }
+            else { evidence.followup_accepted = true; console.log('✓ follow-up sessions.send accepted'); }
+          } else { console.error('✗ sessions.send rejected: ' + JSON.stringify(classified.error)); failures.add(1); }
+        }
+        if (classified.kind === 'event') {
+          const eventName = classified.event || '';
+          const eventData = classified.data || {};
+          const eventStr = JSON.stringify(eventData);
+          if (eventStr.includes(childToken) && isChannelDeliveryEvent(eventName, eventData)) {
+            evidence.child_channel_delivery_observed = true; evidence.no_channel_delivery = false; console.warn('✗ child token appeared in a channel-delivery-shaped event'); failures.add(1);
+          }
+          if (!eventStr.includes(HARNESS_MARKER) && eventStr.includes(`RCDS-SCHEDULED ${rowNonce}`)) { evidence.scheduled_sentinel = true; console.log('✓ scheduled sentinel observed'); }
+          if (!eventStr.includes(HARNESS_MARKER) && eventStr.includes(childToken) && eventName === 'chat' && String(eventData.sessionKey || '').includes(':subagent:continuation-') && eventStr.includes('final')) {
+            if (!evidence.child_completion_observed) { evidence.child_completion_observed = true; console.log('✓ silent child completion observed on internal stream'); socket.setTimeout(() => sendFollowup(socket), Number(__ENV.OPENCLAW_SILENT_FOLLOWUP_AFTER_CHILD_MS || 5000)); }
+          }
+          if (!eventStr.includes(HARNESS_MARKER) && eventStr.includes(`RCDS-PARENT-OBSERVED ${childToken}`)) { evidence.parent_internal_context_observed = true; console.log('✓ parent reported silent child token from internal context'); }
+        }
+        if (evidence.dispatch_accepted && evidence.scheduled_sentinel && evidence.child_completion_observed && evidence.followup_accepted && evidence.parent_internal_context_observed && evidence.no_channel_delivery) { console.log('All required R-CD-SILENT evidence gathered, closing early'); socket.close(); }
+      } catch (e) { console.warn('parse error: ' + e); }
+    });
+    socket.on('error', (e) => { console.error('ws error: ' + (e && e.error ? e.error() : e)); failures.add(1); });
+  });
+
+  evidence.ended = new Date().toISOString(); evidence.duration_ms = Date.now() - started; finalEvidence = evidence; duration.add(evidence.duration_ms);
+  check(res, { 'websocket connected': (r) => r && r.status === 101 });
+  check(null, {
+    'dispatch accepted': () => evidence.dispatch_accepted,
+    'scheduled sentinel observed': () => evidence.scheduled_sentinel,
+    'child completion observed': () => evidence.child_completion_observed,
+    'follow-up accepted': () => evidence.followup_accepted,
+    'parent internal context observed': () => evidence.parent_internal_context_observed,
+    'no child channel delivery': () => evidence.no_channel_delivery,
+  });
+  if (!evidence.dispatch_accepted || !evidence.scheduled_sentinel || !evidence.child_completion_observed || !evidence.followup_accepted || !evidence.parent_internal_context_observed || !evidence.no_channel_delivery) failures.add(1);
+  const passed = (!createDisposableSession || evidence.session_created) && evidence.dispatch_accepted && evidence.scheduled_sentinel && evidence.child_completion_observed && evidence.followup_accepted && evidence.parent_internal_context_observed && evidence.no_channel_delivery;
+  console.log(`R_CD_SILENT_EVIDENCE ${JSON.stringify(evidence)}`);
+  console.log('\n--- R-CD-SILENT EVIDENCE SUMMARY ---'); console.log(JSON.stringify(evidence, null, 2)); console.log('--- END EVIDENCE ---');
+  console.log(`\n[R-CD-SILENT] VERDICT: ${passed ? 'PASS-candidate' : 'PARTIAL-candidate'}`);
+}
+
+export function handleSummary(data) {
+  const timestamp = new Date().toISOString();
+  const passRate = data.metrics.proof_failures?.values?.count === 0;
+  const traceId = finalEvidence?.trace_id || null;
+  const summary = { row: 'R-CD-SILENT', sha: __ENV.OPENCLAW_CANDIDATE_SHA || 'unset', seat: __ENV.OPENCLAW_SEAT_NAME || 'ronan-dgx', timestamp, verdict: passRate ? 'PASS-candidate' : 'PARTIAL-candidate', candidateOnly: true, foldRequiresReview: true, observability: { traceId, traceJson: traceId ? 'pending-fetch' : 'missing' }, review: { status: traceId ? 'ready-for-human-review' : 'review-pending', pendingReceipts: traceId ? [] : ['tempo-trace-json'], notes: traceId ? ['Trace id captured; fetch and attach Tempo trace JSON before canonical fold.'] : ['No trace_id emitted; keep PASS-candidate review-pending until trace JSON is fetched or trace-missing is explicitly accepted.'] }, metrics: { duration_ms: data.metrics.r_cd_silent_duration?.values || null, failures: data.metrics.proof_failures?.values?.count || 0 } };
+  return { stdout: `\n[R-CD-SILENT] Summary: ${summary.verdict} | SHA: ${summary.sha} | Seat: ${summary.seat}\n`, 'r-cd-silent-summary.json': JSON.stringify(summary, null, 2) };
+}

--- a/tools/k6-proofs/scenarios/r-cw-2-immediate-wake.js
+++ b/tools/k6-proofs/scenarios/r-cw-2-immediate-wake.js
@@ -1,0 +1,69 @@
+/** Scenario: R-CW-2 — continue_work(delaySeconds=0) immediate schedule + wake. */
+import ws from 'k6/ws';
+import { check } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
+import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+
+export const options = { scenarios: { r_cw_2_immediate_wake: { executor: 'shared-iterations', vus: 1, iterations: 1, maxDuration: '120s' } }, thresholds: { proof_failures: ['count==0'], r_cw_2_duration: ['p(95)<90000'] } };
+const failures = new Counter('proof_failures');
+const duration = new Trend('r_cw_2_duration');
+const manifest = loadManifestFromEnv();
+const HARNESS_MARKER = '[k6-proof-harness]';
+const DEFAULTS = { sessionKey: 'main', seat: 'cael-dgx', delaySeconds: 0, idempotencyKeyPrefix: 'R-CW-2' };
+let finalEvidence = null;
+function boolEnv(name) { return (__ENV[name] || '').toLowerCase() === 'true'; }
+function invocationCfg() { const inv = manifest?.invocation || {}; return { delaySeconds: Number(inv.delaySeconds ?? __ENV.OPENCLAW_DELAY_SECONDS ?? DEFAULTS.delaySeconds), idempotencyKeyPrefix: inv.idempotencyKeyPrefix || DEFAULTS.idempotencyKeyPrefix, reason: inv.reason || 'k6-proof-R-CW-2-immediate-{{nonce}}' }; }
+function safeRedact(classified) { return redactEvent(classified.payload || classified.data || {}); }
+
+export default function () {
+  const url = __ENV.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
+  const token = __ENV.OPENCLAW_GATEWAY_TOKEN;
+  const requestedSessionKey = manifest?.sessionKey || __ENV.OPENCLAW_SESSION_KEY || DEFAULTS.sessionKey;
+  let sessionKey = requestedSessionKey;
+  const createDisposableSession = boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSION') || boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSIONS');
+  const seat = manifest?.seat || __ENV.OPENCLAW_SEAT_NAME || DEFAULTS.seat;
+  const rowNonce = nonce('R-CW-2');
+  if (!token) { console.error('OPENCLAW_GATEWAY_TOKEN is required'); failures.add(1); return; }
+  if (manifest) { const errors = validateManifest(manifest); if (errors.length) console.warn('Manifest validation warnings: ' + errors.join('; ')); }
+  const inv = invocationCfg();
+  const evidence = { row: 'R-CW-2', manifest_loaded: !!manifest, nonce: rowNonce, seat, requestedSessionKey, sessionKey, session_created: false, created_session_key: null, candidateSha: manifest?.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset', started: new Date().toISOString(), dispatch_accepted: false, scheduled_sentinel: false, immediate_wake_observed: false, prompt_echo_ignored: false, dispatch_accepted_at_ms: null, scheduled_result_at_ms: null, wake_delay_ms: null, trace_id: null, redacted_events: [] };
+  const started = Date.now();
+  const res = ws.connect(url, {}, (socket) => {
+    const tracker = new RequestTracker();
+    function startProofFlow(socket) {
+      tracker.send(socket, 'sessions.messages.subscribe', { key: sessionKey });
+      socket.setTimeout(() => {
+        const reason = `${inv.reason.replace(/\{\{nonce\}\}/g, rowNonce)} -- on continuation wake reply exactly CW2-WOKE ${rowNonce}`;
+        const instruction = `${HARNESS_MARKER} R-CW-2 proof nonce ${rowNonce}. Call continue_work with delaySeconds=${inv.delaySeconds} and reason=${JSON.stringify(reason)}. After the continue_work tool result reports scheduled, reply exactly CW2-SCHEDULED ${rowNonce}. On the continuation wake, reply exactly CW2-WOKE ${rowNonce}. Do not mutate files.`;
+        tracker.send(socket, 'sessions.send', { key: sessionKey, message: instruction, idempotencyKey: `${inv.idempotencyKeyPrefix}-DISPATCH-${rowNonce}` });
+      }, 500);
+      socket.setTimeout(() => socket.close(), 90000);
+    }
+    socket.on('open', () => { socket.send(connectFrame(token)); if (createDisposableSession) { socket.setTimeout(() => { const disposableKey = `r-cw-2-${rowNonce}`.toLowerCase().replace(/[^a-z0-9-]/g, '-'); tracker.send(socket, 'sessions.create', { key: disposableKey, label: `k6 R-CW-2 ${rowNonce}` }); }, 250); } else socket.setTimeout(() => startProofFlow(socket), 500); });
+    socket.on('message', (raw) => {
+      try {
+        const msg = JSON.parse(raw); const classified = tracker.classify(msg);
+        evidence.redacted_events.push({ ts: Date.now(), kind: classified.kind, method: classified.method || null, event: classified.event || null, ok: classified.ok !== undefined ? classified.ok : null, data: safeRedact(classified) });
+        if (classified.kind === 'response' && classified.method === 'sessions.create') { if (classified.ok && classified.payload) { sessionKey = classified.payload.key || sessionKey; evidence.sessionKey = sessionKey; evidence.session_created = true; evidence.created_session_key = sessionKey; console.log('✓ disposable session created: ' + sessionKey); startProofFlow(socket); } else { console.error('✗ sessions.create rejected: ' + JSON.stringify(classified.error)); failures.add(1); socket.close(); } }
+        if (classified.kind === 'response' && classified.method === 'sessions.send') { if (classified.ok) { evidence.dispatch_accepted = true; evidence.dispatch_accepted_at_ms = Date.now(); if (classified.payload?.traceId) evidence.trace_id = classified.payload.traceId; console.log('✓ sessions.send accepted — immediate continue_work turn triggered'); } else { console.error('✗ sessions.send rejected: ' + JSON.stringify(classified.error)); failures.add(1); } }
+        if (classified.kind === 'event') {
+          const eventData = classified.data || {}; const eventStr = JSON.stringify(eventData);
+          if (eventStr.includes(HARNESS_MARKER)) { evidence.prompt_echo_ignored = true; return; }
+          if (!evidence.scheduled_sentinel && eventStr.includes(`CW2-SCHEDULED ${rowNonce}`)) { evidence.scheduled_sentinel = true; evidence.scheduled_result_at_ms = Date.now(); if (eventData.traceId) evidence.trace_id = eventData.traceId; console.log('✓ CW2-SCHEDULED sentinel observed'); }
+          if (evidence.scheduled_sentinel && !evidence.immediate_wake_observed && eventStr.includes(`CW2-WOKE ${rowNonce}`)) { evidence.immediate_wake_observed = true; evidence.wake_delay_ms = evidence.scheduled_result_at_ms ? Date.now() - evidence.scheduled_result_at_ms : null; console.log('✓ CW2-WOKE sentinel observed'); }
+        }
+        if (evidence.dispatch_accepted && evidence.scheduled_sentinel && evidence.immediate_wake_observed) { console.log('All required R-CW-2 evidence gathered, closing early'); socket.close(); }
+      } catch (e) { console.warn('parse error: ' + e); }
+    });
+    socket.on('error', (e) => { console.error('ws error: ' + (e && e.error ? e.error() : e)); failures.add(1); });
+  });
+  evidence.ended = new Date().toISOString(); evidence.duration_ms = Date.now() - started; finalEvidence = evidence; duration.add(evidence.duration_ms);
+  check(res, { 'websocket connected': (r) => r && r.status === 101 });
+  check(null, { 'dispatch accepted': () => evidence.dispatch_accepted, 'scheduled sentinel observed': () => evidence.scheduled_sentinel, 'immediate wake observed': () => evidence.immediate_wake_observed, 'harness prompt echo ignored': () => evidence.prompt_echo_ignored || evidence.scheduled_sentinel });
+  if (!evidence.dispatch_accepted || !evidence.scheduled_sentinel || !evidence.immediate_wake_observed) failures.add(1);
+  const passed = (!createDisposableSession || evidence.session_created) && evidence.dispatch_accepted && evidence.scheduled_sentinel && evidence.immediate_wake_observed;
+  console.log(`R_CW_2_EVIDENCE ${JSON.stringify(evidence)}`);
+  console.log('\n--- R-CW-2 EVIDENCE SUMMARY ---'); console.log(JSON.stringify(evidence, null, 2)); console.log('--- END EVIDENCE ---'); console.log(`\n[R-CW-2] VERDICT: ${passed ? 'PASS-candidate' : 'PARTIAL-candidate'}`);
+}
+export function handleSummary(data) { const timestamp = new Date().toISOString(); const passRate = data.metrics.proof_failures?.values?.count === 0; const traceId = finalEvidence?.trace_id || null; const summary = { row: 'R-CW-2', sha: __ENV.OPENCLAW_CANDIDATE_SHA || 'unset', seat: __ENV.OPENCLAW_SEAT_NAME || 'cael-dgx', timestamp, verdict: passRate ? 'PASS-candidate' : 'PARTIAL-candidate', candidateOnly: true, foldRequiresReview: true, observability: { traceId, traceJson: traceId ? 'pending-fetch' : 'missing' }, review: { status: traceId ? 'ready-for-human-review' : 'review-pending', pendingReceipts: traceId ? [] : ['tempo-trace-json'], notes: traceId ? ['Trace id captured; fetch and attach Tempo trace JSON before canonical fold.'] : ['No trace_id emitted; keep PASS-candidate review-pending until trace JSON is fetched or trace-missing is explicitly accepted.'] }, metrics: { duration_ms: data.metrics.r_cw_2_duration?.values || null, failures: data.metrics.proof_failures?.values?.count || 0 } }; return { stdout: `\n[R-CW-2] Summary: ${summary.verdict} | SHA: ${summary.sha} | Seat: ${summary.seat}\n`, 'r-cw-2-immediate-wake-summary.json': JSON.stringify(summary, null, 2) }; }

--- a/tools/k6-proofs/scenarios/r-cw-3-reason-telemetry.js
+++ b/tools/k6-proofs/scenarios/r-cw-3-reason-telemetry.js
@@ -1,0 +1,77 @@
+/** Scenario: R-CW-3 — continue_work reason telemetry/redaction candidate.
+ *
+ * This row deliberately does NOT overclaim the Tempo assertion in k6. It fires a
+ * nonce-bearing continue_work reason and verifies schedule+wake. Public evidence
+ * redacts the raw reason; the PASS/HONEST-LIMIT boundary is decided by reviewing
+ * fetched Tempo JSON for safe reason attrs present and raw reason absent.
+ */
+import ws from 'k6/ws';
+import { check } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
+import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+
+export const options = { scenarios: { r_cw_3_reason_telemetry: { executor: 'shared-iterations', vus: 1, iterations: 1, maxDuration: '120s' } }, thresholds: { proof_failures: ['count==0'], r_cw_3_duration: ['p(95)<90000'] } };
+const failures = new Counter('proof_failures');
+const duration = new Trend('r_cw_3_duration');
+const manifest = loadManifestFromEnv();
+const HARNESS_MARKER = '[k6-proof-harness]';
+const DEFAULTS = { sessionKey: 'main', seat: 'cael-dgx', delaySeconds: 5, idempotencyKeyPrefix: 'R-CW-3' };
+let finalEvidence = null;
+function boolEnv(name) { return (__ENV[name] || '').toLowerCase() === 'true'; }
+function invocationCfg() { const inv = manifest?.invocation || {}; return { delaySeconds: Number(inv.delaySeconds ?? __ENV.OPENCLAW_DELAY_SECONDS ?? DEFAULTS.delaySeconds), idempotencyKeyPrefix: inv.idempotencyKeyPrefix || DEFAULTS.idempotencyKeyPrefix, reasonPrefix: inv.reasonPrefix || 'k6-proof-R-CW-3-redaction' }; }
+function redactedNoReason(classified) {
+  const redacted = redactEvent(classified.payload || classified.data || {});
+  if (redacted && typeof redacted === 'object') delete redacted.reason;
+  return redacted;
+}
+
+export default function () {
+  const url = __ENV.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
+  const token = __ENV.OPENCLAW_GATEWAY_TOKEN;
+  const requestedSessionKey = manifest?.sessionKey || __ENV.OPENCLAW_SESSION_KEY || DEFAULTS.sessionKey;
+  let sessionKey = requestedSessionKey;
+  const createDisposableSession = boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSION') || boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSIONS');
+  const seat = manifest?.seat || __ENV.OPENCLAW_SEAT_NAME || DEFAULTS.seat;
+  const rowNonce = nonce('R-CW-3');
+  const rawReasonSentinel = `RAW-RCW3-${rowNonce}-${Math.random().toString(36).slice(2, 8)}`;
+  if (!token) { console.error('OPENCLAW_GATEWAY_TOKEN is required'); failures.add(1); return; }
+  if (manifest) { const errors = validateManifest(manifest); if (errors.length) console.warn('Manifest validation warnings: ' + errors.join('; ')); }
+  const inv = invocationCfg();
+  const evidence = { row: 'R-CW-3', manifest_loaded: !!manifest, nonce: rowNonce, seat, requestedSessionKey, sessionKey, session_created: false, created_session_key: null, candidateSha: manifest?.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset', started: new Date().toISOString(), dispatch_accepted: false, scheduled_sentinel: false, wake_observed: false, public_artifact_raw_reason_absent: true, tempo_assertion: 'pending-review', trace_id: null, dispatch_accepted_at_ms: null, scheduled_result_at_ms: null, wake_delay_ms: null, redacted_events: [] };
+  const started = Date.now();
+  const res = ws.connect(url, {}, (socket) => {
+    const tracker = new RequestTracker();
+    function startProofFlow(socket) {
+      tracker.send(socket, 'sessions.messages.subscribe', { key: sessionKey });
+      socket.setTimeout(() => {
+        const rawReason = `${inv.reasonPrefix} ${rawReasonSentinel}; on continuation wake reply exactly CW3-WOKE ${rowNonce}`;
+        const instruction = `${HARNESS_MARKER} R-CW-3 proof nonce ${rowNonce}. Call continue_work with delaySeconds=${inv.delaySeconds} and the supplied reason. After the continue_work tool result reports scheduled, reply exactly CW3-SCHEDULED ${rowNonce}. On the continuation wake, reply exactly CW3-WOKE ${rowNonce}. Supplied reason: ${JSON.stringify(rawReason)}. Do not mutate files.`;
+        tracker.send(socket, 'sessions.send', { key: sessionKey, message: instruction, idempotencyKey: `${inv.idempotencyKeyPrefix}-DISPATCH-${rowNonce}` });
+      }, 500);
+      socket.setTimeout(() => socket.close(), Math.max(90000, (inv.delaySeconds + 60) * 1000));
+    }
+    socket.on('open', () => { socket.send(connectFrame(token)); if (createDisposableSession) { socket.setTimeout(() => { const disposableKey = `r-cw-3-${rowNonce}`.toLowerCase().replace(/[^a-z0-9-]/g, '-'); tracker.send(socket, 'sessions.create', { key: disposableKey, label: `k6 R-CW-3 ${rowNonce}` }); }, 250); } else socket.setTimeout(() => startProofFlow(socket), 500); });
+    socket.on('message', (raw) => {
+      try {
+        const msg = JSON.parse(raw); const classified = tracker.classify(msg);
+        const safeData = redactedNoReason(classified);
+        if (JSON.stringify(safeData).includes(rawReasonSentinel)) evidence.public_artifact_raw_reason_absent = false;
+        evidence.redacted_events.push({ ts: Date.now(), kind: classified.kind, method: classified.method || null, event: classified.event || null, ok: classified.ok !== undefined ? classified.ok : null, data: safeData });
+        if (classified.kind === 'response' && classified.method === 'sessions.create') { if (classified.ok && classified.payload) { sessionKey = classified.payload.key || sessionKey; evidence.sessionKey = sessionKey; evidence.session_created = true; evidence.created_session_key = sessionKey; console.log('✓ disposable session created: ' + sessionKey); startProofFlow(socket); } else { console.error('✗ sessions.create rejected: ' + JSON.stringify(classified.error)); failures.add(1); socket.close(); } }
+        if (classified.kind === 'response' && classified.method === 'sessions.send') { if (classified.ok) { evidence.dispatch_accepted = true; evidence.dispatch_accepted_at_ms = Date.now(); if (classified.payload?.traceId) evidence.trace_id = classified.payload.traceId; console.log('✓ sessions.send accepted — reason telemetry turn triggered'); } else { console.error('✗ sessions.send rejected: ' + JSON.stringify(classified.error)); failures.add(1); } }
+        if (classified.kind === 'event') { const eventData = classified.data || {}; const eventStr = JSON.stringify(eventData); if (eventStr.includes(HARNESS_MARKER)) return; if (!evidence.scheduled_sentinel && eventStr.includes(`CW3-SCHEDULED ${rowNonce}`)) { evidence.scheduled_sentinel = true; evidence.scheduled_result_at_ms = Date.now(); if (eventData.traceId) evidence.trace_id = eventData.traceId; console.log('✓ CW3-SCHEDULED sentinel observed'); } if (evidence.scheduled_sentinel && !evidence.wake_observed && eventStr.includes(`CW3-WOKE ${rowNonce}`)) { evidence.wake_observed = true; evidence.wake_delay_ms = evidence.scheduled_result_at_ms ? Date.now() - evidence.scheduled_result_at_ms : null; console.log('✓ CW3-WOKE sentinel observed'); } }
+        if (evidence.dispatch_accepted && evidence.scheduled_sentinel && evidence.wake_observed) { console.log('Required R-CW-3 schedule/wake evidence gathered, closing early'); socket.close(); }
+      } catch (e) { console.warn('parse error: ' + e); }
+    });
+    socket.on('error', (e) => { console.error('ws error: ' + (e && e.error ? e.error() : e)); failures.add(1); });
+  });
+  evidence.ended = new Date().toISOString(); evidence.duration_ms = Date.now() - started; finalEvidence = evidence; duration.add(evidence.duration_ms);
+  check(res, { 'websocket connected': (r) => r && r.status === 101 });
+  check(null, { 'dispatch accepted': () => evidence.dispatch_accepted, 'scheduled sentinel observed': () => evidence.scheduled_sentinel, 'wake observed': () => evidence.wake_observed, 'raw reason absent from public evidence': () => evidence.public_artifact_raw_reason_absent });
+  if (!evidence.dispatch_accepted || !evidence.scheduled_sentinel || !evidence.wake_observed || !evidence.public_artifact_raw_reason_absent) failures.add(1);
+  const passed = (!createDisposableSession || evidence.session_created) && evidence.dispatch_accepted && evidence.scheduled_sentinel && evidence.wake_observed && evidence.public_artifact_raw_reason_absent;
+  console.log(`R_CW_3_EVIDENCE ${JSON.stringify(evidence)}`);
+  console.log('\n--- R-CW-3 EVIDENCE SUMMARY ---'); console.log(JSON.stringify(evidence, null, 2)); console.log('--- END EVIDENCE ---'); console.log(`\n[R-CW-3] VERDICT: ${passed ? 'HONEST-LIMIT-candidate' : 'PARTIAL-candidate'}`);
+}
+export function handleSummary(data) { const timestamp = new Date().toISOString(); const passRate = data.metrics.proof_failures?.values?.count === 0; const traceId = finalEvidence?.trace_id || null; const summary = { row: 'R-CW-3', sha: __ENV.OPENCLAW_CANDIDATE_SHA || 'unset', seat: __ENV.OPENCLAW_SEAT_NAME || 'cael-dgx', timestamp, verdict: passRate ? 'HONEST-LIMIT-candidate' : 'PARTIAL-candidate', candidateOnly: true, foldRequiresReview: true, observability: { traceId, traceJson: traceId ? 'pending-fetch' : 'missing' }, review: { status: 'review-pending', pendingReceipts: ['tempo-trace-json', 'reason-telemetry-redaction-review'], notes: ['k6 proves dispatch/schedule/wake and keeps the raw reason out of public evidence.', 'Before folding PASS, fetch Tempo trace JSON and verify safe reason attributes are present while the raw reason sentinel is absent. If trace fetch is unavailable, keep this as HONEST-LIMIT-candidate.'] }, metrics: { duration_ms: data.metrics.r_cw_3_duration?.values || null, failures: data.metrics.proof_failures?.values?.count || 0 } }; return { stdout: `\n[R-CW-3] Summary: ${summary.verdict} | SHA: ${summary.sha} | Seat: ${summary.seat}\n`, 'r-cw-3-reason-telemetry-summary.json': JSON.stringify(summary, null, 2) }; }


### PR DESCRIPTION
## Summary

- promote three non-config Project 81 rows from construct-only/manual registry to runnable k6 scenarios: `R-CD-SILENT`, `R-CW-2`, `R-CW-3`
- add row runbooks and workflow/README entries for the new runnable scenario basenames
- narrow `R-CD-SILENT` no-channel detector to channel-delivery-shaped events and wait for the silent child internal completion before parent follow-up
- keep `R-CW-3` honest-limit: k6 proves schedule/wake + public raw-reason redaction only; Tempo JSON review remains required for PASS fold

## Verification

- `node --check tools/k6-proofs/scenarios/r-cd-silent.js`
- `node --check tools/k6-proofs/scenarios/r-cw-2-immediate-wake.js`
- `node --check tools/k6-proofs/scenarios/r-cw-3-reason-telemetry.js`
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs`
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs`
- `node tools/k6-proofs/scripts/list-runnable-rows.mjs --live-suite` → 22 rows
- `./scripts/run-proofs.sh --dry-run R-CD-SILENT,R-CW-2,R-CW-3 7bf6980bde7617a8850766043339443dbd6262f5`

## Live smoke notes

Candidate/deployed mismatch was present on the seat (`7bf6980...` vs deployed `OpenClaw 2026.6.11 (b40e59f)`), so live smoke is candidate evidence / honest-limit, not canonical fold material.

- `R-CD-SILENT`: PASS-candidate under `/tmp/p81-rcd-silent-smoke2/.../R-CD-SILENT/ronan/20260707T235620Z-r-cd-silent`; trace id null, trace review remains debt.
- `R-CW-2`: partial under `/tmp/p81-rcw23-smoke/.../R-CW-2/ronan/20260707T235710Z-r-cw-2`; dispatch + scheduled sentinel observed, no wake sentinel in disposable session.
- `R-CW-3`: partial under `/tmp/p81-rcw3-smoke/.../R-CW-3/ronan/20260707T235910Z-r-cw-3`; dispatch + scheduled sentinel observed, no wake sentinel in disposable session; Tempo review still required even with wake.
- Baseline `R-CW-1` disposable-session smoke also stopped at scheduled-only (`/tmp/p81-rcw1-baseline/...`), so the CW partial shape is recorded as a disposable-session/runtime observation rather than a scenario detector failure.
