### PR TITLE
Clarify proof corpus drift transposition

### DIFF
--- a/PROOFS/24838c4d470804425da59279647745dcac555a25/METHOD.md
+++ b/PROOFS/24838c4d470804425da59279647745dcac555a25/METHOD.md
@@ -17,10 +17,10 @@
 4. Split rows around partial/static blockers so one row cannot suppress unrelated artifact upload.
 5. Preserve uploaded Actions artifacts under `artifacts/fresh-5292/actions/` and failed-row logs under `artifacts/fresh-5292/actions-logs/`.
 6. Fold row state from reviewed row evidence, not workflow conclusion alone.
-7. After proof generation, absorb current upstream/main into the safe assembly branch, refresh generated/docs surfaces where needed, validate focused runtime/protocol/docs surfaces, and full-copy transpose the 5292 corpus to push SHA `24838c4d470804425da59279647745dcac555a25`.
+7. During proof generation and PR-presentation preparation, absorb current upstream/main drift into the safe assembly branch, refresh generated/docs surfaces where needed, validate the touched non-continuation drift slices, and full-copy transpose the 5292 corpus to push SHA `24838c4d470804425da59279647745dcac555a25`.
 8. Re-query Tempo after ingestion delay for R-CW-3, because trace absence in the immediate k6 window is not a permanent failure. Add the late Cael/Ronan trace JSON receipts and fold R-CW-3 by the reviewed trace bytes.
 
-This corpus does not claim a second live gateway proof run at 24838c4. It preserves `proof_source_sha=5292af40d0ad5303b85a678f6e629503a8725848` and `proof_push_sha=24838c4d470804425da59279647745dcac555a25`.
+This corpus does not claim a second live gateway proof run at 24838c4. It preserves `proof_source_sha=5292af40d0ad5303b85a678f6e629503a8725848` and `proof_push_sha=24838c4d470804425da59279647745dcac555a25` because the final drift corrections were freshness/ancestry take-backs that did not modify the continuation proof surface under test.
 
 ## Classification rules used for this corpus
 

--- a/PROOFS/24838c4d470804425da59279647745dcac555a25/README.md
+++ b/PROOFS/24838c4d470804425da59279647745dcac555a25/README.md
@@ -14,7 +14,7 @@ The fresh rerun leaves one row honest-limit in this corpus:
 
 The prior full-copy corpus for `46872994e4cae80830c381cb49456e8c77583d7e` was valid for that safe push, but upstream/main advanced again before PR-presentation. The safe assembly branch was refreshed to `5292af40d0ad5303b85a678f6e629503a8725848`, and that refresh touched runtime/continuation-adjacent surface. Cael and Ronan were therefore redeployed to `5292af40d0ad5303b85a678f6e629503a8725848` and the gateway-live Project 81 rows were rerun against the deployed 5292 gateways.
 
-After the 5292 proof corpus was finalized, upstream/main advanced again. The safe assembly branch absorbed current upstream/main cleanly, refreshed generated/docs surfaces where needed, and landed at push SHA `24838c4d470804425da59279647745dcac555a25`. This tree is the required full-copy corpus at that safe push SHA; `proof_source_sha` remains the deployed 5292 rerun.
+After the 5292 proof corpus was finalized, upstream/main advanced again during proof generation and PR-presentation preparation. The safe assembly branch absorbed current upstream/main cleanly, refreshed generated/docs surfaces where needed, and landed at push SHA `24838c4d470804425da59279647745dcac555a25`. These final drift corrections did not change the continuation proof surface exercised by the 5292 run, so this tree is the required full-copy corpus at the safe push SHA while `proof_source_sha` remains the deployed 5292 rerun.
 
 ## Methodology upgrade
 

--- a/PROOFS/24838c4d470804425da59279647745dcac555a25/proofs-manifest.json
+++ b/PROOFS/24838c4d470804425da59279647745dcac555a25/proofs-manifest.json
@@ -1355,9 +1355,9 @@
   "proof_push_sha": "24838c4d470804425da59279647745dcac555a25",
   "proof_source_sha": "5292af40d0ad5303b85a678f6e629503a8725848",
   "seeded_from": "4f924d1fafff95264b4e2730005f0a218a6fffde",
-  "seed_reason": "Full-copy transpose from the 4f924d1 Project 81 proof corpus after safe assembly absorbed the UI sidebar upstream drift. The 5292 live proof artifacts remain the proof source; this tree is the self-contained corpus for the safe push SHA.",
+  "seed_reason": "Full-copy transpose from the 4f924d1 Project 81 proof corpus after safe assembly absorbed UI sidebar upstream drift that landed during proof generation/PR-presentation preparation. The final drift corrections did not modify the continuation proof surface; the 5292 live proof artifacts remain the proof source, and this tree is the self-contained corpus for the safe push SHA.",
   "notes": [
-    "Safe assembly push SHA 24838c4d470804425da59279647745dcac555a25 includes the clean UI sidebar upstream drift take-back after the 5292 live proof rerun; proof_source_sha remains 5292af40d0ad5303b85a678f6e629503a8725848.",
+    "Safe assembly push SHA 24838c4d470804425da59279647745dcac555a25 includes clean non-continuation upstream drift take-backs that landed during proof generation/PR-presentation preparation; proof_source_sha remains 5292af40d0ad5303b85a678f6e629503a8725848.",
     "Fresh live rows were rerun against deployed 5292af40 on Cael/Ronan with disposable proof sessions.",
     "Corpus-dependent/static rows remain carried from 46872994 because they validate committed proof packets rather than live gateway behavior.",
     "R-CD-MODEL-TOOL is folded as pass by console evidence in runs 28996028254/28996030407 despite generated summary PARTIAL-candidate.",

--- a/PROOFS/INDEX.json
+++ b/PROOFS/INDEX.json
@@ -16,8 +16,8 @@
     "honest_limit": 1,
     "missing": 0
   },
-  "disposition_note": "Full copied Project 81 corpus for safe assembly push SHA 24838c4d470804425da59279647745dcac555a25. Live proof source remains deployed 5292af40 on Cael/Ronan; this corpus transposes those reviewed proof bytes to the safe push SHA after clean upstream drift take-backs. R-CW-3 is closed by late Tempo receipts; only R-RC-2 remains honest-limit; no fail or missing rows remain.",
-  "methodology_note": "Project 81 k6 scenarios drive the deployed OpenClaw web/Gateway interface over WebSocket/API and preserve row-scoped artifacts. This INDEX points at a full-copy PROOFS/<sha>/ corpus; fresh 5292 artifacts are under artifacts/fresh-5292/ and carried static/manual corpus rows stay in-place with explicit classification.",
+  "disposition_note": "Full copied Project 81 corpus for safe assembly push SHA 24838c4d470804425da59279647745dcac555a25. Live proof source remains deployed 5292af40 on Cael/Ronan; this corpus transposes those reviewed proof bytes to the safe push SHA because upstream drift landed during proof generation/PR-presentation preparation. The final drift corrections were validated non-continuation-surface take-backs for ancestry/freshness. R-CW-3 is closed by late Tempo receipts; only R-RC-2 remains honest-limit; no fail or missing rows remain.",
+  "methodology_note": "Project 81 k6 scenarios drive the deployed OpenClaw web/Gateway interface over WebSocket/API and preserve row-scoped artifacts. This INDEX points at a full-copy PROOFS/<sha>/ corpus; fresh 5292 artifacts are under artifacts/fresh-5292/ and carried static/manual corpus rows stay in-place with explicit classification. The proof_source_sha differs from proof_push_sha because non-continuation upstream drift landed during proof generation and was folded before PR-presentation.",
   "navigation": "clawsweeper: read INDEX.json -> current_sha -> manifest_path -> rows[]",
   "generated": "2026-07-09",
   "generated_by": "frond-scribe (copilot) from Cael/Ronan fresh 5292 Project 81 rerun artifacts",


### PR DESCRIPTION
## Summary

Clarify the current `PROOFS/24838c4...` corpus note for the proof-source vs push-SHA split:

- upstream drift landed during proof generation / PR-presentation preparation;
- the final drift corrections were validated non-continuation-surface take-backs for freshness/ancestry;
- therefore `proof_source_sha` remains the deployed 5292 live rerun while `proof_push_sha` is the final safe assembly SHA.

## Validation

- `node tools/k6-proofs/scripts/validate-corpus.mjs --sha 24838c4d470804425da59279647745dcac555a25`
- `node tools/k6-proofs/scripts/validate-corpus.mjs --index`
- `git diff --check`
