### PR TITLE
fix(proofs): ignore support directories in manifest checker

### DIFF
--- a/tools/k6-proofs/scripts/__tests__/check-proof-row-manifests.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/check-proof-row-manifests.test.mjs
@@ -1,0 +1,72 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = new URL('../../../..', import.meta.url).pathname;
+const script = join(repoRoot, 'tools/k6-proofs/scripts/check-proof-row-manifests.mjs');
+const SHA = '0123456789abcdef0123456789abcdef01234567';
+
+async function withFixture({ rows = ['R-OK'], manifests = [{ file: 'r-ok.json', rowId: 'R-OK' }] }, fn) {
+  const root = await mkdtemp(join(tmpdir(), 'p81-proof-row-manifests-'));
+  try {
+    const corpus = join(root, 'PROOFS', SHA);
+    const manifestsDir = join(root, 'tools/k6-proofs/manifests');
+    await mkdir(corpus, { recursive: true });
+    await mkdir(manifestsDir, { recursive: true });
+    await writeFile(join(root, 'PROOFS/INDEX.json'), `${JSON.stringify({ current_sha: SHA })}\n`);
+    for (const row of rows) await mkdir(join(corpus, row), { recursive: true });
+    for (const manifest of manifests) {
+      const content = manifest.raw ?? `${JSON.stringify({ rowId: manifest.rowId })}\n`;
+      await writeFile(join(manifestsDir, manifest.file), content);
+    }
+    return await fn(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+function run(root) {
+  return spawnSync(process.execPath, [script], { cwd: root, encoding: 'utf8' });
+}
+
+test('ignores proof-corpus support directories while checking real rows', async () => {
+  await withFixture({ rows: ['R-OK', 'artifacts', 'gates'] }, async (root) => {
+    const result = run(root);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /Proof rows: 1/);
+    assert.match(result.stdout, /Missing manifests: 0/);
+  });
+});
+
+test('fails closed for missing, invalid, and duplicate manifests', async (t) => {
+  await t.test('missing manifest', async () => {
+    await withFixture({ rows: ['R-MISSING'], manifests: [] }, async (root) => {
+      const result = run(root);
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /proof rows missing manifest entries: R-MISSING/);
+    });
+  });
+
+  await t.test('invalid manifest JSON', async () => {
+    await withFixture({ manifests: [{ file: 'r-ok.json', raw: '{not json}\n' }] }, async (root) => {
+      const result = run(root);
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /SyntaxError/);
+    });
+  });
+
+  await t.test('duplicate row ID', async () => {
+    await withFixture({ manifests: [
+      { file: 'r-ok-a.json', rowId: 'R-OK' },
+      { file: 'r-ok-b.json', rowId: 'r-ok' },
+    ] }, async (root) => {
+      const result = run(root);
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /duplicate manifest row IDs: R-OK/);
+    });
+  });
+});

--- a/tools/k6-proofs/scripts/check-proof-row-manifests.mjs
+++ b/tools/k6-proofs/scripts/check-proof-row-manifests.mjs
@@ -13,6 +13,7 @@ const root = process.cwd();
 const indexPath = path.join(root, 'PROOFS', 'INDEX.json');
 const manifestsDir = path.join(root, 'tools', 'k6-proofs', 'manifests');
 const failures = [];
+const SUPPORT_DIRECTORIES = new Set(['artifacts', 'gates']);
 
 if (!existsSync(indexPath)) failures.push(`missing ${indexPath}`);
 if (!existsSync(manifestsDir)) failures.push(`missing ${manifestsDir}`);
@@ -29,7 +30,7 @@ if (!failures.length) {
     proofRows = readdirSync(corpusDir, { withFileTypes: true })
       .filter((entry) => entry.isDirectory())
       .map((entry) => entry.name)
-      .filter((name) => name !== 'gates')
+      .filter((name) => !SUPPORT_DIRECTORIES.has(name))
       .sort();
   }
 }
@@ -45,6 +46,15 @@ if (!failures.length) {
 const proofRowUpperSet = new Set(proofRows.map((r) => r.toUpperCase()));
 const manifestByUpper = new Map(manifestRows.map((row) => [row.rowId.toUpperCase(), row]));
 const missing = proofRows.filter((row) => !manifestByUpper.has(row.toUpperCase()));
+const duplicateManifestRows = [...manifestRows.reduce((byRow, row) => {
+  const key = row.rowId.toUpperCase();
+  const entries = byRow.get(key) ?? [];
+  entries.push(row.file);
+  byRow.set(key, entries);
+  return byRow;
+}, new Map())]
+  .filter(([, files]) => files.length > 1)
+  .map(([rowId, files]) => `${rowId} (${files.join(', ')})`);
 
 // Manifest-only rows: in the live-suite manifest catalog but not yet in the canonical proof
 // board corpus (e.g. model-override rows, R-CW-4, R-OBS-status). These are k6-runnable
@@ -55,6 +65,9 @@ const manifestOnly = manifestRows.filter(
 
 if (missing.length) {
   failures.push(`proof rows missing manifest entries: ${missing.join(', ')}`);
+}
+if (duplicateManifestRows.length) {
+  failures.push(`duplicate manifest row IDs: ${duplicateManifestRows.join('; ')}`);
 }
 
 console.log(`Current corpus: PROOFS/${currentSha}`);


### PR DESCRIPTION
Closes #406.\n\nThe proof-row manifest checker now excludes the corpus support directories artifacts and gates from row enumeration. It also detects duplicate row IDs case-insensitively instead of silently overwriting them.\n\nCoverage invokes the CLI against isolated fixtures to prove: artifacts is ignored; missing manifests fail; malformed JSON fails; duplicate row IDs fail.\n\nValidation: node --test tools/k6-proofs/scripts/__tests__/*.test.mjs (98 passing); node tools/k6-proofs/scripts/check-proof-row-manifests.mjs.\n\nNo live proof row, trace collector, continuation behavior, or Project 81 accepted-compaction fixture was changed.