### PR TITLE
P81 #331: wire accepted-compaction temp Gateway startup

### DIFF
--- a/tools/k6-proofs/fixtures/accepted-request-compaction/README.md
+++ b/tools/k6-proofs/fixtures/accepted-request-compaction/README.md
@@ -1,6 +1,6 @@
 # Accepted `request_compaction` fixture
 
-This fixture is the Project 81 scaffold for proving the **accepted** compaction path, separate from the existing threshold-rejection canaries (`R-RC-1` and ordinary `R-RC-2`). Live execution is gated behind an explicit review flag; today the runner implements preflight plus a deterministic local mock provider, and the downstream phases (temp Gateway spawn, `request_compaction` RPC, lifecycle wait, successor sentinel) live behind dependency-injected stubs so the follow-up review PR can wire them without a second refactor.
+This fixture is the Project 81 scaffold for proving the **accepted** compaction path, separate from the existing threshold-rejection canaries (`R-RC-1` and ordinary `R-RC-2`). Live execution is gated behind an explicit review flag; today the runner implements preflight, a deterministic local mock provider, and an isolated temp-Gateway startup/probe/stop step. The downstream phases (`request_compaction` RPC, lifecycle wait, successor sentinel) still live behind dependency-injected stubs so the follow-up review PR can wire them without a second refactor.
 
 ## Contract
 
@@ -37,7 +37,7 @@ The dry-run starts no Gateway and touches no production config. It writes:
 
 The plan artifact includes the required environment, receipt names, non-PASS classifications, and guardrails for the reviewed live implementation.
 
-## Live orchestration (mock-provider + preflight only in this increment)
+## Live orchestration (mock provider + temp Gateway startup in this increment)
 
 `--run` requires **three** independent signals so we never start a subprocess
 by accident:
@@ -52,11 +52,13 @@ With the review gate, the runner executes the live orchestration state machine w
 
 - Deterministic loopback mock provider startup with OpenAI-compatible `/v1/responses` and `/v1/chat/completions` routes. The provider returns fixed high-input token usage suitable for the later context-forcing phase and writes `mock-provider.json` / `mock-provider-stop.json` receipts.
 - Preflight validation of the OpenClaw source dir (`--openclaw-dir` or `OPENCLAW_ACCEPTED_COMPACTION_OPENCLAW_DIR`). Directories that live inside any production marker (`~/.openclaw`, `~/flesh_beast_tmp/openclaw`) are refused with `BLOCKED-openclaw-dir-inside-production`. Reviewed source-only guards are required before the default hint directory may be used.
-- Free port allocation on 127.0.0.1 (releases the port immediately; the temp Gateway will re-bind when the live implementation lands).
+- Free port allocation on 127.0.0.1 (releases the port immediately; the temp Gateway re-binds it during startup).
 - Redacted temp config write to `<tempRoot>/config/openclaw.json`. The fixture token is never written to disk — the config carries `<REDACTED-fixture-token>`, and the model provider baseUrl points at the deterministic mock provider port.
 - `preflight-context.json` receipt with candidate SHA, openclaw entrypoint, port candidate, mock provider port, and configured context budget.
+- Isolated temp Gateway command spawn with temp-only `OPENCLAW_CONFIG_PATH`, `OPENCLAW_STATE_DIR`, `OPENCLAW_WORKSPACE_DIR`, `OPENCLAW_GATEWAY_PORT`, and loopback `/health` + `/status` readiness probes. Startup writes `temp-gateway-start.json`; cleanup writes `temp-gateway-stop.json`.
+- Optional test/review command override via `OPENCLAW_ACCEPTED_COMPACTION_GATEWAY_CMD_JSON`, a JSON argv template supporting `{{ENTRYPOINT}}`, `{{PORT}}`, `{{CONFIG_PATH}}`, `{{STATE_DIR}}`, `{{WORKSPACE_DIR}}`, `{{LOGS_DIR}}`, and `{{TMP_ROOT}}`.
 
-After mock-provider/preflight the state machine calls the temp-Gateway start step, which is currently unimplemented and causes the runner to classify as `HONEST-LIMIT-live-orchestration-preflight-only`, exit 3, `pass:false`, with `phase: "temp-gateway-start"`. This is intentional: no PASS is possible until the isolated Gateway, RPC, compaction lifecycle, and lifeboat receipts are wired.
+After temp Gateway readiness the state machine calls context-budget forcing, which is currently unimplemented and causes the runner to classify as `HONEST-LIMIT-live-orchestration-preflight-only`, exit 3, `pass:false`, with `phase: "force-context-budget"`. If the temp Gateway cannot start or become ready, the runner classifies as `BLOCKED-temp-gateway-start`. This is intentional: no PASS is possible until the RPC, compaction lifecycle, and lifeboat receipts are wired.
 
 Example:
 
@@ -83,6 +85,7 @@ The future live runner must make these explicit and redacted in artifacts:
 - `OPENCLAW_STATE_DIR=<tmp>/state`
 - `OPENCLAW_WORKSPACE_DIR=<tmp>/workspace`
 - `OPENCLAW_ACCEPTED_COMPACTION_PORT=<free-port>` (0 = allocate during preflight)
+- optional `OPENCLAW_ACCEPTED_COMPACTION_GATEWAY_CMD_JSON='["node","/path/to/mock-temp-gateway.mjs","--port","{{PORT}}"]'` for review/test command override
 - `OPENCLAW_GATEWAY_WS=ws://127.0.0.1:<port>`
 - `OPENCLAW_GATEWAY_TOKEN=<fixture-token>` (never written to disk)
 - `OPENCLAW_CANDIDATE_SHA=<40-char-sha>`

--- a/tools/k6-proofs/fixtures/accepted-request-compaction/mock-temp-gateway.mjs
+++ b/tools/k6-proofs/fixtures/accepted-request-compaction/mock-temp-gateway.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import { createServer } from 'node:http';
+import process from 'node:process';
+
+function parsePort(argv) {
+  const index = argv.indexOf('--port');
+  if (index >= 0 && argv[index + 1]) return Number(argv[index + 1]);
+  return Number(process.env.OPENCLAW_GATEWAY_PORT || 0);
+}
+
+const port = parsePort(process.argv.slice(2));
+if (!Number.isInteger(port) || port <= 0 || port > 65_535) {
+  console.error('mock temp gateway requires --port <1-65535>');
+  process.exit(2);
+}
+
+const server = createServer((req, res) => {
+  if (req.url === '/health') {
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify({ ok: true, fixture: 'accepted-compaction-temp-gateway' }));
+    return;
+  }
+  if (req.url === '/status') {
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify({ status: 'ok', fixture: 'accepted-compaction-temp-gateway' }));
+    return;
+  }
+  res.statusCode = 404;
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify({ error: 'not found' }));
+});
+
+server.listen({ host: '127.0.0.1', port }, () => {
+  console.log(`mock temp gateway ready on ${port}`);
+});
+
+const stop = () => server.close(() => process.exit(0));
+process.on('SIGTERM', stop);
+process.on('SIGINT', stop);

--- a/tools/k6-proofs/scripts/__tests__/accepted-compaction-fixture.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/accepted-compaction-fixture.test.mjs
@@ -206,11 +206,12 @@ test('run with --enable-live-orchestration refuses openclaw-dir inside productio
   }
 });
 
-test('run with --enable-live-orchestration starts mock provider, writes preflight-context/temp config, then stops at temp gateway stub', async () => {
+test('run with --enable-live-orchestration starts mock provider, writes preflight-context/temp config, then attempts temp gateway', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'openclaw-accepted-compaction-live-preflight-'));
   try {
     // Provide a fake openclaw source dir outside the production markers that
-    // contains a stub entrypoint file, so preflight succeeds.
+    // contains a stub entrypoint file, so preflight succeeds. The default
+    // Gateway command tries to execute that stub and therefore fails readiness.
     const openclawDir = join(dir, 'openclaw-fake');
     const { mkdir, writeFile } = await import('node:fs/promises');
     await mkdir(openclawDir, { recursive: true });
@@ -228,7 +229,7 @@ test('run with --enable-live-orchestration starts mock provider, writes prefligh
     assert.equal(run.status, 3, run.stderr || run.stdout);
     const parsed = JSON.parse(run.stdout);
     assert.equal(parsed.pass, false);
-    assert.equal(parsed.outcome, 'HONEST-LIMIT-live-orchestration-preflight-only');
+    assert.equal(parsed.outcome, 'BLOCKED-temp-gateway-start');
     assert.equal(parsed.phase, 'temp-gateway-start');
 
     const preflight = JSON.parse(await readFile(join(dir, 'artifacts', 'preflight-context.json'), 'utf8'));
@@ -245,15 +246,60 @@ test('run with --enable-live-orchestration starts mock provider, writes prefligh
     assert.doesNotMatch(JSON.stringify(config), /secret-token-must-not-print/);
     assert.doesNotMatch(JSON.stringify(config), /openai-secret-must-not-print/);
 
+    const phaseError = JSON.parse(await readFile(join(dir, 'artifacts', 'temp-gateway-start-error.json'), 'utf8'));
+    assert.equal(phaseError.step, 'startTempGateway');
+
+    const cleanup = JSON.parse(await readFile(join(dir, 'artifacts', 'cleanup.json'), 'utf8'));
+    assert.equal(cleanup.productionConfigTouched, false);
+    assert.equal(cleanup.gatewayStopped, null, 'gateway did not reach a start receipt');
+    assert.equal(cleanup.mockProviderStopped.stopped, true);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('run with mock temp gateway advances the blocker to context-budget forcing', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'openclaw-accepted-compaction-mock-gateway-'));
+  try {
+    const openclawDir = join(dir, 'openclaw-fake');
+    const { mkdir, writeFile } = await import('node:fs/promises');
+    await mkdir(openclawDir, { recursive: true });
+    await writeFile(join(openclawDir, 'openclaw.mjs'), '// stub\n');
+    const mockGateway = join(repoRoot, 'tools/k6-proofs/fixtures/accepted-request-compaction/mock-temp-gateway.mjs');
+    const run = runFixture([
+      '--run',
+      '--enable-live-orchestration',
+      '--tmpdir', join(dir, 'fixture'),
+      '--artifact-dir', join(dir, 'artifacts'),
+      '--openclaw-dir', openclawDir,
+      '--json',
+    ], {
+      OPENCLAW_ACCEPTED_COMPACTION_FIXTURE: 'true',
+      OPENCLAW_ACCEPTED_COMPACTION_GATEWAY_CMD_JSON: JSON.stringify([process.execPath, mockGateway, '--port', '{{PORT}}']),
+    });
+    assert.equal(run.status, 3, run.stderr || run.stdout);
+    const parsed = JSON.parse(run.stdout);
+    assert.equal(parsed.pass, false);
+    assert.equal(parsed.outcome, 'HONEST-LIMIT-live-orchestration-preflight-only');
+    assert.equal(parsed.phase, 'force-context-budget');
+
+    const start = JSON.parse(await readFile(join(dir, 'artifacts', 'temp-gateway-start.json'), 'utf8'));
+    assert.equal(start.port > 0, true);
+    assert.equal(start.probe.healthStatus, 200);
+    assert.equal(start.probe.statusStatus, 200);
+
+    const stop = JSON.parse(await readFile(join(dir, 'artifacts', 'temp-gateway-stop.json'), 'utf8'));
+    assert.equal(stop.stopped, true);
+
     const honestLimit = JSON.parse(await readFile(
       join(dir, 'artifacts', 'live-orchestration-not-yet-implemented.json'),
       'utf8',
     ));
-    assert.equal(honestLimit.step, 'startTempGateway');
+    assert.equal(honestLimit.step, 'forceContextBudget');
 
     const cleanup = JSON.parse(await readFile(join(dir, 'artifacts', 'cleanup.json'), 'utf8'));
     assert.equal(cleanup.productionConfigTouched, false);
-    assert.equal(cleanup.gatewayStopped, null, 'no gateway ever started');
+    assert.equal(cleanup.gatewayStopped.stopped, true);
     assert.equal(cleanup.mockProviderStopped.stopped, true);
   } finally {
     await rm(dir, { recursive: true, force: true });

--- a/tools/k6-proofs/scripts/__tests__/accepted-compaction-orchestrator.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/accepted-compaction-orchestrator.test.mjs
@@ -234,6 +234,7 @@ test('runOrchestration reaches request-compaction phase and classifies FAIL when
     const liveSteps = makeUnimplementedLiveSteps();
     liveSteps.startMockProvider = async () => ({ pid: 1, port: 65001 });
     liveSteps.startTempGateway = async () => ({ pid: 2, port: 65002 });
+    liveSteps.stopTempGateway = async () => ({ stopped: true, stopSignal: 'TEST' });
     liveSteps.forceContextBudget = async () => ({ effectiveFraction: 0.82 });
     liveSteps.stageLifeboat = async () => ({ delegateId: 'delegate-abc' });
     liveSteps.requestCompaction = async () => {

--- a/tools/k6-proofs/scripts/lib/accepted-compaction-orchestrator.mjs
+++ b/tools/k6-proofs/scripts/lib/accepted-compaction-orchestrator.mjs
@@ -496,6 +496,32 @@ export async function runOrchestration({
     });
   };
 
+  const stopStartedTempGateway = async () => {
+    if (!receipts.startTempGateway || cleanupState.gatewayStopped) return;
+    const stopped = await liveSteps.stopTempGateway({
+      args,
+      paths,
+      port,
+      openclaw,
+      receipts,
+      gateway: receipts.startTempGateway,
+    });
+    cleanupState.gatewayStopped = stopped;
+    if (stopped?.artifact) {
+      emit(stopped.artifact.name, stopped.artifact.body);
+    } else {
+      emit('temp-gateway-stop.json', {
+        schema: 'openclaw.project81.accepted-request-compaction.temp-gateway-stop.v1',
+        ...(stopped && typeof stopped === 'object' ? stopped : { stopped: Boolean(stopped) }),
+      });
+    }
+  };
+
+  const stopStartedLiveProcesses = async () => {
+    await stopStartedTempGateway();
+    await stopStartedMockProvider();
+  };
+
   // Phase 3: start deterministic local mock provider before config write so
   // the temp Gateway config can point at a real loopback baseUrl.
   try {
@@ -578,7 +604,7 @@ export async function runOrchestration({
           step,
           reason,
         });
-        await stopStartedMockProvider();
+        await stopStartedLiveProcesses();
         return finish(NON_PASS_OUTCOMES.LIVE_SEND_NOT_IMPLEMENTED, phase, {
           preflight,
         });
@@ -589,7 +615,7 @@ export async function runOrchestration({
         step,
         reason,
       });
-      await stopStartedMockProvider();
+      await stopStartedLiveProcesses();
       return finish(failureOutcome, phase, { preflight });
     }
   }
@@ -601,6 +627,6 @@ export async function runOrchestration({
     schema: 'openclaw.project81.accepted-request-compaction.trace.v1',
     reason: 'trace validation not yet integrated in this increment',
   });
-  await stopStartedMockProvider();
+  await stopStartedLiveProcesses();
   return finish(NON_PASS_OUTCOMES.LIVE_SEND_NOT_IMPLEMENTED, 'trace-validation', { preflight });
 }

--- a/tools/k6-proofs/scripts/run-accepted-compaction-fixture.mjs
+++ b/tools/k6-proofs/scripts/run-accepted-compaction-fixture.mjs
@@ -20,8 +20,9 @@
  * successor sentinel) live behind dependency-injected stubs so the
  * follow-up review PR can wire them without a second refactor.
  */
-import { chmodSync, mkdirSync, writeFileSync } from 'node:fs';
+import { chmodSync, createWriteStream, mkdirSync, writeFileSync } from 'node:fs';
 import { mkdtemp } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -43,6 +44,10 @@ const DEFAULT_RESERVE_TOKENS = 2_000;
 const DEFAULT_TIMEOUT_MS = 180_000;
 const DEFAULT_PORT = 0;
 const DEFAULT_MODEL = 'fixture/openai-compatible-local';
+const DEFAULT_GATEWAY_PROBE_TIMEOUT_MS = 30_000;
+const DEFAULT_GATEWAY_STOP_TIMEOUT_MS = 5_000;
+const FIXTURE_GATEWAY_TOKEN = '<REDACTED-fixture-token>';
+
 
 function usage() {
   return `Usage: node tools/k6-proofs/scripts/run-accepted-compaction-fixture.mjs --plan [options]
@@ -61,6 +66,7 @@ Options:
   --reserve-tokens <n>             Compaction reserveTokens/floor (default: ${DEFAULT_RESERVE_TOKENS}).
   --timeout-ms <n>                 Lifecycle timeout (default: ${DEFAULT_TIMEOUT_MS}).
   --port <n>                       Temp Gateway port, 0 = allocate free port during preflight.
+  OPENCLAW_ACCEPTED_COMPACTION_GATEWAY_CMD_JSON  Optional JSON argv template for temp Gateway command. Supports {{ENTRYPOINT}}, {{PORT}}, {{CONFIG_PATH}}, {{STATE_DIR}}, {{WORKSPACE_DIR}}, {{LOGS_DIR}}, {{TMP_ROOT}}.
   --retain-tmp                    Mark temp root retained in cleanup plan.
   --json                          Print machine-readable result.
   --help                          Show this help.
@@ -392,6 +398,174 @@ function writeReviewGateArtifacts(args, paths, plan) {
   writeJson(path.join(paths.artifactDir, 'outcome.json'), outcome);
 }
 
+function resolveGatewayCommandTemplate() {
+  const raw = process.env.OPENCLAW_ACCEPTED_COMPACTION_GATEWAY_CMD_JSON;
+  if (!raw) return [process.execPath, '{{ENTRYPOINT}}', 'gateway'];
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`OPENCLAW_ACCEPTED_COMPACTION_GATEWAY_CMD_JSON must be valid JSON: ${error.message}`);
+  }
+  if (!Array.isArray(parsed) || parsed.length === 0 || parsed.some((part) => typeof part !== 'string' || part.length === 0)) {
+    throw new Error('OPENCLAW_ACCEPTED_COMPACTION_GATEWAY_CMD_JSON must be a non-empty JSON array of strings');
+  }
+  return parsed;
+}
+
+function interpolateCommandParts(template, replacements) {
+  return template.map((part) => part.replace(/\{\{([A-Z_]+)\}\}/gu, (_match, key) => replacements[key] ?? _match));
+}
+
+function resolveGatewayCommand({ openclaw, paths, port }) {
+  const parts = interpolateCommandParts(resolveGatewayCommandTemplate(), {
+    ENTRYPOINT: openclaw.entrypoint,
+    PORT: String(port),
+    CONFIG_PATH: paths.configPath,
+    STATE_DIR: paths.stateDir,
+    WORKSPACE_DIR: paths.workspaceDir,
+    LOGS_DIR: paths.logsDir,
+    TMP_ROOT: paths.root,
+  });
+  const withPort = parts.some((part) => part === '--port') ? parts : [...parts, '--port', String(port)];
+  return { command: withPort[0], args: withPort.slice(1), display: withPort.join(' ') };
+}
+
+function createExitTracker(child) {
+  const tracker = { result: null, promise: null };
+  tracker.promise = new Promise((resolve) => {
+    child.once('exit', (code, signal) => {
+      tracker.result = { code, signal };
+      resolve(tracker.result);
+    });
+  });
+  return tracker;
+}
+
+async function waitForExit(child, exitTracker) {
+  if (exitTracker?.result) return exitTracker.result;
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return { code: child.exitCode, signal: child.signalCode };
+  }
+  return exitTracker?.promise ?? new Promise((resolve) => child.once('exit', (code, signal) => resolve({ code, signal })));
+}
+
+async function probeGateway(port) {
+  const headers = { authorization: `Bearer ${FIXTURE_GATEWAY_TOKEN}` };
+  const base = `http://127.0.0.1:${port}`;
+  const [health, status] = await Promise.allSettled([
+    fetch(`${base}/health`, { headers }),
+    fetch(`${base}/status`, { headers }),
+  ]);
+  const healthStatus = health.status === 'fulfilled' ? health.value.status : null;
+  const statusStatus = status.status === 'fulfilled' ? status.value.status : null;
+  const ok = health.status === 'fulfilled' && health.value.ok && status.status === 'fulfilled' && status.value.ok;
+  let lastError = null;
+  if (health.status === 'rejected') lastError = health.reason?.message || String(health.reason);
+  else if (status.status === 'rejected') lastError = status.reason?.message || String(status.reason);
+  else if (!ok) lastError = `unexpected probe status health=${healthStatus} status=${statusStatus}`;
+  return { ok, healthStatus, statusStatus, lastError };
+}
+
+async function waitForGatewayReadiness({ child, exitTracker, port, timeoutMs }) {
+  const deadline = Date.now() + Math.min(timeoutMs, DEFAULT_GATEWAY_PROBE_TIMEOUT_MS);
+  let lastProbe = null;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      const exit = await waitForExit(child, exitTracker);
+      throw new Error(`temp Gateway exited before readiness (code=${exit.code ?? 'null'}, signal=${exit.signal ?? 'null'})`);
+    }
+    lastProbe = await probeGateway(port);
+    if (lastProbe.ok) return lastProbe;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`temp Gateway did not become ready before timeout (${Math.min(timeoutMs, DEFAULT_GATEWAY_PROBE_TIMEOUT_MS)}ms; last=${lastProbe?.lastError ?? 'none'})`);
+}
+
+function gatewayEnv({ paths, port }) {
+  return {
+    ...process.env,
+    OPENCLAW_CONFIG_PATH: paths.configPath,
+    OPENCLAW_STATE_DIR: paths.stateDir,
+    OPENCLAW_WORKSPACE_DIR: paths.workspaceDir,
+    OPENCLAW_GATEWAY_PORT: String(port),
+    OPENCLAW_GATEWAY_TOKEN: FIXTURE_GATEWAY_TOKEN,
+    OPENCLAW_ACCEPTED_COMPACTION_FIXTURE: 'true',
+    OPENCLAW_ACCEPTED_COMPACTION_TMPDIR: paths.root,
+  };
+}
+
+async function startTempGateway({ args, paths, port, openclaw }) {
+  mkdirSync(paths.logsDir, { recursive: true, mode: 0o700 });
+  const command = resolveGatewayCommand({ openclaw, paths, port });
+  const stdoutPath = path.join(paths.logsDir, 'temp-gateway.stdout.log');
+  const stderrPath = path.join(paths.logsDir, 'temp-gateway.stderr.log');
+  const stdout = createWriteStream(stdoutPath, { flags: 'a', mode: 0o600 });
+  const stderr = createWriteStream(stderrPath, { flags: 'a', mode: 0o600 });
+  let child;
+  try {
+    child = spawn(command.command, command.args, {
+      cwd: openclaw.dir,
+      env: gatewayEnv({ paths, port }),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    stdout.end();
+    stderr.end();
+    throw new Error(`failed to spawn temp Gateway command "${command.display}": ${error.message}`);
+  }
+  child.stdout.pipe(stdout);
+  child.stderr.pipe(stderr);
+  const exitTracker = createExitTracker(child);
+  try {
+    const probe = await waitForGatewayReadiness({ child, exitTracker, port, timeoutMs: args.timeoutMs });
+    return {
+      kind: 'temp-gateway-started',
+      pid: child.pid ?? null,
+      port,
+      child,
+      exitTracker,
+      logs: { stdout: stdoutPath, stderr: stderrPath },
+      artifact: {
+        name: 'temp-gateway-start.json',
+        body: {
+          schema: 'openclaw.project81.accepted-request-compaction.temp-gateway-start.v1',
+          pid: child.pid ?? null,
+          port,
+          command: command.display,
+          probe,
+          logs: { stdout: stdoutPath, stderr: stderrPath },
+        },
+      },
+    };
+  } catch (error) {
+    child.kill('SIGTERM');
+    stdout.end();
+    stderr.end();
+    throw error;
+  }
+}
+
+async function stopTempGateway({ gateway }) {
+  if (!gateway?.child) {
+    return { stopped: false, reason: 'no temp gateway process receipt' };
+  }
+  const { child, exitTracker } = gateway;
+  if (child.exitCode !== null || child.signalCode !== null) {
+    const exit = await waitForExit(child, exitTracker);
+    return { stopped: true, alreadyExited: true, observedExit: exit };
+  }
+  child.kill('SIGTERM');
+  const exit = await Promise.race([
+    waitForExit(child, exitTracker),
+    new Promise((resolve) => setTimeout(() => resolve(null), DEFAULT_GATEWAY_STOP_TIMEOUT_MS)),
+  ]);
+  if (exit) return { stopped: true, stopSignal: 'SIGTERM', observedExit: exit };
+  child.kill('SIGKILL');
+  return { stopped: true, stopSignal: 'SIGKILL', stopForced: true, observedExit: await waitForExit(child, exitTracker) };
+}
+
+
 /**
  * Test-only hook: an alternative orchestrator factory may be injected via
  * globalThis.__openclawAcceptedCompactionTestHooks.orchestratorFactory. The
@@ -412,6 +586,8 @@ function resolveOrchestratorInvocation({ args, paths, plan }) {
     liveSteps: {
       ...makeUnimplementedLiveSteps(),
       startMockProvider: startFixtureMockProvider,
+      startTempGateway,
+      stopTempGateway,
     },
   };
 }


### PR DESCRIPTION
## Summary

- wires the next #331 accepted-compaction fixture increment: isolated temp Gateway command spawn, loopback `/health` + `/status` readiness probe, and stop receipt
- keeps the fixture fail-closed: no accepted `request_compaction` PASS claim; a successful temp Gateway probe advances the blocker to `phase:"force-context-budget"`
- adds a tiny mock temp Gateway for review/tests via `OPENCLAW_ACCEPTED_COMPACTION_GATEWAY_CMD_JSON`
- updates docs so the next blocker is explicit: context-budget forcing/RPC/lifecycle/lifeboat receipts

## Verification

```bash
node --check tools/k6-proofs/scripts/run-accepted-compaction-fixture.mjs
node --check tools/k6-proofs/scripts/lib/accepted-compaction-orchestrator.mjs
node --check tools/k6-proofs/fixtures/accepted-request-compaction/mock-temp-gateway.mjs
node --test tools/k6-proofs/scripts/__tests__/accepted-compaction-orchestrator.test.mjs tools/k6-proofs/scripts/__tests__/accepted-compaction-fixture.test.mjs
node tools/k6-proofs/scripts/check-manifest-scenarios.mjs
node tools/k6-proofs/scripts/check-scenario-alignment.mjs
node tools/k6-proofs/scripts/check-proof-row-manifests.mjs
node tools/k6-proofs/scripts/validate-corpus.mjs --current
git diff --check
```

Focused live-review smoke with the mock temp Gateway:

- exits `3` / `pass:false`
- `outcome:"HONEST-LIMIT-live-orchestration-preflight-only"`
- `phase:"force-context-budget"`
- emits `temp-gateway-start.json` with `/health` + `/status` 200
- emits `temp-gateway-stop.json` with clean SIGTERM exit

## Boundary

Still no production config writes, no production Gateway restart, no threshold lowering, no hosted frontier token burn, and no PASS from threshold rejection.

Closes no issue; advances #331.
