### PR TITLE
fix(proofs): run read-only preflight through live runner

### DIFF
--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -80,10 +80,22 @@ If k6 is missing, the version differs, continuation is disabled/missing, require
 
 ### 2. Preflight check
 
+The supported live preflight is non-mutating: it authenticates only to read
+gateway/session/tool inventory and writes its declared review receipts. It does
+not create a session, dispatch a continuation, or fire a proof row.
+
 ```bash
 OPENCLAW_GATEWAY_TOKEN="***" \
 OPENCLAW_ROW_MANIFEST="tools/k6-proofs/manifests/preflight.example.json" \
   k6 run tools/k6-proofs/scenarios/preflight.js
+```
+
+Use the row-list runner when you need the same bounded journal and artifact
+layout as a live proof run:
+
+```bash
+cd tools/k6-proofs
+OPENCLAW_GATEWAY_TOKEN="***" ./scripts/run-proofs.sh --live preflight <candidate-sha>
 ```
 
 ### 3. Run an existing scenario (manifest-driven)

--- a/tools/k6-proofs/manifests/preflight.example.json
+++ b/tools/k6-proofs/manifests/preflight.example.json
@@ -5,7 +5,7 @@
   "candidateSha": "82827d3cbcba92ff6e19863b30615db028c2651c",
   "seat": "emeric-nuc",
   "sessionKey": "${OPENCLAW_SESSION_KEY}",
-  "transport": "offline",
+  "transport": "websocket",
   "toolSurface": "read-only",
   "mutates": false,
   "timeoutSeconds": 30,
@@ -26,8 +26,8 @@
     "file": "preflight.js"
   },
   "liveRunSafety": {
-    "classification": "static-preflight-only",
-    "requiresLiveGatewayToken": false,
+    "classification": "k6-runnable",
+    "requiresLiveGatewayToken": true,
     "requiresTargetSessionKey": false,
     "requiresCandidateSha": false,
     "requiresExternalAgentOrToolInvocation": false,
@@ -39,7 +39,7 @@
       "seat-readiness"
     ],
     "foldRequiresReview": true,
-    "notes": "Offline golden-path/preflight metadata is concurrency-safe. Live preflight may use a token, but this example must remain safe without secrets."
+    "notes": "The live preflight is read-only and concurrency-safe, but it authenticates to the gateway. Use the documented runner command with an operator token; offline golden-path validation remains available without secrets."
   },
   "expectedReceipts": [
     {

--- a/tools/k6-proofs/scripts/__tests__/live-run-guard.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/live-run-guard.test.mjs
@@ -99,18 +99,18 @@ test('live-run guard still permits ordinary k6-runnable manifests with required 
   assert.equal(parsed.classification, 'k6-runnable');
 });
 
-test('live-run guard still permits static preflight manifests without live candidate env', async () => {
+test('read-only preflight uses the supported live k6 runner contract', async () => {
   const manifest = join(repoRoot, 'tools/k6-proofs/manifests/preflight.example.json');
-  const run = runGuard(manifest, {
-    OPENCLAW_GATEWAY_TOKEN: '',
-    OPENCLAW_CANDIDATE_SHA: '',
-    OPENCLAW_SESSION_KEY: '',
-  });
+  const run = runGuard(manifest);
   assert.equal(run.status, 0, run.stderr || run.stdout);
   const parsed = JSON.parse(run.stdout);
   assert.equal(parsed.ok, true);
   assert.equal(parsed.rowId, 'preflight');
-  assert.equal(parsed.classification, 'static-preflight-only');
+  assert.equal(parsed.classification, 'k6-runnable');
+  assert.equal(parsed.requiresLiveGatewayToken, true);
+  assert.equal(parsed.requiresTargetSessionKey, false);
+  assert.equal(parsed.requiresCandidateSha, false);
+  assert.equal(parsed.requiresExternalAgentOrToolInvocation, false);
 });
 
 test('static corpus validator rows are read-only broad-suite rows', async () => {

--- a/tools/k6-proofs/scripts/__tests__/observability-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/observability-contract.test.mjs
@@ -42,7 +42,7 @@ test('row-result exposes the dashboard v1 observability fields', async () => {
     assert.equal(result.schema, 'openclaw.k6.proof-row-result.v1');
     assert.equal(result.scenario, 'preflight');
     assert.equal(result.toolSurface, 'read-only');
-    assert.equal(result.transport, 'offline');
+    assert.equal(result.transport, 'websocket');
     assert.equal(result.failureClass, 'none');
     assert.equal(result.metrics.proofFailures, 0);
     assert.equal(result.metrics.checksRate, 1);


### PR DESCRIPTION
Fixes #405

Makes the advertised read-only preflight executable by `run-proofs.sh --live` while preserving its non-mutating boundary.

- declares the preflight as authenticated WebSocket / `k6-runnable`
- requires an operator token, but no target session, candidate SHA, or tool invocation
- documents the bounded runner command
- covers the live-run contract and emitted transport value

No session creation, dispatch, proof-row fire, Tempo collector, or #406 manifest-checker changes.

Validation:
- `node --test tools/k6-proofs/scripts/__tests__/*.mjs` (93/93)
- manifest scenario + scenario alignment checks
- `git diff --check`

Known independent baseline failure: `check-proof-row-manifests.mjs` still sees `artifacts/` as a row; that is deliberately left to #406.