### PR TITLE
test: update live-run guard fixtures for static proof rows

### DIFF
--- a/tools/k6-proofs/scripts/__tests__/live-run-guard.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/live-run-guard.test.mjs
@@ -1,8 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { readFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 const repoRoot = new URL('../../../..', import.meta.url).pathname;
 const script = join(repoRoot, 'tools/k6-proofs/scripts/live-run-guard.mjs');
@@ -21,18 +22,70 @@ function runGuard(manifest, extraEnv = {}) {
   });
 }
 
+async function writeManifestFixture(manifest) {
+  const dir = await mkdtemp(join(tmpdir(), 'openclaw-k6-guard-test-'));
+  const file = join(dir, `${manifest.rowId}.json`);
+  await writeFile(file, `${JSON.stringify(manifest, null, 2)}
+`);
+  return { dir, file };
+}
+
+function orchestrationRequiredManifest(rowId) {
+  return {
+    schema: 'openclaw.k6.proof-row-manifest.v1',
+    rowId,
+    transport: 'websocket',
+    toolSurface: 'typed-tool',
+    mutates: true,
+    scenario: {
+      name: `${rowId.toLowerCase()}-fixture`,
+      status: 'scaffold',
+    },
+    expectedReceipts: [
+      { name: 'seat-readiness-continuation-enabled', required: true },
+      { name: 'original-config-captured', required: true },
+      { name: 'failure-safe-restore-armed', required: true },
+      { name: 'config-restored', required: true },
+    ],
+    review: {
+      candidateOnly: true,
+      foldRequiresReview: true,
+    },
+    liveRunSafety: {
+      classification: 'orchestration-required',
+      requiresLiveGatewayToken: true,
+      requiresCandidateSha: true,
+      requiresExternalAgentOrToolInvocation: true,
+      requiresHumanConfirmation: true,
+      sameSessionConcurrencySafe: false,
+      expectedArtifactClass: 'PARTIAL-candidate',
+      requiredReceipts: [
+        'seat-readiness-continuation-enabled',
+        'original-config-captured',
+        'failure-safe-restore-armed',
+        'config-restored',
+      ],
+      foldRequiresReview: true,
+    },
+  };
+}
+
 test('live-run guard fails closed for orchestration-required config-mutating rows', async () => {
-  for (const manifestName of ['r-cw-5.json', 'r-cw-6.json']) {
-    const manifest = join(repoRoot, 'tools/k6-proofs/manifests', manifestName);
-    const run = runGuard(manifest);
-    assert.equal(run.status, 1, `${manifestName} unexpectedly passed: ${run.stdout}`);
-    const parsed = JSON.parse(run.stdout);
-    assert.equal(parsed.ok, false);
-    assert.ok(
-      parsed.errors.some((error) => error.includes('orchestration-required is not directly runnable')),
-      `${manifestName} errors did not include orchestration-required fail-closed guard: ${run.stdout}`,
-    );
-    assert.doesNotMatch(run.stdout, /unit-token-not-printed/);
+  for (const rowId of ['R-CW-COST-CAP-FIXTURE', 'R-CW-CHAIN-CAP-FIXTURE']) {
+    const { dir, file } = await writeManifestFixture(orchestrationRequiredManifest(rowId));
+    try {
+      const run = runGuard(file);
+      assert.equal(run.status, 1, `${rowId} unexpectedly passed: ${run.stdout}`);
+      const parsed = JSON.parse(run.stdout);
+      assert.equal(parsed.ok, false);
+      assert.ok(
+        parsed.errors.some((error) => error.includes('orchestration-required is not directly runnable')),
+        `${rowId} errors did not include orchestration-required fail-closed guard: ${run.stdout}`,
+      );
+      assert.doesNotMatch(run.stdout, /unit-token-not-printed/);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   }
 });
 
@@ -60,28 +113,18 @@ test('live-run guard still permits static preflight manifests without live candi
   assert.equal(parsed.classification, 'static-preflight-only');
 });
 
-test('config-mutating row manifests keep restore/review receipts declared', async () => {
+test('static corpus validator rows are read-only broad-suite rows', async () => {
   for (const manifestName of ['r-cw-5.json', 'r-cw-6.json']) {
     const manifestPath = join(repoRoot, 'tools/k6-proofs/manifests', manifestName);
     const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
-    assert.equal(manifest.mutates, true);
-    assert.equal(manifest.scenario.status, 'scaffold');
-    assert.equal(manifest.liveRunSafety.classification, 'orchestration-required');
+    assert.equal(manifest.mutates, false);
+    assert.equal(manifest.transport, 'offline');
+    assert.equal(manifest.toolSurface, 'read-only');
+    assert.equal(manifest.scenario.status, 'runnable');
+    assert.equal(manifest.scenario.name, 'static-corpus-row-validator');
+    assert.equal(manifest.liveRunSafety.classification, 'k6-runnable');
+    assert.equal(manifest.liveRunSafety.requiresLiveGatewayToken, false);
+    assert.equal(manifest.liveRunSafety.requiresExternalAgentOrToolInvocation, false);
     assert.equal(manifest.liveRunSafety.foldRequiresReview, true);
-    for (const receiptName of [
-      'seat-readiness-continuation-enabled',
-      'original-config-captured',
-      'failure-safe-restore-armed',
-      'config-restored',
-    ]) {
-      assert.ok(
-        manifest.expectedReceipts.some((receipt) => receipt.name === receiptName && receipt.required === true),
-        `${manifestName} missing expected receipt ${receiptName}`,
-      );
-      assert.ok(
-        manifest.liveRunSafety.requiredReceipts.includes(receiptName),
-        `${manifestName} liveRunSafety.requiredReceipts missing ${receiptName}`,
-      );
-    }
   }
 });


### PR DESCRIPTION
## Summary

- decouple `live-run-guard` fail-closed tests from rows that were promoted to offline static validators
- add synthetic orchestration-required manifest fixtures so the guard behavior is still covered
- assert R-CW-5/R-CW-6 are now read-only broad-suite static validator rows

## Gates

- `node --test tools/k6-proofs/scripts/__tests__/live-run-guard.test.mjs`
- `node --test tools/k6-proofs/scripts/__tests__/*.test.mjs`
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs`
