### PR TITLE
Project 81: extend R-CW-3 wake observation window

### DIFF
--- a/RUNBOOKS/project-81/rows/R-CW-3.md
+++ b/RUNBOOKS/project-81/rows/R-CW-3.md
@@ -24,7 +24,7 @@ OPENCLAW_CREATE_DISPOSABLE_SESSION=true \
 
 - Dispatching `sessions.send` accepted.
 - Agent emits `CW3-SCHEDULED <nonce>` only after `continue_work` reports scheduled.
-- Continuation wake emits `CW3-WOKE <nonce>`.
+- Continuation wake emits `CW3-WOKE <nonce>`; the observer stays open up to 10 minutes because quiet/disposable seats can deliver the elected wake several minutes late under active-lane pressure.
 - Public k6 evidence drops the raw reason field/sentinel rather than committing it.
 
 ## Review collection still needed
@@ -55,4 +55,4 @@ R-CW-3 is not an unattended PASS row. The runner may execute it safely, but cano
 
 ## 2026-07-07 smoke note
 
-Disposable-session smoke on `ronan` accepted dispatch and observed `CW3-SCHEDULED`, but did not observe `CW3-WOKE` within the k6 window. This is partial only. Even with a wake, R-CW-3 remains `HONEST-LIMIT-candidate` until Tempo trace JSON is fetched/reviewed for safe reason attrs present and raw reason absent.
+Disposable-session smoke on `ronan` accepted dispatch and observed `CW3-SCHEDULED`, but did not observe `CW3-WOKE` within the original short k6 window. A later session-history receipt showed the elected wake landed about eight minutes late and emitted `CW3-WOKE`; the scenario now keeps the observer open for 10 minutes to reduce false PARTIALs from delayed continuation delivery. Even with a wake, R-CW-3 remains `HONEST-LIMIT-candidate` until Tempo trace JSON is fetched/reviewed for safe reason attrs present and raw reason absent.

--- a/tools/k6-proofs/manifests/r-cw-3.json
+++ b/tools/k6-proofs/manifests/r-cw-3.json
@@ -8,7 +8,7 @@
   "transport": "websocket",
   "toolSurface": "typed-tool",
   "mutates": false,
-  "timeoutSeconds": 120,
+  "timeoutSeconds": 600,
   "gateway": {
     "wsEnv": "OPENCLAW_GATEWAY_WS",
     "tokenEnv": "OPENCLAW_GATEWAY_TOKEN"

--- a/tools/k6-proofs/scenarios/r-cw-3-reason-telemetry.js
+++ b/tools/k6-proofs/scenarios/r-cw-3-reason-telemetry.js
@@ -38,7 +38,7 @@ function extractNestedTraceId(obj) {
   return probe(obj) || probe(obj.result) || probe(obj.state) || probe(obj.payload) || null;
 }
 
-export const options = { scenarios: { r_cw_3_reason_telemetry: { executor: 'shared-iterations', vus: 1, iterations: 1, maxDuration: '120s' } }, thresholds: { proof_failures: ['count==0'], r_cw_3_duration: ['p(95)<90000'] } };
+export const options = { scenarios: { r_cw_3_reason_telemetry: { executor: 'shared-iterations', vus: 1, iterations: 1, maxDuration: '10m' } }, thresholds: { proof_failures: ['count==0'], r_cw_3_duration: ['p(95)<600000'] } };
 const failures = new Counter('proof_failures');
 const duration = new Trend('r_cw_3_duration');
 const manifest = loadManifestFromEnv();
@@ -76,7 +76,7 @@ export default function () {
         const instruction = `${HARNESS_MARKER} R-CW-3 proof nonce ${rowNonce}. Call continue_work with delaySeconds=${inv.delaySeconds} and the supplied reason. After the continue_work tool result reports scheduled, reply exactly CW3-SCHEDULED ${rowNonce}. On the continuation wake, reply exactly CW3-WOKE ${rowNonce}. Supplied reason: ${JSON.stringify(rawReason)}. Do not mutate files.`;
         tracker.send(socket, 'sessions.send', { key: sessionKey, message: instruction, idempotencyKey: `${inv.idempotencyKeyPrefix}-DISPATCH-${rowNonce}` });
       }, 500);
-      socket.setTimeout(() => socket.close(), Math.max(90000, (inv.delaySeconds + 60) * 1000));
+      socket.setTimeout(() => socket.close(), Math.max(600000, (inv.delaySeconds + 540) * 1000));
     }
     socket.on('open', () => { socket.send(connectFrame(token)); if (createDisposableSession) { socket.setTimeout(() => { const disposableKey = `r-cw-3-${rowNonce}`.toLowerCase().replace(/[^a-z0-9-]/g, '-'); tracker.send(socket, 'sessions.create', { key: disposableKey, label: `k6 R-CW-3 ${rowNonce}` }); }, 250); } else socket.setTimeout(() => startProofFlow(socket), 500); });
     socket.on('message', (raw) => {

--- a/tools/k6-proofs/scripts/__tests__/r-cw-3-observation-window.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cw-3-observation-window.test.mjs
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const repoRoot = new URL('../../../..', import.meta.url).pathname;
+const scenarioPath = join(repoRoot, 'tools/k6-proofs/scenarios/r-cw-3-reason-telemetry.js');
+const manifestPath = join(repoRoot, 'tools/k6-proofs/manifests/r-cw-3.json');
+
+test('R-CW-3 observation window tolerates delayed continuation delivery', async () => {
+  const source = await readFile(scenarioPath, 'utf8');
+  assert.match(source, /maxDuration:\s*'10m'/, 'scenario maxDuration should cover multi-minute continuation delivery delays');
+  assert.match(source, /r_cw_3_duration:\s*\['p\(95\)<600000'\]/, 'duration threshold should match the 10m observation window');
+  assert.match(
+    source,
+    /socket\.setTimeout\(\(\) => socket\.close\(\), Math\.max\(600000, \(inv\.delaySeconds \+ 540\) \* 1000\)\)/,
+    'websocket observer should remain open long enough to catch delayed wake receipts',
+  );
+});
+
+test('R-CW-3 manifest timeout matches the long observation window', async () => {
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+  assert.equal(manifest.timeoutSeconds, 600);
+});


### PR DESCRIPTION
## Summary

- extend R-CW-3 k6 observation from the original short window to 10 minutes
- align manifest timeout with that observer window
- document the 2026-07-08 Ronan late-wake receipt: `CW3-WOKE` arrived after k6 had already closed
- add a unit test so the observation window does not regress

This reduces false PARTIALs for delayed continuation delivery. It does **not** claim R-CW-3 PASS; Tempo trace JSON/review remains required or trace-missing stays honest-limit/review debt.

## Evidence

Ronan live artifact `20260708T132813Z-r-cw-3` saw `dispatch_accepted=true` and `CW3-SCHEDULED`, then k6 closed at ~90s with `wake_observed=false`. Session history later showed the continuation wake delivered at `2026-07-08T13:36:42.722Z` and the session emitted `CW3-WOKE R-CW-3-1783517293474-i74ky0zy`; it was a delayed wake, not absence.

## Verification

- `node --check tools/k6-proofs/scenarios/r-cw-3-reason-telemetry.js`
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs`
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs`
- `node tools/k6-proofs/scripts/check-proof-row-manifests.mjs`
- `node --test tools/k6-proofs/scripts/__tests__/*.test.mjs` — 29/29
- `./scripts/run-proofs.sh --dry-run R-CW-3 0ca4ee60c2546ebecf1777719238ce4f1d10bf56`