### PR TITLE
Project 81: fetch Tempo traces via TraceQL selectors

### DIFF
--- a/tools/k6-proofs/scripts/__tests__/tempo-fetch.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/tempo-fetch.test.mjs
@@ -64,3 +64,32 @@ test('can discover trace id from run-dir evidence.jsonl', async () => {
     await rm(root, { recursive: true, force: true });
   }
 });
+
+
+test('can discover trace id from Tempo TraceQL search', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'tempo-fetch-traceql-'));
+  try {
+    await withServer((req, res) => {
+      if (req.url.startsWith('/api/search?')) {
+        assert.match(req.url, /q=%7B\+\.chain\.id\+%3D\+%22chain-1%22\+%7D/);
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({ traces: [{ traceID: 'fedcba9876543210' }] }));
+        return;
+      }
+      assert.equal(req.url, '/api/traces/fedcba9876543210');
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ trace: { spans: [{ spanId: 'abc' }, { spanId: 'def' }] } }));
+    }, async (baseUrl) => {
+      const out = path.join(root, 'trace.json');
+      const run = await runNode(process.execPath, [script, '--traceql', '{ .chain.id = "chain-1" }', '--tempo-url', baseUrl, '--start', '1783518200', '--end', '1783518400', '--out', out], { encoding: 'utf8' });
+      const receipt = JSON.parse(run.stdout);
+      assert.equal(receipt.fetched, true);
+      assert.equal(receipt.traceId, 'fedcba9876543210');
+      assert.equal(receipt.spans, 2);
+      const body = JSON.parse(await readFile(out, 'utf8'));
+      assert.equal(body.trace.spans.length, 2);
+    });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/tools/k6-proofs/scripts/fetch-tempo-trace.mjs
+++ b/tools/k6-proofs/scripts/fetch-tempo-trace.mjs
@@ -11,14 +11,14 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 function usage() {
-  console.error('Usage: node fetch-tempo-trace.mjs (--trace-id <id> | --run-dir <dir>) [--tempo-url http://tempo.dandelion.cult] [--out trace.json]');
+  console.error('Usage: node fetch-tempo-trace.mjs (--trace-id <id> | --run-dir <dir> | --traceql <query>) [--tempo-url http://tempo.dandelion.cult] [--start <unix-seconds>] [--end <unix-seconds>] [--out trace.json]');
 }
 
 function parseArgs(argv) {
   const out = { tempoUrl: process.env.TEMPO_BASE_URL || 'http://tempo.dandelion.cult' };
   for (let i = 2; i < argv.length; i += 1) {
     const arg = argv[i];
-    if (arg === '--trace-id' || arg === '--run-dir' || arg === '--tempo-url' || arg === '--out') {
+    if (arg === '--trace-id' || arg === '--run-dir' || arg === '--traceql' || arg === '--tempo-url' || arg === '--start' || arg === '--end' || arg === '--out') {
       const value = argv[i + 1];
       if (!value || value.startsWith('--')) throw new Error(`missing value for ${arg}`);
       out[arg.slice(2).replace(/-([a-z])/g, (_, c) => c.toUpperCase())] = value;
@@ -53,6 +53,26 @@ async function traceIdFromRunDir(runDir) {
   throw new Error(`no trace_id found in ${evidencePath}`);
 }
 
+
+async function traceIdFromTraceql(baseUrl, traceql, { start, end } = {}) {
+  const query = String(traceql ?? '').trim();
+  if (!query) throw new Error('empty traceql query');
+  const root = String(baseUrl).replace(/\/+$/, '');
+  const params = { q: query, limit: '1' };
+  if (start) params.start = String(start);
+  if (end) params.end = String(end);
+  const url = `${root}/api/search?${new URLSearchParams(params)}`;
+  const response = await fetch(url, { headers: { accept: 'application/json' } });
+  const text = await response.text();
+  if (!response.ok) throw new Error(`Tempo search failed: HTTP ${response.status} ${response.statusText} ${text.slice(0, 240)}`.trim());
+  let json;
+  try { json = JSON.parse(text); }
+  catch { throw new Error(`Tempo search did not return JSON for query ${query}`); }
+  const traceId = json?.traces?.[0]?.traceID || json?.traces?.[0]?.traceId || json?.traces?.[0]?.trace_id;
+  if (!traceId) throw new Error(`Tempo search returned no traces for query ${query}`);
+  return safeTraceId(traceId);
+}
+
 async function fetchTrace(baseUrl, traceId) {
   const root = String(baseUrl).replace(/\/+$/, '');
   const url = `${root}/api/traces/${encodeURIComponent(traceId)}`;
@@ -68,8 +88,8 @@ async function fetchTrace(baseUrl, traceId) {
 async function main() {
   const args = parseArgs(process.argv);
   if (args.help) { usage(); return; }
-  if (args.traceId && args.runDir) throw new Error('choose --trace-id or --run-dir, not both');
-  const traceId = safeTraceId(args.traceId || await traceIdFromRunDir(args.runDir));
+  if ([args.traceId, args.runDir, args.traceql].filter(Boolean).length !== 1) throw new Error('choose exactly one of --trace-id, --run-dir, or --traceql');
+  const traceId = safeTraceId(args.traceId || (args.runDir ? await traceIdFromRunDir(args.runDir) : await traceIdFromTraceql(args.tempoUrl, args.traceql, { start: args.start, end: args.end })));
   const out = args.out
     ? path.resolve(args.out)
     : path.join(path.resolve(args.runDir || process.cwd()), `tempo-trace-${traceId.slice(0, 12)}.json`);


### PR DESCRIPTION
## Summary

- extend `fetch-tempo-trace.mjs` with `--traceql <query>`
- support optional `--start` / `--end` for Tempo search windows
- add test coverage for TraceQL search → trace fetch

This removes the #337 memory-game gap where `R-CW-3` WS evidence has `trace_id=null` but the trace is recoverable by `chain.id`/`flow.id` in Tempo.

## Live proof against #337

For Ronan's long-window `R-CW-3` run:

- chain from session history: `d43880c0-1ac5-4068-aa33-69e1dfb6d4a7`
- command: `node tools/k6-proofs/scripts/fetch-tempo-trace.mjs --traceql '{ .chain.id = "d43880c0-1ac5-4068-aa33-69e1dfb6d4a7" }' --start 1783518200 --end 1783518400 --out /tmp/r-cw-3-traceql-fetch.json`
- fetched trace: `518565900f34f7ba41bcbc3e415d1e1f`
- reviewer: `reason-telemetry-redaction-review-passed`, `publicSafe=true`

## Verification

- `node --check tools/k6-proofs/scripts/fetch-tempo-trace.mjs`
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs`
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs`
- `node tools/k6-proofs/scripts/check-proof-row-manifests.mjs`
- `node --test tools/k6-proofs/scripts/__tests__/tempo-fetch.test.mjs`
- `node --test tools/k6-proofs/scripts/__tests__/r-cw-3-review.test.mjs`
- `node --test tools/k6-proofs/scripts/__tests__/r-cw-3-observation-window.test.mjs`

Closes/advances #337.