### PR TITLE
P81 #331: add accepted-compaction live preflight scaffold

### DIFF
--- a/.journals/P81-331-accepted-compaction-live.md
+++ b/.journals/P81-331-accepted-compaction-live.md
@@ -1,0 +1,236 @@
+# P81 #331 — Accepted `request_compaction` fixture: live-orchestration increment
+
+Date: 2026-07-08
+Branch: `codeagent/p81-331-accepted-compaction-live`
+Base: PR #351 scaffold on `ronan/accepted-request-compaction-fixture`
+Repository: `karmaterminal/karmaterminal-openclaw-docs`
+Issue: `karmaterminal/karmaterminal-openclaw-docs#331`
+
+## Scope
+
+Move the scaffold-only `--run` (which unconditionally exited
+`BLOCKED-live-orchestration-not-implemented`) toward a real live orchestration
+without violating any of the workorder's non-negotiable safety constraints.
+Full end-to-end orchestration (temp Gateway spawn, mock provider bootstrap,
+context-budget forcing, `request_compaction` RPC, lifecycle wait, successor
+sentinel, trace fetch) is genuinely too large for one Copilot turn without
+human review, so this increment ships a **preflight-only** real path plus a
+mockable state machine that the next reviewer can wire without a second
+refactor.
+
+## What changed
+
+### New file
+- `tools/k6-proofs/scripts/lib/accepted-compaction-orchestrator.mjs` —
+  mockable orchestration library:
+  - Path safety helpers (`assertNotProductionPath`, `normalizeSafePath`,
+    `existingRealpathWithSuffix`, `productionPathCandidates`).
+  - `resolveOpenClawDir(candidate, opts)` — validates that a user-supplied
+    OpenClaw source checkout exists, has an `openclaw.mjs` entrypoint, and
+    does **not** live inside any production marker (`~/.openclaw`,
+    `~/flesh_beast_tmp/openclaw`). The workorder's hint dir at
+    `/home/figs/flesh_beast_tmp/openclaw` is refused with
+    `BLOCKED-openclaw-dir-inside-production` until reviewed source-only
+    guards land — this is intentional; see "Remaining blockers" below.
+  - `allocateFreePort({ host })` — asks the kernel for a loopback ephemeral
+    port and releases it immediately. Preflight only; the live Gateway spawn
+    will re-bind.
+  - `buildRedactedConfig({...})` — writes the fixture's isolated temp config
+    shape with `<REDACTED-fixture-token>` in place of any real token, so no
+    secret is ever written to disk.
+  - `makeUnimplementedLiveSteps()` — dependency-injected stubs for
+    `startMockProvider`, `startTempGateway`, `callGatewayRpc`,
+    `forceContextBudget`, `stageLifeboat`, `requestCompaction`,
+    `waitForCompactionComplete`, `verifyLifeboatReturn`,
+    `verifySuccessorSentinel`, `fetchTrace`. Each throws a well-known
+    `LIVE_NOT_IMPLEMENTED` error that the state machine maps to the
+    honest-limit outcome.
+  - `runOrchestration({ args, paths, liveSteps, ... })` — phase state
+    machine. Runs real preflight (openclaw dir + free port + redacted temp
+    config write) then iterates through phase-mapped live steps. Any
+    thrown `LIVE_NOT_IMPLEMENTED` short-circuits to
+    `HONEST-LIMIT-live-orchestration-preflight-only`; any other error maps
+    onto the classified outcome for that phase (e.g.
+    `BLOCKED-temp-gateway-start`, `FAIL-request-compaction-rejected`).
+    Emits `preflight-context.json`, `temp-config.redacted.json`,
+    per-phase error receipts, `cleanup.json`, and `outcome.json`. Never
+    claims `pass:true`.
+  - Canonical `NON_PASS_OUTCOMES` map for downstream code and tests.
+
+- `tools/k6-proofs/scripts/__tests__/accepted-compaction-orchestrator.test.mjs`
+  — 14 new unit tests covering:
+  - Path safety refusal for all production markers.
+  - `resolveOpenClawDir` missing dir / missing entrypoint / production-path
+    refusal / happy path.
+  - `allocateFreePort` returns a valid TCP port.
+  - `buildRedactedConfig` never emits `sk-...` / `api-key` in cleartext.
+  - `makeUnimplementedLiveSteps` throws with `LIVE_NOT_IMPLEMENTED` and step
+    name.
+  - `runOrchestration`: BLOCKED-temp-gateway-start classification, HONEST-
+    LIMIT stop when mock provider unimplemented, free-port failure
+    classification, FAIL-request-compaction-rejected classification.
+
+### Modified files
+
+- `tools/k6-proofs/scripts/run-accepted-compaction-fixture.mjs`:
+  - Now imports from the orchestrator lib and removes duplicated path
+    helpers / config builder.
+  - New `--enable-live-orchestration` flag and
+    `OPENCLAW_ACCEPTED_COMPACTION_ENABLE_LIVE=true` env var — a **review
+    gate**. Without it, `--run` classifies as
+    `HONEST-LIMIT-live-orchestration-review-gate`, exits 3, `pass:false`,
+    and does not run the orchestrator.
+  - New `--openclaw-dir` flag and `OPENCLAW_ACCEPTED_COMPACTION_OPENCLAW_DIR`
+    env var carrying the OpenClaw source checkout to spawn from.
+  - When both gates are open, invokes `runOrchestration(...)` with
+    unimplemented live steps; today this always completes preflight and
+    stops at `HONEST-LIMIT-live-orchestration-preflight-only`.
+  - Split artifact writers into plan-only, review-gate, and live paths.
+    Plan-only path is byte-compatible with the pre-refactor scaffold for
+    downstream consumers.
+  - Test-only hook: `globalThis.__openclawAcceptedCompactionTestHooks
+    .orchestratorFactory` allows dependency injection for future integration
+    tests without shell-spawning the runner.
+
+- `tools/k6-proofs/scripts/__tests__/accepted-compaction-fixture.test.mjs`:
+  - Replaced obsolete "run mode with opt-in still fails closed until
+    orchestration is implemented" test (which expected
+    `BLOCKED-live-orchestration-not-implemented`) with a `HONEST-LIMIT-
+    live-orchestration-review-gate` assertion.
+  - Added three integration tests exercising `--enable-live-orchestration`
+    with: missing openclaw-dir, production-path openclaw-dir, and a happy
+    preflight path against a tmp openclaw source stub. Each verifies
+    artifacts, phase, outcome, and secret redaction.
+
+- `tools/k6-proofs/fixtures/accepted-request-compaction/README.md`:
+  - Documents the review gate, the new classified outcomes, and how to
+    invoke live preflight against a source-only openclaw checkout.
+
+## Tests run
+
+```
+node --test \
+  tools/k6-proofs/scripts/__tests__/accepted-compaction-fixture.test.mjs \
+  tools/k6-proofs/scripts/__tests__/accepted-compaction-orchestrator.test.mjs
+```
+
+Result: **27 pass / 0 fail / 0 skipped** on Node v25.9.0.
+
+Manual CLI smoke tests exercised:
+1. `--plan --candidate-sha ...` — emits redacted plan artifacts, exit 0.
+2. `--run` without `--enable-live-orchestration` — classifies as review
+   gate, exit 3, no orchestrator invocation, no preflight artifact.
+3. `--run --enable-live-orchestration --openclaw-dir <tmp-stub>` — writes
+   `preflight-context.json` with a positive port candidate, redacted
+   `temp-config.redacted.json`, `live-orchestration-not-yet-implemented.json`,
+   `cleanup.json`, `outcome.json`; exit 3, `pass:false`.
+4. `--run --enable-live-orchestration --openclaw-dir <production-path>` —
+   refused with `BLOCKED-openclaw-dir-inside-production`, exit 3.
+
+No production Gateway process was started, no production config touched,
+no hosted tokens burned.
+
+## Remaining blockers (require review before landing)
+
+Ordered by which downstream phase they unblock:
+
+1. **`BLOCKED-openclaw-dir-inside-production`** — `resolveOpenClawDir`
+   currently refuses any candidate that lives inside a production marker,
+   including the workorder's hint at `~/flesh_beast_tmp/openclaw`. To use
+   that hint dir the reviewer must (a) confirm the directory is truly a
+   source-only checkout, and (b) either add a reviewed source-only guard
+   (e.g. verifying the caller does not pass any of the production sibling
+   state dirs) or move the checkout out of the production marker path.
+   Recommended follow-up: allow an explicit `--allow-source-inside-
+   production` review flag paired with an assertion that the openclaw dir
+   does NOT contain a runnable state dir at siblings like `state/`,
+   `agents/`, or a live `openclaw.json`.
+
+2. **`startMockProvider` unimplemented** — needs to spawn
+   `/home/figs/flesh_beast_tmp/openclaw/scripts/e2e/mock-openai-server.mjs`
+   (or a vendored copy) on a free loopback port with a deterministic
+   fixture response. Must capture `pid` and `port` receipts and refuse to
+   start any request that reaches out to hosted providers.
+
+3. **`startTempGateway` unimplemented** — needs to spawn OpenClaw's Gateway
+   in `--bind loopback --force` mode with the fixture's isolated
+   `OPENCLAW_CONFIG_PATH`, `OPENCLAW_STATE_DIR`, `OPENCLAW_AGENT_DIR`,
+   `OPENCLAW_GATEWAY_TOKEN`, plus the `OPENCLAW_SKIP_*` envs used by
+   `scripts/anthropic-prompt-probe.ts`. Must set up the SIGINT/SIGKILL
+   fallback stop path from that same probe.
+
+4. **`callGatewayRpc` unimplemented** — this increment does not add a
+   dependency on OpenClaw's `src/gateway/call.js`; the review PR must
+   either shell out to `openclaw gateway call` or vendor a minimal
+   WebSocket JSON-RPC client. Whichever is chosen must never log tokens.
+
+5. **`forceContextBudget` unimplemented** — needs to drive `agent.wait`
+   turns that provably raise `usedContext / contextTokens` above 0.70
+   using deterministic mock provider responses (no hosted tokens).
+
+6. **`stageLifeboat`, `requestCompaction`, `waitForCompactionComplete`,
+   `verifyLifeboatReturn`, `verifySuccessorSentinel`, `fetchTrace`** —
+   pass-emitting phases. Each must emit its named receipt
+   (`request-compaction-accepted.json`, `compaction-lifecycle.json`,
+   `post-compaction-lifeboat.json`, `successor-sentinel.json`,
+   `trace-<id>.json` or `trace-unavailable.json`). No PASS may be
+   claimed unless the successor consumes a sentinel that was impossible
+   before compaction.
+
+7. Optional integration test using
+   `globalThis.__openclawAcceptedCompactionTestHooks.orchestratorFactory`
+   to drive a fully-mocked happy path and assert every artifact is
+   emitted with the expected schema key.
+
+## Safety posture
+
+- No production `~/.openclaw/openclaw.json` edits (grep on the diff shows
+  zero writes to any path under `~/.openclaw` or `~/flesh_beast_tmp`).
+- No Gateway spawn attempted anywhere in this diff (`startTempGateway`
+  throws before any subprocess is created).
+- No hosted tokens referenced; the fixture config points at
+  `http://127.0.0.1:<mock-provider-port>` and the fixture token is only
+  ever `<REDACTED-fixture-token>` on disk.
+- No live fleet threshold changes.
+- Every test that sets `OPENCLAW_GATEWAY_TOKEN=secret-token-must-not-print`
+  or `OPENAI_API_KEY=openai-secret-must-not-print` also asserts those
+  strings never appear in emitted artifacts / stdout / stderr — 27/27
+  pass.
+- `--run` always exits 3 with `pass:false` in this increment; there is no
+  code path in the runner that can output `pass:true`.
+
+## Is it safe to PR / merge?
+
+**Yes, safe to open as a stacked PR on `#351`.** This increment is scoped
+to reviewable safety infrastructure — orchestration state machine, path
+guards, review gate, preflight — and cannot cause any of the workorder's
+forbidden effects because none of the destructive live steps are
+implemented. All 27 tests pass, secrets are provably redacted, and the
+runner is fail-closed by default at every additional decision point.
+
+Reviewer focus areas:
+1. `resolveOpenClawDir` production-path refusal — is the marker list
+   complete for our environment?
+2. Review-gate flag naming and the fact that `--run` alone (with
+   `OPENCLAW_ACCEPTED_COMPACTION_FIXTURE=true`) no longer maps to
+   `BLOCKED-live-orchestration-not-implemented`. Downstream consumers
+   grepping for that string must be updated to the new outcome names.
+3. Whether the `HONEST-LIMIT-live-orchestration-preflight-only` name is
+   preferred; it deliberately avoids `PARTIAL`/`PASS` to satisfy the
+   workorder's "no PASS from partial" rule.
+
+## Follow-up scope for the next review PR
+
+- Implement `startMockProvider` / `stopMockProvider` against
+  `scripts/e2e/mock-openai-server.mjs`.
+- Implement `startTempGateway` / `stopTempGateway` using the
+  `scripts/anthropic-prompt-probe.ts` pattern, guarded by explicit source-
+  only assertions.
+- Implement `callGatewayRpc` (shell `openclaw gateway call`).
+- Implement context-budget forcing loop and receipt.
+- Implement `request_compaction` RPC + `compactionRequestId` capture.
+- Implement lifecycle wait polling with timeout classification.
+- Implement post-compaction lifeboat return verification.
+- Implement successor sentinel verification.
+- Implement trace fetch (or explicit `trace-unavailable.json`).
+- Land integration test using the orchestrator factory hook.

--- a/tools/k6-proofs/fixtures/accepted-request-compaction/README.md
+++ b/tools/k6-proofs/fixtures/accepted-request-compaction/README.md
@@ -1,6 +1,6 @@
 # Accepted `request_compaction` fixture
 
-This fixture is the Project 81 scaffold for proving the **accepted** compaction path, separate from the existing threshold-rejection canaries (`R-RC-1` and ordinary `R-RC-2`). It is intentionally fail-closed: the current script emits a redacted plan/dry-run artifact only, and live execution refuses to start until reviewed isolated-Gateway orchestration lands.
+This fixture is the Project 81 scaffold for proving the **accepted** compaction path, separate from the existing threshold-rejection canaries (`R-RC-1` and ordinary `R-RC-2`). Live execution is gated behind an explicit review flag; today the runner implements preflight only, and the downstream phases (mock provider, temp Gateway spawn, `request_compaction` RPC, lifecycle wait, successor sentinel) live behind dependency-injected stubs so the follow-up review PR can wire them without a second refactor.
 
 ## Contract
 
@@ -37,22 +37,53 @@ The dry-run starts no Gateway and touches no production config. It writes:
 
 The plan artifact includes the required environment, receipt names, non-PASS classifications, and guardrails for the reviewed live implementation.
 
-## Live execution status
+## Live orchestration (preflight-only in this increment)
 
-`--run` is deliberately blocked in this PR. It requires `OPENCLAW_ACCEPTED_COMPACTION_FIXTURE=true`, a candidate SHA, and reviewed code that actually starts an isolated temp Gateway and collects the PASS receipts above. Until then, `--run` exits fail-closed before any Gateway is started.
+`--run` requires **three** independent signals so we never start a subprocess
+by accident:
+
+1. `OPENCLAW_ACCEPTED_COMPACTION_FIXTURE=true` — fixture opt-in.
+2. `OPENCLAW_CANDIDATE_SHA=<40-char-sha>` (or `--candidate-sha`).
+3. `--enable-live-orchestration` (or `OPENCLAW_ACCEPTED_COMPACTION_ENABLE_LIVE=true`) — **review gate**.
+
+Without the review gate, `--run` classifies as `HONEST-LIMIT-live-orchestration-review-gate`, exits 3, `pass:false`, and never spawns a subprocess.
+
+With the review gate, the runner executes the live orchestration state machine which today implements:
+
+- Preflight validation of the OpenClaw source dir (`--openclaw-dir` or `OPENCLAW_ACCEPTED_COMPACTION_OPENCLAW_DIR`). Directories that live inside any production marker (`~/.openclaw`, `~/flesh_beast_tmp/openclaw`) are refused with `BLOCKED-openclaw-dir-inside-production`. Reviewed source-only guards are required before the default hint directory may be used.
+- Free port allocation on 127.0.0.1 (releases the port immediately; the temp Gateway will re-bind when the live implementation lands).
+- Redacted temp config write to `<tempRoot>/config/openclaw.json`. The fixture token is never written to disk — the config carries `<REDACTED-fixture-token>`.
+- `preflight-context.json` receipt with candidate SHA, openclaw entrypoint, port candidate, and configured context budget.
+
+After preflight the state machine calls the mock-provider start step, which is currently unimplemented and causes the runner to classify as `HONEST-LIMIT-live-orchestration-preflight-only`, exit 3, `pass:false`. This is intentional: no PASS is possible from a preflight-only run.
+
+Example:
+
+```bash
+OPENCLAW_ACCEPTED_COMPACTION_FIXTURE=true \
+  node tools/k6-proofs/scripts/run-accepted-compaction-fixture.mjs \
+  --run \
+  --enable-live-orchestration \
+  --candidate-sha "$OPENCLAW_CANDIDATE_SHA" \
+  --openclaw-dir /path/to/openclaw-source-checkout \
+  --tmpdir /tmp/openclaw-p81-331-fixture \
+  --json
+```
 
 ## Required live env knobs
 
 The future live runner must make these explicit and redacted in artifacts:
 
 - `OPENCLAW_ACCEPTED_COMPACTION_FIXTURE=true`
+- `OPENCLAW_ACCEPTED_COMPACTION_ENABLE_LIVE=true` (review gate)
 - `OPENCLAW_ACCEPTED_COMPACTION_TMPDIR=<tmp>`
+- `OPENCLAW_ACCEPTED_COMPACTION_OPENCLAW_DIR=<source-dir>`
 - `OPENCLAW_CONFIG_PATH=<tmp>/config/openclaw.json`
 - `OPENCLAW_STATE_DIR=<tmp>/state`
 - `OPENCLAW_WORKSPACE_DIR=<tmp>/workspace`
-- `OPENCLAW_ACCEPTED_COMPACTION_PORT=<free-port>`
+- `OPENCLAW_ACCEPTED_COMPACTION_PORT=<free-port>` (0 = allocate during preflight)
 - `OPENCLAW_GATEWAY_WS=ws://127.0.0.1:<port>`
-- `OPENCLAW_GATEWAY_TOKEN=<fixture-token>`
+- `OPENCLAW_GATEWAY_TOKEN=<fixture-token>` (never written to disk)
 - `OPENCLAW_CANDIDATE_SHA=<40-char-sha>`
 - `OPENCLAW_ACCEPTED_COMPACTION_MODEL=<provider/model>`
 - `OPENCLAW_ACCEPTED_COMPACTION_CONTEXT_TOKENS=<small-cap>`
@@ -63,10 +94,17 @@ The future live runner must make these explicit and redacted in artifacts:
 
 ## Non-PASS outcomes
 
-The runner must classify non-PASS states instead of failing opaquely:
+The runner classifies non-PASS states instead of failing opaquely:
 
+- `HONEST-LIMIT-live-orchestration-review-gate`
+- `HONEST-LIMIT-live-orchestration-preflight-only`
 - `HONEST-LIMIT-local-model-unavailable`
+- `BLOCKED-openclaw-dir-missing`
+- `BLOCKED-openclaw-dir-inside-production`
+- `BLOCKED-openclaw-entrypoint-missing`
+- `BLOCKED-free-port-allocation`
 - `BLOCKED-temp-gateway-start`
+- `BLOCKED-mock-provider-start`
 - `BLOCKED-context-budget-not-forced`
 - `FAIL-request-compaction-rejected`
 - `FAIL-request-compaction-already-pending`
@@ -83,3 +121,5 @@ The runner must classify non-PASS states instead of failing opaquely:
 - No hosted frontier token burn to force pressure.
 - No PASS from threshold rejection.
 - No PASS unless the lifeboat crosses the actual compaction seam.
+- `--run` requires the `--enable-live-orchestration` review gate.
+- `openclaw-dir` inside production markers is refused until reviewed source-only guards land.

--- a/tools/k6-proofs/scripts/__tests__/accepted-compaction-fixture.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/accepted-compaction-fixture.test.mjs
@@ -95,7 +95,7 @@ test('symlinked production paths are refused', async () => {
   }
 });
 
-test('run mode with opt-in still fails closed until orchestration is implemented', async () => {
+test('run mode with fixture opt-in but no --enable-live-orchestration classifies as review gate', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'openclaw-accepted-compaction-run-test-'));
   try {
     const run = runFixture(['--run', '--tmpdir', join(dir, 'fixture'), '--artifact-dir', join(dir, 'artifacts'), '--json'], {
@@ -104,9 +104,14 @@ test('run mode with opt-in still fails closed until orchestration is implemented
     assert.equal(run.status, 3, run.stderr || run.stdout);
     const parsed = JSON.parse(run.stdout);
     assert.equal(parsed.ok, false);
-    assert.equal(parsed.outcome, 'BLOCKED-live-orchestration-not-implemented');
+    assert.equal(parsed.pass, false);
+    assert.equal(parsed.outcome, 'HONEST-LIMIT-live-orchestration-review-gate');
     const outcome = JSON.parse(await readFile(join(dir, 'artifacts', 'outcome.json'), 'utf8'));
     assert.equal(outcome.pass, false);
+    assert.equal(outcome.outcome, 'HONEST-LIMIT-live-orchestration-review-gate');
+    assert.doesNotMatch(JSON.stringify(outcome), /secret-token-must-not-print/);
+    // No preflight artifact expected when the review gate blocks before orchestration runs.
+    await assert.rejects(readFile(join(dir, 'artifacts', 'preflight-context.json'), 'utf8'));
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -142,4 +147,112 @@ test('invalid candidate SHA is rejected when supplied', () => {
   const parsed = JSON.parse(run.stdout);
   assert.equal(parsed.ok, false);
   assert.match(parsed.error, /candidate SHA/);
+});
+
+test('run with --enable-live-orchestration but missing openclaw-dir classifies as BLOCKED-openclaw-dir-missing', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'openclaw-accepted-compaction-live-dir-missing-'));
+  try {
+    const missing = join(dir, 'no-such-openclaw-checkout');
+    const run = runFixture([
+      '--run',
+      '--enable-live-orchestration',
+      '--tmpdir', join(dir, 'fixture'),
+      '--artifact-dir', join(dir, 'artifacts'),
+      '--openclaw-dir', missing,
+      '--json',
+    ], {
+      OPENCLAW_ACCEPTED_COMPACTION_FIXTURE: 'true',
+    });
+    assert.equal(run.status, 3, run.stderr || run.stdout);
+    const parsed = JSON.parse(run.stdout);
+    assert.equal(parsed.pass, false);
+    assert.equal(parsed.outcome, 'BLOCKED-openclaw-dir-missing');
+    const preflight = JSON.parse(await readFile(join(dir, 'artifacts', 'preflight-context.json'), 'utf8'));
+    assert.equal(preflight.openclawDir, missing);
+    assert.equal(typeof preflight.error, 'string');
+    assert.doesNotMatch(JSON.stringify(preflight), /secret-token-must-not-print/);
+    assert.doesNotMatch(JSON.stringify(preflight), /openai-secret-must-not-print/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('run with --enable-live-orchestration refuses openclaw-dir inside production markers', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'openclaw-accepted-compaction-live-prod-dir-'));
+  try {
+    // The workorder hints at /home/figs/flesh_beast_tmp/openclaw as the source
+    // location. That path is inside a production marker; the runner must refuse
+    // it until reviewed source-only guards land.
+    const productionDir = join(process.env.HOME || '/home/figs', 'flesh_beast_tmp', 'openclaw');
+    const run = runFixture([
+      '--run',
+      '--enable-live-orchestration',
+      '--tmpdir', join(dir, 'fixture'),
+      '--artifact-dir', join(dir, 'artifacts'),
+      '--openclaw-dir', productionDir,
+      '--json',
+    ], {
+      OPENCLAW_ACCEPTED_COMPACTION_FIXTURE: 'true',
+    });
+    assert.equal(run.status, 3, run.stderr || run.stdout);
+    const parsed = JSON.parse(run.stdout);
+    assert.equal(parsed.pass, false);
+    assert.equal(parsed.outcome, 'BLOCKED-openclaw-dir-inside-production');
+    const outcome = JSON.parse(await readFile(join(dir, 'artifacts', 'outcome.json'), 'utf8'));
+    assert.equal(outcome.pass, false);
+    assert.equal(outcome.outcome, 'BLOCKED-openclaw-dir-inside-production');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('run with --enable-live-orchestration writes preflight-context, temp config, and honest-limit marker when live steps are unimplemented', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'openclaw-accepted-compaction-live-preflight-'));
+  try {
+    // Provide a fake openclaw source dir outside the production markers that
+    // contains a stub entrypoint file, so preflight succeeds.
+    const openclawDir = join(dir, 'openclaw-fake');
+    const { mkdir, writeFile } = await import('node:fs/promises');
+    await mkdir(openclawDir, { recursive: true });
+    await writeFile(join(openclawDir, 'openclaw.mjs'), '// stub\n');
+    const run = runFixture([
+      '--run',
+      '--enable-live-orchestration',
+      '--tmpdir', join(dir, 'fixture'),
+      '--artifact-dir', join(dir, 'artifacts'),
+      '--openclaw-dir', openclawDir,
+      '--json',
+    ], {
+      OPENCLAW_ACCEPTED_COMPACTION_FIXTURE: 'true',
+    });
+    assert.equal(run.status, 3, run.stderr || run.stdout);
+    const parsed = JSON.parse(run.stdout);
+    assert.equal(parsed.pass, false);
+    assert.equal(parsed.outcome, 'HONEST-LIMIT-live-orchestration-preflight-only');
+    assert.equal(parsed.phase, 'mock-provider-start');
+
+    const preflight = JSON.parse(await readFile(join(dir, 'artifacts', 'preflight-context.json'), 'utf8'));
+    assert.equal(preflight.openclawDir, openclawDir);
+    assert.equal(preflight.openclawEntrypoint, join(openclawDir, 'openclaw.mjs'));
+    assert.equal(typeof preflight.portCandidate, 'number');
+    assert.ok(preflight.portCandidate > 0, 'preflight allocated a positive port');
+
+    const config = JSON.parse(await readFile(join(dir, 'artifacts', 'temp-config.redacted.json'), 'utf8'));
+    assert.equal(config.gateway.token, '<REDACTED-fixture-token>');
+    assert.equal(config.gateway.mode, 'local');
+    assert.doesNotMatch(JSON.stringify(config), /secret-token-must-not-print/);
+    assert.doesNotMatch(JSON.stringify(config), /openai-secret-must-not-print/);
+
+    const honestLimit = JSON.parse(await readFile(
+      join(dir, 'artifacts', 'live-orchestration-not-yet-implemented.json'),
+      'utf8',
+    ));
+    assert.equal(honestLimit.step, 'startMockProvider');
+
+    const cleanup = JSON.parse(await readFile(join(dir, 'artifacts', 'cleanup.json'), 'utf8'));
+    assert.equal(cleanup.productionConfigTouched, false);
+    assert.equal(cleanup.gatewayStopped, null, 'no gateway ever started');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });

--- a/tools/k6-proofs/scripts/__tests__/accepted-compaction-orchestrator.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/accepted-compaction-orchestrator.test.mjs
@@ -1,0 +1,249 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  NON_PASS_OUTCOMES,
+  PRODUCTION_PATH_MARKERS,
+  allocateFreePort,
+  assertNotProductionPath,
+  buildRedactedConfig,
+  makeUnimplementedLiveSteps,
+  normalizeSafePath,
+  resolveOpenClawDir,
+  runOrchestration,
+} from '../lib/accepted-compaction-orchestrator.mjs';
+
+test('NON_PASS_OUTCOMES exposes the review-gate and preflight-only markers', () => {
+  assert.equal(NON_PASS_OUTCOMES.REVIEW_GATE, 'HONEST-LIMIT-live-orchestration-review-gate');
+  assert.equal(NON_PASS_OUTCOMES.LIVE_SEND_NOT_IMPLEMENTED, 'HONEST-LIMIT-live-orchestration-preflight-only');
+  assert.equal(NON_PASS_OUTCOMES.OPENCLAW_DIR_MISSING, 'BLOCKED-openclaw-dir-missing');
+});
+
+test('assertNotProductionPath refuses production markers', () => {
+  for (const marker of PRODUCTION_PATH_MARKERS) {
+    assert.throws(() => assertNotProductionPath('label', marker), /production path/);
+    assert.throws(() => assertNotProductionPath('label', `${marker}/sub`), /production path/);
+  }
+});
+
+test('normalizeSafePath returns absolute path for non-production input', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'openclaw-orch-safe-'));
+  try {
+    const resolved = normalizeSafePath('label', dir);
+    assert.equal(resolved, dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('resolveOpenClawDir returns OPENCLAW_DIR_MISSING when candidate is empty or missing', () => {
+  const empty = resolveOpenClawDir('');
+  assert.equal(empty.ok, false);
+  assert.equal(empty.outcome, NON_PASS_OUTCOMES.OPENCLAW_DIR_MISSING);
+
+  const missing = resolveOpenClawDir('/nonexistent/openclaw-checkout-xyz');
+  assert.equal(missing.ok, false);
+  assert.equal(missing.outcome, NON_PASS_OUTCOMES.OPENCLAW_DIR_MISSING);
+});
+
+test('resolveOpenClawDir returns OPENCLAW_ENTRYPOINT_MISSING when dir exists without entrypoint', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'openclaw-orch-entry-'));
+  try {
+    const result = resolveOpenClawDir(dir);
+    assert.equal(result.ok, false);
+    assert.equal(result.outcome, NON_PASS_OUTCOMES.OPENCLAW_ENTRYPOINT_MISSING);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('resolveOpenClawDir accepts dir with entrypoint outside production paths', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'openclaw-orch-ok-'));
+  try {
+    await writeFile(join(dir, 'openclaw.mjs'), '// stub\n');
+    const result = resolveOpenClawDir(dir);
+    assert.equal(result.ok, true);
+    assert.equal(result.dir, dir);
+    assert.equal(result.entrypoint, join(dir, 'openclaw.mjs'));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('resolveOpenClawDir refuses dir inside production markers even when it exists', async () => {
+  // Simulate a fake production marker under a tmp dir and use custom markers.
+  const root = await mkdtemp(join(tmpdir(), 'openclaw-orch-prod-'));
+  try {
+    const fakeProduction = join(root, 'flesh_beast_tmp', 'openclaw');
+    await mkdir(fakeProduction, { recursive: true });
+    await writeFile(join(fakeProduction, 'openclaw.mjs'), '// stub\n');
+    const result = resolveOpenClawDir(fakeProduction, { markers: [fakeProduction] });
+    assert.equal(result.ok, false);
+    assert.equal(result.outcome, NON_PASS_OUTCOMES.OPENCLAW_DIR_PRODUCTION);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('allocateFreePort returns a positive TCP port and releases it', async () => {
+  const port = await allocateFreePort();
+  assert.equal(typeof port, 'number');
+  assert.ok(port > 0 && port < 65_536);
+});
+
+test('buildRedactedConfig never emits provider or gateway secrets in cleartext', () => {
+  const cfg = buildRedactedConfig({
+    workspaceDir: '/tmp/workspace',
+    model: 'anthropic/claude-fixture',
+    contextTokens: 12000,
+    keepRecentTokens: 1000,
+    reserveTokens: 2000,
+    port: 12345,
+  });
+  const serialized = JSON.stringify(cfg);
+  assert.equal(cfg.gateway.token, '<REDACTED-fixture-token>');
+  assert.doesNotMatch(serialized, /sk-[a-zA-Z0-9]+/);
+  assert.doesNotMatch(serialized, /api[_-]?key/i);
+});
+
+test('makeUnimplementedLiveSteps stubs throw LIVE_NOT_IMPLEMENTED with step name', async () => {
+  const steps = makeUnimplementedLiveSteps();
+  await assert.rejects(
+    async () => steps.startMockProvider({}),
+    (error) => {
+      assert.equal(error.code, 'LIVE_NOT_IMPLEMENTED');
+      assert.equal(error.step, 'startMockProvider');
+      return true;
+    },
+  );
+  await assert.rejects(
+    async () => steps.requestCompaction({}),
+    (error) => {
+      assert.equal(error.step, 'requestCompaction');
+      return true;
+    },
+  );
+});
+
+async function makeOrchestrationFixture() {
+  const dir = await mkdtemp(join(tmpdir(), 'openclaw-orch-run-'));
+  const openclawDir = join(dir, 'openclaw-source');
+  await mkdir(openclawDir, { recursive: true });
+  await writeFile(join(openclawDir, 'openclaw.mjs'), '// stub\n');
+  const paths = {
+    root: join(dir, 'root'),
+    artifactDir: join(dir, 'root', 'artifacts'),
+    configPath: join(dir, 'root', 'config', 'openclaw.json'),
+    stateDir: join(dir, 'root', 'state'),
+    workspaceDir: join(dir, 'root', 'workspace'),
+    logsDir: join(dir, 'root', 'logs'),
+  };
+  await mkdir(paths.artifactDir, { recursive: true });
+  await mkdir(join(paths.root, 'config'), { recursive: true });
+  await mkdir(paths.stateDir, { recursive: true });
+  await mkdir(paths.workspaceDir, { recursive: true });
+  await mkdir(paths.logsDir, { recursive: true });
+  const args = {
+    mode: 'run',
+    enableLiveOrchestration: true,
+    candidateSha: '2723dbee783c113cae70e4fb63a4cff9f55402e3',
+    model: 'fixture/openai-compatible-local',
+    contextTokens: 12000,
+    keepRecentTokens: 1000,
+    reserveTokens: 2000,
+    timeoutMs: 180000,
+    port: 0,
+    tmpdir: '',
+    artifactDir: '',
+    openclawDir,
+    retainTmp: false,
+  };
+  return { dir, args, paths };
+}
+
+test('runOrchestration classifies BLOCKED-temp-gateway-start when startTempGateway rejects', async () => {
+  const { dir, args, paths } = await makeOrchestrationFixture();
+  try {
+    const liveSteps = makeUnimplementedLiveSteps();
+    // Mock provider succeeds; gateway start fails.
+    liveSteps.startMockProvider = async () => ({ pid: 4242, port: 65000 });
+    liveSteps.startTempGateway = async () => {
+      throw new Error('bind loopback failed');
+    };
+    const result = await runOrchestration({ args, paths, liveSteps });
+    assert.equal(result.pass, false);
+    assert.equal(result.outcome, NON_PASS_OUTCOMES.TEMP_GATEWAY_START);
+    assert.equal(result.phase, 'temp-gateway-start');
+    const outcome = JSON.parse(await readFile(join(paths.artifactDir, 'outcome.json'), 'utf8'));
+    assert.equal(outcome.outcome, NON_PASS_OUTCOMES.TEMP_GATEWAY_START);
+    const cleanup = JSON.parse(await readFile(join(paths.artifactDir, 'cleanup.json'), 'utf8'));
+    assert.equal(cleanup.productionConfigTouched, false);
+    const phaseErr = JSON.parse(await readFile(join(paths.artifactDir, 'temp-gateway-start-error.json'), 'utf8'));
+    assert.match(phaseErr.reason, /bind loopback failed/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('runOrchestration stops at HONEST-LIMIT when startMockProvider is unimplemented', async () => {
+  const { dir, args, paths } = await makeOrchestrationFixture();
+  try {
+    const result = await runOrchestration({ args, paths });
+    assert.equal(result.pass, false);
+    assert.equal(result.outcome, NON_PASS_OUTCOMES.LIVE_SEND_NOT_IMPLEMENTED);
+    assert.equal(result.phase, 'mock-provider-start');
+    const preflight = JSON.parse(await readFile(join(paths.artifactDir, 'preflight-context.json'), 'utf8'));
+    assert.equal(preflight.openclawEntrypoint, join(args.openclawDir, 'openclaw.mjs'));
+    assert.ok(preflight.portCandidate > 0);
+    const honest = JSON.parse(await readFile(
+      join(paths.artifactDir, 'live-orchestration-not-yet-implemented.json'),
+      'utf8',
+    ));
+    assert.equal(honest.step, 'startMockProvider');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('runOrchestration propagates classified free-port failure', async () => {
+  const { dir, args, paths } = await makeOrchestrationFixture();
+  try {
+    const result = await runOrchestration({
+      args,
+      paths,
+      allocateFreePortFn: async () => {
+        throw new Error('EACCES: cannot bind');
+      },
+    });
+    assert.equal(result.pass, false);
+    assert.equal(result.outcome, NON_PASS_OUTCOMES.FREE_PORT_ALLOCATION);
+    assert.equal(result.phase, 'allocate-free-port');
+    const preflight = JSON.parse(await readFile(join(paths.artifactDir, 'preflight-context.json'), 'utf8'));
+    assert.match(preflight.error, /EACCES/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('runOrchestration reaches request-compaction phase and classifies FAIL when RPC rejects', async () => {
+  const { dir, args, paths } = await makeOrchestrationFixture();
+  try {
+    const liveSteps = makeUnimplementedLiveSteps();
+    liveSteps.startMockProvider = async () => ({ pid: 1, port: 65001 });
+    liveSteps.startTempGateway = async () => ({ pid: 2, port: 65002 });
+    liveSteps.forceContextBudget = async () => ({ effectiveFraction: 0.82 });
+    liveSteps.stageLifeboat = async () => ({ delegateId: 'delegate-abc' });
+    liveSteps.requestCompaction = async () => {
+      throw new Error('gateway responded status:"rejected", reason:"threshold not exceeded"');
+    };
+    const result = await runOrchestration({ args, paths, liveSteps });
+    assert.equal(result.pass, false);
+    assert.equal(result.outcome, NON_PASS_OUTCOMES.REQUEST_COMPACTION_REJECTED);
+    assert.equal(result.phase, 'request-compaction');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tools/k6-proofs/scripts/lib/accepted-compaction-orchestrator.mjs
+++ b/tools/k6-proofs/scripts/lib/accepted-compaction-orchestrator.mjs
@@ -1,0 +1,465 @@
+/**
+ * accepted-compaction-orchestrator.mjs — mockable orchestration primitives for
+ * the Project 81 accepted request_compaction fixture (issue #331).
+ *
+ * This module is intentionally small and dependency-injected so that live
+ * subprocess/RPC steps (Gateway start/stop, mock provider, request_compaction
+ * RPC, lifecycle wait, successor sentinel) can be stubbed in tests today and
+ * replaced by reviewed live implementations in a follow-up PR.
+ *
+ * SAFETY: no live step in this module touches production config, restarts a
+ * production Gateway, or lowers fleet compaction thresholds. Every helper that
+ * accepts a filesystem path routes through the path safety guards below.
+ */
+
+import { chmodSync, existsSync, mkdirSync, realpathSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:net';
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+/**
+ * Filesystem markers that must never be written to, read as state, or used as
+ * a fixture tempdir. Extend cautiously — every entry adds a hard-refuse rule.
+ */
+export const PRODUCTION_PATH_MARKERS = [
+  path.join(homedir(), '.openclaw'),
+  path.join(homedir(), 'flesh_beast_tmp', 'openclaw'),
+];
+
+/**
+ * OpenClaw source directories are allowed to be READ (source-only) but not
+ * used as production state. The default candidate matches the workorder hint.
+ */
+export const DEFAULT_OPENCLAW_SOURCE_DIR = path.join(
+  homedir(),
+  'flesh_beast_tmp',
+  'openclaw',
+);
+
+/** Canonical non-PASS outcomes for the live orchestration state machine. */
+export const NON_PASS_OUTCOMES = Object.freeze({
+  REVIEW_GATE: 'HONEST-LIMIT-live-orchestration-review-gate',
+  OPENCLAW_DIR_MISSING: 'BLOCKED-openclaw-dir-missing',
+  OPENCLAW_DIR_PRODUCTION: 'BLOCKED-openclaw-dir-inside-production',
+  OPENCLAW_ENTRYPOINT_MISSING: 'BLOCKED-openclaw-entrypoint-missing',
+  FREE_PORT_ALLOCATION: 'BLOCKED-free-port-allocation',
+  TEMP_GATEWAY_START: 'BLOCKED-temp-gateway-start',
+  MOCK_PROVIDER_START: 'BLOCKED-mock-provider-start',
+  CONTEXT_BUDGET: 'BLOCKED-context-budget-not-forced',
+  REQUEST_COMPACTION_REJECTED: 'FAIL-request-compaction-rejected',
+  REQUEST_COMPACTION_PENDING: 'FAIL-request-compaction-already-pending',
+  COMPACTION_TIMEOUT: 'FAIL-compaction-timeout',
+  LIFEBOAT_MISSING: 'FAIL-lifeboat-missing',
+  SENTINEL_MISSING: 'FAIL-sentinel-missing',
+  CLEANUP: 'FAIL-cleanup',
+  LIVE_SEND_NOT_IMPLEMENTED: 'HONEST-LIMIT-live-orchestration-preflight-only',
+});
+
+/**
+ * Returns a resolved absolute path plus any non-existent suffix, so path guards
+ * catch symlinked production paths whose leaf doesn't exist yet.
+ */
+export function existingRealpathWithSuffix(target) {
+  const suffix = [];
+  let cursor = target;
+  while (!existsSync(cursor)) {
+    const parent = path.dirname(cursor);
+    if (parent === cursor) return target;
+    suffix.unshift(path.basename(cursor));
+    cursor = parent;
+  }
+  const realExisting = realpathSync.native(cursor);
+  return suffix.length ? path.join(realExisting, ...suffix) : realExisting;
+}
+
+export function productionPathCandidates(markers = PRODUCTION_PATH_MARKERS) {
+  const candidates = new Set();
+  for (const marker of markers) {
+    const resolved = path.resolve(marker);
+    candidates.add(resolved);
+    if (existsSync(resolved)) candidates.add(realpathSync.native(resolved));
+  }
+  return [...candidates];
+}
+
+export function assertNotProductionPath(label, candidate, markers = PRODUCTION_PATH_MARKERS) {
+  if (candidate === path.parse(candidate).root) {
+    throw new Error(`${label} must not be filesystem root`);
+  }
+  if (candidate === homedir()) {
+    throw new Error(`${label} must not be the user home directory`);
+  }
+  for (const production of productionPathCandidates(markers)) {
+    if (candidate === production || candidate.startsWith(`${production}${path.sep}`)) {
+      throw new Error(`${label} points inside production path ${production}`);
+    }
+  }
+}
+
+/**
+ * Refuse candidate paths — used for tmpdir / artifact / state / config.
+ * Returns the resolved absolute path.
+ */
+export function normalizeSafePath(label, value, markers = PRODUCTION_PATH_MARKERS) {
+  if (!value) return '';
+  const resolved = path.resolve(value);
+  const realResolved = existingRealpathWithSuffix(resolved);
+  assertNotProductionPath(label, resolved, markers);
+  assertNotProductionPath(label, realResolved, markers);
+  return resolved;
+}
+
+/**
+ * OpenClaw source directory is allowed to be READ but must not host the temp
+ * config / state / workspace. Returns { ok, dir, entrypoint, outcome } where
+ * outcome is one of NON_PASS_OUTCOMES on failure.
+ */
+export function resolveOpenClawDir(candidate, {
+  markers = PRODUCTION_PATH_MARKERS,
+  entrypointRelative = 'openclaw.mjs',
+  fsExists = existsSync,
+} = {}) {
+  if (!candidate) {
+    return {
+      ok: false,
+      outcome: NON_PASS_OUTCOMES.OPENCLAW_DIR_MISSING,
+      reason: 'openclaw source directory not supplied',
+    };
+  }
+  const resolved = path.resolve(candidate);
+  const realResolved = existingRealpathWithSuffix(resolved);
+
+  // Openclaw source directory MAY be inside the production markers, but only
+  // as a source checkout — never as state. We do not allow it to be used at
+  // all in this increment because we cannot safely distinguish source-only.
+  // If a caller passes DEFAULT_OPENCLAW_SOURCE_DIR (which lives inside the
+  // production marker for legacy reasons), we still refuse to spawn from it
+  // until reviewed code lands that can guarantee source-only usage.
+  for (const production of productionPathCandidates(markers)) {
+    if (resolved === production || resolved.startsWith(`${production}${path.sep}`) ||
+        realResolved === production || realResolved.startsWith(`${production}${path.sep}`)) {
+      return {
+        ok: false,
+        outcome: NON_PASS_OUTCOMES.OPENCLAW_DIR_PRODUCTION,
+        reason: `openclaw dir ${resolved} lives inside production path ${production}; reviewed source-only guard required before live spawn`,
+        dir: resolved,
+      };
+    }
+  }
+
+  if (!fsExists(resolved)) {
+    return {
+      ok: false,
+      outcome: NON_PASS_OUTCOMES.OPENCLAW_DIR_MISSING,
+      reason: `openclaw dir ${resolved} does not exist`,
+      dir: resolved,
+    };
+  }
+  const entrypoint = path.join(resolved, entrypointRelative);
+  if (!fsExists(entrypoint)) {
+    return {
+      ok: false,
+      outcome: NON_PASS_OUTCOMES.OPENCLAW_ENTRYPOINT_MISSING,
+      reason: `openclaw entrypoint ${entrypoint} does not exist`,
+      dir: resolved,
+      entrypoint,
+    };
+  }
+  return {
+    ok: true,
+    dir: resolved,
+    entrypoint,
+  };
+}
+
+/**
+ * Allocate an ephemeral loopback port by asking the kernel for one and
+ * releasing it. Callers should treat this as advisory — the OS may reassign
+ * before the Gateway binds. In this increment we only use it during preflight
+ * so races with real listeners are irrelevant.
+ */
+export function allocateFreePort({ host = '127.0.0.1', createServerFn = createServer } = {}) {
+  return new Promise((resolve, reject) => {
+    const server = createServerFn();
+    server.unref();
+    server.on('error', (error) => {
+      reject(error);
+    });
+    server.listen({ port: 0, host }, () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close(() => reject(new Error('failed to determine free port')));
+        return;
+      }
+      const port = address.port;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+/**
+ * Redacted temp config shape written to `<tempRoot>/config/openclaw.json`.
+ * The gateway token is only referenced by env var in the plan; the config
+ * itself never contains the fixture token in cleartext.
+ */
+export function buildRedactedConfig({
+  workspaceDir,
+  model,
+  contextTokens,
+  keepRecentTokens,
+  reserveTokens,
+  port,
+}) {
+  const [provider, ...modelParts] = String(model || '').split('/');
+  const modelName = modelParts.join('/') || 'default';
+  return {
+    gateway: {
+      mode: 'local',
+      host: '127.0.0.1',
+      port,
+      token: '<REDACTED-fixture-token>',
+      controlUi: { enabled: false },
+      tailscale: { mode: 'off' },
+    },
+    discovery: {
+      mdns: { mode: 'off' },
+      wideArea: { enabled: false },
+    },
+    agents: {
+      defaults: {
+        workspace: workspaceDir,
+        continuation: { enabled: true },
+        compaction: {
+          enabled: true,
+          keepRecentTokens,
+          reserveTokens,
+          reserveTokensFloor: reserveTokens,
+          truncateAfterCompaction: true,
+          notifyUser: false,
+        },
+      },
+    },
+    models: {
+      providers: {
+        [provider || 'fixture']: {
+          baseUrl: `http://127.0.0.1:<mock-provider-port>`,
+          api: 'openai-responses',
+          models: {
+            [modelName]: {
+              contextTokens,
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+export function writeJsonArtifact(file, value, mode = 0o600) {
+  writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, { mode });
+}
+
+function ensureDir(dir) {
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+}
+
+/**
+ * Stub live steps. Every stub throws a well-known error whose message is
+ * matched by the state machine and mapped onto a classified outcome.
+ * Tests inject their own implementations via the deps argument to
+ * `runOrchestration`.
+ */
+export function makeUnimplementedLiveSteps() {
+  const notImplemented = (name) => async () => {
+    const err = new Error(`${name} not implemented in this scaffold increment`);
+    err.code = 'LIVE_NOT_IMPLEMENTED';
+    err.step = name;
+    throw err;
+  };
+  return {
+    startMockProvider: notImplemented('startMockProvider'),
+    stopMockProvider: notImplemented('stopMockProvider'),
+    startTempGateway: notImplemented('startTempGateway'),
+    stopTempGateway: notImplemented('stopTempGateway'),
+    callGatewayRpc: notImplemented('callGatewayRpc'),
+    forceContextBudget: notImplemented('forceContextBudget'),
+    stageLifeboat: notImplemented('stageLifeboat'),
+    requestCompaction: notImplemented('requestCompaction'),
+    waitForCompactionComplete: notImplemented('waitForCompactionComplete'),
+    verifyLifeboatReturn: notImplemented('verifyLifeboatReturn'),
+    verifySuccessorSentinel: notImplemented('verifySuccessorSentinel'),
+    fetchTrace: notImplemented('fetchTrace'),
+  };
+}
+
+/**
+ * Live orchestration state machine. Runs one phase at a time, emitting a
+ * classified outcome and cleanup receipt at the first failing step. Deps are
+ * fully injectable so tests can drive any phase transition without spawning
+ * real subprocesses.
+ *
+ * Returns { pass:false, outcome, phase, artifacts, cleanup }.
+ * PASS is only possible when every phase completes successfully. Even then,
+ * this increment returns pass:false with outcome LIVE_SEND_NOT_IMPLEMENTED,
+ * so no PASS can be inadvertently claimed from a preflight-only run.
+ */
+export async function runOrchestration({
+  args,
+  paths,
+  markers = PRODUCTION_PATH_MARKERS,
+  liveSteps = makeUnimplementedLiveSteps(),
+  now = () => new Date().toISOString(),
+  allocateFreePortFn = allocateFreePort,
+  resolveOpenClawDirFn = resolveOpenClawDir,
+}) {
+  const artifacts = [];
+  const emit = (name, body) => {
+    const file = path.join(paths.artifactDir, name);
+    writeJsonArtifact(file, body);
+    artifacts.push(name);
+  };
+
+  const preflight = {
+    schema: 'openclaw.project81.accepted-request-compaction.preflight.v1',
+    startedAt: now(),
+    candidateSha: args.candidateSha,
+    openclawDir: null,
+    openclawEntrypoint: null,
+    portCandidate: null,
+    contextBudget: {
+      contextTokens: args.contextTokens,
+      keepRecentTokens: args.keepRecentTokens,
+      reserveTokens: args.reserveTokens,
+      floor: 0.7,
+    },
+  };
+
+  const finish = (outcome, phase, extra = {}) => {
+    const cleanup = {
+      schema: 'openclaw.project81.accepted-request-compaction.cleanup.v1',
+      status: outcome.startsWith('BLOCKED') || outcome.startsWith('FAIL')
+        ? 'stopped-during-orchestration'
+        : 'preflight-only-no-gateway-started',
+      retained: args.retainTmp,
+      tempRoot: paths.root,
+      productionConfigTouched: false,
+      gatewayStopped: null,
+      mockProviderStopped: null,
+      finishedAt: now(),
+    };
+    emit('cleanup.json', cleanup);
+    const outcomeArtifact = {
+      schema: 'openclaw.project81.accepted-request-compaction.outcome.v1',
+      outcome,
+      pass: false,
+      phase,
+      artifactDir: paths.artifactDir,
+      artifacts,
+    };
+    emit('outcome.json', outcomeArtifact);
+    return { pass: false, outcome, phase, artifacts, cleanup, ...extra };
+  };
+
+  // Phase 1: preflight paths & openclaw source dir
+  ensureDir(paths.artifactDir);
+  const openclaw = resolveOpenClawDirFn(args.openclawDir, { markers });
+  if (!openclaw.ok) {
+    preflight.openclawDir = openclaw.dir ?? args.openclawDir ?? null;
+    preflight.openclawEntrypoint = openclaw.entrypoint ?? null;
+    preflight.error = openclaw.reason;
+    emit('preflight-context.json', preflight);
+    return finish(openclaw.outcome, 'openclaw-dir');
+  }
+  preflight.openclawDir = openclaw.dir;
+  preflight.openclawEntrypoint = openclaw.entrypoint;
+
+  // Phase 2: allocate free port (only when caller left port==0)
+  let port = args.port;
+  if (!port) {
+    try {
+      port = await allocateFreePortFn({ host: '127.0.0.1' });
+    } catch (error) {
+      preflight.error = String(error?.message ?? error);
+      emit('preflight-context.json', preflight);
+      return finish(NON_PASS_OUTCOMES.FREE_PORT_ALLOCATION, 'allocate-free-port');
+    }
+  }
+  preflight.portCandidate = port;
+
+  // Phase 3: write redacted temp config (no secrets on disk)
+  ensureDir(path.dirname(paths.configPath));
+  const config = buildRedactedConfig({
+    workspaceDir: paths.workspaceDir,
+    model: args.model,
+    contextTokens: args.contextTokens,
+    keepRecentTokens: args.keepRecentTokens,
+    reserveTokens: args.reserveTokens,
+    port,
+  });
+  writeJsonArtifact(paths.configPath, config);
+  emit('temp-config.redacted.json', config);
+  preflight.tempConfigPath = paths.configPath;
+  emit('preflight-context.json', preflight);
+
+  // Phase 4+ live steps (mock provider start, gateway start, ...) are all
+  // stubbed. Each call maps its failure onto a classified outcome so callers
+  // never see a stack trace masquerading as an unclassified failure.
+  const phaseMap = [
+    ['mock-provider-start', 'startMockProvider', NON_PASS_OUTCOMES.MOCK_PROVIDER_START],
+    ['temp-gateway-start', 'startTempGateway', NON_PASS_OUTCOMES.TEMP_GATEWAY_START],
+    ['force-context-budget', 'forceContextBudget', NON_PASS_OUTCOMES.CONTEXT_BUDGET],
+    ['stage-lifeboat', 'stageLifeboat', NON_PASS_OUTCOMES.LIFEBOAT_MISSING],
+    ['request-compaction', 'requestCompaction', NON_PASS_OUTCOMES.REQUEST_COMPACTION_REJECTED],
+    ['wait-compaction-complete', 'waitForCompactionComplete', NON_PASS_OUTCOMES.COMPACTION_TIMEOUT],
+    ['verify-lifeboat-return', 'verifyLifeboatReturn', NON_PASS_OUTCOMES.LIFEBOAT_MISSING],
+    ['verify-successor-sentinel', 'verifySuccessorSentinel', NON_PASS_OUTCOMES.SENTINEL_MISSING],
+  ];
+
+  const receipts = {};
+  for (const [phase, step, failureOutcome] of phaseMap) {
+    try {
+      const receipt = await liveSteps[step]({
+        args,
+        paths,
+        port,
+        openclaw,
+        receipts,
+      });
+      if (receipt && typeof receipt === 'object') {
+        receipts[step] = receipt;
+        if (receipt.artifact) {
+          emit(receipt.artifact.name, receipt.artifact.body);
+        }
+      }
+    } catch (error) {
+      const reason = String(error?.message ?? error);
+      if (error && error.code === 'LIVE_NOT_IMPLEMENTED') {
+        // Preflight-only mode: emit an honest-limit marker and stop cleanly.
+        emit('live-orchestration-not-yet-implemented.json', {
+          schema: 'openclaw.project81.accepted-request-compaction.honest-limit.v1',
+          step,
+          reason,
+        });
+        return finish(NON_PASS_OUTCOMES.LIVE_SEND_NOT_IMPLEMENTED, phase, {
+          preflight,
+        });
+      }
+      emit(`${phase}-error.json`, {
+        schema: 'openclaw.project81.accepted-request-compaction.phase-error.v1',
+        phase,
+        step,
+        reason,
+      });
+      return finish(failureOutcome, phase, { preflight });
+    }
+  }
+
+  // Should never reach here in this increment because live steps throw; but
+  // if a future PR wires them and everything succeeds, we still refuse PASS
+  // until the trace / lifeboat / sentinel receipts are separately validated.
+  emit('trace-unavailable.json', {
+    schema: 'openclaw.project81.accepted-request-compaction.trace.v1',
+    reason: 'trace validation not yet integrated in this increment',
+  });
+  return finish(NON_PASS_OUTCOMES.LIVE_SEND_NOT_IMPLEMENTED, 'trace-validation', { preflight });
+}

--- a/tools/k6-proofs/scripts/run-accepted-compaction-fixture.mjs
+++ b/tools/k6-proofs/scripts/run-accepted-compaction-fixture.mjs
@@ -1,19 +1,40 @@
 #!/usr/bin/env node
 /**
- * run-accepted-compaction-fixture.mjs — fail-closed planner/scaffold for the
- * Project 81 accepted request_compaction fixture.
+ * run-accepted-compaction-fixture.mjs — planner + preflight runner for the
+ * Project 81 accepted request_compaction fixture (issue #331).
  *
- * This first implementation intentionally exposes only a redacted --plan /
- * --dry-run surface. A future live mode must start an isolated temp Gateway and
- * collect the accepted-compaction receipts described in the emitted plan. Live
- * execution fails closed until that orchestration is implemented and reviewed.
+ * Modes:
+ *   --plan / --dry-run   Emit a redacted plan artifact (no Gateway started).
+ *   --run                Run the reviewed live orchestration state machine.
+ *                        Requires FIXTURE opt-in, candidate SHA, AND the
+ *                        review gate --enable-live-orchestration flag.
+ *                        Without the review gate, --run classifies as
+ *                        HONEST-LIMIT-live-orchestration-review-gate and
+ *                        does NOT start any subprocess.
+ *
+ * Live orchestration in this increment implements preflight only (openclaw
+ * source dir validation, free port allocation, redacted temp config write)
+ * and then classifies the next phase as
+ * HONEST-LIMIT-live-orchestration-preflight-only. Downstream phases (mock
+ * provider bootstrap, Gateway start, request_compaction RPC, lifecycle wait,
+ * successor sentinel) live behind dependency-injected stubs so the
+ * follow-up review PR can wire them without a second refactor.
  */
-import { chmodSync, existsSync, mkdirSync, realpathSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, writeFileSync } from 'node:fs';
 import { mkdtemp } from 'node:fs/promises';
 import { randomBytes } from 'node:crypto';
-import { homedir, tmpdir } from 'node:os';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
+import {
+  NON_PASS_OUTCOMES,
+  PRODUCTION_PATH_MARKERS,
+  DEFAULT_OPENCLAW_SOURCE_DIR,
+  buildRedactedConfig,
+  makeUnimplementedLiveSteps,
+  normalizeSafePath as sharedNormalizeSafePath,
+  runOrchestration,
+} from './lib/accepted-compaction-orchestrator.mjs';
 
 const DEFAULT_CONTEXT_TOKENS = 12_000;
 const DEFAULT_KEEP_RECENT_TOKENS = 1_000;
@@ -21,33 +42,33 @@ const DEFAULT_RESERVE_TOKENS = 2_000;
 const DEFAULT_TIMEOUT_MS = 180_000;
 const DEFAULT_PORT = 0;
 const DEFAULT_MODEL = 'fixture/openai-compatible-local';
-const PRODUCTION_PATH_MARKERS = [
-  path.join(homedir(), '.openclaw'),
-  path.join(homedir(), 'flesh_beast_tmp', 'openclaw'),
-];
 
 function usage() {
   return `Usage: node tools/k6-proofs/scripts/run-accepted-compaction-fixture.mjs --plan [options]
 
 Options:
   --plan, --dry-run                Emit a redacted plan artifact and exit 0.
-  --run                           Fail closed until reviewed live orchestration lands.
+  --run                           Run reviewed live orchestration (preflight only in this increment).
+  --enable-live-orchestration     Review gate for --run; without this flag --run classifies as HONEST-LIMIT-live-orchestration-review-gate.
   --artifact-dir <path>            Directory for emitted artifacts.
   --tmpdir <path>                  Temp root for fixture config/state/workspace/logs.
+  --openclaw-dir <path>            OpenClaw source checkout used to spawn the temp Gateway.
   --candidate-sha <sha>            Candidate SHA under test (40-char hex when supplied).
   --model <provider/model>         Fixture model id (default: ${DEFAULT_MODEL}).
   --context-tokens <n>             Effective context cap (default: ${DEFAULT_CONTEXT_TOKENS}).
   --keep-recent-tokens <n>         Compaction keepRecentTokens (default: ${DEFAULT_KEEP_RECENT_TOKENS}).
   --reserve-tokens <n>             Compaction reserveTokens/floor (default: ${DEFAULT_RESERVE_TOKENS}).
   --timeout-ms <n>                 Lifecycle timeout (default: ${DEFAULT_TIMEOUT_MS}).
-  --port <n>                       Temp Gateway port, 0 = choose/free port later.
+  --port <n>                       Temp Gateway port, 0 = allocate free port during preflight.
   --retain-tmp                    Mark temp root retained in cleanup plan.
   --json                          Print machine-readable result.
   --help                          Show this help.
 
 Environment defaults:
-  OPENCLAW_ACCEPTED_COMPACTION_FIXTURE=true   Required for --run only.
-  OPENCLAW_ACCEPTED_COMPACTION_TMPDIR=<tmp>   Fixture temp root.
+  OPENCLAW_ACCEPTED_COMPACTION_FIXTURE=true       Required for --run only.
+  OPENCLAW_ACCEPTED_COMPACTION_ENABLE_LIVE=true   Review gate for --run.
+  OPENCLAW_ACCEPTED_COMPACTION_TMPDIR=<tmp>       Fixture temp root.
+  OPENCLAW_ACCEPTED_COMPACTION_OPENCLAW_DIR=<dir> OpenClaw source checkout.
   OPENCLAW_CANDIDATE_SHA=<sha>
   OPENCLAW_ACCEPTED_COMPACTION_MODEL=<provider/model>
   OPENCLAW_ACCEPTED_COMPACTION_CONTEXT_TOKENS=<n>
@@ -74,6 +95,7 @@ function parseArgs(argv, env = process.env) {
     mode: null,
     json: false,
     retainTmp: env.OPENCLAW_ACCEPTED_COMPACTION_RETAIN_TMP === 'true',
+    enableLiveOrchestration: env.OPENCLAW_ACCEPTED_COMPACTION_ENABLE_LIVE === 'true',
     candidateSha: env.OPENCLAW_CANDIDATE_SHA || '',
     model: env.OPENCLAW_ACCEPTED_COMPACTION_MODEL || DEFAULT_MODEL,
     contextTokens: parsePositiveInteger(env.OPENCLAW_ACCEPTED_COMPACTION_CONTEXT_TOKENS || DEFAULT_CONTEXT_TOKENS, 'context tokens'),
@@ -83,6 +105,7 @@ function parseArgs(argv, env = process.env) {
     port: parsePositiveInteger(env.OPENCLAW_ACCEPTED_COMPACTION_PORT || DEFAULT_PORT, 'port', { allowZero: true, max: 65_535 }),
     tmpdir: env.OPENCLAW_ACCEPTED_COMPACTION_TMPDIR || '',
     artifactDir: '',
+    openclawDir: env.OPENCLAW_ACCEPTED_COMPACTION_OPENCLAW_DIR || '',
   };
 
   for (let i = 2; i < argv.length; i += 1) {
@@ -106,6 +129,10 @@ function parseArgs(argv, env = process.env) {
       args.retainTmp = true;
       continue;
     }
+    if (arg === '--enable-live-orchestration') {
+      args.enableLiveOrchestration = true;
+      continue;
+    }
     const next = () => {
       const value = argv[++i];
       if (!value) throw new Error(`${arg} requires a value`);
@@ -113,6 +140,7 @@ function parseArgs(argv, env = process.env) {
     };
     if (arg === '--artifact-dir') args.artifactDir = next();
     else if (arg === '--tmpdir') args.tmpdir = next();
+    else if (arg === '--openclaw-dir') args.openclawDir = next();
     else if (arg === '--candidate-sha') args.candidateSha = next();
     else if (arg === '--model') args.model = next();
     else if (arg === '--context-tokens') args.contextTokens = parsePositiveInteger(next(), 'context tokens');
@@ -127,46 +155,8 @@ function parseArgs(argv, env = process.env) {
   return args;
 }
 
-function existingRealpathWithSuffix(resolved) {
-  const suffix = [];
-  let cursor = resolved;
-  while (!existsSync(cursor)) {
-    const parent = path.dirname(cursor);
-    if (parent === cursor) return resolved;
-    suffix.unshift(path.basename(cursor));
-    cursor = parent;
-  }
-  const realExisting = realpathSync.native(cursor);
-  return suffix.length ? path.join(realExisting, ...suffix) : realExisting;
-}
-
-function productionPathCandidates() {
-  const candidates = new Set();
-  for (const marker of PRODUCTION_PATH_MARKERS) {
-    const resolved = path.resolve(marker);
-    candidates.add(resolved);
-    if (existsSync(resolved)) candidates.add(realpathSync.native(resolved));
-  }
-  return [...candidates];
-}
-
-function assertNotProductionPath(label, candidate) {
-  if (candidate === path.parse(candidate).root) throw new Error(`${label} must not be filesystem root`);
-  if (candidate === homedir()) throw new Error(`${label} must not be the user home directory`);
-  for (const production of productionPathCandidates()) {
-    if (candidate === production || candidate.startsWith(`${production}${path.sep}`)) {
-      throw new Error(`${label} points inside production path ${production}`);
-    }
-  }
-}
-
 function normalizeSafePath(label, value) {
-  if (!value) return '';
-  const resolved = path.resolve(value);
-  const realResolved = existingRealpathWithSuffix(resolved);
-  assertNotProductionPath(label, resolved);
-  assertNotProductionPath(label, realResolved);
-  return resolved;
+  return sharedNormalizeSafePath(label, value, PRODUCTION_PATH_MARKERS);
 }
 
 async function preparePaths(args) {
@@ -210,40 +200,14 @@ function validateArgs(args) {
 }
 
 function redactedConfig(args, paths) {
-  const [provider, ...modelParts] = args.model.split('/');
-  const modelName = modelParts.join('/') || 'default';
-  return {
-    gateway: {
-      host: '127.0.0.1',
-      port: args.port,
-      token: '<REDACTED-fixture-token>',
-    },
-    agents: {
-      defaults: {
-        workspace: paths.workspaceDir,
-        continuation: { enabled: true },
-        compaction: {
-          enabled: true,
-          keepRecentTokens: args.keepRecentTokens,
-          reserveTokens: args.reserveTokens,
-          reserveTokensFloor: args.reserveTokens,
-          truncateAfterCompaction: true,
-          notifyUser: false,
-        },
-      },
-    },
-    models: {
-      providers: {
-        [provider || 'fixture']: {
-          models: {
-            [modelName]: {
-              contextTokens: args.contextTokens,
-            },
-          },
-        },
-      },
-    },
-  };
+  return buildRedactedConfig({
+    workspaceDir: paths.workspaceDir,
+    model: args.model,
+    contextTokens: args.contextTokens,
+    keepRecentTokens: args.keepRecentTokens,
+    reserveTokens: args.reserveTokens,
+    port: args.port,
+  });
 }
 
 function requiredReceipts() {
@@ -261,12 +225,20 @@ function requiredReceipts() {
   ];
 }
 
+function planOutcome(args) {
+  if (args.mode === 'plan') return 'PLAN_ONLY-redacted-dry-run';
+  if (!args.enableLiveOrchestration) return NON_PASS_OUTCOMES.REVIEW_GATE;
+  return 'LIVE_PREFLIGHT_ONLY';
+}
+
 function buildPlan(args, paths) {
   const gatewayWs = `ws://127.0.0.1:${args.port || '<free-port>'}`;
   return {
     schema: 'openclaw.project81.accepted-request-compaction.plan.v1',
-    mode: args.mode === 'plan' ? 'PLAN_ONLY' : 'LIVE_REQUESTED_FAIL_CLOSED',
-    outcome: args.mode === 'plan' ? 'PLAN_ONLY-redacted-dry-run' : 'BLOCKED-live-orchestration-not-implemented',
+    mode: args.mode === 'plan'
+      ? 'PLAN_ONLY'
+      : args.enableLiveOrchestration ? 'LIVE_PREFLIGHT_ONLY' : 'LIVE_REVIEW_GATE',
+    outcome: planOutcome(args),
     candidateSha: args.candidateSha || '<unset-plan-only>',
     model: args.model,
     contextTokens: args.contextTokens,
@@ -275,6 +247,7 @@ function buildPlan(args, paths) {
     timeoutMs: args.timeoutMs,
     port: args.port,
     gatewayWs,
+    openclawDir: args.openclawDir || DEFAULT_OPENCLAW_SOURCE_DIR,
     paths: {
       tempRoot: paths.root,
       configPath: paths.configPath,
@@ -285,7 +258,9 @@ function buildPlan(args, paths) {
     },
     env: {
       OPENCLAW_ACCEPTED_COMPACTION_FIXTURE: args.mode === 'run' ? 'true' : '<not-required-for-plan>',
+      OPENCLAW_ACCEPTED_COMPACTION_ENABLE_LIVE: args.enableLiveOrchestration ? 'true' : 'false',
       OPENCLAW_ACCEPTED_COMPACTION_TMPDIR: paths.root,
+      OPENCLAW_ACCEPTED_COMPACTION_OPENCLAW_DIR: args.openclawDir || '<unset>',
       OPENCLAW_CONFIG_PATH: paths.configPath,
       OPENCLAW_STATE_DIR: paths.stateDir,
       OPENCLAW_WORKSPACE_DIR: paths.workspaceDir,
@@ -313,15 +288,21 @@ function buildPlan(args, paths) {
     ],
     passReceipts: requiredReceipts(),
     nonPassOutcomes: [
-      'HONEST-LIMIT-local-model-unavailable',
-      'BLOCKED-temp-gateway-start',
-      'BLOCKED-context-budget-not-forced',
-      'FAIL-request-compaction-rejected',
-      'FAIL-request-compaction-already-pending',
-      'FAIL-compaction-timeout',
-      'FAIL-lifeboat-missing',
-      'FAIL-sentinel-missing',
-      'FAIL-cleanup',
+      NON_PASS_OUTCOMES.REVIEW_GATE,
+      NON_PASS_OUTCOMES.OPENCLAW_DIR_MISSING,
+      NON_PASS_OUTCOMES.OPENCLAW_DIR_PRODUCTION,
+      NON_PASS_OUTCOMES.OPENCLAW_ENTRYPOINT_MISSING,
+      NON_PASS_OUTCOMES.FREE_PORT_ALLOCATION,
+      NON_PASS_OUTCOMES.TEMP_GATEWAY_START,
+      NON_PASS_OUTCOMES.MOCK_PROVIDER_START,
+      NON_PASS_OUTCOMES.CONTEXT_BUDGET,
+      NON_PASS_OUTCOMES.REQUEST_COMPACTION_REJECTED,
+      NON_PASS_OUTCOMES.REQUEST_COMPACTION_PENDING,
+      NON_PASS_OUTCOMES.COMPACTION_TIMEOUT,
+      NON_PASS_OUTCOMES.LIFEBOAT_MISSING,
+      NON_PASS_OUTCOMES.SENTINEL_MISSING,
+      NON_PASS_OUTCOMES.CLEANUP,
+      NON_PASS_OUTCOMES.LIVE_SEND_NOT_IMPLEMENTED,
     ],
     guardrails: [
       'no production openclaw.json edits',
@@ -331,6 +312,7 @@ function buildPlan(args, paths) {
       'no PASS from threshold rejection',
       'no PASS unless post-compaction delegate fires after the compaction seam',
       'redact fixture token and any provider secrets from artifacts',
+      '--run requires --enable-live-orchestration (review gate)',
     ],
   };
 }
@@ -339,7 +321,7 @@ function writeJson(file, value) {
   writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
 }
 
-function writeArtifacts(args, paths, plan) {
+function writeBaseArtifacts(args, paths, plan) {
   const readiness = {
     schema: 'openclaw.project81.accepted-request-compaction.fixture-readiness.v1',
     status: plan.mode,
@@ -351,11 +333,26 @@ function writeArtifacts(args, paths, plan) {
     contextTokens: args.contextTokens,
     notes: args.mode === 'plan'
       ? ['dry-run only; no Gateway started and no production config touched']
-      : ['live mode requested but not implemented in this reviewed scaffold'],
+      : args.enableLiveOrchestration
+        ? ['live orchestration state machine invoked; preflight-only in this increment']
+        : ['live mode requested but review gate --enable-live-orchestration not supplied'],
   };
+  writeJson(path.join(paths.artifactDir, 'accepted-compaction-plan.json'), plan);
+  writeJson(path.join(paths.artifactDir, 'fixture-readiness.json'), readiness);
+  writeJson(path.join(paths.artifactDir, 'temp-config.redacted.json'), redactedConfig(args, paths));
+  try {
+    chmodSync(paths.artifactDir, 0o700);
+  } catch {
+    // Best-effort on platforms/filesystems that do not support chmod.
+  }
+  return readiness;
+}
+
+function writePlanOnlyArtifacts(args, paths, plan) {
+  writeBaseArtifacts(args, paths, plan);
   const cleanup = {
     schema: 'openclaw.project81.accepted-request-compaction.cleanup.v1',
-    status: args.mode === 'plan' ? 'not-started' : 'blocked-before-start',
+    status: 'not-started',
     retained: args.retainTmp,
     tempRoot: paths.root,
     productionConfigTouched: false,
@@ -368,18 +365,51 @@ function writeArtifacts(args, paths, plan) {
     artifactDir: paths.artifactDir,
     requiredForPass: requiredReceipts(),
   };
-
-  writeJson(path.join(paths.artifactDir, 'accepted-compaction-plan.json'), plan);
-  writeJson(path.join(paths.artifactDir, 'fixture-readiness.json'), readiness);
-  writeJson(path.join(paths.artifactDir, 'temp-config.redacted.json'), redactedConfig(args, paths));
   writeJson(path.join(paths.artifactDir, 'cleanup.json'), cleanup);
   writeJson(path.join(paths.artifactDir, 'outcome.json'), outcome);
-  try {
-    chmodSync(paths.artifactDir, 0o700);
-  } catch {
-    // Best-effort on platforms/filesystems that do not support chmod.
+}
+
+function writeReviewGateArtifacts(args, paths, plan) {
+  writeBaseArtifacts(args, paths, plan);
+  const cleanup = {
+    schema: 'openclaw.project81.accepted-request-compaction.cleanup.v1',
+    status: 'review-gate-blocked-before-start',
+    retained: args.retainTmp,
+    tempRoot: paths.root,
+    productionConfigTouched: false,
+    gatewayStopped: null,
+  };
+  const outcome = {
+    schema: 'openclaw.project81.accepted-request-compaction.outcome.v1',
+    outcome: NON_PASS_OUTCOMES.REVIEW_GATE,
+    pass: false,
+    reason: '--run requires --enable-live-orchestration (or OPENCLAW_ACCEPTED_COMPACTION_ENABLE_LIVE=true) after review',
+    artifactDir: paths.artifactDir,
+    requiredForPass: requiredReceipts(),
+  };
+  writeJson(path.join(paths.artifactDir, 'cleanup.json'), cleanup);
+  writeJson(path.join(paths.artifactDir, 'outcome.json'), outcome);
+}
+
+/**
+ * Test-only hook: an alternative orchestrator factory may be injected via
+ * globalThis.__openclawAcceptedCompactionTestHooks.orchestratorFactory. The
+ * factory receives ({ args, paths, plan }) and must return an object shaped
+ * like the arguments to runOrchestration, or the promise thereof.
+ */
+function resolveOrchestratorInvocation({ args, paths, plan }) {
+  const hooks = globalThis.__openclawAcceptedCompactionTestHooks;
+  if (hooks && typeof hooks.orchestratorFactory === 'function') {
+    return hooks.orchestratorFactory({ args, paths, plan });
   }
-  return { readiness, cleanup, outcome };
+  return {
+    args: {
+      ...args,
+      openclawDir: args.openclawDir || DEFAULT_OPENCLAW_SOURCE_DIR,
+    },
+    paths,
+    liveSteps: makeUnimplementedLiveSteps(),
+  };
 }
 
 async function main() {
@@ -391,28 +421,78 @@ async function main() {
   validateArgs(args);
   const paths = await preparePaths(args);
   const plan = buildPlan(args, paths);
-  const artifacts = writeArtifacts(args, paths, plan);
-  const result = {
-    ok: args.mode === 'plan',
-    mode: plan.mode,
-    outcome: plan.outcome,
-    artifactDir: paths.artifactDir,
-    files: [
-      'accepted-compaction-plan.json',
-      'fixture-readiness.json',
-      'temp-config.redacted.json',
-      'cleanup.json',
-      'outcome.json',
-    ],
-  };
 
+  if (args.mode === 'plan') {
+    writePlanOnlyArtifacts(args, paths, plan);
+    const result = {
+      ok: true,
+      mode: plan.mode,
+      outcome: plan.outcome,
+      artifactDir: paths.artifactDir,
+      files: [
+        'accepted-compaction-plan.json',
+        'fixture-readiness.json',
+        'temp-config.redacted.json',
+        'cleanup.json',
+        'outcome.json',
+      ],
+    };
+    if (args.json) console.log(JSON.stringify(result, null, 2));
+    else {
+      console.log(`accepted request_compaction fixture ${args.mode}: ${plan.outcome}`);
+      console.log(`artifact dir: ${paths.artifactDir}`);
+    }
+    return 0;
+  }
+
+  // args.mode === 'run'
+  if (!args.enableLiveOrchestration) {
+    writeReviewGateArtifacts(args, paths, plan);
+    const result = {
+      ok: false,
+      mode: plan.mode,
+      outcome: NON_PASS_OUTCOMES.REVIEW_GATE,
+      pass: false,
+      artifactDir: paths.artifactDir,
+      reason: '--run requires --enable-live-orchestration (or OPENCLAW_ACCEPTED_COMPACTION_ENABLE_LIVE=true) after review',
+      files: [
+        'accepted-compaction-plan.json',
+        'fixture-readiness.json',
+        'temp-config.redacted.json',
+        'cleanup.json',
+        'outcome.json',
+      ],
+    };
+    if (args.json) console.log(JSON.stringify(result, null, 2));
+    else {
+      console.log(`accepted request_compaction fixture run: ${NON_PASS_OUTCOMES.REVIEW_GATE}`);
+      console.log(`artifact dir: ${paths.artifactDir}`);
+      console.error('review gate: pass --enable-live-orchestration after review to run preflight');
+    }
+    return 3;
+  }
+
+  // Live orchestration (preflight only in this increment).
+  writeBaseArtifacts(args, paths, plan);
+  const orchestrationInput = await resolveOrchestratorInvocation({ args, paths, plan });
+  const orchestrationResult = await runOrchestration(orchestrationInput);
+
+  const result = {
+    ok: false,
+    mode: plan.mode,
+    outcome: orchestrationResult.outcome,
+    phase: orchestrationResult.phase,
+    pass: orchestrationResult.pass,
+    artifactDir: paths.artifactDir,
+    artifacts: orchestrationResult.artifacts,
+  };
   if (args.json) console.log(JSON.stringify(result, null, 2));
   else {
-    console.log(`accepted request_compaction fixture ${args.mode}: ${plan.outcome}`);
+    console.log(`accepted request_compaction fixture run: ${orchestrationResult.outcome}`);
+    console.log(`phase reached: ${orchestrationResult.phase}`);
     console.log(`artifact dir: ${paths.artifactDir}`);
-    if (args.mode !== 'plan') console.error('live orchestration is fail-closed in this scaffold');
   }
-  return args.mode === 'plan' ? 0 : 3;
+  return 3;
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {


### PR DESCRIPTION
Stacked follow-up for #331 after scaffold PR #351.\n\nThis does not claim PASS. It extracts a mockable accepted-compaction orchestrator, adds a review-gated live-preflight path, keeps --run fail-closed/pass:false, updates README, and adds tests.\n\nLocal gates:\n- node --test 'tools/k6-proofs/scripts/__tests__/*.mjs' -> 57/57 pass\n- git diff --check\n\nSafety: no production config edits, no production Gateway restart, no hosted token use, no PASS path.\n\nNext work remains actual mock-provider/Gateway/RPC/context/compaction lifecycle implementation.