### PR TITLE
P81 #121: document portable observability endpoints in pipeline

### DIFF
--- a/tools/k6-proofs/k6-proofs-pipeline.xml
+++ b/tools/k6-proofs/k6-proofs-pipeline.xml
@@ -16,13 +16,20 @@
        ═══════════════════════════════════════════════════════════════ -->
   <Infrastructure>
     <Component id="k6" location="/home/figs/bin/k6" version="2.0.0" seats="ronan-dgx"/>
-    <Component id="prometheus" url="http://prometheus.dandelion.cult" port="80" host="silas-k3s"/>
-    <Component id="grafana" url="http://grafana.dandelion.cult" port="80" host="silas-k3s"/>
-    <Component id="loki" url="http://loki.dandelion.cult" port="80" host="silas-k3s"/>
-    <Component id="tempo" url="http://tempo.dandelion.cult" port="80" host="silas-k3s"/>
+    <Component id="prometheus" urlEnv="OPENCLAW_PROOFS_PROMETHEUS_BASE_URL" defaultUrl="http://prometheus.dandelion.cult" port="80" host="fleet-default"/>
+    <Component id="grafana" urlEnv="OPENCLAW_PROOFS_GRAFANA_BASE_URL" defaultUrl="http://grafana.dandelion.cult" port="80" host="fleet-default"/>
+    <Component id="loki" urlEnv="OPENCLAW_PROOFS_LOKI_BASE_URL" defaultUrl="http://loki.dandelion.cult" port="80" host="fleet-default"/>
+    <Component id="tempo" urlEnv="OPENCLAW_PROOFS_TEMPO_BASE_URL" defaultUrl="http://tempo.dandelion.cult" port="80" host="fleet-default"/>
     <Component id="gateway" url="http://127.0.0.1:18789" path="/health" expect="ok:true"/>
     <Component id="harness" repo="karmaterminal/karmaterminal-openclaw-docs" path="tools/k6-proofs/"/>
-    <Component id="runner" path="tools/k6-proofs/run-proof.sh" auto-detects="sha,seat,prometheus-url"/>
+    <Component id="runner" path="tools/k6-proofs/run-proof.sh" auto-detects="sha,seat,observability-env"/>
+    <EndpointEnv>
+      <Var name="OPENCLAW_PROOFS_TEMPO_BASE_URL" fallback="TEMPO_BASE_URL" fleetDefault="http://tempo.dandelion.cult" purpose="Tempo query API for trace JSON receipts"/>
+      <Var name="OPENCLAW_PROOFS_LOKI_BASE_URL" fallback="LOKI_BASE_URL" fleetDefault="http://loki.dandelion.cult" purpose="Loki API for log correlation"/>
+      <Var name="OPENCLAW_PROOFS_PROMETHEUS_BASE_URL" fallback="PROMETHEUS_BASE_URL" fleetDefault="http://prometheus.dandelion.cult" purpose="Prometheus query API"/>
+      <Var name="OPENCLAW_PROOFS_PROMETHEUS_RW_URL" fallback="K6_PROMETHEUS_RW_SERVER_URL" fleetDefault="http://prometheus.dandelion.cult/api/v1/write" purpose="k6 Prometheus remote-write output"/>
+      <Var name="OPENCLAW_PROOFS_GRAFANA_BASE_URL" fleetDefault="http://grafana.dandelion.cult" purpose="Dashboard links only"/>
+    </EndpointEnv>
   </Infrastructure>
 
   <!-- ═══════════════════════════════════════════════════════════════
@@ -254,8 +261,8 @@
        ═══════════════════════════════════════════════════════════════ -->
   <Metrics>
     <Convention>Prefix all custom metrics with row name: r_cd_1_pass, r_cd_1_duration_ms, r_cd_1_pass_rate</Convention>
-    <Output endpoint="http://prometheus.dandelion.cult/api/v1/write" protocol="prometheus-remote-write"/>
-    <Query>curl "http://prometheus.dandelion.cult/api/v1/query?query=k6_{metric}"</Query>
+    <Output endpointEnv="OPENCLAW_PROOFS_PROMETHEUS_RW_URL" defaultEndpoint="${OPENCLAW_PROOFS_PROMETHEUS_BASE_URL:-http://prometheus.dandelion.cult}/api/v1/write" protocol="prometheus-remote-write"/>
+    <Query>curl "${OPENCLAW_PROOFS_PROMETHEUS_BASE_URL:-http://prometheus.dandelion.cult}/api/v1/query?query=k6_{metric}"</Query>
     <Dashboard path="k6-proofs/dashboards/k6-proofs.json" grafana-uid="k6-proofs-continuation"/>
   </Metrics>
 

--- a/tools/k6-proofs/skill/SKILL.md
+++ b/tools/k6-proofs/skill/SKILL.md
@@ -7,10 +7,10 @@ Build, run, and maintain k6 proof-row scenarios for the OpenClaw continuation fe
 
 ### Infrastructure (resolve per seat before proof-standard runs)
 - **k6** — proof-standard expectation is `v2.0.0`; run `node tools/k6-proofs/scripts/seat-readiness-preflight.mjs --json` on the target seat before folding evidence.
-- **Prometheus** — metrics store for candidate rows (fleet example: `prometheus.dandelion.cult`).
+- **Prometheus** — metrics store for candidate rows; set `OPENCLAW_PROOFS_PROMETHEUS_BASE_URL` / `OPENCLAW_PROOFS_PROMETHEUS_RW_URL` for non-fleet runs (fleet default: `prometheus.dandelion.cult`).
 - **Grafana** — dashboards (contract in `tools/k6-proofs/METRICS.md`; JSON in `tools/k6-proofs/dashboards/k6-proofs.json`).
-- **Loki** — log aggregation for nonce-correlated journal receipts.
-- **Tempo** — distributed tracing; raw trace JSON is the proof surface for continuation spans.
+- **Loki** — log aggregation for nonce-correlated journal receipts; set `OPENCLAW_PROOFS_LOKI_BASE_URL` for non-fleet runs.
+- **Tempo** — distributed tracing; raw trace JSON is the proof surface for continuation spans; set `OPENCLAW_PROOFS_TEMPO_BASE_URL` for non-fleet runs.
 - **Alloy / OTel Collector** — forwards logs and traces from seats into Loki/Tempo.
 
 ### Repo Structure


### PR DESCRIPTION
## Summary

Follow-up to #357: make the machine-readable pipeline + harness skill carry the same portability contract.

- changes `k6-proofs-pipeline.xml` infrastructure components from dandelion-only URLs to env-backed endpoint metadata
- adds an `EndpointEnv` block for Tempo/Loki/Prometheus/Grafana endpoint variables and fleet defaults
- updates the detailed k6-proofs skill to name the portable endpoint envs instead of treating fleet DNS as the only shape

## Verification

```bash
node --check tools/k6-proofs/scripts/fetch-tempo-trace.mjs
bash -n tools/k6-proofs/run-proof.sh
bash -n tools/k6-proofs/scripts/run-proofs.sh
node tools/k6-proofs/scripts/check-manifest-scenarios.mjs
node tools/k6-proofs/scripts/check-scenario-alignment.mjs
node tools/k6-proofs/scripts/check-proof-row-manifests.mjs
node tools/k6-proofs/scripts/validate-corpus.mjs --current
git diff --check
```

Refs #121.
