### PR TITLE
tools: add R-CW-3 reason telemetry review helper

### DIFF
--- a/RUNBOOKS/project-81/rows/R-CW-3.md
+++ b/RUNBOOKS/project-81/rows/R-CW-3.md
@@ -27,11 +27,27 @@ OPENCLAW_CREATE_DISPOSABLE_SESSION=true \
 - Continuation wake emits `CW3-WOKE <nonce>`.
 - Public k6 evidence drops the raw reason field/sentinel rather than committing it.
 
-## Manual collection still needed
+## Review collection still needed
 
-- Fetch Tempo trace JSON for the emitted trace id when available.
-- Verify the trace has safe reason telemetry attributes and does not contain the raw reason sentinel.
-- If trace fetch/emission is unavailable, keep the run as `HONEST-LIMIT-candidate`; do not overclaim PASS.
+Fetch Tempo trace JSON for the emitted trace id when available, then run the review helper:
+
+```bash
+node tools/k6-proofs/scripts/fetch-tempo-trace.mjs \
+  --run-dir /tmp/k6-proof-runs/<sha>/R-CW-3/<seat>/<run-id>
+
+node tools/k6-proofs/scripts/review-r-cw-3-reason-telemetry.mjs \
+  --run-dir /tmp/k6-proof-runs/<sha>/R-CW-3/<seat>/<run-id> \
+  --tempo-trace /tmp/k6-proof-runs/<sha>/R-CW-3/<seat>/<run-id>/tempo-trace-<trace>.json
+```
+
+The helper writes `r-cw-3-reason-telemetry-review.json`. It passes only when:
+
+- dispatch, `CW3-SCHEDULED`, and `CW3-WOKE` are all present in the run evidence;
+- public k6 evidence says the raw reason sentinel was not preserved;
+- Tempo contains safe `reason.present`, `reason.length`, and `reason.hash` attributes;
+- Tempo does not contain the raw `RAW-RCW3-*` sentinel or `k6-proof-R-CW-3-redaction` reason prefix.
+
+If trace fetch/emission is unavailable, or the helper exits non-zero, keep the run as `HONEST-LIMIT-candidate` / review-pending; do not overclaim PASS.
 
 ## Fold guidance
 

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -217,6 +217,21 @@ node tools/k6-proofs/scripts/fetch-tempo-trace.mjs \
   --run-dir /tmp/k6-proof-runs/<sha>/<row>/<seat>/<run-id>
 ```
 
+For `R-CW-3`, automate the repeatable reason-telemetry/redaction review after
+fetching the trace:
+
+```bash
+node tools/k6-proofs/scripts/review-r-cw-3-reason-telemetry.mjs \
+  --run-dir /tmp/k6-proof-runs/<sha>/R-CW-3/<seat>/<run-id> \
+  --tempo-trace /tmp/k6-proof-runs/<sha>/R-CW-3/<seat>/<run-id>/tempo-trace-<trace>.json
+```
+
+The helper writes `r-cw-3-reason-telemetry-review.json`, passes only when the
+run saw dispatch/schedule/wake, Tempo contains safe `reason.present`,
+`reason.length`, and `reason.hash` attributes, and the raw `RAW-RCW3-*` reason
+sentinel / `k6-proof-R-CW-3-redaction` prefix are absent from the trace. It is a
+review artifact, not a Gateway action.
+
 When reviewing an existing candidate-run bundle, summarize pending review receipts
 before attempting Tempo fetches:
 

--- a/tools/k6-proofs/scripts/__tests__/r-cw-3-review.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cw-3-review.test.mjs
@@ -1,0 +1,78 @@
+import { mkdtemp, mkdir, writeFile, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const script = path.resolve('tools/k6-proofs/scripts/review-r-cw-3-reason-telemetry.mjs');
+const runNode = promisify(execFile);
+
+async function fixtureRunDir() {
+  const root = await mkdtemp(path.join(tmpdir(), 'r-cw-3-review-'));
+  const runDir = path.join(root, 'run');
+  await mkdir(runDir, { recursive: true });
+  await writeFile(path.join(runDir, 'evidence.jsonl'), `${JSON.stringify({
+    row: 'R-CW-3',
+    nonce: 'R-CW-3-abc',
+    trace_id: '0123456789abcdef',
+    dispatch_accepted: true,
+    scheduled_sentinel: true,
+    wake_observed: true,
+    public_artifact_raw_reason_absent: true,
+  })}\n`);
+  return { root, runDir };
+}
+
+const safeTrace = {
+  batches: [{
+    scopeSpans: [{
+      spans: [{
+        name: 'continuation.work',
+        attributes: [
+          { key: 'reason.present', value: { boolValue: true } },
+          { key: 'reason.length', value: { intValue: '83' } },
+          { key: 'reason.hash', value: { stringValue: 'abc123' } },
+        ],
+      }],
+    }],
+  }],
+};
+
+test('passes when wake evidence and safe reason attrs are present and raw reason is absent', async () => {
+  const { root, runDir } = await fixtureRunDir();
+  try {
+    const tracePath = path.join(runDir, 'tempo-trace-0123456789ab.json');
+    const out = path.join(runDir, 'review.json');
+    await writeFile(tracePath, `${JSON.stringify(safeTrace)}\n`);
+    const run = await runNode(process.execPath, [script, '--run-dir', runDir, '--out', out], { encoding: 'utf8' });
+    assert.match(run.stdout, /reason-telemetry-redaction-review-passed/);
+    const receipt = JSON.parse(await readFile(out, 'utf8'));
+    assert.equal(receipt.checks.safeReasonAttrsPresent.ok, true);
+    assert.equal(receipt.checks.rawReasonAbsentFromTempo.ok, true);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('fails closed when Tempo contains the raw R-CW-3 reason sentinel', async () => {
+  const { root, runDir } = await fixtureRunDir();
+  try {
+    const tracePath = path.join(runDir, 'tempo.json');
+    await writeFile(tracePath, `${JSON.stringify({
+      ...safeTrace,
+      raw: 'k6-proof-R-CW-3-redaction RAW-RCW3-R-CW-3-abc-secret',
+    })}\n`);
+    await assert.rejects(
+      runNode(process.execPath, [script, '--run-dir', runDir, '--tempo-trace', tracePath], { encoding: 'utf8' }),
+      (error) => {
+        assert.equal(error.code, 1);
+        assert.match(error.stdout, /review-pending/);
+        return true;
+      },
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/tools/k6-proofs/scripts/review-r-cw-3-reason-telemetry.mjs
+++ b/tools/k6-proofs/scripts/review-r-cw-3-reason-telemetry.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * Review helper for Project 81 R-CW-3 reason telemetry/redaction receipts.
+ *
+ * This script does not run Gateway work. It inspects an existing R-CW-3 run
+ * directory and its fetched Tempo trace JSON, then writes a public-safe review
+ * receipt. It automates the repeatable part of the manual review:
+ *   - schedule + wake evidence exists
+ *   - public k6 artifact says the raw reason was not preserved
+ *   - Tempo trace contains safe reason telemetry attrs
+ *   - Tempo trace does not contain the raw reason sentinel/prefix
+ */
+import { readFile, writeFile, mkdir, readdir } from 'node:fs/promises';
+import path from 'node:path';
+
+const RAW_SENTINEL_PREFIX = 'RAW-RCW3-';
+const REASON_PREFIX = 'k6-proof-R-CW-3-redaction';
+
+function usage() {
+  console.error('Usage: node review-r-cw-3-reason-telemetry.mjs --run-dir <R-CW-3 run dir> [--tempo-trace <trace.json>] [--out <receipt.json>]');
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--run-dir' || arg === '--tempo-trace' || arg === '--out') {
+      const value = argv[i + 1];
+      if (!value || value.startsWith('--')) throw new Error(`missing value for ${arg}`);
+      out[arg.slice(2).replace(/-([a-z])/g, (_, c) => c.toUpperCase())] = value;
+      i += 1;
+    } else if (arg === '--help' || arg === '-h') {
+      out.help = true;
+    } else {
+      throw new Error(`unexpected argument: ${arg}`);
+    }
+  }
+  return out;
+}
+
+async function readJson(file) {
+  return JSON.parse(await readFile(file, 'utf8'));
+}
+
+async function readEvidence(runDir) {
+  const evidencePath = path.join(runDir, 'evidence.jsonl');
+  const text = await readFile(evidencePath, 'utf8');
+  const rows = [];
+  for (const line of text.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    rows.push(JSON.parse(line));
+  }
+  if (!rows.length) throw new Error(`no evidence rows in ${evidencePath}`);
+  return rows[rows.length - 1];
+}
+
+async function findTempoTrace(runDir, explicit) {
+  if (explicit) return path.resolve(explicit);
+  const entries = await readdir(runDir).catch(() => []);
+  const matches = entries.filter((name) => /^tempo-trace-[A-Fa-f0-9]{8,64}\.json$/.test(name)).sort();
+  if (matches.length === 1) return path.join(runDir, matches[0]);
+  if (matches.length > 1) throw new Error(`multiple tempo trace JSON files found in ${runDir}; pass --tempo-trace explicitly`);
+  throw new Error(`no tempo-trace-<trace>.json found in ${runDir}; fetch it first or pass --tempo-trace`);
+}
+
+function extractAttributes(obj, out = []) {
+  if (!obj || typeof obj !== 'object') return out;
+  if (Array.isArray(obj)) {
+    for (const item of obj) extractAttributes(item, out);
+    return out;
+  }
+  if (typeof obj.key === 'string' && obj.value && typeof obj.value === 'object') {
+    out.push({ key: obj.key, value: otelValueToScalar(obj.value) });
+  }
+  for (const value of Object.values(obj)) extractAttributes(value, out);
+  return out;
+}
+
+function otelValueToScalar(value) {
+  if (!value || typeof value !== 'object') return value;
+  for (const key of ['stringValue', 'intValue', 'doubleValue', 'boolValue']) {
+    if (Object.prototype.hasOwnProperty.call(value, key)) return value[key];
+  }
+  if (value.arrayValue) return JSON.stringify(value.arrayValue);
+  if (value.kvlistValue) return JSON.stringify(value.kvlistValue);
+  return JSON.stringify(value);
+}
+
+function allStrings(obj, out = []) {
+  if (obj == null) return out;
+  if (typeof obj === 'string') { out.push(obj); return out; }
+  if (typeof obj === 'number' || typeof obj === 'boolean') { out.push(String(obj)); return out; }
+  if (Array.isArray(obj)) { for (const item of obj) allStrings(item, out); return out; }
+  if (typeof obj === 'object') {
+    for (const [key, value] of Object.entries(obj)) {
+      out.push(key);
+      allStrings(value, out);
+    }
+  }
+  return out;
+}
+
+function status(ok, evidence) {
+  return { ok, evidence };
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) { usage(); return; }
+  if (!args.runDir) throw new Error('--run-dir is required');
+  const runDir = path.resolve(args.runDir);
+  const tempoTracePath = await findTempoTrace(runDir, args.tempoTrace);
+  const outPath = path.resolve(args.out || path.join(runDir, 'r-cw-3-reason-telemetry-review.json'));
+
+  const evidence = await readEvidence(runDir);
+  const trace = await readJson(tempoTracePath);
+  const attrs = extractAttributes(trace);
+  const strings = allStrings(trace);
+  const attrKeys = new Set(attrs.map((a) => a.key));
+  const hasReasonPresent = attrs.some((a) => a.key === 'reason.present' && (a.value === true || a.value === 'true'));
+  const hasReasonLength = attrKeys.has('reason.length');
+  const hasReasonHash = attrKeys.has('reason.hash');
+  const hasSafeReasonAttrs = hasReasonPresent && hasReasonLength && hasReasonHash;
+  const rawSentinelHits = strings.filter((s) => s.includes(RAW_SENTINEL_PREFIX));
+  const rawReasonPrefixHits = strings.filter((s) => s.includes(REASON_PREFIX));
+  const rawReasonAbsent = rawSentinelHits.length === 0 && rawReasonPrefixHits.length === 0;
+
+  const checks = {
+    row: status(evidence.row === 'R-CW-3', evidence.row || null),
+    dispatchAccepted: status(evidence.dispatch_accepted === true, evidence.dispatch_accepted === true),
+    scheduledSentinel: status(evidence.scheduled_sentinel === true, evidence.scheduled_sentinel === true),
+    wakeObserved: status(evidence.wake_observed === true, evidence.wake_observed === true),
+    publicArtifactRawReasonAbsent: status(evidence.public_artifact_raw_reason_absent === true, evidence.public_artifact_raw_reason_absent === true),
+    tempoTraceJson: status(Boolean(trace), path.basename(tempoTracePath)),
+    safeReasonAttrsPresent: status(hasSafeReasonAttrs, {
+      'reason.present': hasReasonPresent,
+      'reason.length': hasReasonLength,
+      'reason.hash': hasReasonHash,
+    }),
+    rawReasonAbsentFromTempo: status(rawReasonAbsent, {
+      rawSentinelPrefixHits: rawSentinelHits.length,
+      rawReasonPrefixHits: rawReasonPrefixHits.length,
+    }),
+  };
+  const passed = Object.values(checks).every((check) => check.ok);
+  const receipt = {
+    schema: 'openclaw.k6.r-cw-3-reason-telemetry-review.v1',
+    generatedAt: new Date().toISOString(),
+    runDir,
+    tempoTraceJson: tempoTracePath,
+    row: 'R-CW-3',
+    nonce: evidence.nonce || null,
+    traceId: evidence.trace_id || null,
+    verdict: passed ? 'reason-telemetry-redaction-review-passed' : 'review-pending',
+    checks,
+    safeReasonAttributeKeys: attrs.map((a) => a.key).filter((key) => key.startsWith('reason.')).sort(),
+    publicSafe: true,
+  };
+  await mkdir(path.dirname(outPath), { recursive: true });
+  await writeFile(outPath, `${JSON.stringify(receipt, null, 2)}\n`);
+  console.log(JSON.stringify({ out: outPath, verdict: receipt.verdict, passed }, null, 2));
+  if (!passed) process.exitCode = 1;
+}
+
+main().catch((error) => {
+  usage();
+  console.error(error && error.stack ? error.stack : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Move the repeatable part of the `R-CW-3` reason-telemetry/redaction review out of manual inference and into a small review helper.

Adds:
- `tools/k6-proofs/scripts/review-r-cw-3-reason-telemetry.mjs`
- node:test coverage for pass + fail-closed raw-reason cases
- README/runbook guidance for using it after `fetch-tempo-trace.mjs`

The helper is non-mutating: it only reads an existing `R-CW-3` run directory + fetched Tempo JSON and writes a public-safe `r-cw-3-reason-telemetry-review.json` receipt. It passes only when:

- dispatch, `CW3-SCHEDULED`, and `CW3-WOKE` are present in run evidence
- public k6 evidence says the raw reason sentinel was not preserved
- Tempo includes safe `reason.present`, `reason.length`, and `reason.hash` attrs
- Tempo does not include raw `RAW-RCW3-*` / `k6-proof-R-CW-3-redaction` text

This does not turn `R-CW-3` into unattended PASS by itself; trace fetch/emission and review receipt remain required. It just makes the sibling runtime guidance executable and fail-closed.

Refs #333.

## Verification

```bash
node --check tools/k6-proofs/scripts/review-r-cw-3-reason-telemetry.mjs
node --test tools/k6-proofs/scripts/__tests__/r-cw-3-review.test.mjs
node tools/k6-proofs/scripts/check-manifest-scenarios.mjs
node tools/k6-proofs/scripts/check-scenario-alignment.mjs
node tools/k6-proofs/scripts/check-proof-row-manifests.mjs
(cd tools/k6-proofs && ./scripts/run-proofs.sh --dry-run R-CW-3 be28d60d8b9fee851aa97df3b9d863c8cb033f86)
```
