### PR TITLE
tools: promote static continuation proof validators

### DIFF
--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -107,6 +107,10 @@ GitHub Actions workflow choices. Current workflow-runnable basenames are:
 - `r-cw-2-immediate-wake`
 - `r-cw-3-reason-telemetry`
 - `r-cw-4-chain-depth`
+- `r-cw-7`
+- `r-cw-delegate-child-live`
+- `r-cw-delegate-token`
+- `r-cw-multi`
 - `r-cw-delegate-self-continuation`
 - `r-cw-token-bracket`
 - `r-obs-status`

--- a/tools/k6-proofs/manifests/r-cw-7.json
+++ b/tools/k6-proofs/manifests/r-cw-7.json
@@ -8,21 +8,27 @@
   "transport": "offline",
   "toolSurface": "read-only",
   "mutates": false,
-  "timeoutSeconds": 0,
+  "timeoutSeconds": 15,
   "scenario": {
-    "name": "r-cw-7",
-    "description": "continue_work traceparent propagation source/test manual proof row. Registered to keep the executable-suite manifest catalog aligned with the 29-row manual proof corpus; not an unattended k6 scenario yet.",
+    "name": "static-corpus-row-validator",
+    "description": "Static validator for committed runtime traceparent propagation source/test receipts.",
     "methods": [
-      "manual-corpus-review"
+      "manual-corpus-review",
+      "static-artifact-parse"
     ],
-    "status": "construct-only",
-    "notes": "Construct-only registry entry. The current PROOFS corpus carries manual evidence for this row; promote to scaffold/runnable only after a reviewed k6 fixture exists."
+    "status": "runnable",
+    "file": "static-corpus-row-validator.js"
   },
   "expectedReceipts": [
     {
-      "name": "manual-row-corpus-receipt",
+      "name": "traceparent-propagation-artifacts",
       "required": true,
-      "description": "Current PROOFS/<sha> corpus contains reviewed manual evidence for this row."
+      "description": "Current PROOFS corpus receipts parse for this row."
+    },
+    {
+      "name": "traceparent-propagation-tests",
+      "required": true,
+      "description": "Committed evidence satisfies the row-specific PASS predicate."
     }
   ],
   "artifactDestination": {
@@ -35,21 +41,22 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Catalog coverage entry only. Does not make the row runnable and does not change the canonical PROOFS corpus."
+    "notes": "Static artifact validator for R-CW-7. Validates committed corpus receipts; does not fire live behavior."
   },
   "liveRunSafety": {
-    "classification": "construct-only",
+    "classification": "k6-runnable",
     "requiresLiveGatewayToken": false,
     "requiresTargetSessionKey": false,
-    "requiresCandidateSha": false,
+    "requiresCandidateSha": true,
     "requiresExternalAgentOrToolInvocation": false,
     "requiresHumanConfirmation": false,
     "sameSessionConcurrencySafe": true,
-    "expectedArtifactClass": "construct-only",
+    "expectedArtifactClass": "PASS-candidate",
     "requiredReceipts": [
-      "manual-row-corpus-receipt"
+      "traceparent-propagation-artifacts",
+      "traceparent-propagation-tests"
     ],
     "foldRequiresReview": true,
-    "notes": "Not included in --live-suite. This entry exists so every current manual proof row has an explicit manifest record."
+    "notes": "Offline/static current-corpus validator; safe in broad suite because it does not connect to or mutate gateway state."
   }
 }

--- a/tools/k6-proofs/manifests/r-cw-delegate-child-live.json
+++ b/tools/k6-proofs/manifests/r-cw-delegate-child-live.json
@@ -8,21 +8,27 @@
   "transport": "offline",
   "toolSurface": "read-only",
   "mutates": false,
-  "timeoutSeconds": 0,
+  "timeoutSeconds": 15,
   "scenario": {
-    "name": "r-cw-delegate-child-live",
-    "description": "delegate child schedules its own continue_work manual proof row. Registered to keep the executable-suite manifest catalog aligned with the 29-row manual proof corpus; not an unattended k6 scenario yet.",
+    "name": "static-corpus-row-validator",
+    "description": "Static validator for committed delegate-child self-continuation hop1/hop2 receipts.",
     "methods": [
-      "manual-corpus-review"
+      "manual-corpus-review",
+      "static-artifact-parse"
     ],
-    "status": "construct-only",
-    "notes": "Construct-only registry entry. The current PROOFS corpus carries manual evidence for this row; promote to scaffold/runnable only after a reviewed k6 fixture exists."
+    "status": "runnable",
+    "file": "static-corpus-row-validator.js"
   },
   "expectedReceipts": [
     {
-      "name": "manual-row-corpus-receipt",
+      "name": "delegate-child-hop-artifacts",
       "required": true,
-      "description": "Current PROOFS/<sha> corpus contains reviewed manual evidence for this row."
+      "description": "Current PROOFS corpus receipts parse for this row."
+    },
+    {
+      "name": "delegate-child-hop2-executed",
+      "required": true,
+      "description": "Committed evidence satisfies the row-specific PASS predicate."
     }
   ],
   "artifactDestination": {
@@ -35,21 +41,22 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Catalog coverage entry only. Does not make the row runnable and does not change the canonical PROOFS corpus."
+    "notes": "Static artifact validator for R-CW-DELEGATE-CHILD-LIVE. Validates committed corpus receipts; does not fire live behavior."
   },
   "liveRunSafety": {
-    "classification": "construct-only",
+    "classification": "k6-runnable",
     "requiresLiveGatewayToken": false,
     "requiresTargetSessionKey": false,
-    "requiresCandidateSha": false,
+    "requiresCandidateSha": true,
     "requiresExternalAgentOrToolInvocation": false,
     "requiresHumanConfirmation": false,
     "sameSessionConcurrencySafe": true,
-    "expectedArtifactClass": "construct-only",
+    "expectedArtifactClass": "PASS-candidate",
     "requiredReceipts": [
-      "manual-row-corpus-receipt"
+      "delegate-child-hop-artifacts",
+      "delegate-child-hop2-executed"
     ],
     "foldRequiresReview": true,
-    "notes": "Not included in --live-suite. This entry exists so every current manual proof row has an explicit manifest record."
+    "notes": "Offline/static current-corpus validator; safe in broad suite because it does not connect to or mutate gateway state."
   }
 }

--- a/tools/k6-proofs/manifests/r-cw-delegate-token.json
+++ b/tools/k6-proofs/manifests/r-cw-delegate-token.json
@@ -8,21 +8,27 @@
   "transport": "offline",
   "toolSurface": "read-only",
   "mutates": false,
-  "timeoutSeconds": 0,
+  "timeoutSeconds": 15,
   "scenario": {
-    "name": "r-cw-delegate-token",
-    "description": "delegate child bare CONTINUE_WORK token manual proof row. Registered to keep the executable-suite manifest catalog aligned with the 29-row manual proof corpus; not an unattended k6 scenario yet.",
+    "name": "static-corpus-row-validator",
+    "description": "Static validator for committed delegate child bare-token continuation receipts.",
     "methods": [
-      "manual-corpus-review"
+      "manual-corpus-review",
+      "static-artifact-parse"
     ],
-    "status": "construct-only",
-    "notes": "Construct-only registry entry. The current PROOFS corpus carries manual evidence for this row; promote to scaffold/runnable only after a reviewed k6 fixture exists."
+    "status": "runnable",
+    "file": "static-corpus-row-validator.js"
   },
   "expectedReceipts": [
     {
-      "name": "manual-row-corpus-receipt",
+      "name": "delegate-token-artifacts",
       "required": true,
-      "description": "Current PROOFS/<sha> corpus contains reviewed manual evidence for this row."
+      "description": "Current PROOFS corpus receipts parse for this row."
+    },
+    {
+      "name": "bare-token-hop2-executed",
+      "required": true,
+      "description": "Committed evidence satisfies the row-specific PASS predicate."
     }
   ],
   "artifactDestination": {
@@ -35,21 +41,22 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Catalog coverage entry only. Does not make the row runnable and does not change the canonical PROOFS corpus."
+    "notes": "Static artifact validator for R-CW-DELEGATE-TOKEN. Validates committed corpus receipts; does not fire live behavior."
   },
   "liveRunSafety": {
-    "classification": "construct-only",
+    "classification": "k6-runnable",
     "requiresLiveGatewayToken": false,
     "requiresTargetSessionKey": false,
-    "requiresCandidateSha": false,
+    "requiresCandidateSha": true,
     "requiresExternalAgentOrToolInvocation": false,
     "requiresHumanConfirmation": false,
     "sameSessionConcurrencySafe": true,
-    "expectedArtifactClass": "construct-only",
+    "expectedArtifactClass": "PASS-candidate",
     "requiredReceipts": [
-      "manual-row-corpus-receipt"
+      "delegate-token-artifacts",
+      "bare-token-hop2-executed"
     ],
     "foldRequiresReview": true,
-    "notes": "Not included in --live-suite. This entry exists so every current manual proof row has an explicit manifest record."
+    "notes": "Offline/static current-corpus validator; safe in broad suite because it does not connect to or mutate gateway state."
   }
 }

--- a/tools/k6-proofs/manifests/r-cw-multi.json
+++ b/tools/k6-proofs/manifests/r-cw-multi.json
@@ -8,21 +8,27 @@
   "transport": "offline",
   "toolSurface": "read-only",
   "mutates": false,
-  "timeoutSeconds": 0,
+  "timeoutSeconds": 15,
   "scenario": {
-    "name": "r-cw-multi",
-    "description": "multiple continue_work same-turn manual proof row. Registered to keep the executable-suite manifest catalog aligned with the 29-row manual proof corpus; not an unattended k6 scenario yet.",
+    "name": "static-corpus-row-validator",
+    "description": "Static validator for committed same-turn multi continue_work fanout/collapse receipts.",
     "methods": [
-      "manual-corpus-review"
+      "manual-corpus-review",
+      "static-artifact-parse"
     ],
-    "status": "construct-only",
-    "notes": "Construct-only registry entry. The current PROOFS corpus carries manual evidence for this row; promote to scaffold/runnable only after a reviewed k6 fixture exists."
+    "status": "runnable",
+    "file": "static-corpus-row-validator.js"
   },
   "expectedReceipts": [
     {
-      "name": "manual-row-corpus-receipt",
+      "name": "multi-work-artifacts",
       "required": true,
-      "description": "Current PROOFS/<sha> corpus contains reviewed manual evidence for this row."
+      "description": "Current PROOFS corpus receipts parse for this row."
+    },
+    {
+      "name": "fanout-collapse-semantics",
+      "required": true,
+      "description": "Committed evidence satisfies the row-specific PASS predicate."
     }
   ],
   "artifactDestination": {
@@ -35,21 +41,22 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Catalog coverage entry only. Does not make the row runnable and does not change the canonical PROOFS corpus."
+    "notes": "Static artifact validator for R-CW-MULTI. Validates committed corpus receipts; does not fire live behavior."
   },
   "liveRunSafety": {
-    "classification": "construct-only",
+    "classification": "k6-runnable",
     "requiresLiveGatewayToken": false,
     "requiresTargetSessionKey": false,
-    "requiresCandidateSha": false,
+    "requiresCandidateSha": true,
     "requiresExternalAgentOrToolInvocation": false,
     "requiresHumanConfirmation": false,
     "sameSessionConcurrencySafe": true,
-    "expectedArtifactClass": "construct-only",
+    "expectedArtifactClass": "PASS-candidate",
     "requiredReceipts": [
-      "manual-row-corpus-receipt"
+      "multi-work-artifacts",
+      "fanout-collapse-semantics"
     ],
     "foldRequiresReview": true,
-    "notes": "Not included in --live-suite. This entry exists so every current manual proof row has an explicit manifest record."
+    "notes": "Offline/static current-corpus validator; safe in broad suite because it does not connect to or mutate gateway state."
   }
 }

--- a/tools/k6-proofs/scenarios/static-corpus-row-validator.js
+++ b/tools/k6-proofs/scenarios/static-corpus-row-validator.js
@@ -1,0 +1,178 @@
+/**
+ * Generic offline/static current-corpus validator for manual Project 81 rows.
+ *
+ * The row manifest selects the row via rowId. This validates committed PROOFS
+ * receipts only; it does not connect to a gateway, fire continuation tools,
+ * mutate config, or claim fresh live behavior.
+ */
+import { check } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+
+export const options = {
+  scenarios: { static_corpus_row_validator: { executor: 'shared-iterations', vus: 1, iterations: 1, maxDuration: '15s' } },
+  thresholds: { proof_failures: ['count==0'], static_corpus_row_duration: ['p(95)<10000'] },
+};
+
+const failures = new Counter('proof_failures');
+const duration = new Trend('static_corpus_row_duration');
+const manifest = loadManifestFromEnv();
+const index = JSON.parse(open('../../../PROOFS/INDEX.json'));
+const currentSha = index.current_sha;
+const carriedFrom = index.carried_from || currentSha;
+
+function includesAny(text, needles) { return needles.some((needle) => text.includes(needle)); }
+function allPresent(obj) { return Object.values(obj).every(Boolean); }
+function rowRoot(row) { return `../../../PROOFS/${currentSha}/${row}/cael-dgx`; }
+function readMaybe(path) { try { return open(path); } catch (e) { return ''; } }
+function readJsonMaybe(path) { const raw = readMaybe(path); return raw ? JSON.parse(raw) : null; }
+
+const selectedRow = manifest?.rowId || '';
+const roots = {
+  rcw7: rowRoot('R-CW-7'),
+  childLive: rowRoot('R-CW-DELEGATE-CHILD-LIVE'),
+  delegateToken: rowRoot('R-CW-DELEGATE-TOKEN'),
+  multi: rowRoot('R-CW-MULTI'),
+};
+
+const corpus = {};
+if (selectedRow === 'R-CW-7') {
+  corpus.rcw7 = {
+    evidence: readMaybe(`${roots.rcw7}/EVIDENCE.md`),
+    testLog: readMaybe(`${roots.rcw7}/test/focused-traceparent-tests.log`),
+    sourceSnippets: readMaybe(`${roots.rcw7}/source/source-snippets.md`),
+    sourceSha: readMaybe(`${roots.rcw7}/source/source-sha.txt`),
+  };
+}
+if (selectedRow === 'R-CW-DELEGATE-CHILD-LIVE') {
+  corpus.childLive = {
+    evidence: readMaybe(`${roots.childLive}/EVIDENCE.md`),
+    hop1: readMaybe(`${roots.childLive}/hop1.txt`),
+    hop2: readMaybe(`${roots.childLive}/hop2.txt`),
+    verifier: readMaybe(`${roots.childLive}/verifier-receipt.txt`),
+    flow: readMaybe(`${roots.childLive}/flow-runs.json`),
+    tempo: readMaybe(`${roots.childLive}/tempo-attribute-receipt.txt`),
+  };
+}
+if (selectedRow === 'R-CW-DELEGATE-TOKEN') {
+  corpus.delegateToken = {
+    evidence: readMaybe(`${roots.delegateToken}/EVIDENCE.md`),
+    childAudit: readMaybe(`${roots.delegateToken}/child-transcript-tool-audit.md`),
+    journal: readMaybe(`${roots.delegateToken}/journal-continuation-excerpt.log`),
+    flowRows: readMaybe(`${roots.delegateToken}/flow-runs-matching-full.jsonl`),
+    toolAudit: readMaybe(`${roots.delegateToken}/tempo-child-tool-audit.txt`),
+  };
+}
+if (selectedRow === 'R-CW-MULTI') {
+  corpus.multi = {
+    evidence: readMaybe(`${roots.multi}/EVIDENCE.md`),
+    sourceReceipts: readMaybe(`${roots.multi}/source-tool-receipts.jsonl`),
+    flowRows: readMaybe(`${roots.multi}/flow-runs-final.json`),
+    journal: readMaybe(`${roots.multi}/journal-continuation-lines.txt`),
+    wakeReceipts: readMaybe(`${roots.multi}/wake-and-folded-receipts.txt`),
+    traceSummary: readMaybe(`${roots.multi}/tempo/trace-summary.jsonl`),
+  };
+}
+
+function validateRcw7() {
+  const root = roots.rcw7;
+  const { evidence, testLog, sourceSnippets, sourceSha } = corpus.rcw7;
+  const checks = {
+    passScope: evidence.includes('PASS') && evidence.includes('runtime traceparent propagation'),
+    internalNotPublic: evidence.includes('internal protocol field') && sourceSnippets.includes('x-openclaw-internal'),
+    autoPickup: evidence.includes('auto-picks the active runtime trace context') || sourceSnippets.includes('auto-picks the active runtime trace context'),
+    dispatchPreserves: evidence.includes('threads persisted traceparent into spawned continuation runs') || sourceSnippets.includes('threads persisted traceparent'),
+    childReceives: evidence.includes('forwards inherited traceparent to the child agent run') || sourceSnippets.includes('forwards inherited traceparent'),
+    testsPassed: testLog.includes('passed 3 Vitest shards') || evidence.includes('142 passed / 0 failed'),
+    sourceSha: sourceSha.includes(currentSha) || evidence.includes(currentSha),
+  };
+  return { checks, source_files: { evidence: `${root}/EVIDENCE.md`, testLog: `${root}/test/focused-traceparent-tests.log`, sourceSnippets: `${root}/source/source-snippets.md` } };
+}
+
+function validateDelegateChildLive() {
+  const root = roots.childLive;
+  const { evidence, hop1, hop2, verifier, flow, tempo } = corpus.childLive;
+  const checks = {
+    verdictPass: evidence.includes('Verdict') && evidence.includes('PASS'),
+    hop1BeforeWork: hop1.includes('HOP1-WROTE-BEFORE-CONTINUE_WORK'),
+    hop2AfterWake: hop2.includes('hop2-EXECUTED after child continuation wake'),
+    verifierBoth: verifier.includes('hop1_exists=yes') && verifier.includes('hop2_exists=yes'),
+    parentDelegateTrace: tempo.includes('continuation.delegate.dispatch') && tempo.includes('delegate.mode=normal'),
+    childWorkFireTrace: tempo.includes('continuation.work.fire') && tempo.includes('delay.ms=5000'),
+    flowReceipts: flow.includes('continuation_work') || flow.includes('continuation-work'),
+  };
+  return { checks, source_files: { evidence: `${root}/EVIDENCE.md`, hop1: `${root}/hop1.txt`, hop2: `${root}/hop2.txt`, verifier: `${root}/verifier-receipt.txt`, tempo: `${root}/tempo-attribute-receipt.txt` } };
+}
+
+function validateDelegateToken() {
+  const root = roots.delegateToken;
+  const { evidence, childAudit, journal, flowRows, toolAudit } = corpus.delegateToken;
+  const checks = {
+    verdictPass: evidence.includes('Verdict') && evidence.includes('PASS'),
+    bareToken: evidence.includes('CONTINUE_WORK:5') && childAudit.includes('CONTINUE_WORK:5'),
+    tokenOrigin: journal.includes('origin=bracket kind=work') || evidence.includes('origin=bracket kind=work'),
+    noTypedChildTool: includesAny(childAudit, ['no child `toolCall` blocks', 'No child typed `continue_work` tool call']) || evidence.includes('no child `openclaw.tool.execution` span for typed `continue_work`'),
+    secondTurn: evidence.includes('Real second child turn') && evidence.includes('Disposition: `granted`'),
+    durableWork: flowRows.includes('core/continuation-work') && flowRows.includes('status') && flowRows.includes('succeeded'),
+    tempoWorkFire: toolAudit.includes('continuation.work') || evidence.includes('continuation.work.fire'),
+  };
+  return { checks, source_files: { evidence: `${root}/EVIDENCE.md`, childAudit: `${root}/child-transcript-tool-audit.md`, journal: `${root}/journal-continuation-excerpt.log`, flowRows: `${root}/flow-runs-matching-full.jsonl`, tempoAudit: `${root}/tempo-child-tool-audit.txt` } };
+}
+
+function validateRcwMulti() {
+  const root = roots.multi;
+  const { evidence, sourceReceipts, flowRows, journal, wakeReceipts, traceSummary } = corpus.multi;
+  const checks = {
+    verdictPass: evidence.includes('PASS') && evidence.includes('fanout/collapse semantics'),
+    threeToolReceipts: (sourceReceipts.match(/"status":"scheduled"/g) || []).length >= 3,
+    grantedA: flowRows.includes('disposition') && flowRows.includes('granted'),
+    foldedBC: (flowRows.match(/folded-active/g) || []).length >= 2,
+    journalFolded: journal.includes('continuation:work-folded-active'),
+    noInventedMarkers: evidence.includes('No B/C wake markers were invented') || wakeReceipts.includes('folded-active'),
+    traceThreeWorkSpans: (traceSummary.match(/continuation.work/g) || []).length >= 3,
+  };
+  return { checks, source_files: { evidence: `${root}/EVIDENCE.md`, sourceReceipts: `${root}/source-tool-receipts.jsonl`, flowRows: `${root}/flow-runs-final.json`, journal: `${root}/journal-continuation-lines.txt`, traceSummary: `${root}/tempo/trace-summary.jsonl` } };
+}
+
+const validators = {
+  'R-CW-7': validateRcw7,
+  'R-CW-DELEGATE-CHILD-LIVE': validateDelegateChildLive,
+  'R-CW-DELEGATE-TOKEN': validateDelegateToken,
+  'R-CW-MULTI': validateRcwMulti,
+};
+
+export default function () {
+  const started = Date.now();
+  if (!manifest?.rowId) { console.error('OPENCLAW_ROW_MANIFEST with rowId is required'); failures.add(1); return; }
+  const errors = validateManifest(manifest);
+  if (errors.length > 0) console.warn(`Manifest validation warnings: ${errors.join('; ')}`);
+  const validator = validators[manifest.rowId];
+  if (!validator) { console.error(`No static validator implemented for ${manifest.rowId}`); failures.add(1); return; }
+  const result = validator();
+  const evidence = {
+    row: manifest.rowId,
+    manifest_loaded: true,
+    candidateSha: manifest.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
+    currentProofSha: currentSha,
+    carriedFrom,
+    started: new Date(started).toISOString(),
+    checks: result.checks,
+    source_files: result.source_files,
+  };
+  const ok = allPresent(result.checks);
+  evidence.ended = new Date().toISOString();
+  evidence.duration_ms = Date.now() - started;
+  evidence.verdict = ok ? 'PASS-candidate' : 'FAIL-candidate';
+  duration.add(evidence.duration_ms);
+  const checkSpec = {};
+  for (const [name, value] of Object.entries(result.checks)) checkSpec[name] = () => value;
+  check(null, checkSpec);
+  if (!ok) failures.add(1);
+  console.log(`STATIC_CORPUS_ROW_EVIDENCE ${JSON.stringify(evidence)}`);
+}
+
+export function handleSummary(data) {
+  const failuresCount = data.metrics.proof_failures?.values?.count || 0;
+  const row = manifest?.rowId || 'UNKNOWN';
+  return { 'static-corpus-row-summary.json': JSON.stringify({ row, sha: __ENV.OPENCLAW_CANDIDATE_SHA || 'unset', verdict: failuresCount === 0 ? 'PASS-candidate' : 'FAIL-candidate', metrics: { failures: failuresCount, duration_ms: data.metrics.static_corpus_row_duration?.values || null } }, null, 2) };
+}


### PR DESCRIPTION
## Summary

Promotes four additional non-mutating Project 81 rows to safe offline/static k6 validators over the committed current PROOFS corpus:

- `R-CW-7` — runtime traceparent propagation source/test receipts
- `R-CW-DELEGATE-CHILD-LIVE` — delegate child self-continuation hop1/hop2 receipts
- `R-CW-DELEGATE-TOKEN` — delegate child bare-token continuation receipts
- `R-CW-MULTI` — same-turn multi-`continue_work` fanout/collapse receipts

Adds a shared `static-corpus-row-validator.js` scenario keyed by `OPENCLAW_ROW_MANIFEST` / row id.

Scope: these are static artifact validators. They do not connect to a gateway, fire continuation tools, mutate config, restart anything, or claim fresh live behavior.

This raises the unattended live-suite list to 29 entries including ancillary/model/status rows. It does **not** mean all 29 manual corpus rows are live-fire automated: the remaining config/compaction/collapse rows stay scaffolded behind restore/restart or orchestration discipline.

## Validation

- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs` ✅
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs` ✅
- `node tools/k6-proofs/scripts/check-proof-row-manifests.mjs` ✅
- `node tools/k6-proofs/scripts/validate-corpus.mjs --current` ✅
- `k6 run scenarios/static-corpus-row-validator.js` for `R-CW-7` ✅
- `k6 run scenarios/static-corpus-row-validator.js` for `R-CW-DELEGATE-CHILD-LIVE` ✅
- `k6 run scenarios/static-corpus-row-validator.js` for `R-CW-DELEGATE-TOKEN` ✅
- `k6 run scenarios/static-corpus-row-validator.js` for `R-CW-MULTI` ✅
- workflow-equivalent `run-proofs.sh --dry-run live-suite` resolves 29 entries ✅
- `git diff --check` ✅
