### PR TITLE
Project 81: honor explicit proof-runner session selectors

### DIFF
--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -75,7 +75,14 @@ export OPENCLAW_RUNTIME_BUILD_SHA="$DEPLOYED_BUILD_STAMP"
 # Resolve Session Key
 if [[ -z "${OPENCLAW_SESSION_KEY:-}" ]]; then
   echo "Resolving session key for selector: $SESSION_SELECTOR"
-  export OPENCLAW_SESSION_KEY="main" # Fallback/stub. In a full implementation this shells out to `openclaw sessions --json`
+  case "$SESSION_SELECTOR" in
+    main|agent:*)
+      export OPENCLAW_SESSION_KEY="$SESSION_SELECTOR"
+      ;;
+    *)
+      export OPENCLAW_SESSION_KEY="main" # Fallback/stub. In a full implementation this shells out to `openclaw sessions --json`
+      ;;
+  esac
 fi
 
 echo "=========================================================="


### PR DESCRIPTION
## Summary

- make `run-proofs.sh --session agent:...` populate `OPENCLAW_SESSION_KEY` with that explicit agent session instead of silently falling back to `main`
- keep existing fallback behavior for unresolved selectors like `discord-channel:...`

This addresses the #337 harness oddity where a run passed a subagent session selector but evidence recorded `sessionKey: main`.

## Verification

- `bash -n tools/k6-proofs/scripts/run-proofs.sh`
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs`
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs`
- `node tools/k6-proofs/scripts/check-proof-row-manifests.mjs`
- `./scripts/run-proofs.sh --dry-run --session agent:main:subagent:test-selector R-CW-3 29a7479b13810ac36a48455d221091573caf8be6` → `Session: agent:main:subagent:test-selector`
- `./scripts/run-proofs.sh --dry-run R-CW-3 29a7479b13810ac36a48455d221091573caf8be6` → `Session: main`

Closes/advances #337.