### PR TITLE
docs: refresh Project 81 35-row suite floor

### DIFF
--- a/RUNBOOKS/project-81/EXECUTABLE-SUITE.md
+++ b/RUNBOOKS/project-81/EXECUTABLE-SUITE.md
@@ -2,7 +2,7 @@
 
 Goal: give a reviewer or maintainer a small, repeatable path from a normal OpenClaw checkout to a candidate proof bundle.
 
-This quickstart intentionally covers only unattended `k6-runnable` rows. Rows marked `orchestration-required`, `scaffold`, or `construct-only` stay out of the broad suite until a reviewed fixture exists. The manifest catalog still records every current manual PROOFS row so the public surface explains the full 29-row corpus, not only the currently automated subset.
+This quickstart intentionally covers unattended `k6-runnable` rows. At this catalog floor the unattended suite resolves to 35 rows, but that does **not** mean 35 fresh live behavior captures: the suite includes live WebSocket rows, read-only/status rows, offline static committed-packet validators, and threshold/honest-limit canaries. Rows that still require an accepted-path fixture remain documented as review debt instead of being over-claimed.
 
 ## 1. Install k6
 
@@ -45,11 +45,13 @@ ROWS="$(node scripts/list-runnable-rows.mjs --live-suite)"
 printf '%s\n' "$ROWS"
 ```
 
-This excludes static preflight and any `orchestration-required` rows. As of this catalog, it prints the 19-row broad live suite:
+This excludes the static preflight helper. As of this catalog, it prints the 35-row unattended suite:
 
 ```text
-R-CD-1,R-CD-2,R-CD-4,R-CD-CHAINED-DEPTH-2,R-CD-MODEL-CHAINED-ALT,R-CD-MODEL-DEFAULT,R-CD-MODEL-TOKEN,R-CD-MODEL-TOOL,R-CD-TOKEN,R-CONFIG-defaults,R-CONFIG-INTERSESSION,R-CW-1,R-CW-4,R-CW-DELEGATE-SELF-CONTINUATION,R-CW-TOKEN,R-OBS-1,R-OBS-2,R-OBS-status,R-RC-1
+R-CD-1,R-CD-2,R-CD-3,R-CD-4,R-CD-CHAINED-DEPTH-2,R-CD-COLLECTION-ON-COLLAPSE,R-CD-MODEL-CHAINED-ALT,R-CD-MODEL-DEFAULT,R-CD-MODEL-TOKEN,R-CD-MODEL-TOOL,R-CD-RETURN-OVERLAP,R-CD-SILENT,R-CD-TOKEN,R-CONFIG-defaults,R-CONFIG-INTERSESSION,R-CW-1,R-CW-2,R-CW-3,R-CW-4,R-CW-5,R-CW-6,R-CW-7,R-CW-DELEGATE-CHILD-LIVE,R-CW-DELEGATE-SELF-CONTINUATION,R-CW-DELEGATE-TOKEN,R-CW-MULTI-COLLAPSE,R-CW-MULTI,R-CW-TOKEN,R-OBS-1,R-OBS-2,R-OBS-status,R-RC-1,R-RC-2,R-REGRESSION-TRAP-TESTS,R-TRACE-REDACTION-1121
 ```
+
+Treat that list as a runnable review queue, not a single proof class. `transport=offline` rows parse committed proof packets; `HONEST-LIMIT-candidate` rows prove the safe reachable canary path when the full behavior needs a fixture.
 
 ## GitHub Actions option
 
@@ -103,12 +105,14 @@ node scripts/check-proof-row-manifests.mjs
 
 Fetch Tempo trace JSON when a row records a non-null trace id. If a row records `traceId: null`, treat trace JSON as unavailable review debt or an honest limit; do not invent a fetchable trace.
 
-## Held rows
+## Coverage caveats
 
-These rows are intentionally excluded from the broad unattended suite:
+No Project 81 proof row is currently hidden from `live-suite` because of a `scaffold`, `construct-only`, or `orchestration-required` manifest. `preflight` remains outside the suite because it is the static readiness helper.
 
-- `R-CD-3` — post-compaction seam lifecycle; staging is proven, full seam is captured as review addenda when naturally observed.
-- `R-CD-COLLECTION-ON-COLLAPSE` — detached intermediate/root collection semantics need reviewed fixture.
-- `R-CW-5` — cost-cap config mutation requires backup/restore and explicit confirmation.
-- `R-CW-6` — max-chain config mutation/restart requires backup/restore and explicit confirmation.
-- `R-RC-2` — request_compaction accept path mutates session context and must be serialized under human-confirmed fixture.
+Several rows are runnable only as bounded review candidates:
+
+- `R-CD-3` stages the post-compaction lifeboat and accepts threshold refusal as an honest limit; a naturally accepted compaction seam remains review debt until a fixture drives the over-threshold path.
+- `R-RC-2` proves delegated `request_compaction` reaches the child and returns a structured threshold rejection in ordinary disposable sessions; accepted compaction is a separate fixture problem.
+- `R-CD-COLLECTION-ON-COLLAPSE`, `R-CW-5`, `R-CW-6`, and `R-CW-MULTI-COLLAPSE` are static committed-packet validators. They make historical proof packets mechanically checkable; they do not mutate config or rerun the original live collapse/cost-cap/max-chain behavior.
+
+If a future PR adds an accepted-compaction or config-mutating live fixture, it must include backup/restore or isolated-temp-state receipts before claiming a fresh live PASS.

--- a/RUNBOOKS/project-81/README.md
+++ b/RUNBOOKS/project-81/README.md
@@ -21,17 +21,19 @@ cd tools/k6-proofs
 
 For an external/reviewer-facing path from “install k6” to “run the unattended suite,” use [EXECUTABLE-SUITE.md](EXECUTABLE-SUITE.md).
 
-As of the post-#306/#307 Project 81 surface, the broad live slice is:
+As of the current Project 81 surface, `list-runnable-rows --live-suite` resolves to 35 unattended rows:
 
 ```text
-R-CD-1,R-CD-2,R-CD-4,R-CD-CHAINED-DEPTH-2,R-CD-MODEL-CHAINED-ALT,R-CD-MODEL-DEFAULT,R-CD-MODEL-TOKEN,R-CD-MODEL-TOOL,R-CD-SILENT,R-CD-TOKEN,R-CONFIG-defaults,R-CONFIG-INTERSESSION,R-CW-1,R-CW-2,R-CW-3,R-CW-4,R-CW-DELEGATE-SELF-CONTINUATION,R-CW-TOKEN,R-OBS-1,R-OBS-2,R-OBS-status,R-RC-1
+R-CD-1,R-CD-2,R-CD-3,R-CD-4,R-CD-CHAINED-DEPTH-2,R-CD-COLLECTION-ON-COLLAPSE,R-CD-MODEL-CHAINED-ALT,R-CD-MODEL-DEFAULT,R-CD-MODEL-TOKEN,R-CD-MODEL-TOOL,R-CD-RETURN-OVERLAP,R-CD-SILENT,R-CD-TOKEN,R-CONFIG-defaults,R-CONFIG-INTERSESSION,R-CW-1,R-CW-2,R-CW-3,R-CW-4,R-CW-5,R-CW-6,R-CW-7,R-CW-DELEGATE-CHILD-LIVE,R-CW-DELEGATE-SELF-CONTINUATION,R-CW-DELEGATE-TOKEN,R-CW-MULTI-COLLAPSE,R-CW-MULTI,R-CW-TOKEN,R-OBS-1,R-OBS-2,R-OBS-status,R-RC-1,R-RC-2,R-REGRESSION-TRAP-TESTS,R-TRACE-REDACTION-1121
 ```
+
+That count is a runner surface, not a proof-class claim. It includes fresh live WebSocket rows, read-only/status probes, offline static committed-packet validators, and threshold/honest-limit canaries. A `PASS-candidate` or `HONEST-LIMIT-candidate` still needs row-specific review before any canonical fold.
 
 `preflight` remains `static-preflight-only`: the runner performs seat-readiness preflight for live runs, but the preflight manifest row is intentionally skipped by live-run guard.
 
-Use this directory as the accumulator. When a scaffold row becomes runnable, add or update `RUNBOOKS/project-81/rows/<ROW>.md` in the same PR as the scenario/manifest change.
+Use this directory as the accumulator. When a scaffold row becomes runnable, add or update `RUNBOOKS/project-81/rows/<ROW>.md` or a fixture note in the same PR as the scenario/manifest change. Static committed-packet validators may stay manifest-driven when the manifest and executable-suite docs already describe the review caveat.
 
-## Current runnable row runbooks
+## Current row runbooks
 
 - [preflight](rows/preflight.md) — static preflight / seat-readiness helper
 - [R-CD-1](rows/R-CD-1.md)
@@ -56,6 +58,8 @@ Use this directory as the accumulator. When a scaffold row becomes runnable, add
 - [R-OBS-2](rows/R-OBS-2.md)
 - [R-OBS-status](rows/R-OBS-status.md)
 - [R-RC-1](rows/R-RC-1.md)
+
+Rows promoted as static committed-packet validators or honest-limit canaries may be runnable from manifests before they have a dedicated per-row runbook. In that case, use the manifest, `EXECUTABLE-SUITE.md`, and the generated candidate report as the review surface.
 
 ## Shared execution pattern
 

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -347,32 +347,49 @@ This is **declared in the manifest before the run**, not a post-hoc excuse. The 
 
 ## Row coverage
 
-| Row | Scenario | Surface | Expected outcome |
-|-----|----------|---------|-----------------|
-| preflight | `preflight` | read-only | Candidate; gateway/session/tool inventory check |
-| R-CD-1 | `r-cd-1-typed-delegate` | typed-tool | Candidate; continue_delegate schedule/spawn/return path |
-| R-CD-2 | `r-cd-2-silent-wake` | typed-tool | PASS-candidate when dispatch/session-events observed and no channel delivery appears |
-| R-CD-4 | `r-cd-4-target-session-key` | typed-tool | Candidate; verify target-vs-parent session events, not `tasks.list` |
-| R-CD-CHAINED-DEPTH-2 | `r-cd-chained-depth-2` | typed-tool | Candidate; verify nonce-correlated chain return on subscribed session stream |
-| R-CD-TOKEN | `r-cd-token-bracket-delegate` | bracket-token | Candidate; terminal `[[CONTINUE_DELEGATE: ...]]` from lightContext/raw final text schedules and returns |
-| R-CD-MODEL-DEFAULT | `r-cd-model-default` | typed-tool | Candidate; delegate inherits default provider/model without override |
-| R-CD-MODEL-TOOL | `r-cd-model-tool` | typed-tool | Candidate; explicit model override request byte must match observed child model byte |
-| R-CD-MODEL-CHAINED-ALT | `r-cd-model-chained-alt` | typed-tool | Candidate; depth-1 delegate schedules depth-2 delegate with explicit alternate model |
-| R-CD-MODEL-TOKEN | `r-cd-model-token` | bracket-token | Candidate; bracket `model=` modifier parse + observed child model byte |
-| R-CD-COLLECTION-ON-COLLAPSE | planned `r-cd-collection-on-collapse` | typed-tool | Scaffold; A→B→C detached-intermediate collapse with root collection + no-orphan guard |
-| R-CONFIG-defaults | `r-config-defaults` | read-only | Candidate; continuation config defaults/readiness check |
-| R-CW-1 | `r-cw-1-tool-schedule-wake` | typed-tool | Candidate; continue_work schedule + wake |
-| R-CW-4 | `r-cw-4-chain-depth` | typed-tool | Candidate; continue_work chain depth across multiple hops |
-| R-CW-DELEGATE-SELF-CONTINUATION | `r-cw-delegate-self-continuation` | typed-tool | Candidate; delegate child self-continuation path |
-| R-CW-TOKEN | `r-cw-token-bracket` | bracket-token | Candidate; bare `CONTINUE_WORK:N` from scanned final text drives hop-2 |
-| R-OBS-1 | `r-obs-1` | read-only | Candidate; status-card observability via session_status tool |
-| R-OBS-status | `r-obs-status` | read-only | Candidate; gateway status/observer receipt check |
-| R-RC-1 | `r-rc-1` | typed-tool | Candidate; request_compaction below-threshold structured rejection |
-| R-CW overview | `r-cw` | read-only/infrastructure | Candidate; combined continue_work infrastructure check |
+`live-suite` currently resolves to 35 unattended rows. This table is generated from the manifest floor, but the outcome column is intentionally conservative: offline rows validate committed packets, and honest-limit rows do not become accepted-path proofs just because they are runnable.
 
-Other manifests may be `scaffold` or `construct-only`: they are tracked rows,
-but not workflow-runnable until a matching `tools/k6-proofs/scenarios/<name>.js`
-exists and the manifest is promoted to `scenario.status="runnable"`.
+| Row | Scenario | Surface | Expected outcome |
+|-----|----------|---------|------------------|
+| R-CD-1 | `r-cd-1-typed-delegate` | websocket/typed-tool | PASS-candidate; runnable candidate requiring row review |
+| R-CD-2 | `r-cd-2-silent-wake` | websocket/typed-tool | PASS-candidate; runnable candidate requiring row review |
+| R-CD-3 | `r-cd-3-post-compaction` | websocket/typed-tool | HONEST-LIMIT-candidate; reaches safe threshold/staging path, accepted compaction remains fixture-gated |
+| R-CD-4 | `r-cd-4-target-session-key` | websocket/typed-tool | PASS-candidate; runnable candidate requiring row review |
+| R-CD-CHAINED-DEPTH-2 | `r-cd-chained-depth-2` | websocket/typed-tool | PASS-candidate; runnable candidate requiring row review |
+| R-CD-COLLECTION-ON-COLLAPSE | `static-corpus-row-validator` | offline/read-only | PASS-candidate; static committed-packet validator, no fresh gateway behavior |
+| R-CD-MODEL-CHAINED-ALT | `r-cd-model-chained-alt` | websocket/typed-tool | PASS-candidate; runnable candidate requiring row review |
+| R-CD-MODEL-DEFAULT | `r-cd-model-default` | websocket/mixed | PASS-candidate; runnable candidate requiring row review |
+| R-CD-MODEL-TOKEN | `r-cd-model-token` | websocket/bracket-token | PASS-candidate; runnable candidate requiring row review |
+| R-CD-MODEL-TOOL | `r-cd-model-tool` | websocket/typed-tool | HONEST-LIMIT-candidate; model override reachability depends on allowed model/provider |
+| R-CD-RETURN-OVERLAP | `r-cd-return-overlap` | offline/read-only | PASS-candidate; static committed-packet validator, no fresh gateway behavior |
+| R-CD-SILENT | `r-cd-silent` | websocket/typed-tool | PASS-candidate; runnable candidate requiring row review |
+| R-CD-TOKEN | `r-cd-token-bracket-delegate` | websocket/bracket-token | PASS-candidate; runnable candidate requiring row review |
+| R-CONFIG-INTERSESSION | `r-config-intersession` | websocket/read-only | PASS-candidate; runnable candidate requiring row review |
+| R-CONFIG-defaults | `r-config-defaults` | websocket/read-only | PASS-candidate; runnable candidate requiring row review |
+| R-CW-1 | `r-cw-1-tool-schedule-wake` | websocket/typed-tool | PASS-candidate; runnable candidate requiring row review |
+| R-CW-2 | `r-cw-2-immediate-wake` | websocket/typed-tool | PASS-candidate; runnable candidate requiring row review |
+| R-CW-3 | `r-cw-3-reason-telemetry` | websocket/typed-tool | HONEST-LIMIT-candidate; reason telemetry/redaction review may limit fold |
+| R-CW-4 | `r-cw-4-chain-depth` | websocket/typed-tool | PASS-candidate; runnable candidate requiring row review |
+| R-CW-5 | `static-corpus-row-validator` | offline/read-only | PASS-candidate; static committed-packet validator, no fresh gateway behavior |
+| R-CW-6 | `static-corpus-row-validator` | offline/read-only | PASS-candidate; static committed-packet validator, no fresh gateway behavior |
+| R-CW-7 | `static-corpus-row-validator` | offline/read-only | PASS-candidate; static committed-packet validator, no fresh gateway behavior |
+| R-CW-DELEGATE-CHILD-LIVE | `static-corpus-row-validator` | offline/read-only | PASS-candidate; static committed-packet validator, no fresh gateway behavior |
+| R-CW-DELEGATE-SELF-CONTINUATION | `r-cw-delegate-self-continuation` | websocket/typed-tool | PASS-candidate; runnable candidate requiring row review |
+| R-CW-DELEGATE-TOKEN | `static-corpus-row-validator` | offline/read-only | PASS-candidate; static committed-packet validator, no fresh gateway behavior |
+| R-CW-MULTI | `static-corpus-row-validator` | offline/read-only | PASS-candidate; static committed-packet validator, no fresh gateway behavior |
+| R-CW-MULTI-COLLAPSE | `static-corpus-row-validator` | offline/read-only | PASS-candidate; static committed-packet validator, no fresh gateway behavior |
+| R-CW-TOKEN | `r-cw-token-bracket` | websocket/bracket-token | PASS-candidate; runnable candidate requiring row review |
+| R-OBS-1 | `r-obs-1` | websocket/typed-tool | PASS-candidate; runnable candidate requiring row review |
+| R-OBS-2 | `r-obs-2` | offline/read-only | PASS-candidate; static committed-packet validator, no fresh gateway behavior |
+| R-OBS-status | `r-obs-status` | ws-status-probe/read-only | PASS-candidate; runnable candidate requiring row review |
+| R-RC-1 | `r-rc-1-threshold-reject` | websocket/typed-tool | PASS-candidate; runnable candidate requiring row review |
+| R-RC-2 | `r-rc-2-delegate-request-compaction` | websocket/typed-tool | HONEST-LIMIT-candidate; reaches safe threshold/staging path, accepted compaction remains fixture-gated |
+| R-REGRESSION-TRAP-TESTS | `r-regression-trap-tests` | offline/read-only | PASS-candidate; static committed-packet validator, no fresh gateway behavior |
+| R-TRACE-REDACTION-1121 | `r-trace-redaction-1121` | offline/read-only | PASS-candidate; static committed-packet validator, no fresh gateway behavior |
+
+`preflight` remains `static-preflight-only` and is skipped by `--live-suite`; the runner still performs seat-readiness preflight for live runs.
+
+Future manifests may again be `scaffold`, `construct-only`, or `orchestration-required`. Such rows are tracked, but not workflow-runnable until a matching scenario exists and the manifest is promoted to `scenario.status="runnable"` plus `liveRunSafety.classification="k6-runnable"`.
 
 ## Guardrails
 


### PR DESCRIPTION
## Summary
- refresh Project 81 runbook wording from the old 19/29-row floor to the current 35-row unattended suite
- replace the stale held-row block with current coverage caveats for static committed-packet validators and honest-limit threshold canaries
- update k6 proof README row coverage so “35 runnable” does not read as “35 fresh live behavior captures”

## Exact grep hits changed
- `RUNBOOKS/project-81/EXECUTABLE-SUITE.md:5` — old “full 29-row corpus” framing
- `RUNBOOKS/project-81/EXECUTABLE-SUITE.md:48-51` — old “19-row broad live suite” list
- `RUNBOOKS/project-81/EXECUTABLE-SUITE.md:106-114` — stale “Held rows” block for `R-CD-3`, `R-CD-COLLECTION-ON-COLLAPSE`, `R-CW-5`, `R-CW-6`, `R-RC-2`
- `RUNBOOKS/project-81/README.md:24-29` — old “post-#306/#307 broad live slice” and 22-row list
- `RUNBOOKS/project-81/README.md:32-59` — row-runbook wording that implied runnable rows must always have a dedicated row file
- `tools/k6-proofs/README.md:349-376` — stale row coverage table, including `R-CD-COLLECTION-ON-COLLAPSE` as “planned/scaffold”

Residual grep over current docs touched here is clean for: `post-#306`, `19-row`, `22-row`, `29-row`, `full 29`, `Held rows`, `This excludes static preflight`, `Scaffold;`.

## Verification
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs`
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs`
- `node tools/k6-proofs/scripts/check-proof-row-manifests.mjs`
- `ROWS=$(node tools/k6-proofs/scripts/list-runnable-rows.mjs --live-suite); ./scripts/run-proofs.sh --dry-run "$ROWS" 89b33211005534e2dad969f2d04f5d0e73c13141`

## Notes
Docs-only truth-maintenance PR. No manifest changes, no live-suite changes, no accepted-compaction implementation, no config mutation, no restart.