### PR TITLE
PROOFS: note automated k6 methodology in index

### DIFF
--- a/PROOFS/INDEX.json
+++ b/PROOFS/INDEX.json
@@ -17,6 +17,7 @@
     "missing": 0
   },
   "disposition_note": "Project 81 live k6 first-fire corpus on Cael and Ronan. Full artifacts copied from /tmp/p81-* roots. This is a method-upgrade corpus: known row-shaped Gateway/web submit traffic, per-row artifacts, issue-linked partials, and explicit R-RC-2 honest-limit despite generated PASS mismatch (#373).",
+  "methodology_note": "Proof generation is now automation-first: Project 81 k6 scenarios deterministically drive the deployed OpenClaw web/Gateway interface over WebSocket/API, emit row-scoped submit traffic, and preserve per-row receipts, logs, metrics, and artifacts. Treat this index as the machine entrypoint, then follow manifest_path -> rows[] -> evidence_doc/artifact paths; partial and honest_limit states are intentional review outputs, not missing proof attempts.",
   "navigation": "clawsweeper: read INDEX.json -> current_sha -> manifest_path -> rows[]",
   "generated": "2026-07-09",
   "generated_by": "frond-scribe (copilot) from Cael/Ronan live P81 proof artifacts",


### PR DESCRIPTION
## What changed

Adds a concise `methodology_note` to `PROOFS/INDEX.json` so machine consumers can tell that the current Project 81 corpus is automation-first, not hand-prose proofing:

- deterministic Project 81 k6 scenarios
- direct OpenClaw web/Gateway WebSocket/API submits
- row-scoped submit traffic
- preserved receipts/logs/metrics/artifacts
- partial/honest_limit as intentional review states, not missing attempts

## Validation

- `jq -e . PROOFS/INDEX.json`
- `node tools/k6-proofs/scripts/validate-corpus.mjs --index`
- `git diff --check`
