### PR TITLE
tools: harden R-CD-MODEL-TOOL against echo pass

### DIFF
--- a/RUNBOOKS/project-81/rows/R-CD-MODEL-TOOL.md
+++ b/RUNBOOKS/project-81/rows/R-CD-MODEL-TOOL.md
@@ -9,7 +9,7 @@
 
 ## Purpose
 
-Typed continue_delegate with explicit model override; child reports requested model byte.
+Typed continue_delegate with explicit model override; child reports its runtime-context model byte. The requested model is deliberately omitted from the child task so the row cannot pass by prompt echo.
 
 ## Commands
 
@@ -24,7 +24,7 @@ Live candidate run:
 
 ```bash
 cd tools/k6-proofs
-OPENCLAW_GATEWAY_TOKEN=*** OPENCLAW_SESSION_KEY=<target-session-key> OPENCLAW_CREATE_DISPOSABLE_SESSION=true   ./scripts/run-proofs.sh --live R-CD-MODEL-TOOL <candidate-sha>
+OPENCLAW_GATEWAY_TOKEN=*** OPENCLAW_SESSION_KEY=<target-session-key> OPENCLAW_CREATE_DISPOSABLE_SESSION=true OPENCLAW_ALT_MODEL=<provider/model>   ./scripts/run-proofs.sh --live R-CD-MODEL-TOOL <candidate-sha>
 ```
 
 When using the GitHub Actions wrapper, include `R-CD-MODEL-TOOL` in the `rows` input and keep `create_disposable_sessions=true` for broad slices.
@@ -41,7 +41,8 @@ When using the GitHub Actions wrapper, include `R-CD-MODEL-TOOL` in the `rows` i
 - Preserve the full candidate-run artifact directory, not only the summary JSON.
 - Review `run-result.json` for `review.status` and `pendingReceipts`; trace/receipt-marker gaps make the row review-pending, not failed.
 - Fetch and commit Tempo trace JSON when a trace id is emitted.
-- For model rows, record the requested model byte and observed child model byte in the fold note.
+- For model rows, record the requested model byte and observed child runtime-context model byte in the fold note.
+- Confirm the child task did not include the requested model string; otherwise the run is echo-contaminated and cannot be folded as PASS.
 - For token/bracket rows, record the surface class used (raw final text vs message-body) because scanner availability is the proof boundary.
 
 ## Fold guidance
@@ -56,4 +57,4 @@ A k6 `PASS-candidate` is review input, not a canonical proof fold. Fold only aft
 
 ## Nuance / caveat
 
-If the child observes fallback/inherited model instead of the requested model, package as HONEST-LIMIT-candidate with mismatch evidence, not pass.
+If the child observes fallback/inherited/UNKNOWN model instead of the requested model, package as HONEST-LIMIT-candidate with mismatch evidence, not pass. A child self-report is only useful when the requested model was not present in the child prompt; otherwise it proves echo, not runtime selection.

--- a/tools/k6-proofs/manifests/r-cd-model-tool.json
+++ b/tools/k6-proofs/manifests/r-cd-model-tool.json
@@ -31,8 +31,8 @@
     "forms": [
       "typed-tool-model-override"
     ],
-    "model": "${OPENCLAW_ALT_MODEL:-github-copilot/goldeneye}",
-    "promptTemplate": "Proof nonce {{nonce}}: report your observed provider/model and the nonce only. Do not mutate files. Do not post to any channel.",
+    "model": "${OPENCLAW_ALT_MODEL:-github-copilot/claude-sonnet-4.6}",
+    "promptTemplate": "Proof nonce {{nonce}}: report the current model identity from runtime context and the nonce only. The requested model is intentionally omitted from the child task to prevent echo-based false PASS. Do not mutate files. Do not post to any channel.",
     "idempotencyKeyPrefix": "R-CD-MODEL-TOOL"
   },
   "expectedReceipts": [
@@ -77,7 +77,7 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "PASS-candidate only when requested model byte and observed child model byte match. If #1103 reproduces, fold as HONEST-LIMIT-candidate with the mismatch evidence, not as pass."
+    "notes": "PASS-candidate only when requested model byte and observed child runtime-context model byte match. The child task must not include the requested model; if the child reports UNKNOWN/fallback/inherited model or no child model byte, fold as HONEST-LIMIT-candidate with mismatch evidence, not as pass."
   },
   "liveRunSafety": {
     "classification": "k6-runnable",
@@ -96,6 +96,6 @@
       "return-payload"
     ],
     "foldRequiresReview": true,
-    "notes": "Explicit model override row. If child observes fallback/inherited model, package as HONEST-LIMIT with mismatch evidence, not pass."
+    "notes": "Explicit model override row. Prevent echo-based false PASS by omitting requested model from the child task; if child observes UNKNOWN/fallback/inherited model, package as HONEST-LIMIT with mismatch evidence, not pass."
   }
 }

--- a/tools/k6-proofs/scenarios/r-cd-model-tool.js
+++ b/tools/k6-proofs/scenarios/r-cd-model-tool.js
@@ -9,83 +9,180 @@ export const options = {
   scenarios: { r_cd_model_tool: { executor: 'shared-iterations', vus: 1, iterations: 1, maxDuration: '210s' } },
   thresholds: { proof_failures: ['count==0'], r_cd_model_tool_duration: ['p(95)<180000'] },
 };
+
 const failures = new Counter('proof_failures');
 const duration = new Trend('r_cd_model_tool_duration');
 const manifest = loadManifestFromEnv();
-const DEFAULTS = { sessionKey:'main', seat:'cael-dgx', delaySeconds:1, idempotencyKeyPrefix:'R-CD-MODEL-TOOL', requestedModel:'gpt' };
-const HARNESS_MARKER='[k6-proof-harness]';
-function boolEnv(name){ return (__ENV[name]||'').toLowerCase()==='true'; }
+const DEFAULTS = {
+  sessionKey: 'main',
+  seat: 'cael-dgx',
+  delaySeconds: 1,
+  idempotencyKeyPrefix: 'R-CD-MODEL-TOOL',
+  requestedModel: 'github-copilot/claude-sonnet-4.6',
+};
+const HARNESS_MARKER = '[k6-proof-harness]';
 
-export default function(){
-  const url=__ENV.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
-  const token=__ENV.OPENCLAW_GATEWAY_TOKEN;
-  const requestedSessionKey=manifest?.sessionKey || __ENV.OPENCLAW_SESSION_KEY || DEFAULTS.sessionKey;
-  let sessionKey=requestedSessionKey;
-  const createDisposableSession=boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSION') || boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSIONS');
-  const seat=manifest?.seat || __ENV.OPENCLAW_SEAT_NAME || DEFAULTS.seat;
-  const rowNonce=nonce('R-CD-MODEL-TOOL');
-  const inv=manifest?.invocation || {};
-  const requestedModel=__ENV.OPENCLAW_ALT_MODEL || inv.model || DEFAULTS.requestedModel;
-  const delaySeconds=Number(inv.delaySeconds ?? __ENV.OPENCLAW_DELAY_SECONDS ?? DEFAULTS.delaySeconds);
-  const idPrefix=inv.idempotencyKeyPrefix || DEFAULTS.idempotencyKeyPrefix;
-  if(!token){ console.error('OPENCLAW_GATEWAY_TOKEN is required'); failures.add(1); return; }
-  if(manifest){ const errors=validateManifest(manifest); if(errors.length) console.warn('Manifest validation warnings: '+errors.join('; ')); }
-  const evidence={ row:'R-CD-MODEL-TOOL', manifest_loaded:!!manifest, nonce:rowNonce, seat, requestedSessionKey, sessionKey, session_created:false, created_session_key:null, candidateSha:manifest?.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset', started:new Date().toISOString(), requested_model_byte:requestedModel, dispatch_accepted:false, child_session_observed:false, child_model_byte:null, model_matches:false, return_payload:false, trace_id:null, redacted_events:[] };
-  const started=Date.now();
-  const res=ws.connect(url,{},(socket)=>{
-    const tracker=new RequestTracker();
-    function start(socket){
-      tracker.send(socket,'sessions.messages.subscribe',{key:sessionKey});
-      socket.setTimeout(()=>{
-        const childTask='Proof nonce '+rowNonce+': reply exactly MODEL-TOOL-CHILD '+rowNonce+' MODEL '+requestedModel+'. Do not mutate files. Do not post externally.';
-        const instruction=HARNESS_MARKER+' R-CD-MODEL-TOOL nonce '+rowNonce+'. Call continue_delegate with task='+JSON.stringify(childTask)+', mode="normal", delaySeconds='+delaySeconds+', model='+JSON.stringify(requestedModel)+'. After the continue_delegate tool result reports scheduled, reply exactly MODEL-TOOL-PARENT-SCHEDULED '+rowNonce+' REQUESTED '+requestedModel+'. No other action.';
-        tracker.send(socket,'sessions.send',{key:sessionKey,message:instruction,idempotencyKey:idPrefix+'-DISPATCH-'+rowNonce});
-      },500);
-      socket.setTimeout(()=>socket.close(),180000);
+function boolEnv(name) { return (__ENV[name] || '').toLowerCase() === 'true'; }
+function normalizeModel(value) { return String(value || '').trim().replace(/[.,;:]+$/, ''); }
+function escapeRegex(value) { return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
+let finalEvidence = null;
+
+export default function() {
+  const url = __ENV.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
+  const token = __ENV.OPENCLAW_GATEWAY_TOKEN;
+  const requestedSessionKey = manifest?.sessionKey || __ENV.OPENCLAW_SESSION_KEY || DEFAULTS.sessionKey;
+  let sessionKey = requestedSessionKey;
+  const createDisposableSession = boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSION') || boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSIONS');
+  const seat = manifest?.seat || __ENV.OPENCLAW_SEAT_NAME || DEFAULTS.seat;
+  const rowNonce = nonce('R-CD-MODEL-TOOL');
+  const inv = manifest?.invocation || {};
+  const requestedModel = normalizeModel(__ENV.OPENCLAW_ALT_MODEL || inv.model || DEFAULTS.requestedModel);
+  const delaySeconds = Number(inv.delaySeconds ?? __ENV.OPENCLAW_DELAY_SECONDS ?? DEFAULTS.delaySeconds);
+  const idPrefix = inv.idempotencyKeyPrefix || DEFAULTS.idempotencyKeyPrefix;
+  if (!token) { console.error('OPENCLAW_GATEWAY_TOKEN is required'); failures.add(1); return; }
+  if (manifest) { const errors = validateManifest(manifest); if (errors.length) console.warn('Manifest validation warnings: ' + errors.join('; ')); }
+
+  const evidence = {
+    row: 'R-CD-MODEL-TOOL',
+    manifest_loaded: !!manifest,
+    nonce: rowNonce,
+    seat,
+    requestedSessionKey,
+    sessionKey,
+    session_created: false,
+    created_session_key: null,
+    candidateSha: manifest?.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
+    started: new Date().toISOString(),
+    requested_model_byte: requestedModel,
+    requested_model_source: 'continue_delegate.model parameter',
+    dispatch_accepted: false,
+    parent_scheduled_sentinel: false,
+    child_session_observed: false,
+    child_model_byte: null,
+    child_model_source: null,
+    model_matches: false,
+    return_payload: false,
+    trace_id: null,
+    honest_limit_reason: null,
+    redacted_events: [],
+  };
+  const started = Date.now();
+
+  const res = ws.connect(url, {}, (socket) => {
+    const tracker = new RequestTracker();
+    function start(socket) {
+      tracker.send(socket, 'sessions.messages.subscribe', { key: sessionKey });
+      socket.setTimeout(() => {
+        // Deliberately do NOT include requestedModel in the child task. The child
+        // must report its own runtime identity instead of echoing the request.
+        const childTask =
+          'Proof nonce ' + rowNonce + ': read your runtime context/current model identity. ' +
+          'Reply exactly MODEL-TOOL-CHILD ' + rowNonce + ' MODEL <provider/model>. ' +
+          'Use UNKNOWN only if no runtime model identity is available. Do not mutate files. Do not post externally.';
+        const instruction =
+          HARNESS_MARKER + ' R-CD-MODEL-TOOL nonce ' + rowNonce + '. ' +
+          'Call continue_delegate with task=' + JSON.stringify(childTask) +
+          ', mode="normal", delaySeconds=' + delaySeconds +
+          ', model=' + JSON.stringify(requestedModel) + '. ' +
+          'After the continue_delegate tool result reports scheduled, reply exactly ' +
+          'MODEL-TOOL-PARENT-SCHEDULED ' + rowNonce + ' REQUESTED ' + requestedModel + '. No other action.';
+        tracker.send(socket, 'sessions.send', {
+          key: sessionKey,
+          message: instruction,
+          idempotencyKey: idPrefix + '-DISPATCH-' + rowNonce,
+        });
+      }, 500);
+      socket.setTimeout(() => socket.close(), 180000);
     }
-    socket.on('open',()=>{ socket.send(connectFrame(token)); if(createDisposableSession){ socket.setTimeout(()=>{ const key=('r-cd-model-tool-'+rowNonce).toLowerCase().replace(/[^a-z0-9-]/g,'-'); tracker.send(socket,'sessions.create',{key,label:'k6 R-CD-MODEL-TOOL '+rowNonce}); },250); } else socket.setTimeout(()=>start(socket),500); });
-    socket.on('message',(raw)=>{
-      try{
-        const msg=JSON.parse(raw); const classified=tracker.classify(msg);
-        evidence.redacted_events.push({ts:Date.now(),kind:classified.kind,method:classified.method||null,event:classified.event||null,ok:classified.ok!==undefined?classified.ok:null,data:classified.payload?redactEvent(classified.payload):null});
-        if(classified.kind==='response' && classified.method==='sessions.create'){
-          if(classified.ok && classified.payload){ sessionKey=classified.payload.key||sessionKey; evidence.sessionKey=sessionKey; evidence.session_created=true; evidence.created_session_key=sessionKey; console.log('✓ disposable session created: '+sessionKey); start(socket); }
-          else{ console.error('✗ sessions.create rejected: '+JSON.stringify(classified.error)); failures.add(1); socket.close(); }
+    socket.on('open', () => {
+      socket.send(connectFrame(token));
+      if (createDisposableSession) {
+        socket.setTimeout(() => {
+          const key = ('r-cd-model-tool-' + rowNonce).toLowerCase().replace(/[^a-z0-9-]/g, '-');
+          tracker.send(socket, 'sessions.create', { key, label: 'k6 R-CD-MODEL-TOOL ' + rowNonce });
+        }, 250);
+      } else socket.setTimeout(() => start(socket), 500);
+    });
+    socket.on('message', (raw) => {
+      try {
+        const msg = JSON.parse(raw); const classified = tracker.classify(msg);
+        evidence.redacted_events.push({
+          ts: Date.now(),
+          kind: classified.kind,
+          method: classified.method || null,
+          event: classified.event || null,
+          ok: classified.ok !== undefined ? classified.ok : null,
+          data: classified.payload ? redactEvent(classified.payload) : null,
+        });
+        if (classified.kind === 'response' && classified.method === 'sessions.create') {
+          if (classified.ok && classified.payload) {
+            sessionKey = classified.payload.key || sessionKey;
+            evidence.sessionKey = sessionKey;
+            evidence.session_created = true;
+            evidence.created_session_key = sessionKey;
+            console.log('✓ disposable session created: ' + sessionKey);
+            start(socket);
+          } else { console.error('✗ sessions.create rejected: ' + JSON.stringify(classified.error)); failures.add(1); socket.close(); }
         }
-        if(classified.kind==='response' && classified.method==='sessions.send'){
-          if(classified.ok){ evidence.dispatch_accepted=true; if(classified.payload?.traceId) evidence.trace_id=classified.payload.traceId; console.log('✓ sessions.send accepted — explicit model delegate turn triggered'); }
-          else{ console.error('✗ sessions.send rejected: '+JSON.stringify(classified.error)); failures.add(1); }
+        if (classified.kind === 'response' && classified.method === 'sessions.send') {
+          if (classified.ok) {
+            evidence.dispatch_accepted = true;
+            if (classified.payload?.traceId) evidence.trace_id = classified.payload.traceId;
+            console.log('✓ sessions.send accepted — explicit model delegate turn triggered');
+          } else { console.error('✗ sessions.send rejected: ' + JSON.stringify(classified.error)); failures.add(1); }
         }
-        if(classified.kind==='event'){
-          const eventData=classified.data||{}; const eventStr=JSON.stringify(eventData);
-          if(eventData.traceId) evidence.trace_id=eventData.traceId;
-          if(eventData.childSessionKey) evidence.child_session_observed=true;
-          if(eventStr.includes(rowNonce) && !eventStr.includes(HARNESS_MARKER)){
-            if(eventStr.includes('MODEL-TOOL-PARENT-SCHEDULED')) console.log('✓ parent scheduled sentinel observed');
-            if(eventStr.includes('MODEL-TOOL-CHILD '+rowNonce)){
-              evidence.child_session_observed=true; evidence.return_payload=true;
-              const m=eventStr.match(/MODEL ([A-Za-z0-9_.\/-]+)/);
-              if(m) evidence.child_model_byte=m[1];
-              if(eventStr.includes('MODEL '+requestedModel)) evidence.model_matches=true;
+        if (classified.kind === 'event') {
+          const eventData = classified.data || {}; const eventStr = JSON.stringify(eventData);
+          if (eventData.traceId) evidence.trace_id = eventData.traceId;
+          if (eventData.childSessionKey) evidence.child_session_observed = true;
+          if (eventStr.includes(rowNonce) && !eventStr.includes(HARNESS_MARKER)) {
+            if (eventStr.includes('MODEL-TOOL-PARENT-SCHEDULED')) {
+              evidence.parent_scheduled_sentinel = true;
+              console.log('✓ parent scheduled sentinel observed');
+            }
+            const childMatch = eventStr.match(new RegExp('MODEL-TOOL-CHILD\\s+' + escapeRegex(rowNonce) + '\\s+MODEL\\s+([A-Za-z0-9_.\\/-]+)'));
+            if (childMatch) {
+              evidence.child_session_observed = true;
+              evidence.return_payload = true;
+              evidence.child_model_byte = normalizeModel(childMatch[1]);
+              evidence.child_model_source = 'child runtime-context self-report (requested model omitted from child task)';
+              evidence.model_matches = evidence.child_model_byte === requestedModel;
+              if (!evidence.model_matches) evidence.honest_limit_reason = 'requested/observed model mismatch or unavailable child model byte';
               console.log('✓ MODEL-TOOL-CHILD return payload observed');
             }
           }
         }
-        if(evidence.dispatch_accepted && evidence.child_session_observed && evidence.return_payload){ console.log('R-CD-MODEL-TOOL return gathered, closing early'); socket.close(); }
-      }catch(e){ console.warn('parse error: '+e); }
+        if (evidence.dispatch_accepted && evidence.child_session_observed && evidence.return_payload) {
+          console.log('R-CD-MODEL-TOOL return gathered, closing early');
+          socket.close();
+        }
+      } catch (e) { console.warn('parse error: ' + e); }
     });
-    socket.on('error',(e)=>{ console.error('ws error: '+(e&&e.error?e.error():e)); failures.add(1); });
+    socket.on('error', (e) => { console.error('ws error: ' + (e && e.error ? e.error() : e)); failures.add(1); });
   });
-  evidence.ended=new Date().toISOString(); evidence.duration_ms=Date.now()-started; duration.add(evidence.duration_ms);
-  check(res,{'websocket connected':(r)=>r&&r.status===101});
-  check(null,{'dispatch accepted':()=>evidence.dispatch_accepted,'child session observed':()=>evidence.child_session_observed,'child model byte':()=>!!evidence.child_model_byte,'requested model observed':()=>evidence.model_matches,'return payload':()=>evidence.return_payload});
-  if(!evidence.dispatch_accepted||!evidence.child_session_observed||!evidence.child_model_byte||!evidence.model_matches||!evidence.return_payload) failures.add(1);
-  const passed=(!createDisposableSession||evidence.session_created)&&evidence.dispatch_accepted&&evidence.child_session_observed&&evidence.child_model_byte&&evidence.model_matches&&evidence.return_payload;
-  console.log('\n--- R-CD-MODEL-TOOL EVIDENCE SUMMARY ---'); console.log(JSON.stringify(evidence,null,2)); console.log('--- END EVIDENCE ---'); console.log('\n[R-CD-MODEL-TOOL] VERDICT: '+(passed?'PASS-candidate':'HONEST-LIMIT-candidate'));
+
+  evidence.ended = new Date().toISOString(); evidence.duration_ms = Date.now() - started; duration.add(evidence.duration_ms);
+  finalEvidence = evidence;
+  const complete = (!createDisposableSession || evidence.session_created) && evidence.dispatch_accepted && evidence.parent_scheduled_sentinel && evidence.child_session_observed && evidence.child_model_byte && evidence.return_payload;
+  check(res, { 'websocket connected': (r) => r && r.status === 101 });
+  check(null, {
+    'dispatch accepted': () => evidence.dispatch_accepted,
+    'parent scheduled sentinel': () => evidence.parent_scheduled_sentinel,
+    'child session observed': () => evidence.child_session_observed,
+    'child model byte': () => !!evidence.child_model_byte,
+    'return payload': () => evidence.return_payload,
+    'requested model observed': () => evidence.model_matches,
+  });
+  if (!complete) failures.add(1);
+  const verdict = complete && evidence.model_matches ? 'PASS-candidate' : (complete ? 'HONEST-LIMIT-candidate' : 'PARTIAL-candidate');
+  console.log('\n--- R-CD-MODEL-TOOL EVIDENCE SUMMARY ---'); console.log(JSON.stringify(evidence, null, 2)); console.log('--- END EVIDENCE ---'); console.log('\n[R-CD-MODEL-TOOL] VERDICT: ' + verdict);
 }
 
-export function handleSummary(data){
-  const timestamp=new Date().toISOString(); const passRate=data.metrics.proof_failures?.values?.count===0;
-  const summary={row:'R-CD-MODEL-TOOL',sha:__ENV.OPENCLAW_CANDIDATE_SHA||'unset',seat:__ENV.OPENCLAW_SEAT_NAME||'cael-dgx',timestamp,verdict:passRate?'PASS-candidate':'HONEST-LIMIT-candidate',metrics:{duration_ms:data.metrics.r_cd_model_tool_duration?.values||null,failures:data.metrics.proof_failures?.values?.count||0}};
-  return {stdout:'\n[R-CD-MODEL-TOOL] Summary: '+summary.verdict+' | SHA: '+summary.sha+' | Seat: '+summary.seat+'\n','r-cd-model-tool-summary.json':JSON.stringify(summary,null,2)};
+export function handleSummary(data) {
+  const timestamp = new Date().toISOString();
+  const failuresCount = data.metrics.proof_failures?.values?.count || 0;
+  const complete = !!(finalEvidence?.dispatch_accepted && finalEvidence?.parent_scheduled_sentinel && finalEvidence?.child_session_observed && finalEvidence?.child_model_byte && finalEvidence?.return_payload);
+  const verdict = failuresCount === 0 && finalEvidence?.model_matches ? 'PASS-candidate' : (failuresCount === 0 && complete ? 'HONEST-LIMIT-candidate' : 'PARTIAL-candidate');
+  const summary = { row: 'R-CD-MODEL-TOOL', sha: __ENV.OPENCLAW_CANDIDATE_SHA || 'unset', seat: __ENV.OPENCLAW_SEAT_NAME || 'cael-dgx', timestamp, verdict, requestedModel: finalEvidence?.requested_model_byte || __ENV.OPENCLAW_ALT_MODEL || null, observedModel: finalEvidence?.child_model_byte || null, honestLimitReason: finalEvidence?.honest_limit_reason || null, metrics: { duration_ms: data.metrics.r_cd_model_tool_duration?.values || null, failures: failuresCount } };
+  return { stdout: '\n[R-CD-MODEL-TOOL] Summary: ' + summary.verdict + ' | SHA: ' + summary.sha + ' | Seat: ' + summary.seat + '\n', 'r-cd-model-tool-summary.json': JSON.stringify(summary, null, 2) };
 }


### PR DESCRIPTION
## Summary

Harden the Project 81 `R-CD-MODEL-TOOL` k6 row so it cannot produce a false PASS by asking the delegate child to echo the requested model.

Changes:
- omit the requested model string from the child task; it is now only present in the parent `continue_delegate(model=...)` request byte
- parse `MODEL-TOOL-CHILD <nonce> MODEL <provider/model>` only from an actual child return payload, not from the task template/placeholder
- classify matching requested/observed runtime-context model bytes as `PASS-candidate`; complete-but-mismatched runs remain `HONEST-LIMIT-candidate`; missing child return/model byte remains `PARTIAL-candidate`
- update the manifest/runbook to require the anti-echo condition before any PASS fold

This is non-mutating: no production config changes, no gateway restart, no provider/auth changes.

Fixes #332.

## Verification

Static / alignment:

```bash
node --check tools/k6-proofs/scenarios/r-cd-model-tool.js
node tools/k6-proofs/scripts/check-manifest-scenarios.mjs
node tools/k6-proofs/scripts/check-scenario-alignment.mjs
node tools/k6-proofs/scripts/check-proof-row-manifests.mjs
(cd tools/k6-proofs && ./scripts/run-proofs.sh --dry-run R-CD-MODEL-TOOL 60b4ac19ddde2abfd56f171700c67bc3af20484c)
```

Live smoke, disposable sessions, exact model refs figs asked about:

```bash
OPENCLAW_CREATE_DISPOSABLE_SESSION=true \
OPENCLAW_ALT_MODEL='github-copilot/claude-sonnet-4.6' \
./scripts/run-proofs.sh --live --out-dir /tmp/p81-332-model-patched2-sonnet-20260707T212618 R-CD-MODEL-TOOL 60b4ac19ddde2abfd56f171700c67bc3af20484c
```

Result: `PARTIAL-candidate`, `k6ExitCode=99`, artifacts preserved at:
`/tmp/p81-332-model-patched2-sonnet-20260707T212618/60b4ac19ddde2abfd56f171700c67bc3af20484c/R-CD-MODEL-TOOL/ronan/20260708T042620Z-r-cd-model-tool`

```bash
OPENCLAW_CREATE_DISPOSABLE_SESSION=true \
OPENCLAW_ALT_MODEL='github-copilot/gemini-3.1-pro' \
./scripts/run-proofs.sh --live --out-dir /tmp/p81-332-model-patched2-gemini-20260707T213007 R-CD-MODEL-TOOL 60b4ac19ddde2abfd56f171700c67bc3af20484c
```

Result: `PARTIAL-candidate`, `k6ExitCode=99`, artifacts preserved at:
`/tmp/p81-332-model-patched2-gemini-20260707T213007/60b4ac19ddde2abfd56f171700c67bc3af20484c/R-CD-MODEL-TOOL/ronan/20260708T043009Z-r-cd-model-tool`

Important finding: the old row could report `PASS-candidate` by echoing `github-copilot/claude-sonnet-4.6` / `github-copilot/gemini-3.1-pro` from the child prompt. This PR removes that false-PASS path; the same runtime now honestly stops at partial because no nonce-correlated child runtime model byte is observed in the websocket window.

Note: live runtime stamp is `OpenClaw 2026.6.11 (b40e59f)`, not this docs commit SHA, so live smokes are row-harness behavior checks, not deployed-runtime proof folds.
