### PR TITLE
Extend R-CW-3 live observer window

### DIFF
--- a/RUNBOOKS/project-81/rows/R-CW-3.md
+++ b/RUNBOOKS/project-81/rows/R-CW-3.md
@@ -56,3 +56,9 @@ R-CW-3 is not an unattended PASS row. The runner may execute it safely, but cano
 ## 2026-07-07 smoke note
 
 Disposable-session smoke on `ronan` accepted dispatch and observed `CW3-SCHEDULED`, but did not observe `CW3-WOKE` within the k6 window. This is partial only. Even with a wake, R-CW-3 remains `HONEST-LIMIT-candidate` until Tempo trace JSON is fetched/reviewed for safe reason attrs present and raw reason absent.
+
+## 2026-07-08 delayed-wake diagnosis
+
+The Ronan disposable-session run at `/tmp/p81-r-cw-3-live-20260708T132810Z/db3c660d19c89111008bd85cd7b306c205889c18/R-CW-3/ronan/20260708T132813Z-r-cw-3` did wake after the original observer closed: the TaskFlow due time was `2026-07-08T13:28:39.464Z`, the first due-time drive skipped with `reason=command-queue-busy`, and the wake was delivered at `2026-07-08T13:36:42.722Z` before the agent emitted `CW3-WOKE`. Keep the row review-pending unless the live artifact itself observes `CW3-WOKE`; even then, `trace_id: null` still leaves Tempo/redaction review debt.
+
+Verification with a 10-minute observer at `/tmp/p81-rcw3-observation-window-live-20260708T134502Z/db3c660d19c89111008bd85cd7b306c205889c18/R-CW-3/ronan/20260708T134505Z-r-cw-3` captured `dispatch_accepted=true`, `scheduled_sentinel=true`, `wake_observed=true`, `wake_delay_ms=31481`, and `public_artifact_raw_reason_absent=true`; it still emitted `trace_id=null`, so the verdict remains `HONEST-LIMIT-candidate` / review-pending rather than PASS.

--- a/tools/k6-proofs/scenarios/r-cw-3-reason-telemetry.js
+++ b/tools/k6-proofs/scenarios/r-cw-3-reason-telemetry.js
@@ -11,7 +11,7 @@ import { Counter, Trend } from 'k6/metrics';
 import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
 
-export const options = { scenarios: { r_cw_3_reason_telemetry: { executor: 'shared-iterations', vus: 1, iterations: 1, maxDuration: '120s' } }, thresholds: { proof_failures: ['count==0'], r_cw_3_duration: ['p(95)<90000'] } };
+export const options = { scenarios: { r_cw_3_reason_telemetry: { executor: 'shared-iterations', vus: 1, iterations: 1, maxDuration: '10m' } }, thresholds: { proof_failures: ['count==0'], r_cw_3_duration: ['p(95)<600000'] } };
 const failures = new Counter('proof_failures');
 const duration = new Trend('r_cw_3_duration');
 const manifest = loadManifestFromEnv();
@@ -49,7 +49,7 @@ export default function () {
         const instruction = `${HARNESS_MARKER} R-CW-3 proof nonce ${rowNonce}. Call continue_work with delaySeconds=${inv.delaySeconds} and the supplied reason. After the continue_work tool result reports scheduled, reply exactly CW3-SCHEDULED ${rowNonce}. On the continuation wake, reply exactly CW3-WOKE ${rowNonce}. Supplied reason: ${JSON.stringify(rawReason)}. Do not mutate files.`;
         tracker.send(socket, 'sessions.send', { key: sessionKey, message: instruction, idempotencyKey: `${inv.idempotencyKeyPrefix}-DISPATCH-${rowNonce}` });
       }, 500);
-      socket.setTimeout(() => socket.close(), Math.max(90000, (inv.delaySeconds + 60) * 1000));
+      socket.setTimeout(() => socket.close(), Math.max(600000, (inv.delaySeconds + 360) * 1000));
     }
     socket.on('open', () => { socket.send(connectFrame(token)); if (createDisposableSession) { socket.setTimeout(() => { const disposableKey = `r-cw-3-${rowNonce}`.toLowerCase().replace(/[^a-z0-9-]/g, '-'); tracker.send(socket, 'sessions.create', { key: disposableKey, label: `k6 R-CW-3 ${rowNonce}` }); }, 250); } else socket.setTimeout(() => startProofFlow(socket), 500); });
     socket.on('message', (raw) => {

--- a/tools/k6-proofs/scripts/__tests__/r-cw-3-observation-window.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cw-3-observation-window.test.mjs
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const repoRoot = new URL('../../../..', import.meta.url).pathname;
+const scenarioPath = join(repoRoot, 'tools/k6-proofs/scenarios/r-cw-3-reason-telemetry.js');
+
+test('R-CW-3 observation window tolerates delayed disposable continuation delivery', async () => {
+  const source = await readFile(scenarioPath, 'utf8');
+  assert.match(source, /maxDuration:\s*'10m'/, 'scenario maxDuration should cover multi-minute idle-retry delays');
+  assert.match(source, /r_cw_3_duration:\s*\['p\(95\)<600000'\]/, 'duration threshold should match the 10m observation window');
+  assert.match(
+    source,
+    /socket\.setTimeout\(\(\) => socket\.close\(\), Math\.max\(600000, \(inv\.delaySeconds \+ 360\) \* 1000\)\)/,
+    'websocket observer should remain open long enough to catch delayed wake receipts',
+  );
+});


### PR DESCRIPTION
## Summary

- Extend `R-CW-3` k6 observation from ~90s to 10m so delayed disposable-session continuation wakes can be observed.
- Add a guard test matching the existing `R-CW-4` delayed-continuation timing contract.
- Record the Ronan diagnosis: the prior "no wake" run woke after k6 closed; first due-time drive skipped with `reason=command-queue-busy`, then the continuation delivered later.

## Verification

- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs`
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs`
- `node tools/k6-proofs/scripts/check-proof-row-manifests.mjs`
- `node --test tools/k6-proofs/scripts/__tests__/*.test.mjs` (28 pass)
- Live disposable R-CW-3 on Ronan with this branch: `/tmp/p81-rcw3-observation-window-live-20260708T134502Z/db3c660d19c89111008bd85cd7b306c205889c18/R-CW-3/ronan/20260708T134505Z-r-cw-3`
  - `k6ExitCode=0`
  - `dispatch_accepted=true`
  - `scheduled_sentinel=true`
  - `wake_observed=true`
  - `wake_delay_ms=31481`
  - `public_artifact_raw_reason_absent=true`
  - `trace_id=null`

## Review note

This does not claim R-CW-3 PASS. The row remains `HONEST-LIMIT-candidate` / review-pending until trace JSON and reason telemetry/redaction review are available or explicitly accepted as honest-limit debt.

Refs #333.
