### PR TITLE
Project 81: sync e08 model-tool evidence header

### DIFF
--- a/PROOFS/e08f696618da57e7267a2148578fa4ab0d8b0d01/R-CD-MODEL-TOOL/EVIDENCE.md
+++ b/PROOFS/e08f696618da57e7267a2148578fa4ab0d8b0d01/R-CD-MODEL-TOOL/EVIDENCE.md
@@ -3,7 +3,7 @@
 - **Aggregate state:** `pass`
 - **Candidate SHA:** `e08f696618da57e7267a2148578fa4ab0d8b0d01`
 - **Issue links:** karmaterminal/karmaterminal-openclaw-docs#367
-- **Review note:** Partial on both Cael/Ronan: parent scheduled, child/model byte not fully observed in live row output. Tracked in #367.
+- **Review note:** First Cael/Ronan k6 rows were partial because the child/model byte was not observed; Cael's gemini rerun now supplies the child runtime model byte and return payload. #367 remains preserved as method friction.
 
 ## Seat artifacts
 


### PR DESCRIPTION
Follow-up to #379.

#379 correctly folded the `R-CD-MODEL-TOOL` gemini child-model byte receipt and manifest rollup to `35 / 34 pass / 0 partial / 1 honest_limit`, but the row `EVIDENCE.md` header/review note still carried the earlier partial disposition.

This updates only `R-CD-MODEL-TOOL/EVIDENCE.md` so the human-readable header matches the manifest/manual closeout.

Validation:
- `node tools/k6-proofs/scripts/validate-corpus.mjs --current --json` → `failed=false`
- header/manifest mismatch scan → `[]`
- `git diff --check` clean

No change to `R-RC-2`: it remains `honest_limit`.