### PR TITLE
Project 81: harden R-CW-3 trace-id extraction receipt

### DIFF
--- a/tools/k6-proofs/scenarios/r-cw-3-reason-telemetry.js
+++ b/tools/k6-proofs/scenarios/r-cw-3-reason-telemetry.js
@@ -11,6 +11,33 @@ import { Counter, Trend } from 'k6/metrics';
 import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
 
+/**
+ * Extract a hex trace ID from a W3C traceparent header string.
+ * Format: 00-<32-hex-traceId>-<16-hex-spanId>-<flags>
+ * Returns null when the input is absent or malformed.
+ */
+function parseTraceparent(header) {
+  if (!header || typeof header !== 'string') return null;
+  const parts = header.split('-');
+  return (parts.length >= 4 && /^[0-9a-f]{32}$/.test(parts[1])) ? parts[1] : null;
+}
+
+/**
+ * Scan an object one level deep for traceId / trace_id / traceparent fields,
+ * trying sub-objects keyed by 'result', 'state', or 'payload' as well.
+ * Returns the first found hex trace ID, or null.
+ */
+function extractNestedTraceId(obj) {
+  if (!obj || typeof obj !== 'object') return null;
+  const probe = (o) => {
+    if (!o || typeof o !== 'object') return null;
+    if (o.traceId && /^[0-9a-f]{8,64}$/i.test(String(o.traceId))) return String(o.traceId).toLowerCase();
+    if (o.trace_id && /^[0-9a-f]{8,64}$/i.test(String(o.trace_id))) return String(o.trace_id).toLowerCase();
+    return parseTraceparent(o.traceparent);
+  };
+  return probe(obj) || probe(obj.result) || probe(obj.state) || probe(obj.payload) || null;
+}
+
 export const options = { scenarios: { r_cw_3_reason_telemetry: { executor: 'shared-iterations', vus: 1, iterations: 1, maxDuration: '120s' } }, thresholds: { proof_failures: ['count==0'], r_cw_3_duration: ['p(95)<90000'] } };
 const failures = new Counter('proof_failures');
 const duration = new Trend('r_cw_3_duration');
@@ -38,7 +65,7 @@ export default function () {
   if (!token) { console.error('OPENCLAW_GATEWAY_TOKEN is required'); failures.add(1); return; }
   if (manifest) { const errors = validateManifest(manifest); if (errors.length) console.warn('Manifest validation warnings: ' + errors.join('; ')); }
   const inv = invocationCfg();
-  const evidence = { row: 'R-CW-3', manifest_loaded: !!manifest, nonce: rowNonce, seat, requestedSessionKey, sessionKey, session_created: false, created_session_key: null, candidateSha: manifest?.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset', started: new Date().toISOString(), dispatch_accepted: false, scheduled_sentinel: false, wake_observed: false, public_artifact_raw_reason_absent: true, tempo_assertion: 'pending-review', trace_id: null, dispatch_accepted_at_ms: null, scheduled_result_at_ms: null, wake_delay_ms: null, redacted_events: [] };
+  const evidence = { row: 'R-CW-3', manifest_loaded: !!manifest, nonce: rowNonce, seat, requestedSessionKey, sessionKey, session_created: false, created_session_key: null, candidateSha: manifest?.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset', started: new Date().toISOString(), dispatch_accepted: false, scheduled_sentinel: false, wake_observed: false, public_artifact_raw_reason_absent: true, tempo_assertion: 'pending-review', trace_id: null, trace_id_source: null, dispatch_accepted_at_ms: null, scheduled_result_at_ms: null, wake_delay_ms: null, redacted_events: [] };
   const started = Date.now();
   const res = ws.connect(url, {}, (socket) => {
     const tracker = new RequestTracker();
@@ -55,12 +82,39 @@ export default function () {
     socket.on('message', (raw) => {
       try {
         const msg = JSON.parse(raw); const classified = tracker.classify(msg);
+        // Belt-and-suspenders: capture traceId from the raw gateway frame before
+        // classification drops root-level fields (classify returns data:msg.payload).
+        // Covers: msg.traceId, msg.trace_id, W3C msg.traceparent, and nested state/result.
+        if (!evidence.trace_id) {
+          const rootId = extractNestedTraceId(msg);
+          if (rootId) { evidence.trace_id = rootId; evidence.trace_id_source = 'root-frame'; }
+        }
         const safeData = redactedNoReason(classified);
         if (JSON.stringify(safeData).includes(rawReasonSentinel)) evidence.public_artifact_raw_reason_absent = false;
         evidence.redacted_events.push({ ts: Date.now(), kind: classified.kind, method: classified.method || null, event: classified.event || null, ok: classified.ok !== undefined ? classified.ok : null, data: safeData });
         if (classified.kind === 'response' && classified.method === 'sessions.create') { if (classified.ok && classified.payload) { sessionKey = classified.payload.key || sessionKey; evidence.sessionKey = sessionKey; evidence.session_created = true; evidence.created_session_key = sessionKey; console.log('✓ disposable session created: ' + sessionKey); startProofFlow(socket); } else { console.error('✗ sessions.create rejected: ' + JSON.stringify(classified.error)); failures.add(1); socket.close(); } }
-        if (classified.kind === 'response' && classified.method === 'sessions.send') { if (classified.ok) { evidence.dispatch_accepted = true; evidence.dispatch_accepted_at_ms = Date.now(); if (classified.payload?.traceId) evidence.trace_id = classified.payload.traceId; console.log('✓ sessions.send accepted — reason telemetry turn triggered'); } else { console.error('✗ sessions.send rejected: ' + JSON.stringify(classified.error)); failures.add(1); } }
-        if (classified.kind === 'event') { const eventData = classified.data || {}; const eventStr = JSON.stringify(eventData); if (eventStr.includes(HARNESS_MARKER)) return; if (!evidence.scheduled_sentinel && eventStr.includes(`CW3-SCHEDULED ${rowNonce}`)) { evidence.scheduled_sentinel = true; evidence.scheduled_result_at_ms = Date.now(); if (eventData.traceId) evidence.trace_id = eventData.traceId; console.log('✓ CW3-SCHEDULED sentinel observed'); } if (evidence.scheduled_sentinel && !evidence.wake_observed && eventStr.includes(`CW3-WOKE ${rowNonce}`)) { evidence.wake_observed = true; evidence.wake_delay_ms = evidence.scheduled_result_at_ms ? Date.now() - evidence.scheduled_result_at_ms : null; console.log('✓ CW3-WOKE sentinel observed'); } }
+        if (classified.kind === 'response' && classified.method === 'sessions.send') {
+          if (classified.ok) {
+            evidence.dispatch_accepted = true; evidence.dispatch_accepted_at_ms = Date.now();
+            // Try camelCase, snake_case, and W3C traceparent from the response payload.
+            if (!evidence.trace_id) {
+              const sendId = extractNestedTraceId(classified.payload);
+              if (sendId) { evidence.trace_id = sendId; evidence.trace_id_source = 'sessions.send-response'; }
+            }
+            console.log('✓ sessions.send accepted — reason telemetry turn triggered');
+          } else { console.error('✗ sessions.send rejected: ' + JSON.stringify(classified.error)); failures.add(1); }
+        }
+        if (classified.kind === 'event') { const eventData = classified.data || {}; const eventStr = JSON.stringify(eventData); if (eventStr.includes(HARNESS_MARKER)) return;
+          if (!evidence.scheduled_sentinel && eventStr.includes(`CW3-SCHEDULED ${rowNonce}`)) {
+            evidence.scheduled_sentinel = true; evidence.scheduled_result_at_ms = Date.now();
+            // Try eventData (msg.payload) plus the full raw message for this frame.
+            if (!evidence.trace_id) {
+              const schedId = extractNestedTraceId(eventData) || extractNestedTraceId(msg);
+              if (schedId) { evidence.trace_id = schedId; evidence.trace_id_source = 'cw3-scheduled-event'; }
+            }
+            console.log('✓ CW3-SCHEDULED sentinel observed');
+          }
+          if (evidence.scheduled_sentinel && !evidence.wake_observed && eventStr.includes(`CW3-WOKE ${rowNonce}`)) { evidence.wake_observed = true; evidence.wake_delay_ms = evidence.scheduled_result_at_ms ? Date.now() - evidence.scheduled_result_at_ms : null; console.log('✓ CW3-WOKE sentinel observed'); } }
         if (evidence.dispatch_accepted && evidence.scheduled_sentinel && evidence.wake_observed) { console.log('Required R-CW-3 schedule/wake evidence gathered, closing early'); socket.close(); }
       } catch (e) { console.warn('parse error: ' + e); }
     });
@@ -78,6 +132,7 @@ export function handleSummary(data) {
   const timestamp = new Date().toISOString();
   const failuresCount = data.metrics.proof_failures?.values?.count || 0;
   const traceId = finalEvidence?.trace_id || null;
+  const traceIdSource = finalEvidence?.trace_id_source || null;
   const verdict = failuresCount === 0 ? 'HONEST-LIMIT-candidate' : 'PARTIAL-candidate';
   const pendingReceipts = ['reason-telemetry-redaction-review'];
   if (!traceId) pendingReceipts.unshift('tempo-trace-json');
@@ -86,8 +141,8 @@ export function handleSummary(data) {
       ? 'k6 proved dispatch/schedule/wake and kept the raw reason out of public evidence; fold still requires Tempo reason telemetry/redaction review.'
       : 'This run did not prove the full schedule/wake path. Preserve k6.log/evidence and do not fold as PASS.',
     traceId
-      ? 'Trace id captured; fetch Tempo trace JSON and verify safe reason attributes are present while the raw reason sentinel is absent.'
-      : 'No trace_id emitted. Keep this as HONEST-LIMIT/PARTIAL until trace JSON is fetched or trace-missing is explicitly accepted.',
+      ? `Trace id captured from ${traceIdSource || 'unknown source'}; fetch Tempo trace JSON and verify safe reason attributes are present while the raw reason sentinel is absent.`
+      : 'No traceId emitted by gateway WS API: checked root frame (traceId/trace_id/traceparent), sessions.send response payload, and CW3-SCHEDULED event data (including nested result/state/payload). This is a gateway API limitation — the WS protocol for these methods does not expose a traceId. Keep as HONEST-LIMIT/trace-missing until trace JSON is obtained via Tempo search (query by chain.id or flow.id attributes) or trace-missing is explicitly accepted.',
   ];
   const summary = {
     row: 'R-CW-3',
@@ -98,7 +153,7 @@ export function handleSummary(data) {
     candidateOnly: true,
     foldRequiresReview: true,
     evidenceJsonl: 'evidence.jsonl',
-    observability: { traceId, traceJson: traceId ? 'pending-fetch' : 'missing' },
+    observability: { traceId, traceIdSource, traceJson: traceId ? 'pending-fetch' : 'missing' },
     review: { status: 'review-pending', pendingReceipts, notes },
     metrics: { duration_ms: data.metrics.r_cw_3_duration?.values || null, failures: failuresCount },
   };


### PR DESCRIPTION
## Summary

Closes/advances #337; feeds #333.

- hardens `R-CW-3` trace id extraction across root frames, payloads, nested result/state payloads, and W3C `traceparent`
- records `trace_id_source` in evidence/summary observability when a trace id is found
- clarifies the honest-limit note when no trace id is exposed by the Gateway WS frames

## Diagnosis

The 2026-07-08 live run proved schedule+wake and public raw-reason absence but emitted `trace_id: null`. Inspection shows Gateway WS frames for this row do not currently include `traceId` / `trace_id` / `traceparent`; earlier corpus trace acquisition came from Tempo attribute search using durable flow/chain ids, not from the WS receipt.

This patch makes the harness exhaustive if Gateway starts exposing trace ids later, while keeping the current disposition honest: no PASS without a trace JSON/review receipt or an accepted honest-limit.

## Gates

- `node --check tools/k6-proofs/scenarios/r-cw-3-reason-telemetry.js`
- `node --check tools/k6-proofs/scripts/review-r-cw-3-reason-telemetry.mjs`
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs`
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs`
- `node tools/k6-proofs/scripts/check-proof-row-manifests.mjs`
- `node --test tools/k6-proofs/scripts/__tests__/*.test.mjs` — 27/27 pass
