### PR TITLE
P81 #331: wire accepted compaction mock provider

### DIFF
--- a/tools/k6-proofs/fixtures/accepted-request-compaction/README.md
+++ b/tools/k6-proofs/fixtures/accepted-request-compaction/README.md
@@ -1,6 +1,6 @@
 # Accepted `request_compaction` fixture
 
-This fixture is the Project 81 scaffold for proving the **accepted** compaction path, separate from the existing threshold-rejection canaries (`R-RC-1` and ordinary `R-RC-2`). Live execution is gated behind an explicit review flag; today the runner implements preflight only, and the downstream phases (mock provider, temp Gateway spawn, `request_compaction` RPC, lifecycle wait, successor sentinel) live behind dependency-injected stubs so the follow-up review PR can wire them without a second refactor.
+This fixture is the Project 81 scaffold for proving the **accepted** compaction path, separate from the existing threshold-rejection canaries (`R-RC-1` and ordinary `R-RC-2`). Live execution is gated behind an explicit review flag; today the runner implements preflight plus a deterministic local mock provider, and the downstream phases (temp Gateway spawn, `request_compaction` RPC, lifecycle wait, successor sentinel) live behind dependency-injected stubs so the follow-up review PR can wire them without a second refactor.
 
 ## Contract
 
@@ -37,7 +37,7 @@ The dry-run starts no Gateway and touches no production config. It writes:
 
 The plan artifact includes the required environment, receipt names, non-PASS classifications, and guardrails for the reviewed live implementation.
 
-## Live orchestration (preflight-only in this increment)
+## Live orchestration (mock-provider + preflight only in this increment)
 
 `--run` requires **three** independent signals so we never start a subprocess
 by accident:
@@ -50,12 +50,13 @@ Without the review gate, `--run` classifies as `HONEST-LIMIT-live-orchestration-
 
 With the review gate, the runner executes the live orchestration state machine which today implements:
 
+- Deterministic loopback mock provider startup with OpenAI-compatible `/v1/responses` and `/v1/chat/completions` routes. The provider returns fixed high-input token usage suitable for the later context-forcing phase and writes `mock-provider.json` / `mock-provider-stop.json` receipts.
 - Preflight validation of the OpenClaw source dir (`--openclaw-dir` or `OPENCLAW_ACCEPTED_COMPACTION_OPENCLAW_DIR`). Directories that live inside any production marker (`~/.openclaw`, `~/flesh_beast_tmp/openclaw`) are refused with `BLOCKED-openclaw-dir-inside-production`. Reviewed source-only guards are required before the default hint directory may be used.
 - Free port allocation on 127.0.0.1 (releases the port immediately; the temp Gateway will re-bind when the live implementation lands).
-- Redacted temp config write to `<tempRoot>/config/openclaw.json`. The fixture token is never written to disk — the config carries `<REDACTED-fixture-token>`.
-- `preflight-context.json` receipt with candidate SHA, openclaw entrypoint, port candidate, and configured context budget.
+- Redacted temp config write to `<tempRoot>/config/openclaw.json`. The fixture token is never written to disk — the config carries `<REDACTED-fixture-token>`, and the model provider baseUrl points at the deterministic mock provider port.
+- `preflight-context.json` receipt with candidate SHA, openclaw entrypoint, port candidate, mock provider port, and configured context budget.
 
-After preflight the state machine calls the mock-provider start step, which is currently unimplemented and causes the runner to classify as `HONEST-LIMIT-live-orchestration-preflight-only`, exit 3, `pass:false`. This is intentional: no PASS is possible from a preflight-only run.
+After mock-provider/preflight the state machine calls the temp-Gateway start step, which is currently unimplemented and causes the runner to classify as `HONEST-LIMIT-live-orchestration-preflight-only`, exit 3, `pass:false`, with `phase: "temp-gateway-start"`. This is intentional: no PASS is possible until the isolated Gateway, RPC, compaction lifecycle, and lifeboat receipts are wired.
 
 Example:
 

--- a/tools/k6-proofs/scripts/__tests__/accepted-compaction-fixture.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/accepted-compaction-fixture.test.mjs
@@ -206,7 +206,7 @@ test('run with --enable-live-orchestration refuses openclaw-dir inside productio
   }
 });
 
-test('run with --enable-live-orchestration writes preflight-context, temp config, and honest-limit marker when live steps are unimplemented', async () => {
+test('run with --enable-live-orchestration starts mock provider, writes preflight-context/temp config, then stops at temp gateway stub', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'openclaw-accepted-compaction-live-preflight-'));
   try {
     // Provide a fake openclaw source dir outside the production markers that
@@ -229,17 +229,19 @@ test('run with --enable-live-orchestration writes preflight-context, temp config
     const parsed = JSON.parse(run.stdout);
     assert.equal(parsed.pass, false);
     assert.equal(parsed.outcome, 'HONEST-LIMIT-live-orchestration-preflight-only');
-    assert.equal(parsed.phase, 'mock-provider-start');
+    assert.equal(parsed.phase, 'temp-gateway-start');
 
     const preflight = JSON.parse(await readFile(join(dir, 'artifacts', 'preflight-context.json'), 'utf8'));
     assert.equal(preflight.openclawDir, openclawDir);
     assert.equal(preflight.openclawEntrypoint, join(openclawDir, 'openclaw.mjs'));
     assert.equal(typeof preflight.portCandidate, 'number');
     assert.ok(preflight.portCandidate > 0, 'preflight allocated a positive port');
+    assert.ok(preflight.mockProvider.port > 0, 'preflight recorded mock provider port');
 
     const config = JSON.parse(await readFile(join(dir, 'artifacts', 'temp-config.redacted.json'), 'utf8'));
     assert.equal(config.gateway.token, '<REDACTED-fixture-token>');
     assert.equal(config.gateway.mode, 'local');
+    assert.match(config.models.providers.fixture.baseUrl, /^http:\/\/127\.0\.0\.1:\d+$/);
     assert.doesNotMatch(JSON.stringify(config), /secret-token-must-not-print/);
     assert.doesNotMatch(JSON.stringify(config), /openai-secret-must-not-print/);
 
@@ -247,11 +249,12 @@ test('run with --enable-live-orchestration writes preflight-context, temp config
       join(dir, 'artifacts', 'live-orchestration-not-yet-implemented.json'),
       'utf8',
     ));
-    assert.equal(honestLimit.step, 'startMockProvider');
+    assert.equal(honestLimit.step, 'startTempGateway');
 
     const cleanup = JSON.parse(await readFile(join(dir, 'artifacts', 'cleanup.json'), 'utf8'));
     assert.equal(cleanup.productionConfigTouched, false);
     assert.equal(cleanup.gatewayStopped, null, 'no gateway ever started');
+    assert.equal(cleanup.mockProviderStopped.stopped, true);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/tools/k6-proofs/scripts/__tests__/accepted-compaction-orchestrator.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/accepted-compaction-orchestrator.test.mjs
@@ -247,3 +247,52 @@ test('runOrchestration reaches request-compaction phase and classifies FAIL when
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test('startFixtureMockProvider serves deterministic OpenAI-compatible responses and stops cleanly', async () => {
+  const { startFixtureMockProvider, stopFixtureMockProvider } = await import('../lib/accepted-compaction-orchestrator.mjs');
+  const receipt = await startFixtureMockProvider();
+  try {
+    assert.equal(receipt.kind, 'fixture-mock-provider');
+    assert.ok(receipt.port > 0 && receipt.port < 65_536);
+    const response = await fetch(`http://127.0.0.1:${receipt.port}/v1/responses`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ model: 'fixture/openai-compatible-local', input: 'hello' }),
+    });
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.status, 'completed');
+    assert.equal(body.usage.total_tokens, 9016);
+    assert.equal(receipt.requests.length, 1);
+  } finally {
+    const stopped = await stopFixtureMockProvider(receipt);
+    assert.equal(stopped.stopped, true);
+    assert.equal(stopped.requestCount, 1);
+  }
+});
+
+test('runOrchestration with fixture mock provider advances blocker to temp gateway start', async () => {
+  const { dir, args, paths } = await makeOrchestrationFixture();
+  const { startFixtureMockProvider } = await import('../lib/accepted-compaction-orchestrator.mjs');
+  try {
+    const liveSteps = makeUnimplementedLiveSteps();
+    liveSteps.startMockProvider = startFixtureMockProvider;
+    const result = await runOrchestration({ args, paths, liveSteps });
+    assert.equal(result.pass, false);
+    assert.equal(result.outcome, NON_PASS_OUTCOMES.LIVE_SEND_NOT_IMPLEMENTED);
+    assert.equal(result.phase, 'temp-gateway-start');
+    const preflight = JSON.parse(await readFile(join(paths.artifactDir, 'preflight-context.json'), 'utf8'));
+    assert.ok(preflight.mockProvider.port > 0);
+    const config = JSON.parse(await readFile(join(paths.configPath), 'utf8'));
+    assert.match(config.models.providers.fixture.baseUrl, /^http:\/\/127\.0\.0\.1:\d+$/);
+    const mock = JSON.parse(await readFile(join(paths.artifactDir, 'mock-provider.json'), 'utf8'));
+    assert.equal(mock.usageShape, 'deterministic-high-input-token-fixture');
+    const stop = JSON.parse(await readFile(join(paths.artifactDir, 'mock-provider-stop.json'), 'utf8'));
+    assert.equal(stop.stopped, true);
+    const outcome = JSON.parse(await readFile(join(paths.artifactDir, 'outcome.json'), 'utf8'));
+    assert.equal(outcome.phase, 'temp-gateway-start');
+    assert.equal(outcome.pass, false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tools/k6-proofs/scripts/lib/accepted-compaction-orchestrator.mjs
+++ b/tools/k6-proofs/scripts/lib/accepted-compaction-orchestrator.mjs
@@ -13,6 +13,7 @@
  */
 
 import { chmodSync, existsSync, mkdirSync, realpathSync, writeFileSync } from 'node:fs';
+import { createServer as createHttpServer } from 'node:http';
 import { createServer } from 'node:net';
 import { homedir } from 'node:os';
 import path from 'node:path';
@@ -209,6 +210,7 @@ export function buildRedactedConfig({
   keepRecentTokens,
   reserveTokens,
   port,
+  mockProviderPort = '<mock-provider-port>',
 }) {
   const [provider, ...modelParts] = String(model || '').split('/');
   const modelName = modelParts.join('/') || 'default';
@@ -242,7 +244,7 @@ export function buildRedactedConfig({
     models: {
       providers: {
         [provider || 'fixture']: {
-          baseUrl: `http://127.0.0.1:<mock-provider-port>`,
+          baseUrl: `http://127.0.0.1:${mockProviderPort}`,
           api: 'openai-responses',
           models: {
             [modelName]: {
@@ -257,6 +259,97 @@ export function buildRedactedConfig({
 
 export function writeJsonArtifact(file, value, mode = 0o600) {
   writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, { mode });
+}
+
+
+export async function startFixtureMockProvider({
+  host = '127.0.0.1',
+  createServerFn = createHttpServer,
+  now = () => new Date().toISOString(),
+} = {}) {
+  const requests = [];
+  const server = createServerFn((req, res) => {
+    const chunks = [];
+    req.on('data', (chunk) => chunks.push(chunk));
+    req.on('end', () => {
+      const body = Buffer.concat(chunks).toString('utf8');
+      requests.push({ method: req.method, url: req.url, bodyBytes: Buffer.byteLength(body), at: now() });
+      res.setHeader('content-type', 'application/json');
+      if (req.method === 'POST' && req.url === '/v1/responses') {
+        res.end(JSON.stringify({
+          id: 'resp_accepted_compaction_fixture',
+          object: 'response',
+          created_at: 0,
+          status: 'completed',
+          model: 'fixture/openai-compatible-local',
+          output: [{
+            id: 'msg_fixture',
+            type: 'message',
+            status: 'completed',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'ACCEPTED_COMPACTION_FIXTURE_RESPONSE' }],
+          }],
+          usage: { input_tokens: 9000, output_tokens: 16, total_tokens: 9016 },
+        }));
+        return;
+      }
+      if (req.method === 'POST' && req.url === '/v1/chat/completions') {
+        res.end(JSON.stringify({
+          id: 'chatcmpl_accepted_compaction_fixture',
+          object: 'chat.completion',
+          created: 0,
+          model: 'fixture/openai-compatible-local',
+          choices: [{ index: 0, message: { role: 'assistant', content: 'ACCEPTED_COMPACTION_FIXTURE_RESPONSE' }, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 9000, completion_tokens: 16, total_tokens: 9016 },
+        }));
+        return;
+      }
+      res.statusCode = 404;
+      res.end(JSON.stringify({ error: { message: 'fixture mock provider route not found' } }));
+    });
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen({ port: 0, host }, resolve);
+  });
+  server.unref();
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('fixture mock provider failed to expose a TCP port');
+  }
+  return {
+    kind: 'fixture-mock-provider',
+    host,
+    port: address.port,
+    startedAt: now(),
+    requests,
+    server,
+    artifact: {
+      name: 'mock-provider.json',
+      body: {
+        schema: 'openclaw.project81.accepted-request-compaction.mock-provider.v1',
+        host,
+        port: address.port,
+        startedAt: now(),
+        routes: ['/v1/responses', '/v1/chat/completions'],
+        usageShape: 'deterministic-high-input-token-fixture',
+      },
+    },
+  };
+}
+
+export async function stopFixtureMockProvider(receipt, { now = () => new Date().toISOString() } = {}) {
+  if (!receipt?.server) return { stopped: false, reason: 'no mock provider server receipt', stoppedAt: now() };
+  await new Promise((resolve, reject) => {
+    receipt.server.close((error) => (error ? reject(error) : resolve()));
+  });
+  return {
+    stopped: true,
+    stoppedAt: now(),
+    requestCount: Array.isArray(receipt.requests) ? receipt.requests.length : null,
+  };
 }
 
 function ensureDir(dir) {
@@ -334,6 +427,11 @@ export async function runOrchestration({
     },
   };
 
+  const cleanupState = {
+    gatewayStopped: null,
+    mockProviderStopped: null,
+  };
+
   const finish = (outcome, phase, extra = {}) => {
     const cleanup = {
       schema: 'openclaw.project81.accepted-request-compaction.cleanup.v1',
@@ -343,8 +441,8 @@ export async function runOrchestration({
       retained: args.retainTmp,
       tempRoot: paths.root,
       productionConfigTouched: false,
-      gatewayStopped: null,
-      mockProviderStopped: null,
+      gatewayStopped: cleanupState.gatewayStopped,
+      mockProviderStopped: cleanupState.mockProviderStopped,
       finishedAt: now(),
     };
     emit('cleanup.json', cleanup);
@@ -386,7 +484,49 @@ export async function runOrchestration({
   }
   preflight.portCandidate = port;
 
-  // Phase 3: write redacted temp config (no secrets on disk)
+  const receipts = {};
+
+  const stopStartedMockProvider = async () => {
+    if (!receipts.startMockProvider || cleanupState.mockProviderStopped) return;
+    const stopped = await stopFixtureMockProvider(receipts.startMockProvider, { now });
+    cleanupState.mockProviderStopped = stopped;
+    emit('mock-provider-stop.json', {
+      schema: 'openclaw.project81.accepted-request-compaction.mock-provider-stop.v1',
+      ...stopped,
+    });
+  };
+
+  // Phase 3: start deterministic local mock provider before config write so
+  // the temp Gateway config can point at a real loopback baseUrl.
+  try {
+    const receipt = await liveSteps.startMockProvider({ args, paths, port, openclaw, receipts });
+    if (receipt && typeof receipt === 'object') {
+      receipts.startMockProvider = receipt;
+      preflight.mockProvider = { host: receipt.host ?? '127.0.0.1', port: receipt.port ?? null };
+      if (receipt.artifact) emit(receipt.artifact.name, receipt.artifact.body);
+    }
+  } catch (error) {
+    const reason = String(error?.message ?? error);
+    if (error && error.code === 'LIVE_NOT_IMPLEMENTED') {
+      emit('live-orchestration-not-yet-implemented.json', {
+        schema: 'openclaw.project81.accepted-request-compaction.honest-limit.v1',
+        step: 'startMockProvider',
+        reason,
+      });
+      emit('preflight-context.json', preflight);
+      return finish(NON_PASS_OUTCOMES.LIVE_SEND_NOT_IMPLEMENTED, 'mock-provider-start', { preflight });
+    }
+    emit('mock-provider-start-error.json', {
+      schema: 'openclaw.project81.accepted-request-compaction.phase-error.v1',
+      phase: 'mock-provider-start',
+      step: 'startMockProvider',
+      reason,
+    });
+    emit('preflight-context.json', preflight);
+    return finish(NON_PASS_OUTCOMES.MOCK_PROVIDER_START, 'mock-provider-start', { preflight });
+  }
+
+  // Phase 4: write redacted temp config (no secrets on disk)
   ensureDir(path.dirname(paths.configPath));
   const config = buildRedactedConfig({
     workspaceDir: paths.workspaceDir,
@@ -395,17 +535,16 @@ export async function runOrchestration({
     keepRecentTokens: args.keepRecentTokens,
     reserveTokens: args.reserveTokens,
     port,
+    mockProviderPort: receipts.startMockProvider?.port ?? '<mock-provider-port>',
   });
   writeJsonArtifact(paths.configPath, config);
   emit('temp-config.redacted.json', config);
   preflight.tempConfigPath = paths.configPath;
   emit('preflight-context.json', preflight);
 
-  // Phase 4+ live steps (mock provider start, gateway start, ...) are all
-  // stubbed. Each call maps its failure onto a classified outcome so callers
-  // never see a stack trace masquerading as an unclassified failure.
+  // Phase 5+ live steps. Each call maps its failure onto a classified outcome
+  // so callers never see a stack trace masquerading as an unclassified failure.
   const phaseMap = [
-    ['mock-provider-start', 'startMockProvider', NON_PASS_OUTCOMES.MOCK_PROVIDER_START],
     ['temp-gateway-start', 'startTempGateway', NON_PASS_OUTCOMES.TEMP_GATEWAY_START],
     ['force-context-budget', 'forceContextBudget', NON_PASS_OUTCOMES.CONTEXT_BUDGET],
     ['stage-lifeboat', 'stageLifeboat', NON_PASS_OUTCOMES.LIFEBOAT_MISSING],
@@ -415,7 +554,6 @@ export async function runOrchestration({
     ['verify-successor-sentinel', 'verifySuccessorSentinel', NON_PASS_OUTCOMES.SENTINEL_MISSING],
   ];
 
-  const receipts = {};
   for (const [phase, step, failureOutcome] of phaseMap) {
     try {
       const receipt = await liveSteps[step]({
@@ -440,6 +578,7 @@ export async function runOrchestration({
           step,
           reason,
         });
+        await stopStartedMockProvider();
         return finish(NON_PASS_OUTCOMES.LIVE_SEND_NOT_IMPLEMENTED, phase, {
           preflight,
         });
@@ -450,6 +589,7 @@ export async function runOrchestration({
         step,
         reason,
       });
+      await stopStartedMockProvider();
       return finish(failureOutcome, phase, { preflight });
     }
   }
@@ -461,5 +601,6 @@ export async function runOrchestration({
     schema: 'openclaw.project81.accepted-request-compaction.trace.v1',
     reason: 'trace validation not yet integrated in this increment',
   });
+  await stopStartedMockProvider();
   return finish(NON_PASS_OUTCOMES.LIVE_SEND_NOT_IMPLEMENTED, 'trace-validation', { preflight });
 }

--- a/tools/k6-proofs/scripts/run-accepted-compaction-fixture.mjs
+++ b/tools/k6-proofs/scripts/run-accepted-compaction-fixture.mjs
@@ -32,6 +32,7 @@ import {
   DEFAULT_OPENCLAW_SOURCE_DIR,
   buildRedactedConfig,
   makeUnimplementedLiveSteps,
+  startFixtureMockProvider,
   normalizeSafePath as sharedNormalizeSafePath,
   runOrchestration,
 } from './lib/accepted-compaction-orchestrator.mjs';
@@ -334,7 +335,7 @@ function writeBaseArtifacts(args, paths, plan) {
     notes: args.mode === 'plan'
       ? ['dry-run only; no Gateway started and no production config touched']
       : args.enableLiveOrchestration
-        ? ['live orchestration state machine invoked; preflight-only in this increment']
+        ? ['live orchestration state machine invoked; deterministic mock provider is wired; temp Gateway remains stubbed']
         : ['live mode requested but review gate --enable-live-orchestration not supplied'],
   };
   writeJson(path.join(paths.artifactDir, 'accepted-compaction-plan.json'), plan);
@@ -408,7 +409,10 @@ function resolveOrchestratorInvocation({ args, paths, plan }) {
       openclawDir: args.openclawDir || DEFAULT_OPENCLAW_SOURCE_DIR,
     },
     paths,
-    liveSteps: makeUnimplementedLiveSteps(),
+    liveSteps: {
+      ...makeUnimplementedLiveSteps(),
+      startMockProvider: startFixtureMockProvider,
+    },
   };
 }
 


### PR DESCRIPTION
## Summary

Refs #331.

Moves the accepted `request_compaction` fixture one live-orchestration step past the scaffold/preflight line:

- adds a deterministic loopback OpenAI-compatible mock provider
  - `/v1/responses`
  - `/v1/chat/completions`
  - fixed high-input token usage shape for the later context-forcing phase
- wires the reviewed `--run --enable-live-orchestration` path to start/stop that provider
- writes `mock-provider.json` and `mock-provider-stop.json` receipts
- writes the temp Gateway config with a real loopback mock-provider `baseUrl`
- advances the honest blocker from `mock-provider-start` to `temp-gateway-start`
- keeps `pass:false`; no accepted-compaction PASS is claimed

## Current classification after this PR

This does **not** solve #331 end-to-end. It reduces the next exact blocker to isolated temp Gateway startup/RPC wiring:

- outcome: `HONEST-LIMIT-live-orchestration-preflight-only`
- phase: `temp-gateway-start`
- `pass:false`

Remaining work before PASS remains: isolated Gateway start, disposable proof session/RPC path, deterministic context-forcing over threshold, staged post-compaction delegate, accepted `request_compaction` receipt, compaction lifecycle wait, lifeboat return, successor sentinel, and trace/cleanup receipts.

## Verification

- `node --check tools/k6-proofs/scripts/lib/accepted-compaction-orchestrator.mjs`
- `node --check tools/k6-proofs/scripts/run-accepted-compaction-fixture.mjs`
- `node --test tools/k6-proofs/scripts/__tests__/*.test.mjs` — 59/59 pass
- live-gated fixture smoke against temp paths:
  - `OPENCLAW_ACCEPTED_COMPACTION_FIXTURE=true node tools/k6-proofs/scripts/run-accepted-compaction-fixture.mjs --run --enable-live-orchestration --json --openclaw-dir /tmp/oc-openclaw-331-source --tmpdir /tmp/oc-p81-331-fix-tmp2 --artifact-dir /tmp/oc-p81-331-fix-art2 --candidate-sha 5881ad679795d7d77d7d3cae3082c51e5844321b`
  - observed `phase: "temp-gateway-start"`, `pass:false`, mock provider receipt present, temp config `baseUrl` set to `http://127.0.0.1:<mock-port>`
