### PR TITLE
Project 81: sync e08 manual closeout evidence headers

### DIFF
--- a/PROOFS/e08f696618da57e7267a2148578fa4ab0d8b0d01/R-CONFIG-DEFAULTS/EVIDENCE.md
+++ b/PROOFS/e08f696618da57e7267a2148578fa4ab0d8b0d01/R-CONFIG-DEFAULTS/EVIDENCE.md
@@ -1,9 +1,9 @@
 # R-CONFIG-DEFAULTS evidence — e08f696 live P81 run
 
-- **Aggregate state:** `partial`
+- **Aggregate state:** `pass`
 - **Candidate SHA:** `e08f696618da57e7267a2148578fa4ab0d8b0d01`
 - **Issue links:** karmaterminal/karmaterminal-openclaw-docs#368
-- **Review note:** Partial on both Cael/Ronan: config read/default byte not fully observed. Tracked in #368.
+- **Review note:** First k6 run was partial on both Cael/Ronan for config read/default bytes; manual path-scoped receipts now close the row. #368 remains preserved as method friction.
 
 ## Seat artifacts
 

--- a/PROOFS/e08f696618da57e7267a2148578fa4ab0d8b0d01/R-CONFIG-INTERSESSION/EVIDENCE.md
+++ b/PROOFS/e08f696618da57e7267a2148578fa4ab0d8b0d01/R-CONFIG-INTERSESSION/EVIDENCE.md
@@ -1,9 +1,9 @@
 # R-CONFIG-INTERSESSION evidence — e08f696 live P81 run
 
-- **Aggregate state:** `partial`
+- **Aggregate state:** `pass`
 - **Candidate SHA:** `e08f696618da57e7267a2148578fa4ab0d8b0d01`
 - **Issue links:** karmaterminal/karmaterminal-openclaw-docs#369
-- **Review note:** Partial on both Cael/Ronan: config read/cross-session byte not fully observed. Tracked in #369.
+- **Review note:** First k6 run was partial on both Cael/Ronan for config read/cross-session bytes; manual path-scoped receipts now close the row. #369 remains preserved as method friction.
 
 ## Seat artifacts
 

--- a/PROOFS/e08f696618da57e7267a2148578fa4ab0d8b0d01/R-CW-3/EVIDENCE.md
+++ b/PROOFS/e08f696618da57e7267a2148578fa4ab0d8b0d01/R-CW-3/EVIDENCE.md
@@ -1,9 +1,9 @@
 # R-CW-3 evidence — e08f696 live P81 run
 
-- **Aggregate state:** `honest_limit`
+- **Aggregate state:** `pass`
 - **Candidate SHA:** `e08f696618da57e7267a2148578fa4ab0d8b0d01`
 - **Issue links:** karmaterminal/karmaterminal-openclaw-docs#372
-- **Review note:** No clean PASS fold: Cael partial on missing wake/Tempo receipt after accepted dispatch; Ronan HONEST-LIMIT-candidate. Tracked in #372.
+- **Review note:** First k6 fold was not clean PASS: Cael missed wake/Tempo receipt after accepted dispatch and Ronan was HONEST-LIMIT-candidate; manual Tempo receipts now close the row. #372 remains preserved as method friction.
 
 ## Seat artifacts
 


### PR DESCRIPTION
Follow-up to #377.

#377 correctly folded the e08 manual receipts and manifest rollup to `35 / 33 pass / 1 partial / 1 honest_limit`, but the per-row `EVIDENCE.md` headers for the three manually-closed rows still carried their pre-closeout aggregate states/review notes.

This PR updates only those headers/notes for:
- `R-CONFIG-DEFAULTS`
- `R-CONFIG-INTERSESSION`
- `R-CW-3`

Validation:
- `node tools/k6-proofs/scripts/validate-corpus.mjs --current --json` → `failed=false`
- header/manifest mismatch scan → `[]`
- `git diff --check` clean

No change to the remaining non-pass rows: `R-CD-MODEL-TOOL` stays `partial`; `R-RC-2` stays `honest_limit`.