### PR TITLE
P81 #121: parameterize observability endpoints

### DIFF
--- a/RUNBOOKS/PROOF-CORPUS-METHOD.md
+++ b/RUNBOOKS/PROOF-CORPUS-METHOD.md
@@ -187,16 +187,16 @@ For EACH continuation-tool fire (R-CW / R-CD / R-RC rows), capture the actual Gr
 
 Required evidence:
 - **Trace ID** emitted by the fire (visible in journal `[continuation:…]` log lines + tool-result payload)
-- **Tempo URL** pointing at the trace: `http://tempo.dandelion.cult/api/traces/<trace-id>`
+- **Tempo URL** pointing at the trace, parameterized by `${OPENCLAW_PROOFS_TEMPO_BASE_URL:-http://tempo.dandelion.cult}`: `<tempo-base>/api/traces/<trace-id>`
 - **Span hierarchy export JSON** from Tempo at `R-<row>/<descriptive>_trace.json`
 - **For chained / inter-session / post-compaction rows**: trace-parent stitching evidence across the spans (continuation.delegate.dispatch → child openclaw.run, etc.)
 
-Dead-simple Tempo HTTP API recipe (Tempo is reachable at `http://tempo.dandelion.cult` on port 80; DNS `10.0.0.99`):
+Dead-simple Tempo HTTP API recipe (Tempo is reachable on the dandelion fleet at `http://tempo.dandelion.cult` on port 80; portable runs should set `OPENCLAW_PROOFS_TEMPO_BASE_URL` to their Tempo query endpoint):
 
 1. Find your trace-id if it is not already in your journal `[continuation:…]` line / tool-result. Search your own seat's fires via TraceQL:
 
    ```bash
-   curl -sG http://tempo.dandelion.cult/api/search \
+   curl -sG ${OPENCLAW_PROOFS_TEMPO_BASE_URL:-http://tempo.dandelion.cult}/api/search \
      --data-urlencode 'q={ resource.service.name="<your-seat>-prince" && .gen_ai.tool.name="continue_delegate" }' \
      --data-urlencode "start=$(date -d '8 hours ago' +%s)" \
      --data-urlencode "end=$(date +%s)" \
@@ -208,7 +208,7 @@ Dead-simple Tempo HTTP API recipe (Tempo is reachable at `http://tempo.dandelion
 2. Export the full span-tree JSON. This one curl is the required span-hierarchy export:
 
    ```bash
-   curl -sS "http://tempo.dandelion.cult/api/traces/<TRACE_ID>" \
+   curl -sS "${OPENCLAW_PROOFS_TEMPO_BASE_URL:-http://tempo.dandelion.cult}/api/traces/<TRACE_ID>" \
      -o PROOFS/<FULL_SHA>/R-<row>/<descriptive>_trace.json
    ```
 

--- a/RUNBOOKS/project-81/README.md
+++ b/RUNBOOKS/project-81/README.md
@@ -127,7 +127,7 @@ Most continuation rows still need one or more of these after k6 runs:
 - Tempo trace JSON, not just a trace URL:
 
   ```bash
-  curl -fsS "http://tempo.dandelion.cult/api/traces/<trace-id>" \
+  curl -fsS "${OPENCLAW_PROOFS_TEMPO_BASE_URL:-http://tempo.dandelion.cult}/api/traces/<trace-id>" \
     -o PROOFS/<sha>/<row>/<seat>/tempo/trace-<trace-id>.json
   ```
 

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -203,12 +203,21 @@ raw websocket events, tokens, or local private paths.
 ## Tempo trace receipts
 
 When a live row emits a `trace_id`, `run-proofs.sh` now attempts to fetch the
-matching Tempo JSON from `TEMPO_BASE_URL` (default `http://tempo.dandelion.cult`)
+matching Tempo JSON from `OPENCLAW_PROOFS_TEMPO_BASE_URL` / `TEMPO_BASE_URL` (fleet default `http://tempo.dandelion.cult`)
 and saves it beside the candidate run artifacts as `tempo-trace-<trace>.json`.
 The fetch receipt is stored in `tempo-trace-receipt.json`; fetch failures are
 kept non-fatal by default and leave `tempo-trace-json` review-pending. Set
 `OPENCLAW_PROOFS_K6_TEMPO_REQUIRED=true` only when a missing trace JSON should
 fail the run.
+
+Portable endpoint env vars for reviewer/fork runs:
+
+- `OPENCLAW_PROOFS_TEMPO_BASE_URL` (or legacy `TEMPO_BASE_URL`) — Tempo query base URL for trace fetches.
+- `OPENCLAW_PROOFS_LOKI_BASE_URL` (or legacy `LOKI_BASE_URL`) — Loki base URL for scenarios that probe log infra.
+- `OPENCLAW_PROOFS_PROMETHEUS_BASE_URL` — Prometheus query base URL.
+- `OPENCLAW_PROOFS_PROMETHEUS_RW_URL` (or legacy `K6_PROMETHEUS_RW_SERVER_URL`) — Prometheus remote-write endpoint for `run-proof.sh`.
+
+The dandelion.cult URLs are defaults for our fleet, not requirements for the methodology.
 
 Manual fetch:
 

--- a/tools/k6-proofs/run-proof.sh
+++ b/tools/k6-proofs/run-proof.sh
@@ -5,7 +5,7 @@
 #          ./run-proof.sh r-cd-1 --env GATEWAY_HOST=10.0.0.246
 #
 # Outputs:
-#   - Metrics → Prometheus (prometheus.dandelion.cult) → Grafana
+#   - Metrics → ${OPENCLAW_PROOFS_PROMETHEUS_RW_URL:-Prometheus remote write} → Grafana
 #   - Logs → stdout + Loki (via journal)
 #   - Summary → ./<scenario>-summary.json + report.html (if handleSummary defined)
 
@@ -45,13 +45,19 @@ fi
 SEAT="${OPENCLAW_SEAT_NAME:-${PROOF_SEAT:-$(hostname)}}"
 SHA="${OPENCLAW_CANDIDATE_SHA:-${PROOF_SHA:-$(openclaw --version 2>/dev/null | awk '{print $3}' | tr -d '()' || echo 'unknown')}}"
 
-# Prometheus Remote Write target
-PROM_URL="${K6_PROMETHEUS_RW_SERVER_URL:-http://prometheus.dandelion.cult/api/v1/write}"
+# Portable observability endpoints. Fleet defaults keep current prince behavior, while
+# OPENCLAW_PROOFS_* env vars let reviewers point the suite at their own stack.
+TEMPO_BASE_URL="${OPENCLAW_PROOFS_TEMPO_BASE_URL:-${TEMPO_BASE_URL:-http://tempo.dandelion.cult}}"
+LOKI_BASE_URL="${OPENCLAW_PROOFS_LOKI_BASE_URL:-${LOKI_BASE_URL:-http://loki.dandelion.cult}}"
+PROMETHEUS_BASE_URL="${OPENCLAW_PROOFS_PROMETHEUS_BASE_URL:-${PROMETHEUS_BASE_URL:-http://prometheus.dandelion.cult}}"
+PROM_URL="${OPENCLAW_PROOFS_PROMETHEUS_RW_URL:-${K6_PROMETHEUS_RW_SERVER_URL:-${PROMETHEUS_BASE_URL%/}/api/v1/write}}"
 
 echo "═══════════════════════════════════════════════════════"
 echo " k6 PROOFS: ${SCENARIO}"
 echo " Seat: ${SEAT} | SHA: ${SHA}"
-echo " Prometheus: ${PROM_URL}"
+echo " Prometheus RW: ${PROM_URL}"
+echo " Tempo: ${TEMPO_BASE_URL}"
+echo " Loki: ${LOKI_BASE_URL}"
 echo "═══════════════════════════════════════════════════════"
 
 exec k6 run "${SCENARIO_FILE}" \
@@ -61,4 +67,10 @@ exec k6 run "${SCENARIO_FILE}" \
   --env "OPENCLAW_CANDIDATE_SHA=${SHA}" \
   --env "OPENCLAW_SEAT_NAME=${SEAT}" \
   --env "K6_PROMETHEUS_RW_SERVER_URL=${PROM_URL}" \
+  --env "OPENCLAW_PROOFS_TEMPO_BASE_URL=${TEMPO_BASE_URL}" \
+  --env "TEMPO_BASE_URL=${TEMPO_BASE_URL}" \
+  --env "OPENCLAW_PROOFS_LOKI_BASE_URL=${LOKI_BASE_URL}" \
+  --env "LOKI_BASE_URL=${LOKI_BASE_URL}" \
+  --env "OPENCLAW_PROOFS_PROMETHEUS_BASE_URL=${PROMETHEUS_BASE_URL}" \
+  --env "PROMETHEUS_BASE_URL=${PROMETHEUS_BASE_URL}" \
   "$@"

--- a/tools/k6-proofs/scenarios/r-cw-1.js
+++ b/tools/k6-proofs/scenarios/r-cw-1.js
@@ -17,6 +17,7 @@
  *   GATEWAY_HOST  - gateway hostname (default: 127.0.0.1)
  *   GATEWAY_PORT  - gateway port (default: 18789)
  *   OPENCLAW_GATEWAY_TOKEN - operator auth token (required)
+ *   OPENCLAW_PROOFS_TEMPO_BASE_URL / TEMPO_BASE_URL - Tempo base URL for trace links/probes
  *   PROOF_SHA     - deployed SHA for report metadata
  *   PROOF_SEAT    - seat name for report metadata
  */
@@ -30,6 +31,7 @@ const GATEWAY_PORT = __ENV.GATEWAY_PORT || '18789';
 const GATEWAY_BASE = `http://${GATEWAY_HOST}:${GATEWAY_PORT}`;
 const PROOF_SHA = __ENV.PROOF_SHA || 'unknown';
 const PROOF_SEAT = __ENV.PROOF_SEAT || __ENV.HOSTNAME || 'cael-dgx';
+const TEMPO_BASE_URL = (__ENV.OPENCLAW_PROOFS_TEMPO_BASE_URL || __ENV.TEMPO_BASE_URL || `http://${__ENV.TEMPO_HOST || 'tempo.dandelion.cult'}`).replace(/\/+$/, '');
 
 // Custom metrics
 const cwAccepted = new Counter('r_cw_1_accepted');
@@ -92,8 +94,7 @@ export default function () {
   }
 
   // Step 3: Verify Tempo stack (for post-run trace pull)
-  const tempoHost = __ENV.TEMPO_HOST || 'tempo.dandelion.cult';
-  const tempoRes = http.get(`http://${tempoHost}/ready`, { timeout: '5s' });
+  const tempoRes = http.get(`${TEMPO_BASE_URL}/ready`, { timeout: '5s' });
   const tempoAlive = check(tempoRes, {
     '[R-CW-1] tempo reachable': (r) => r.status === 200 || r.status === 0,
   });
@@ -121,7 +122,7 @@ export default function () {
   console.log(`[R-CW-1] Proof nonce for correlation: ${proofNonce}`);
   console.log(`[R-CW-1] Post-run evidence:`);
   console.log(`[R-CW-1]   journal: journalctl --user -u openclaw-gateway --since "5min ago" | grep "continuation.work"`);
-  console.log(`[R-CW-1]   tempo: curl http://tempo.dandelion.cult/api/traces/<traceparent-from-tool-response>`);
+  console.log(`[R-CW-1]   tempo: curl ${TEMPO_BASE_URL}/api/traces/<traceparent-from-tool-response>`);
 
   cwAccepted.add(1);
   cwWoke.add(1);
@@ -144,7 +145,7 @@ export function handleSummary(data) {
     metrics: data.metrics,
     evidence: {
       journalGrep: 'journalctl --user -u openclaw-gateway --since "5min ago" | grep "continuation.work"',
-      tempoCorrelation: 'curl http://tempo.dandelion.cult/api/traces/<traceparent>',
+      tempoCorrelation: `curl ${TEMPO_BASE_URL}/api/traces/<traceparent>`,
     },
   };
 

--- a/tools/k6-proofs/scenarios/r-cw.js
+++ b/tools/k6-proofs/scenarios/r-cw.js
@@ -28,6 +28,9 @@ const GATEWAY_PORT = __ENV.GATEWAY_PORT || '18789';
 const GATEWAY_BASE = `http://${GATEWAY_HOST}:${GATEWAY_PORT}`;
 const PROOF_SHA = __ENV.PROOF_SHA || 'unknown';
 const PROOF_SEAT = __ENV.PROOF_SEAT || __ENV.HOSTNAME || 'cael-dgx';
+const TEMPO_BASE_URL = (__ENV.OPENCLAW_PROOFS_TEMPO_BASE_URL || __ENV.TEMPO_BASE_URL || `http://${__ENV.TEMPO_HOST || 'tempo.dandelion.cult'}`).replace(/\/+$/, '');
+const LOKI_BASE_URL = (__ENV.OPENCLAW_PROOFS_LOKI_BASE_URL || __ENV.LOKI_BASE_URL || `http://${__ENV.LOKI_HOST || 'loki.dandelion.cult'}`).replace(/\/+$/, '');
+const PROMETHEUS_BASE_URL = (__ENV.OPENCLAW_PROOFS_PROMETHEUS_BASE_URL || __ENV.PROMETHEUS_BASE_URL || `http://${__ENV.PROM_HOST || 'prometheus.dandelion.cult'}`).replace(/\/+$/, '');
 
 // Metrics
 const checksRun = new Counter('r_cw_checks_run');
@@ -83,12 +86,8 @@ export default function () {
   }
 
   // 3. Observability stack checks (needed for R-CW-3, R-CW-7 trace correlation)
-  const tempoHost = __ENV.TEMPO_HOST || 'tempo.dandelion.cult';
-  const lokiHost = __ENV.LOKI_HOST || 'loki.dandelion.cult';
-  const promHost = __ENV.PROM_HOST || 'prometheus.dandelion.cult';
-
   checksRun.add(1);
-  const tempo = http.get(`http://${tempoHost}/ready`, { timeout: '5s' });
+  const tempo = http.get(`${TEMPO_BASE_URL}/ready`, { timeout: '5s' });
   const tempoOk = check(tempo, {
     '[R-CW] tempo ready (trace correlation)': (r) => r.status === 200,
   });
@@ -99,7 +98,7 @@ export default function () {
   }
 
   checksRun.add(1);
-  const loki = http.get(`http://${lokiHost}/ready`, { timeout: '5s' });
+  const loki = http.get(`${LOKI_BASE_URL}/ready`, { timeout: '5s' });
   const lokiOk = check(loki, {
     '[R-CW] loki ready (log correlation)': (r) => r.status === 200,
   });
@@ -107,7 +106,7 @@ export default function () {
   else console.warn(`[R-CW] Loki not ready — journal-based correlation available as fallback`);
 
   checksRun.add(1);
-  const prom = http.get(`http://${promHost}/-/ready`, { timeout: '5s' });
+  const prom = http.get(`${PROMETHEUS_BASE_URL}/-/ready`, { timeout: '5s' });
   const promOk = check(prom, {
     '[R-CW] prometheus ready (metrics destination)': (r) => r.status === 200,
   });

--- a/tools/k6-proofs/scripts/__tests__/tempo-fetch.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/tempo-fetch.test.mjs
@@ -93,3 +93,26 @@ test('can discover trace id from Tempo TraceQL search', async () => {
     await rm(root, { recursive: true, force: true });
   }
 });
+
+test('uses OPENCLAW_PROOFS_TEMPO_BASE_URL when --tempo-url is omitted', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'tempo-fetch-env-'));
+  try {
+    await withServer((req, res) => {
+      assert.equal(req.url, '/api/traces/1111222233334444');
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ trace: { spans: [{ spanId: 'env' }] } }));
+    }, async (baseUrl) => {
+      const out = path.join(root, 'trace.json');
+      const run = await runNode(process.execPath, [script, '--trace-id', '1111222233334444', '--out', out], {
+        encoding: 'utf8',
+        env: { ...process.env, OPENCLAW_PROOFS_TEMPO_BASE_URL: baseUrl, TEMPO_BASE_URL: 'http://unused.invalid' },
+      });
+      const receipt = JSON.parse(run.stdout);
+      assert.equal(receipt.fetched, true);
+      assert.equal(receipt.traceId, '1111222233334444');
+      assert.equal(receipt.spans, 1);
+    });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/tools/k6-proofs/scripts/fetch-tempo-trace.mjs
+++ b/tools/k6-proofs/scripts/fetch-tempo-trace.mjs
@@ -10,12 +10,20 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
-function usage() {
-  console.error('Usage: node fetch-tempo-trace.mjs (--trace-id <id> | --run-dir <dir> | --traceql <query>) [--tempo-url http://tempo.dandelion.cult] [--start <unix-seconds>] [--end <unix-seconds>] [--out trace.json]');
+const DEFAULT_TEMPO_BASE_URL = 'http://tempo.dandelion.cult';
+
+function defaultTempoUrl(env = process.env) {
+  return env.OPENCLAW_PROOFS_TEMPO_BASE_URL || env.TEMPO_BASE_URL || DEFAULT_TEMPO_BASE_URL;
 }
 
-function parseArgs(argv) {
-  const out = { tempoUrl: process.env.TEMPO_BASE_URL || 'http://tempo.dandelion.cult' };
+function usage() {
+  console.error(`Usage: node fetch-tempo-trace.mjs (--trace-id <id> | --run-dir <dir> | --traceql <query>) [--tempo-url <base-url>] [--start <unix-seconds>] [--end <unix-seconds>] [--out trace.json]
+
+Tempo endpoint resolution: --tempo-url, else OPENCLAW_PROOFS_TEMPO_BASE_URL, else TEMPO_BASE_URL, else ${DEFAULT_TEMPO_BASE_URL}.`);
+}
+
+function parseArgs(argv, env = process.env) {
+  const out = { tempoUrl: defaultTempoUrl(env) };
   for (let i = 2; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === '--trace-id' || arg === '--run-dir' || arg === '--traceql' || arg === '--tempo-url' || arg === '--start' || arg === '--end' || arg === '--out') {

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -72,6 +72,12 @@ if [[ "$DEPLOYED_BUILD_STAMP" == "unknown" && -f ~/.openclaw/openclaw.json ]]; t
 fi
 export OPENCLAW_RUNTIME_BUILD_SHA="$DEPLOYED_BUILD_STAMP"
 
+# Portable observability endpoints. Defaults preserve the dandelion fleet, but
+# reviewers can override without editing scripts or docs-local config.
+export OPENCLAW_PROOFS_TEMPO_BASE_URL="${OPENCLAW_PROOFS_TEMPO_BASE_URL:-${TEMPO_BASE_URL:-http://tempo.dandelion.cult}}"
+export OPENCLAW_PROOFS_LOKI_BASE_URL="${OPENCLAW_PROOFS_LOKI_BASE_URL:-${LOKI_BASE_URL:-http://loki.dandelion.cult}}"
+export OPENCLAW_PROOFS_PROMETHEUS_BASE_URL="${OPENCLAW_PROOFS_PROMETHEUS_BASE_URL:-${PROMETHEUS_BASE_URL:-http://prometheus.dandelion.cult}}"
+
 # Resolve Session Key
 if [[ -z "${OPENCLAW_SESSION_KEY:-}" ]]; then
   echo "Resolving session key for selector: $SESSION_SELECTOR"
@@ -245,7 +251,7 @@ PY_EVIDENCE_JSONL
         TRACE_ID="$(jq -r 'select((.trace_id // "") != "") | .trace_id' "$RUN_DIR/evidence.jsonl" | head -n 1)"
         if [[ -n "$TRACE_ID" ]]; then
           TEMPO_TRACE_JSON="$RUN_DIR/tempo-trace-${TRACE_ID:0:12}.json"
-          if node scripts/fetch-tempo-trace.mjs --trace-id "$TRACE_ID" --out "$TEMPO_TRACE_JSON" > "$RUN_DIR/tempo-trace-receipt.json" 2> "$RUN_DIR/tempo-trace-error.log"; then
+          if node scripts/fetch-tempo-trace.mjs --trace-id "$TRACE_ID" --tempo-url "$OPENCLAW_PROOFS_TEMPO_BASE_URL" --out "$TEMPO_TRACE_JSON" > "$RUN_DIR/tempo-trace-receipt.json" 2> "$RUN_DIR/tempo-trace-error.log"; then
             TRACE_STATUS="present"
             echo "[$ROW_ID] TEMPO TRACE: $TEMPO_TRACE_JSON"
           else


### PR DESCRIPTION
## Summary

- parameterizes P81/k6 observability endpoints so reviewer/fork runs can point at their own Tempo/Loki/Prometheus without editing scripts
- adds `OPENCLAW_PROOFS_TEMPO_BASE_URL`, `OPENCLAW_PROOFS_LOKI_BASE_URL`, `OPENCLAW_PROOFS_PROMETHEUS_BASE_URL`, and `OPENCLAW_PROOFS_PROMETHEUS_RW_URL` while preserving dandelion defaults
- teaches `fetch-tempo-trace.mjs` to prefer `OPENCLAW_PROOFS_TEMPO_BASE_URL` when `--tempo-url` is omitted
- propagates endpoint env through `run-proof.sh`, `run-proofs.sh`, and R-CW observability scenarios
- updates Project 81/runbook docs to describe the portable endpoint knobs

## Verification

```bash
node --check tools/k6-proofs/scripts/fetch-tempo-trace.mjs
node --check tools/k6-proofs/scenarios/r-cw-1.js
node --check tools/k6-proofs/scenarios/r-cw.js
bash -n tools/k6-proofs/run-proof.sh
bash -n tools/k6-proofs/scripts/run-proofs.sh
node --test tools/k6-proofs/scripts/__tests__/tempo-fetch.test.mjs tools/k6-proofs/scripts/__tests__/metrics-export.test.mjs
node tools/k6-proofs/scripts/check-manifest-scenarios.mjs
node tools/k6-proofs/scripts/check-scenario-alignment.mjs
node tools/k6-proofs/scripts/check-proof-row-manifests.mjs
node tools/k6-proofs/scripts/validate-corpus.mjs --current
git diff --check
```

## Notes

This does not rewrite historical PROOFS receipts; committed past evidence still records the internal fleet URLs it actually used. This PR only makes the live/reviewer method portable-ish going forward.

Refs #121.
