### PR TITLE
fix(proofs): fail closed R-CD-2 lifecycle verdict

### DIFF
--- a/tools/k6-proofs/manifests/r-cd-2.json
+++ b/tools/k6-proofs/manifests/r-cd-2.json
@@ -44,7 +44,8 @@
       "dispatch-accepted",
       "parent-wake-event",
       "no-channel-delivery",
-      "trace-id"
+      "trace-id",
+      "continuation-lifecycle-correlation"
     ],
     "foldRequiresReview": true,
     "notes": "Live continuation row. Fail closed when token/session env is missing, serialize per target session, and treat generated output as a PASS-candidate until required receipts are reviewed."
@@ -79,6 +80,11 @@
       "name": "trace-id",
       "required": true,
       "description": "Trace ID from dispatch response or optional task metadata; Tempo trace JSON must be fetched before folding a PASS."
+    },
+    {
+      "name": "continuation-lifecycle-correlation",
+      "required": true,
+      "description": "Redacted nonce-correlated typed continue_delegate tool span plus continuation.delegate.dispatch and continuation.delegate.fire on one silent-wake chain; generic delayed session traffic is non-authoritative context only."
     }
   ],
   "artifactDestination": {
@@ -91,6 +97,6 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Silent-wake path. PASS-candidate when: (1) dispatching agent turn accepted, (2) parent session emits wake/agent events, (3) NO channel message delivered from the delegate return, and (4) trace/receipt artifacts are fetched for review. A nonce-correlated tasks.list row is optional because continue_delegate uses pending-delegate/subagent surfaces, not the generic task registry."
+    "notes": "Silent-wake path. The WebSocket stream records behavioral context and no-channel delivery only. PASS-candidate requires the redacted nonce-correlated lifecycle receipt: typed continue_delegate tool execution plus continuation.delegate.dispatch and continuation.delegate.fire on one silent-wake chain. A nonce-correlated tasks.list row is optional because continue_delegate uses pending-delegate/subagent surfaces, not the generic task registry."
   }
 }

--- a/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
+++ b/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
@@ -343,16 +343,21 @@ export default function () {
     console.error('FAIL: silent-wake delegate produced channel output');
   }
 
-  // Verdict — PASS when: turn triggered + events flowing + no channel delivery
-  const passed = (!createDisposableSession || evidence.session_created) &&
+  // The WebSocket stream can only establish behavioral context.  A generic
+  // delayed session.message is not proof that the typed continuation call ran;
+  // run-proofs.sh promotes this row only after the nonce-correlated Tempo
+  // lifecycle receipt validates typed tool -> dispatch -> fire on one chain.
+  const behaviorObserved = (!createDisposableSession || evidence.session_created) &&
     evidence.tool_accepted && evidence.agent_turn_observed &&
     evidence.parent_wake_observed && !evidence.channel_message_observed;
+  evidence.lifecycle_correlation_required = true;
+  evidence.behavior_observed = behaviorObserved;
 
   console.log(`R_CD_2_EVIDENCE ${JSON.stringify(evidence)}`);
   console.log(`\n--- R-CD-2 EVIDENCE SUMMARY ---`);
   console.log(JSON.stringify(evidence, null, 2));
   console.log(`--- END EVIDENCE ---`);
-  console.log(`\n[R-CD-2] VERDICT: ${passed ? 'PASS-candidate' : 'PARTIAL-candidate'}`);
+  console.log('\n[R-CD-2] VERDICT: PARTIAL-candidate (awaiting continuation lifecycle correlation)');
 }
 
 export function handleSummary(data) {
@@ -364,7 +369,7 @@ export function handleSummary(data) {
     sha: __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
     seat: __ENV.OPENCLAW_SEAT_NAME || 'ronan-dgx',
     timestamp,
-    verdict: passRate ? 'PASS-candidate' : 'PARTIAL-candidate',
+    verdict: 'PARTIAL-candidate',
     candidateOnly: true,
     foldRequiresReview: true,
     observability: {
@@ -372,11 +377,11 @@ export function handleSummary(data) {
       traceJson: traceId ? 'pending-fetch' : 'missing',
     },
     review: {
-      status: traceId ? 'ready-for-human-review' : 'review-pending',
-      pendingReceipts: traceId ? [] : ['tempo-trace-json'],
-      notes: traceId
-        ? ['Trace id captured; fetch and attach Tempo trace JSON before canonical fold.']
-        : ['No trace_id was emitted by this candidate run; keep PASS-candidate as review-pending until trace JSON is fetched or the fold explicitly accepts trace-missing.'],
+      status: 'review-pending',
+      pendingReceipts: ['continuation-trace-correlation'],
+      notes: [
+        'Behavioral WebSocket events are non-authoritative context. Only the redacted nonce-correlated typed-tool/dispatch/fire lifecycle receipt can promote this row.',
+      ],
     },
     metrics: {
       duration_ms: data.metrics.r_cd_2_duration && data.metrics.r_cd_2_duration.values || null,

--- a/tools/k6-proofs/scripts/__tests__/continuation-row-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/continuation-row-contract.test.mjs
@@ -88,3 +88,17 @@ test('row runner keeps private acquisition transient and publishes sanitized evi
   assert.doesNotMatch(runner, /gateway-journal\.private/);
   assert.doesNotMatch(runner, /sessionKey:\$session/);
 });
+
+test('R-CD-2 cannot pass from generic delayed traffic without lifecycle correlation', async () => {
+  const manifest = JSON.parse(await readFile(path.join(manifestsDir, 'r-cd-2.json'), 'utf8'));
+  const scenario = await readFile(path.join(scenariosDir, 'r-cd-2-silent-wake.js'), 'utf8');
+  const runner = await readFile(path.join(repoRoot, 'tools/k6-proofs/scripts/run-proofs.sh'), 'utf8');
+
+  assert.ok(manifest.liveRunSafety.requiredReceipts.includes('continuation-lifecycle-correlation'));
+  assert.match(scenario, /generic[\s\S]*delayed session\.message is not proof/);
+  assert.match(scenario, /VERDICT: PARTIAL-candidate \(awaiting continuation lifecycle correlation\)/);
+  assert.match(runner, /validate-r-cd-2-lifecycle\.mjs/);
+  assert.match(runner, /SUMMARY_VERDICT_SOURCE="continuation-lifecycle-receipt"/);
+  assert.match(runner, /Final verdict reconciled from the redacted continuation lifecycle receipt/);
+  assert.match(runner, /generic delayed session traffic is non-authoritative/);
+});

--- a/tools/k6-proofs/scripts/__tests__/r-cd-2-lifecycle-receipt.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cd-2-lifecycle-receipt.test.mjs
@@ -1,0 +1,69 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const script = path.resolve('tools/k6-proofs/scripts/validate-r-cd-2-lifecycle.mjs');
+
+async function withTmp(run) {
+  const dir = await mkdtemp(path.join(tmpdir(), 'r-cd-2-lifecycle-'));
+  try {
+    await run(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+function validate(correlation, out) {
+  const args = [script, '--out', out];
+  if (correlation) args.push('--correlation', correlation);
+  return spawnSync(process.execPath, args, { encoding: 'utf8' });
+}
+
+test('July outer-send plus delayed-generic-event shape is an explicit non-pass without lifecycle correlation', async () => {
+  await withTmp(async (dir) => {
+    const out = path.join(dir, 'lifecycle.json');
+    const run = validate(null, out);
+    const receipt = JSON.parse(await readFile(out, 'utf8'));
+    assert.equal(run.status, 1);
+    assert.equal(receipt.outcome, 'PARTIAL-candidate');
+    assert.equal(receipt.lifecycleReceipt, 'missing');
+    assert.equal(receipt.failureClass, 'continuation-lifecycle-missing');
+    assert.match(receipt.failures.join(' '), /correlation is missing/);
+  });
+});
+
+test('complete redacted silent-wake typed-tool/dispatch/fire topology can pass', async () => {
+  await withTmp(async (dir) => {
+    const correlation = path.join(dir, 'continuation-trace-correlation.json');
+    const out = path.join(dir, 'lifecycle.json');
+    await writeFile(correlation, `${JSON.stringify({
+      schema: 'openclaw.k6.continuation-trace-correlation.v1',
+      row: 'R-CD-2',
+      traceId: '11111111111111111111111111111111',
+      chainId: 'chain-safe-example',
+      toolSpanIds: ['aaaaaaaaaaaaaaaa'],
+      dispatchSpanId: 'bbbbbbbbbbbbbbbb',
+      fireSpanId: 'cccccccccccccccc',
+      sameTrace: true,
+      distinctSpans: true,
+      reason: { hash: '1234567890abcdef', length: 42, rawPersisted: false },
+      continuation: {
+        tool: 'continue_delegate',
+        acceptSpan: 'continuation.delegate.dispatch',
+        fireSpan: 'continuation.delegate.fire',
+      },
+      delegate: { mode: 'silent-wake' },
+    })}\n`);
+    const run = validate(correlation, out);
+    const receipt = JSON.parse(await readFile(out, 'utf8'));
+    assert.equal(run.status, 0, run.stderr);
+    assert.equal(receipt.outcome, 'PASS-candidate');
+    assert.equal(receipt.lifecycleReceipt, 'present');
+    assert.deepEqual(receipt.failures, []);
+    assert.equal(receipt.correlation.mode, 'silent-wake');
+    assert.doesNotMatch(JSON.stringify(receipt), /raw task|Proof nonce/i);
+  });
+});

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -368,6 +368,8 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
     TEMPO_TRACE_JSON=""
     CORRELATION_RECEIPT_PATH=""
     CORRELATION_RECEIPT=""
+    R_CD_2_LIFECYCLE_RECEIPT=""
+    R_CD_2_LIFECYCLE_STATUS="not-applicable"
     REVIEW_PENDING_RECEIPTS='[]'
     if [[ "$GATEWAY_JOURNAL_STATUS" != "captured" ]]; then
       REVIEW_PENDING_RECEIPTS='["gateway-journal"]'
@@ -446,6 +448,53 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
       )"
     fi
 
+    # R-CD-2 must never promote outer sessions.send acceptance plus a generic
+    # delayed session.message into a pass. The collector receipt is the only
+    # authority for its typed-tool -> dispatch -> fire lifecycle evidence.
+    if [[ "$ROW_ID" == "R-CD-2" ]]; then
+      R_CD_2_LIFECYCLE_RECEIPT="r-cd-2-lifecycle-receipt.json"
+      R_CD_2_LIFECYCLE_ARGS=(--out "$RUN_DIR/$R_CD_2_LIFECYCLE_RECEIPT")
+      if [[ -n "$CORRELATION_RECEIPT_PATH" ]]; then
+        R_CD_2_LIFECYCLE_ARGS+=(--correlation "$CORRELATION_RECEIPT_PATH")
+      fi
+      if node scripts/validate-r-cd-2-lifecycle.mjs "${R_CD_2_LIFECYCLE_ARGS[@]}"; then
+        R_CD_2_LIFECYCLE_STATUS="present"
+        SUMMARY_VERDICT="PASS-candidate"
+        SUMMARY_VERDICT_SOURCE="continuation-lifecycle-receipt"
+      else
+        R_CD_2_LIFECYCLE_STATUS="missing"
+        SUMMARY_VERDICT="PARTIAL-candidate"
+        SUMMARY_VERDICT_SOURCE="continuation-lifecycle-receipt"
+        REVIEW_PENDING_RECEIPTS="$(jq -cn --argjson current "$REVIEW_PENDING_RECEIPTS" '$current + ["continuation-lifecycle-correlation"] | unique')"
+      fi
+      if [[ -f "$RUN_DIR/r-cd-2-summary.json" ]]; then
+        SUMMARY_REVIEW_STATUS="ready-for-human-review"
+        if [[ "$R_CD_2_LIFECYCLE_STATUS" != "present" ]]; then
+          SUMMARY_REVIEW_STATUS="review-pending"
+        fi
+        jq \
+          --arg verdict "$SUMMARY_VERDICT" \
+          --arg status "$SUMMARY_REVIEW_STATUS" \
+          --arg lifecycleStatus "$R_CD_2_LIFECYCLE_STATUS" \
+          '.verdict = $verdict
+           | .review.status = $status
+           | .review.pendingReceipts = (if $lifecycleStatus == "present" then [] else ["continuation-lifecycle-correlation"] end)
+           | .review.notes = ["Final verdict reconciled from the redacted continuation lifecycle receipt."]' \
+          "$RUN_DIR/r-cd-2-summary.json" > "$RUN_DIR/r-cd-2-summary.json.tmp"
+        mv "$RUN_DIR/r-cd-2-summary.json.tmp" "$RUN_DIR/r-cd-2-summary.json"
+        SUMMARY_FILE_VERDICT="$SUMMARY_VERDICT"
+      fi
+      jq -n \
+        --arg schema "openclaw.k6.verdict-reconciliation.v1" \
+        --arg selected "$SUMMARY_VERDICT" \
+        --arg selectedSource "$SUMMARY_VERDICT_SOURCE" \
+        --arg vuLog "$VU_LOG_VERDICT" \
+        --arg summaryFile "$SUMMARY_FILE_VERDICT" \
+        --arg lifecycleStatus "$R_CD_2_LIFECYCLE_STATUS" \
+        '{schema:$schema, selectedVerdict:$selected, selectedSource:$selectedSource, vuLogVerdict:(if $vuLog == "" then null else $vuLog end), summaryFileVerdict:(if $summaryFile == "unknown" then null else $summaryFile end), lifecycleStatus:$lifecycleStatus, reason:"R-CD-2 final classification is owned by the redacted continuation lifecycle receipt; generic delayed session traffic is non-authoritative."}' \
+        > "$RUN_DIR/verdict-reconciliation.json"
+    fi
+
     if ! node "$ARTIFACT_SANITIZER" \
       --input "$PRIVATE_EVIDENCE_FILE" \
       --out "$RUN_DIR/evidence.jsonl" \
@@ -499,6 +548,8 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
       --arg traceId "$TRACE_ID" \
       --arg tempoTraceJson "$TEMPO_TRACE_JSON" \
       --arg correlationReceipt "$CORRELATION_RECEIPT" \
+      --arg lifecycleReceipt "$R_CD_2_LIFECYCLE_RECEIPT" \
+      --arg lifecycleStatus "$R_CD_2_LIFECYCLE_STATUS" \
       --arg serviceLogStatus "$GATEWAY_JOURNAL_STATUS" \
       --arg verdict "$SUMMARY_VERDICT" \
       --arg verdictSource "$SUMMARY_VERDICT_SOURCE" \
@@ -507,7 +558,7 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
       --argjson summaryFiles "$SUMMARY_FILES_JSON" \
       --argjson evidence "$EVIDENCE_JSON" \
       --argjson reviewPendingReceipts "$REVIEW_PENDING_RECEIPTS" \
-      '{k6ExitCode:$rc, postprocessExitCode:$postprocessRc, effectiveExitCode:$effectiveRc, endedAt:$ended, verdict:(if $verdict == "unknown" then null else $verdict end), verdictSource:$verdictSource, summaryFileVerdict:(if $summaryFileVerdict == "unknown" then null else $summaryFileVerdict end), vuLogVerdict:(if $vuLogVerdict == "" then null else $vuLogVerdict end), summaryFiles:$summaryFiles, evidence:$evidence, candidateOnly:true, foldRequiresReview:true, observability:{traceStatus:$traceStatus, traceId:(if $traceId == "" then null else $traceId end), tempoTraceJson:(if $tempoTraceJson == "" then null else $tempoTraceJson end), correlationReceipt:(if $correlationReceipt == "" then null else $correlationReceipt end), serviceLogStatus:$serviceLogStatus, serviceLog:"gateway-journal.log", serviceLogCapture:"gateway-journal-capture.json", serviceLogRedaction:"gateway-journal-redaction.json"}, review:{status:(if ($reviewPendingReceipts|length)>0 then "review-pending" else "ready-for-human-review" end), pendingReceipts:$reviewPendingReceipts}}' \
+      '{k6ExitCode:$rc, postprocessExitCode:$postprocessRc, effectiveExitCode:$effectiveRc, endedAt:$ended, verdict:(if $verdict == "unknown" then null else $verdict end), verdictSource:$verdictSource, summaryFileVerdict:(if $summaryFileVerdict == "unknown" then null else $summaryFileVerdict end), vuLogVerdict:(if $vuLogVerdict == "" then null else $vuLogVerdict end), summaryFiles:$summaryFiles, evidence:$evidence, candidateOnly:true, foldRequiresReview:true, observability:{traceStatus:$traceStatus, traceId:(if $traceId == "" then null else $traceId end), tempoTraceJson:(if $tempoTraceJson == "" then null else $tempoTraceJson end), correlationReceipt:(if $correlationReceipt == "" then null else $correlationReceipt end), lifecycleReceipt:(if $lifecycleReceipt == "" then null else $lifecycleReceipt end), lifecycleStatus:$lifecycleStatus, serviceLogStatus:$serviceLogStatus, serviceLog:"gateway-journal.log", serviceLogCapture:"gateway-journal-capture.json", serviceLogRedaction:"gateway-journal-redaction.json"}, review:{status:(if ($reviewPendingReceipts|length)>0 then "review-pending" else "ready-for-human-review" end), pendingReceipts:$reviewPendingReceipts}}' \
       > "$RUN_DIR/run-result.json"
     METRICS_ARGS=(--run-dir "$RUN_DIR" --prometheus-out "$RUN_DIR/openclaw-proofs-k6.prom" --otlp-out "$RUN_DIR/openclaw-proofs-k6.otlp.json")
     if [[ -n "${OPENCLAW_PROOFS_K6_OTLP_ENDPOINT:-}" ]]; then

--- a/tools/k6-proofs/scripts/validate-r-cd-2-lifecycle.mjs
+++ b/tools/k6-proofs/scripts/validate-r-cd-2-lifecycle.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from 'node:fs/promises';
+
+function usage() {
+  console.error('Usage: node validate-r-cd-2-lifecycle.mjs --correlation <path> --out <path>');
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 2; index < argv.length; index += 1) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!['--correlation', '--out'].includes(key) || !value || value.startsWith('--')) {
+      throw new Error(`invalid argument: ${key}`);
+    }
+    args[key.slice(2)] = value;
+    index += 1;
+  }
+  if (!args.out) throw new Error('--out is required');
+  return args;
+}
+
+function isHex(value, length) {
+  return new RegExp(`^[0-9a-f]{${length}}$`, 'i').test(String(value || ''));
+}
+
+function verdict(receipt) {
+  const failures = [];
+  if (!receipt) {
+    failures.push('continuation-trace-correlation is missing');
+  } else {
+    if (receipt.schema !== 'openclaw.k6.continuation-trace-correlation.v1') failures.push('unexpected correlation schema');
+    if (receipt.row !== 'R-CD-2') failures.push('correlation receipt is not for R-CD-2');
+    if (receipt.continuation?.tool !== 'continue_delegate') failures.push('typed continue_delegate tool receipt is missing');
+    if (receipt.continuation?.acceptSpan !== 'continuation.delegate.dispatch') failures.push('delegate dispatch receipt is missing');
+    if (receipt.continuation?.fireSpan !== 'continuation.delegate.fire') failures.push('delegate fire receipt is missing');
+    if (receipt.delegate?.mode !== 'silent-wake') failures.push('delegate mode is not silent-wake');
+    if (receipt.sameTrace !== true || !isHex(receipt.traceId, 32)) failures.push('typed tool, dispatch, and fire are not correlated to one trace');
+    if (!receipt.chainId || !isHex(receipt.dispatchSpanId, 16) || !isHex(receipt.fireSpanId, 16) || receipt.dispatchSpanId === receipt.fireSpanId) {
+      failures.push('delegate dispatch/fire chain is incomplete');
+    }
+    if (!Array.isArray(receipt.toolSpanIds) || receipt.toolSpanIds.length !== 1 || !receipt.toolSpanIds.every((id) => isHex(id, 16))) {
+      failures.push('expected exactly one typed tool execution span');
+    }
+    if (receipt.distinctSpans !== true) failures.push('typed tool, dispatch, and fire spans are not distinct');
+    if (receipt.reason?.rawPersisted !== false || Object.hasOwn(receipt.reason || {}, 'raw')) failures.push('correlation receipt is not public-safe');
+  }
+
+  return {
+    schema: 'openclaw.k6.r-cd-2-lifecycle-receipt.v1',
+    row: 'R-CD-2',
+    outcome: failures.length === 0 ? 'PASS-candidate' : 'PARTIAL-candidate',
+    lifecycleReceipt: failures.length === 0 ? 'present' : 'missing',
+    failureClass: failures.length === 0 ? null : 'continuation-lifecycle-missing',
+    failures,
+    correlation: receipt && failures.length === 0 ? {
+      traceId: receipt.traceId,
+      chainId: receipt.chainId,
+      toolSpanId: receipt.toolSpanIds[0],
+      dispatchSpanId: receipt.dispatchSpanId,
+      fireSpanId: receipt.fireSpanId,
+      mode: receipt.delegate.mode,
+    } : null,
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  let correlation = null;
+  if (args.correlation) {
+    try {
+      correlation = JSON.parse(await readFile(args.correlation, 'utf8'));
+    } catch {
+      // A missing or malformed receipt is an explicit non-pass, not a parser crash.
+    }
+  }
+  const result = verdict(correlation);
+  await writeFile(args.out, `${JSON.stringify(result, null, 2)}\n`);
+  console.log(JSON.stringify(result));
+  process.exitCode = result.outcome === 'PASS-candidate' ? 0 : 1;
+}
+
+main().catch((error) => {
+  usage();
+  console.error(error?.stack || String(error));
+  process.exitCode = 2;
+});


### PR DESCRIPTION
Closes #408.

R-CD-2 now treats WebSocket dispatch/wake observations as behavioral context only. Its final candidate verdict is reconciled from a public-safe continuation lifecycle receipt that requires one nonce-correlated `continue_delegate` tool span plus `continuation.delegate.dispatch` and `continuation.delegate.fire` on the same `silent-wake` chain.

Missing, malformed, replay-unsafe, or otherwise invalid lifecycle correlation produces an explicit `PARTIAL-candidate` receipt; it cannot remain a review-pending pass. The no-channel-delivery condition remains required but is not positive lifecycle proof.

Tests:
- `node --test tools/k6-proofs/scripts/__tests__/*.test.mjs` (101/101)
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs`
- `node tools/k6-proofs/scripts/check-proof-row-manifests.mjs --corpus PROOFS`
- `bash -n tools/k6-proofs/scripts/run-proofs.sh`