### PR TITLE
proofs: fail closed R-CD-2 lifecycle

### DIFF
--- a/tools/k6-proofs/lib/r-cd-2-lifecycle.js
+++ b/tools/k6-proofs/lib/r-cd-2-lifecycle.js
@@ -1,0 +1,312 @@
+const SCHEDULED_SENTINEL_PREFIX = 'RCD2-DELEGATE-SCHEDULED';
+
+function eventText(eventData) {
+  try {
+    return JSON.stringify(eventData || {});
+  } catch {
+    return '';
+  }
+}
+
+function transcriptMessageText(eventName, eventData) {
+  if (eventName !== 'session.message' || eventData?.message?.role !== 'assistant') {
+    return '';
+  }
+  const content = eventData?.message?.content;
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  const texts = [];
+  for (const block of content) {
+    if (typeof block === 'string') {
+      texts.push(block);
+    } else if (
+      block &&
+      typeof block === 'object' &&
+      ['text', 'output_text'].includes(block.type) &&
+      typeof block.text === 'string'
+    ) {
+      texts.push(block.text);
+    }
+  }
+  return texts.join('\n');
+}
+
+function hasCorrelatedSilentStatusReceipt(eventName, eventData, rowNonce) {
+  if (eventName !== 'session.message' || eventData?.message?.role !== 'assistant') {
+    return false;
+  }
+  const content = eventData?.message?.content;
+  if (!Array.isArray(content)) return false;
+  for (const block of content) {
+    if (!block || typeof block !== 'object') continue;
+    const name = block.name || block.toolName;
+    if (name !== 'continue_status') continue;
+    const args = block.arguments || block.input || block.args;
+    if (!args || typeof args !== 'object') continue;
+    if (
+      args.notify === false &&
+      args.outcome === 'done' &&
+      eventText(args).includes(rowNonce)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isMatchingDispatchLifecycle(eventName, eventData, dispatchRunId) {
+  return Boolean(
+    eventName === 'agent' &&
+      dispatchRunId &&
+      eventData?.runId === dispatchRunId,
+  );
+}
+
+function redactedFailureReceipt(eventName, eventData, dispatchRunId, observedAtMs) {
+  const text = eventText(eventData).toLowerCase();
+  const matchingLifecycle = isMatchingDispatchLifecycle(
+    eventName,
+    eventData,
+    dispatchRunId,
+  );
+  const stream = String(eventData?.stream || '').toLowerCase();
+  const phase = String(eventData?.data?.phase || '').toLowerCase();
+  const livenessState = String(eventData?.data?.livenessState || '').toLowerCase();
+  const status = String(
+    eventData?.status ||
+      eventData?.state ||
+      eventData?.outcome ||
+      eventData?.data?.status ||
+      '',
+  ).toLowerCase();
+  const lifecycleFailed =
+    matchingLifecycle &&
+    (stream === 'error' ||
+      (stream === 'lifecycle' && ['error', 'failed', 'failure'].includes(phase)) ||
+      (stream === 'lifecycle' &&
+        phase === 'end' &&
+        ['error', 'failed', 'failure'].includes(status)) ||
+      (stream === 'lifecycle' &&
+        phase === 'end' &&
+        (eventData?.data?.replayInvalid === true ||
+          eventData?.data?.aborted === true ||
+          ['blocked', 'abandoned'].includes(livenessState))));
+
+  if (lifecycleFailed) {
+    let kind = 'dispatching-turn-failed';
+    if (eventData?.data?.replayInvalid === true) {
+      kind = 'dispatching-turn-replay-invalid';
+    } else if (eventData?.data?.aborted === true) {
+      kind = 'dispatching-turn-aborted';
+    } else if (['blocked', 'abandoned'].includes(livenessState)) {
+      kind = 'dispatching-turn-not-live';
+    } else if (
+      text.includes('continue_delegate') &&
+      (text.includes('replay-unsafe') || text.includes('enclosing turn was incomplete'))
+    ) {
+      kind = 'delegate-replay-unsafe';
+    } else if (text.includes('model override') && text.includes('not allowed')) {
+      kind = 'model-policy-rejected';
+    } else if (
+      (text.includes('provider') || text.includes('openai responses')) &&
+      (text.includes('transport error') ||
+        text.includes('request failed') ||
+        text.includes('connection error'))
+    ) {
+      kind = 'provider-transport-error';
+    }
+    return {
+      kind,
+      sourceEvent: eventName || 'unknown',
+      correlation: 'dispatch-run-id',
+      observedAtMs,
+    };
+  }
+
+  if (eventName !== 'session.message') return null;
+
+  const messageText = transcriptMessageText(eventName, eventData).toLowerCase();
+  let kind = null;
+  if (
+    messageText.includes('continue_delegate') &&
+    (messageText.includes('replay-unsafe') ||
+      messageText.includes('enclosing turn was incomplete'))
+  ) {
+    kind = 'delegate-replay-unsafe';
+  } else if (
+    messageText.includes('model override') &&
+    messageText.includes('not allowed')
+  ) {
+    kind = 'model-policy-rejected';
+  } else if (
+    (messageText.includes('provider') || messageText.includes('openai responses')) &&
+    (messageText.includes('transport error') ||
+      messageText.includes('request failed') ||
+      messageText.includes('connection error'))
+  ) {
+    kind = 'provider-transport-error';
+  }
+  if (kind) {
+    return {
+      kind,
+      sourceEvent: eventName || 'unknown',
+      correlation: 'subscribed-session-after-dispatch',
+      observedAtMs,
+    };
+  }
+
+  return null;
+}
+
+export function rCd2ScheduledSentinel(rowNonce) {
+  return `${SCHEDULED_SENTINEL_PREFIX} ${rowNonce}`;
+}
+
+export function isRcd2OutboundChannelDeliveryEvent(eventName, eventData) {
+  const lowerName = String(eventName || '').toLowerCase();
+  const namedDelivery =
+    lowerName.includes('delivery') &&
+    (lowerName.includes('channel') ||
+      lowerName.includes('message') ||
+      lowerName.includes('outbound'));
+  if (namedDelivery) return true;
+  if (!eventData || typeof eventData !== 'object') return false;
+
+  const channelTarget =
+    eventData.channelId ||
+    eventData.channel_id ||
+    eventData.targetChannel ||
+    eventData.deliveryChannel;
+  const deliveryStatus = String(
+    eventData.deliveryStatus ||
+      eventData.delivery_state ||
+      eventData.deliveryState ||
+      '',
+  ).toLowerCase();
+  if (Boolean(channelTarget) && ['sent', 'delivered', 'completed'].includes(deliveryStatus)) {
+    return true;
+  }
+
+  const message = eventData.message;
+  if (!message || typeof message !== 'object') return false;
+  const isMessageToolResult =
+    ['tool', 'toolResult'].includes(message.role) && message.toolName === 'message';
+  if (
+    isMessageToolResult &&
+    message.details &&
+    typeof message.details === 'object' &&
+    message.details.result &&
+    typeof message.details.result === 'object' &&
+    (typeof message.details.result.messageId === 'string' ||
+      (message.details.result.receipt &&
+        typeof message.details.result.receipt === 'object'))
+  ) {
+    return true;
+  }
+  if (isMessageToolResult && Array.isArray(message.content)) {
+    for (const block of message.content) {
+      if (!block || typeof block !== 'object' || typeof block.text !== 'string') continue;
+      try {
+        const parsed = JSON.parse(block.text);
+        const result = parsed && typeof parsed === 'object' ? parsed.result : null;
+        if (
+          result &&
+          typeof result === 'object' &&
+          (typeof result.messageId === 'string' ||
+            (result.receipt && typeof result.receipt === 'object'))
+        ) {
+          return true;
+        }
+      } catch {
+        // Non-JSON tool result text cannot prove delivery.
+      }
+    }
+  }
+  const statuses = [];
+  const appendStatus = (value) => {
+    if (typeof value === 'string') statuses.push(value.toLowerCase());
+  };
+  appendStatus(message.details?.deliveryStatus);
+  appendStatus(message.details?.delivery?.status);
+  if (Array.isArray(message.content)) {
+    for (const block of message.content) {
+      if (!block || typeof block !== 'object') continue;
+      appendStatus(block.details?.deliveryStatus);
+      appendStatus(block.result?.deliveryStatus);
+      appendStatus(block.result?.details?.deliveryStatus);
+    }
+  }
+  return statuses.some((value) => ['sent', 'delivered', 'completed'].includes(value));
+}
+
+export function classifyRcd2LifecycleEvent({
+  eventName,
+  eventData,
+  rowNonce,
+  harnessMarker,
+  toolAccepted,
+  dispatchRunId,
+  delegateScheduledAtMs,
+  dispatchTurnCompletedAtMs,
+  wakeGateMs,
+  nowMs,
+}) {
+  const messageText = transcriptMessageText(eventName, eventData);
+  const harnessEcho = messageText.includes(harnessMarker);
+  const scheduledSentinel = messageText.includes(rCd2ScheduledSentinel(rowNonce));
+  const correlatedReturn =
+    !scheduledSentinel &&
+    (messageText.includes(rowNonce) ||
+      hasCorrelatedSilentStatusReceipt(eventName, eventData, rowNonce));
+  const dispatchTurnCompleted =
+    isMatchingDispatchLifecycle(eventName, eventData, dispatchRunId) &&
+    String(eventData?.stream || '').toLowerCase() === 'lifecycle' &&
+    String(eventData?.data?.phase || '').toLowerCase() === 'end' &&
+    eventData?.data?.willRetry !== true &&
+    eventData?.data?.completed !== false &&
+    eventData?.data?.replayInvalid !== true &&
+    eventData?.data?.aborted !== true &&
+    !['blocked', 'abandoned'].includes(
+      String(eventData?.data?.livenessState || '').toLowerCase(),
+    );
+  const delegateScheduledReceipt =
+    toolAccepted &&
+    !harnessEcho &&
+    messageText.includes(rCd2ScheduledSentinel(rowNonce));
+  const parentWakeObserved =
+    toolAccepted &&
+    !harnessEcho &&
+    correlatedReturn &&
+    delegateScheduledAtMs !== null &&
+    dispatchTurnCompletedAtMs !== null &&
+    eventName === 'session.message' &&
+    nowMs >= delegateScheduledAtMs + wakeGateMs &&
+    nowMs >= dispatchTurnCompletedAtMs;
+  const failureReceipt =
+    toolAccepted && !harnessEcho
+      ? redactedFailureReceipt(eventName, eventData, dispatchRunId, nowMs)
+      : null;
+
+  return {
+    delegateScheduledReceipt,
+    parentWakeObserved,
+    dispatchTurnCompleted,
+    failureReceipt,
+  };
+}
+
+export function isRcd2LifecyclePass(evidence) {
+  return Boolean(
+    evidence &&
+      evidence.disposable_session_required &&
+      evidence.session_created &&
+      evidence.session_unbound_confirmed &&
+      evidence.tool_accepted &&
+      evidence.delegate_scheduled_receipt &&
+      evidence.dispatch_turn_completed &&
+      evidence.parent_wake_observed &&
+      evidence.post_wake_quiet_completed &&
+      !evidence.dispatch_failure_observed &&
+      !evidence.channel_message_observed,
+  );
+}

--- a/tools/k6-proofs/manifests/r-cd-2.json
+++ b/tools/k6-proofs/manifests/r-cd-2.json
@@ -19,6 +19,7 @@
     "methods": [
       "sessions.send",
       "sessions.messages.subscribe",
+      "sessions.list",
       "tasks.list"
     ],
     "status": "runnable",
@@ -34,15 +35,19 @@
   "liveRunSafety": {
     "classification": "k6-runnable",
     "requiresLiveGatewayToken": true,
-    "requiresTargetSessionKey": true,
+    "requiresTargetSessionKey": false,
     "requiresCandidateSha": true,
     "requiresExternalAgentOrToolInvocation": true,
     "sameSessionConcurrencySafe": false,
     "expectedArtifactClass": "PASS-candidate",
     "requiredReceipts": [
       "seat-readiness",
+      "unbound-disposable-session",
       "dispatch-accepted",
+      "delegate-scheduled-receipt",
+      "dispatch-turn-completed",
       "parent-wake-event",
+      "post-wake-no-delivery-window",
       "no-channel-delivery",
       "trace-id"
     ],
@@ -50,6 +55,11 @@
     "notes": "Live continuation row. Fail closed when token/session env is missing, serialize per target session, and treat generated output as a PASS-candidate until required receipts are reviewed."
   },
   "expectedReceipts": [
+    {
+      "name": "unbound-disposable-session",
+      "required": true,
+      "description": "Fresh disposable session created and confirmed through sessions.list with no channel delivery binding"
+    },
     {
       "name": "dispatch-accepted",
       "required": true,
@@ -59,6 +69,26 @@
       "name": "task-ledger-entry",
       "required": false,
       "description": "Optional extra context from the generic TaskFlow task ledger; continue_delegate does not reliably write here"
+    },
+    {
+      "name": "delegate-scheduled-receipt",
+      "required": true,
+      "description": "Nonce-correlated parent receipt emitted only after the continue_delegate tool result reports scheduled"
+    },
+    {
+      "name": "dispatch-failure-receipt",
+      "required": false,
+      "description": "Redacted fail-closed classification when the provider/agent turn fails or queued continue_delegate is incomplete/replay-unsafe"
+    },
+    {
+      "name": "dispatch-turn-completed",
+      "required": true,
+      "description": "Run-ID-correlated terminal lifecycle success for the dispatching parent turn"
+    },
+    {
+      "name": "post-wake-no-delivery-window",
+      "required": true,
+      "description": "Bounded observation window after the correlated parent wake with no outbound channel-delivery event"
     },
     {
       "name": "child-session-key",
@@ -91,6 +121,6 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Silent-wake path. PASS-candidate when: (1) dispatching agent turn accepted, (2) parent session emits wake/agent events, (3) NO channel message delivered from the delegate return, and (4) trace/receipt artifacts are fetched for review. A nonce-correlated tasks.list row is optional because continue_delegate uses pending-delegate/subagent surfaces, not the generic task registry."
+    "notes": "Silent-wake path. PASS-candidate requires: (1) a fresh disposable session confirmed to have no channel binding, (2) dispatching agent turn accepted, (3) nonce-correlated delegate-scheduled receipt, (4) run-ID-correlated terminal success for the dispatching turn, (5) nonce-correlated delayed parent wake after scheduling, (6) a bounded post-wake window with no explicit message-tool delivery receipt, and (7) trace/receipt artifacts fetched for review. Provider/turn failure or incomplete/replay-unsafe delegate rejection is fail-closed PARTIAL-candidate. Bound live sessions are intentionally unsupported because the subscribed Gateway stream does not expose a reliable normal channel-delivery receipt."
   }
 }

--- a/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
+++ b/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
@@ -23,6 +23,13 @@ import { Counter, Trend } from 'k6/metrics';
 import crypto from 'k6/crypto';
 import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+import { closeSocketAfterDelay } from '../lib/socket-close.js';
+import {
+  classifyRcd2LifecycleEvent,
+  isRcd2OutboundChannelDeliveryEvent,
+  isRcd2LifecyclePass,
+  rCd2ScheduledSentinel,
+} from '../lib/r-cd-2-lifecycle.js';
 
 export const options = {
   scenarios: {
@@ -41,7 +48,6 @@ export const options = {
 
 const failures = new Counter('proof_failures');
 const duration = new Trend('r_cd_2_duration');
-let finalEvidence = null;
 
 // --- Manifest-driven config ---
 const manifest = loadManifestFromEnv();
@@ -65,32 +71,38 @@ function invocationCfg() {
   };
 }
 
-export function isOutboundChannelDeliveryEvent(eventName, eventData) {
-  const lowerName = String(eventName || '').toLowerCase();
-  const namedDelivery = lowerName.includes('delivery') &&
-    (lowerName.includes('channel') || lowerName.includes('message') || lowerName.includes('outbound'));
-  if (namedDelivery) return true;
-  if (!eventData || typeof eventData !== 'object') return false;
-
-  const channelTarget = eventData.channelId || eventData.channel_id ||
-    eventData.targetChannel || eventData.deliveryChannel;
-  const deliveryStatus = String(
-    eventData.deliveryStatus || eventData.delivery_state || eventData.deliveryState || '',
-  ).toLowerCase();
-  return Boolean(channelTarget) && ['sent', 'delivered', 'completed'].includes(deliveryStatus);
-}
-
 export default function () {
   const url = __ENV.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
   const token = __ENV.OPENCLAW_GATEWAY_TOKEN;
   const requestedSessionKey = manifest && manifest.sessionKey || __ENV.OPENCLAW_SESSION_KEY || DEFAULTS.sessionKey;
   let sessionKey = requestedSessionKey;
-  const createDisposableSession = (__ENV.OPENCLAW_CREATE_DISPOSABLE_SESSION || '').toLowerCase() === 'true';
+  const disposableEnv =
+    __ENV.OPENCLAW_CREATE_DISPOSABLE_SESSION ||
+    __ENV.OPENCLAW_CREATE_DISPOSABLE_SESSIONS ||
+    'true';
+  const createDisposableSession = disposableEnv.toLowerCase() === 'true';
   const seat = manifest && manifest.seat || __ENV.OPENCLAW_SEAT_NAME || DEFAULTS.seat;
   const rowNonce = nonce('R-CD-2');
+  const postWakeQuietMs = Number(__ENV.OPENCLAW_R_CD_2_POST_WAKE_QUIET_MS || 5000);
 
   if (!token) {
     console.error('OPENCLAW_GATEWAY_TOKEN is required');
+    failures.add(1);
+    return;
+  }
+  if (!createDisposableSession) {
+    console.error('R-CD-2 requires an unbound disposable session for no-channel proof');
+    failures.add(1);
+    return;
+  }
+  if (
+    !Number.isFinite(postWakeQuietMs) ||
+    postWakeQuietMs < 1000 ||
+    postWakeQuietMs > 30000
+  ) {
+    console.error(
+      'OPENCLAW_R_CD_2_POST_WAKE_QUIET_MS must be a finite value from 1000 through 30000',
+    );
     failures.add(1);
     return;
   }
@@ -110,11 +122,15 @@ export default function () {
     sessionKey,
     requestedSessionKey,
     session_created: false,
+    session_unbound_confirmed: false,
     created_session_key: null,
     candidateSha: manifest && manifest.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
     started: new Date().toISOString(),
+    disposable_session_required: createDisposableSession,
     // Required receipts
     tool_accepted: false,
+    delegate_scheduled_receipt: false,
+    delegate_scheduled_at_ms: null,
     task_created: false,
     task_mode: null,
     // Silent-wake specific
@@ -124,12 +140,20 @@ export default function () {
     channel_message_observed: false, // MUST stay false for PASS
     silent_status_record_observed: false,
     dispatch_accepted_at_ms: null,
+    dispatch_run_id: null,
+    dispatch_turn_completed: false,
+    dispatch_turn_completed_at_ms: null,
     wake_gate_ms: Number(__ENV.OPENCLAW_MIN_DELEGATE_DELAY_MS || 5000),
+    parent_wake_observed_at_ms: null,
+    post_wake_quiet_ms: postWakeQuietMs,
+    post_wake_quiet_completed: false,
     child_session: null,
     reason_hash: null,
     reason_length: null,
     delegate_mode: null,
     trace_id: null,
+    dispatch_failure_observed: false,
+    failure_receipt: null,
     redacted_events: [],
   };
 
@@ -137,8 +161,35 @@ export default function () {
 
   const res = ws.connect(url, {}, (socket) => {
     const tracker = new RequestTracker();
+    let successCloseScheduled = false;
+    let proofFlowStarted = false;
+
+    function maybeScheduleSuccessClose() {
+      if (
+        successCloseScheduled ||
+        !evidence.delegate_scheduled_receipt ||
+        !evidence.dispatch_turn_completed ||
+        !evidence.parent_wake_observed ||
+        evidence.dispatch_failure_observed ||
+        evidence.channel_message_observed
+      ) {
+        return;
+      }
+      const closeAfterMs =
+        evidence.parent_wake_observed_at_ms + evidence.post_wake_quiet_ms;
+      const remainingMs = Math.max(0, closeAfterMs - Date.now());
+      successCloseScheduled = true;
+      closeSocketAfterDelay(socket, remainingMs, () => {
+        if (!evidence.dispatch_failure_observed && !evidence.channel_message_observed) {
+          evidence.post_wake_quiet_completed = true;
+          console.log('✓ bounded post-wake no-delivery window completed');
+        }
+      });
+    }
 
     function startProofFlow(socket) {
+      if (proofFlowStarted) return;
+      proofFlowStarted = true;
       // Subscribe to parent session messages to detect wake + verify no channel delivery.
       // Protocol: sessions.messages.subscribe uses 'key' not 'sessionKey'.
       tracker.send(socket, 'sessions.messages.subscribe', { key: sessionKey });
@@ -153,7 +204,10 @@ export default function () {
         evidence.reason_hash = crypto.sha256(prompt, 'hex').slice(0, 16);
         evidence.reason_length = prompt.length;
         evidence.delegate_mode = inv.mode;
-        const agentInstruction = `[k6-proof-harness] Call continue_delegate with: task="${prompt}", mode="${inv.mode}", delaySeconds=${inv.delaySeconds}. This is a proof run — execute the tool call immediately, no other action needed.`;
+        const agentInstruction =
+          `[k6-proof-harness] Call continue_delegate with: task="${prompt}", mode="${inv.mode}", delaySeconds=${inv.delaySeconds}. ` +
+          `After the continue_delegate tool result reports scheduled, reply exactly ${rCd2ScheduledSentinel(rowNonce)}. ` +
+          `This is a proof run — execute the tool call immediately, no other action needed.`;
         tracker.send(socket, 'sessions.send', {
           key: sessionKey,
           message: agentInstruction,
@@ -181,8 +235,6 @@ export default function () {
             label: `k6 R-CD-2 ${rowNonce}`,
           });
         }, 250);
-      } else {
-        socket.setTimeout(() => startProofFlow(socket), 500);
       }
     });
 
@@ -207,11 +259,43 @@ export default function () {
             evidence.session_created = true;
             evidence.created_session_key = sessionKey;
             console.log(`✓ disposable session created: ${sessionKey}`);
-            startProofFlow(socket);
+            tracker.send(socket, 'sessions.list', { limit: 10, search: sessionKey });
           } else {
             console.error(`✗ sessions.create rejected: ${JSON.stringify(classified.error)}`);
             failures.add(1);
             socket.close();
+          }
+        }
+
+        if (classified.kind === 'response' && classified.method === 'sessions.list') {
+          if (!classified.ok) {
+            console.error(`✗ sessions.list rejected: ${JSON.stringify(classified.error)}`);
+            failures.add(1);
+            socket.close();
+          } else {
+            const sessions = Array.isArray(classified.payload && classified.payload.sessions)
+              ? classified.payload.sessions
+              : [];
+            const created = sessions.find((session) => session && session.key === sessionKey);
+            const deliveryContext = created && created.deliveryContext || {};
+            const hasChannelBinding = Boolean(
+              created &&
+                (created.lastChannel ||
+                  created.lastTo ||
+                  created.lastAccountId ||
+                  deliveryContext.channel ||
+                  deliveryContext.to ||
+                  deliveryContext.accountId),
+            );
+            if (!created || hasChannelBinding) {
+              console.error('✗ disposable session is missing or has a channel delivery binding');
+              failures.add(1);
+              socket.close();
+            } else {
+              evidence.session_unbound_confirmed = true;
+              console.log('✓ disposable session has no channel delivery binding');
+              startProofFlow(socket);
+            }
           }
         }
 
@@ -220,6 +304,7 @@ export default function () {
           if (classified.ok) {
             evidence.tool_accepted = true;
             evidence.dispatch_accepted_at_ms = Date.now();
+            evidence.dispatch_run_id = classified.payload && classified.payload.runId || null;
             if (classified.payload && classified.payload.traceId) evidence.trace_id = classified.payload.traceId;
             console.log('✓ sessions.send accepted — agent turn triggered for R-CD-2 (mode=silent-wake)');
           } else if (classified.error) {
@@ -249,6 +334,18 @@ export default function () {
           const eventName = classified.event || '';
           const eventData = classified.data || {};
           const eventStr = JSON.stringify(eventData);
+          const lifecycle = classifyRcd2LifecycleEvent({
+            eventName,
+            eventData,
+            rowNonce,
+            harnessMarker: '[k6-proof-harness]',
+            toolAccepted: evidence.tool_accepted,
+            dispatchRunId: evidence.dispatch_run_id,
+            delegateScheduledAtMs: evidence.delegate_scheduled_at_ms,
+            dispatchTurnCompletedAtMs: evidence.dispatch_turn_completed_at_ms,
+            wakeGateMs: evidence.wake_gate_ms,
+            nowMs: Date.now(),
+          });
 
           // Some target sessions emit generic agent lifecycle events rather than
           // an early session.message before the delayed wake. Count these as the
@@ -257,19 +354,36 @@ export default function () {
             evidence.agent_turn_observed = true;
           }
 
-          // session.message events immediately after sessions.send are the dispatching
-          // agent turn, not the silent-wake return.  The delegate delay is clamped
-          // by the gateway, so only count a parent wake after the minimum delay.
-          if (eventName === 'session.message' && evidence.tool_accepted) {
-            const elapsed = evidence.dispatch_accepted_at_ms ? Date.now() - evidence.dispatch_accepted_at_ms : 0;
-            if (elapsed >= evidence.wake_gate_ms) {
-              evidence.parent_wake_observed = true;
-              evidence.agent_turn_observed = true;
-              console.log('✓ delayed session.message event observed (silent-wake return candidate)');
-            } else {
-              evidence.agent_turn_observed = true;
-              console.log('✓ initial session.message event observed (dispatching agent turn)');
-            }
+          if (lifecycle.delegateScheduledReceipt) {
+            evidence.delegate_scheduled_receipt = true;
+            evidence.delegate_scheduled_at_ms = Date.now();
+            evidence.agent_turn_observed = true;
+            console.log('✓ correlated continue_delegate scheduled receipt observed');
+          }
+
+          if (lifecycle.dispatchTurnCompleted) {
+            evidence.dispatch_turn_completed = true;
+            evidence.dispatch_turn_completed_at_ms = Date.now();
+            console.log('✓ dispatching agent turn completed successfully');
+          }
+
+          if (lifecycle.parentWakeObserved) {
+            evidence.parent_wake_observed = true;
+            evidence.parent_wake_observed_at_ms =
+              evidence.parent_wake_observed_at_ms || Date.now();
+            evidence.agent_turn_observed = true;
+            console.log('✓ correlated delayed parent wake observed after delegate scheduling receipt');
+          } else if (eventName === 'session.message' && evidence.tool_accepted) {
+            evidence.agent_turn_observed = true;
+            console.log('ℹ session.message observed without qualified continuation wake');
+          }
+
+          if (lifecycle.failureReceipt && !evidence.dispatch_failure_observed) {
+            evidence.dispatch_failure_observed = true;
+            evidence.failure_receipt = lifecycle.failureReceipt;
+            failures.add(1);
+            console.warn(`✗ dispatching turn failed: ${lifecycle.failureReceipt.kind}`);
+            socket.close();
           }
 
           // continue_status({ notify:false }) is internal completion bookkeeping,
@@ -285,26 +399,15 @@ export default function () {
           // Negative check: only an explicit outbound-delivery-shaped event counts.
           // Generic agent/chat events can contain the full transcript plus routing
           // metadata, so substring checks for "channel" and "deliver" are unsafe.
-          if (eventStr.includes(rowNonce) &&
-              isOutboundChannelDeliveryEvent(eventName, eventData)) {
-            if (eventStr.includes('[k6-proof-harness]')) {
-              evidence.dispatch_channel_message_observed = true;
-              console.log('ℹ dispatch instruction channel event observed (not delegate return)');
-            } else {
-              evidence.channel_message_observed = true;
-              console.warn('✗ Delegate channel delivery detected — silent mode violated!');
-              failures.add(1);
-            }
+          if (isRcd2OutboundChannelDeliveryEvent(eventName, eventData)) {
+            evidence.channel_message_observed = true;
+            console.warn('✗ Outbound channel delivery detected — silent mode violated!');
+            failures.add(1);
+            socket.close();
           }
         }
 
-        // Early close only after a delayed parent wake candidate is observed; task
-        // ledger context remains optional.  Do not close on the initial dispatch
-        // agent turn, or this row only proves sessions.send.
-        if (evidence.tool_accepted && evidence.parent_wake_observed) {
-          console.log('Primary silent-wake evidence gathered, closing early');
-          socket.close();
-        }
+        maybeScheduleSuccessClose();
       } catch (e) {
         console.warn(`parse error: ${e}`);
       }
@@ -318,7 +421,6 @@ export default function () {
 
   evidence.ended = new Date().toISOString();
   evidence.duration_ms = Date.now() - started;
-  finalEvidence = evidence;
   duration.add(evidence.duration_ms);
 
   // Checks — core evidence for silent-wake proof:
@@ -329,24 +431,25 @@ export default function () {
   // use their own tracking surface, not the generic task ledger.
   check(res, { 'websocket connected': (r) => r && r.status === 101 });
   check(null, {
+    'unbound disposable session confirmed': () => evidence.session_unbound_confirmed,
     'agent turn triggered (sessions.send accepted)': () => evidence.tool_accepted,
     'dispatching agent turn observed': () => evidence.agent_turn_observed,
-    'delayed parent wake candidate observed': () => evidence.parent_wake_observed,
+    'correlated delegate scheduled receipt observed': () => evidence.delegate_scheduled_receipt,
+    'dispatching agent turn completed successfully': () => evidence.dispatch_turn_completed,
+    'correlated delayed parent wake observed after scheduling': () => evidence.parent_wake_observed,
+    'post-wake no-delivery window completed': () => evidence.post_wake_quiet_completed,
+    'dispatching turn stayed successful': () => !evidence.dispatch_failure_observed,
     'no channel delivery (silent verified)': () => !evidence.channel_message_observed,
   });
 
-  if (!evidence.tool_accepted || !evidence.agent_turn_observed || !evidence.parent_wake_observed) {
+  const passed = isRcd2LifecyclePass(evidence);
+  if (!passed && !evidence.dispatch_failure_observed) {
     failures.add(1);
   }
   if (evidence.channel_message_observed) {
     failures.add(1);
     console.error('FAIL: silent-wake delegate produced channel output');
   }
-
-  // Verdict — PASS when: turn triggered + events flowing + no channel delivery
-  const passed = (!createDisposableSession || evidence.session_created) &&
-    evidence.tool_accepted && evidence.agent_turn_observed &&
-    evidence.parent_wake_observed && !evidence.channel_message_observed;
 
   console.log(`R_CD_2_EVIDENCE ${JSON.stringify(evidence)}`);
   console.log(`\n--- R-CD-2 EVIDENCE SUMMARY ---`);
@@ -358,25 +461,23 @@ export default function () {
 export function handleSummary(data) {
   const timestamp = new Date().toISOString();
   const passRate = data.metrics.proof_failures && data.metrics.proof_failures.values && data.metrics.proof_failures.values.count === 0;
-  const traceId = finalEvidence && finalEvidence.trace_id || null;
+  const passed = passRate;
   const summary = {
     row: 'R-CD-2',
     sha: __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
     seat: __ENV.OPENCLAW_SEAT_NAME || 'ronan-dgx',
     timestamp,
-    verdict: passRate ? 'PASS-candidate' : 'PARTIAL-candidate',
+    verdict: passed ? 'PASS-candidate' : 'PARTIAL-candidate',
     candidateOnly: true,
     foldRequiresReview: true,
-    observability: {
-      traceId,
-      traceJson: traceId ? 'pending-fetch' : 'missing',
-    },
     review: {
-      status: traceId ? 'ready-for-human-review' : 'review-pending',
-      pendingReceipts: traceId ? [] : ['tempo-trace-json'],
-      notes: traceId
-        ? ['Trace id captured; fetch and attach Tempo trace JSON before canonical fold.']
-        : ['No trace_id was emitted by this candidate run; keep PASS-candidate as review-pending until trace JSON is fetched or the fold explicitly accepts trace-missing.'],
+      status: 'review-pending',
+      receiptSource: 'run-proofs evidence extraction and Tempo postprocessing',
+      notes: [
+        passed
+          ? 'VU lifecycle checks passed; external postprocessing must still attach the required Tempo trace before folding.'
+          : 'No successful correlated continuation lifecycle was proven; retain the redacted failure receipt and do not fold as PASS.',
+      ],
     },
     metrics: {
       duration_ms: data.metrics.r_cd_2_duration && data.metrics.r_cd_2_duration.values || null,

--- a/tools/k6-proofs/scripts/__tests__/r-cd-2-lifecycle.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cd-2-lifecycle.test.mjs
@@ -1,0 +1,424 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import {
+  classifyRcd2LifecycleEvent,
+  isRcd2OutboundChannelDeliveryEvent,
+  isRcd2LifecyclePass,
+  rCd2ScheduledSentinel,
+} from '../../lib/r-cd-2-lifecycle.js';
+
+const rowNonce = 'R-CD-2-fixture';
+const harnessMarker = '[k6-proof-harness]';
+
+function classify(overrides) {
+  return classifyRcd2LifecycleEvent({
+    eventName: 'session.message',
+    eventData: {},
+    rowNonce,
+    harnessMarker,
+    toolAccepted: true,
+    dispatchRunId: 'dispatch-run',
+    delegateScheduledAtMs: null,
+    dispatchTurnCompletedAtMs: 500,
+    wakeGateMs: 5000,
+    nowMs: 10000,
+    ...overrides,
+  });
+}
+
+test('R-CD-2 does not treat a generic delayed message after scheduling as a continuation wake', () => {
+  const event = classify({
+    eventData: {
+      sessionKey: `r-cd-2-${rowNonce}`,
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'unrelated activity' }],
+        metadata: { continuation: rowNonce },
+      },
+    },
+    delegateScheduledAtMs: 1000,
+  });
+
+  assert.equal(event.delegateScheduledReceipt, false);
+  assert.equal(event.parentWakeObserved, false);
+  assert.equal(
+    isRcd2LifecyclePass({
+      disposable_session_required: true,
+      session_created: true,
+      session_unbound_confirmed: true,
+      tool_accepted: true,
+      delegate_scheduled_receipt: false,
+      dispatch_turn_completed: true,
+      parent_wake_observed: true,
+      post_wake_quiet_completed: true,
+      dispatch_failure_observed: false,
+      channel_message_observed: false,
+    }),
+    false,
+  );
+});
+
+test('R-CD-2 ignores nonce-bearing tool-call arguments when correlating the wake', () => {
+  const event = classify({
+    eventData: {
+      message: {
+        role: 'assistant',
+        content: [
+          {
+            type: 'toolCall',
+            name: 'continue_delegate',
+            arguments: { task: `reply DONE ${rowNonce}` },
+          },
+        ],
+      },
+    },
+    delegateScheduledAtMs: 1000,
+  });
+
+  assert.equal(event.delegateScheduledReceipt, false);
+  assert.equal(event.parentWakeObserved, false);
+});
+
+test('R-CD-2 rejects user-authored lifecycle sentinels', () => {
+  const event = classify({
+    eventData: {
+      message: {
+        role: 'user',
+        content: [{ type: 'text', text: rCd2ScheduledSentinel(rowNonce) }],
+      },
+    },
+    delegateScheduledAtMs: 1000,
+  });
+
+  assert.equal(event.delegateScheduledReceipt, false);
+  assert.equal(event.parentWakeObserved, false);
+});
+
+test('R-CD-2 does not reuse a repeated scheduled sentinel as the delayed wake', () => {
+  const event = classify({
+    eventData: {
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: rCd2ScheduledSentinel(rowNonce) }],
+      },
+    },
+    delegateScheduledAtMs: 1000,
+    dispatchTurnCompletedAtMs: 2000,
+  });
+
+  assert.equal(event.delegateScheduledReceipt, true);
+  assert.equal(event.parentWakeObserved, false);
+});
+
+test('R-CD-2 accepts a correlated assistant continue_status receipt as the silent wake', () => {
+  const event = classify({
+    eventData: {
+      message: {
+        role: 'assistant',
+        content: [
+          {
+            type: 'toolCall',
+            name: 'continue_status',
+            arguments: {
+              notify: false,
+              outcome: 'done',
+              status: `completed ${rowNonce}`,
+            },
+          },
+        ],
+      },
+    },
+    delegateScheduledAtMs: 1000,
+  });
+
+  assert.equal(event.parentWakeObserved, true);
+});
+
+test('R-CD-2 accepts a wake only after the correlated scheduled receipt and delay gate', () => {
+  const scheduledAtMs = 1000;
+  const scheduled = classify({
+    eventData: {
+      sessionKey: `r-cd-2-${rowNonce}`,
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: rCd2ScheduledSentinel(rowNonce) }],
+      },
+    },
+    nowMs: scheduledAtMs,
+  });
+  const wake = classify({
+    eventData: {
+      sessionKey: `r-cd-2-${rowNonce}`,
+      message: { role: 'assistant', content: [{ type: 'text', text: `DONE ${rowNonce}` }] },
+    },
+    delegateScheduledAtMs: scheduledAtMs,
+    nowMs: scheduledAtMs + 5000,
+  });
+
+  assert.equal(scheduled.delegateScheduledReceipt, true);
+  assert.equal(wake.parentWakeObserved, true);
+  assert.equal(
+    isRcd2LifecyclePass({
+      disposable_session_required: true,
+      session_created: true,
+      session_unbound_confirmed: true,
+      tool_accepted: true,
+      delegate_scheduled_receipt: true,
+      dispatch_turn_completed: true,
+      parent_wake_observed: true,
+      post_wake_quiet_completed: true,
+      dispatch_failure_observed: false,
+      channel_message_observed: false,
+    }),
+    true,
+  );
+});
+
+test('R-CD-2 emits redacted failure receipts for rejected dispatching turns', () => {
+  const providerFailure = classify({
+    eventData: {
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'OpenAI Responses transport error' }],
+      },
+    },
+  });
+  const replayUnsafe = classify({
+    eventData: {
+      message: {
+        role: 'assistant',
+        content: [
+          {
+            type: 'text',
+            text: 'Failed 1 queued continue_delegate election(s) because the enclosing turn was incomplete and replay-unsafe',
+          },
+        ],
+      },
+    },
+  });
+
+  assert.deepEqual(providerFailure.failureReceipt, {
+    kind: 'provider-transport-error',
+    sourceEvent: 'session.message',
+    correlation: 'subscribed-session-after-dispatch',
+    observedAtMs: 10000,
+  });
+  assert.deepEqual(replayUnsafe.failureReceipt, {
+    kind: 'delegate-replay-unsafe',
+    sourceEvent: 'session.message',
+    correlation: 'subscribed-session-after-dispatch',
+    observedAtMs: 10000,
+  });
+  assert.equal(JSON.stringify(replayUnsafe.failureReceipt).includes('continue_delegate'), false);
+});
+
+test('R-CD-2 classifies standard dispatch lifecycle errors and requires terminal success', () => {
+  const lifecycleError = classify({
+    eventName: 'agent',
+    eventData: {
+      runId: 'dispatch-run',
+      stream: 'lifecycle',
+      data: { phase: 'error', error: 'private provider details' },
+    },
+  });
+  const lifecycleEnd = classify({
+    eventName: 'agent',
+    eventData: {
+      runId: 'dispatch-run',
+      stream: 'lifecycle',
+      data: { phase: 'end' },
+    },
+  });
+
+  assert.deepEqual(lifecycleError.failureReceipt, {
+    kind: 'dispatching-turn-failed',
+    sourceEvent: 'agent',
+    correlation: 'dispatch-run-id',
+    observedAtMs: 10000,
+  });
+  assert.equal(lifecycleEnd.dispatchTurnCompleted, true);
+  assert.equal(
+    classify({
+      eventName: 'agent',
+      eventData: {
+        runId: 'dispatch-run',
+        stream: 'lifecycle',
+        data: { phase: 'start', status: 'failed' },
+      },
+    }).failureReceipt,
+    null,
+  );
+  assert.equal(
+    classify({
+      eventName: 'agent',
+      eventData: {
+        runId: 'dispatch-run',
+        stream: 'item',
+        data: { status: 'failed' },
+      },
+    }).failureReceipt,
+    null,
+  );
+  assert.equal(
+    classify({
+      eventName: 'agent',
+      eventData: {
+        runId: 'another-run',
+        stream: 'lifecycle',
+        data: { phase: 'error', error: 'OpenAI Responses transport error' },
+      },
+    }).failureReceipt,
+    null,
+  );
+  assert.equal(
+    isRcd2LifecyclePass({
+      disposable_session_required: true,
+      session_created: true,
+      session_unbound_confirmed: true,
+      tool_accepted: true,
+      delegate_scheduled_receipt: true,
+      dispatch_turn_completed: false,
+      parent_wake_observed: true,
+      post_wake_quiet_completed: true,
+      dispatch_failure_observed: false,
+      channel_message_observed: false,
+    }),
+    false,
+  );
+});
+
+test('R-CD-2 does not pass before the bounded post-wake quiet window completes', () => {
+  assert.equal(
+    isRcd2LifecyclePass({
+      disposable_session_required: true,
+      session_created: true,
+      session_unbound_confirmed: true,
+      tool_accepted: true,
+      delegate_scheduled_receipt: true,
+      dispatch_turn_completed: true,
+      parent_wake_observed: true,
+      post_wake_quiet_completed: false,
+      dispatch_failure_observed: false,
+      channel_message_observed: false,
+    }),
+    false,
+  );
+});
+
+test('R-CD-2 cannot pass without an unbound disposable session receipt', () => {
+  assert.equal(
+    isRcd2LifecyclePass({
+      disposable_session_required: true,
+      session_created: true,
+      session_unbound_confirmed: false,
+      tool_accepted: true,
+      delegate_scheduled_receipt: true,
+      dispatch_turn_completed: true,
+      parent_wake_observed: true,
+      post_wake_quiet_completed: true,
+      dispatch_failure_observed: false,
+      channel_message_observed: false,
+    }),
+    false,
+  );
+});
+
+test('R-CD-2 rejects replay-invalid or abandoned terminal lifecycle events', () => {
+  const invalidEnd = classify({
+    eventName: 'agent',
+    eventData: {
+      runId: 'dispatch-run',
+      stream: 'lifecycle',
+      data: {
+        phase: 'end',
+        replayInvalid: true,
+        aborted: true,
+        livenessState: 'abandoned',
+      },
+    },
+  });
+
+  assert.equal(invalidEnd.dispatchTurnCompleted, false);
+  assert.deepEqual(invalidEnd.failureReceipt, {
+    kind: 'dispatching-turn-replay-invalid',
+    sourceEvent: 'agent',
+    correlation: 'dispatch-run-id',
+    observedAtMs: 10000,
+  });
+});
+
+test('R-CD-2 recognizes status-only outbound delivery receipts', () => {
+  assert.equal(
+    isRcd2OutboundChannelDeliveryEvent('channel.delivery', {
+      channelId: 'proof-channel',
+      deliveryStatus: 'delivered',
+    }),
+    true,
+  );
+  assert.equal(
+    isRcd2OutboundChannelDeliveryEvent('session.message', {
+      message: {
+        role: 'tool',
+        content: [
+          {
+            type: 'toolResult',
+            result: { details: { deliveryStatus: 'sent' } },
+          },
+        ],
+      },
+    }),
+    true,
+  );
+  assert.equal(
+    isRcd2OutboundChannelDeliveryEvent('session.message', {
+      message: {
+        role: 'toolResult',
+        toolName: 'message',
+        details: {
+          result: {
+            receipt: {
+              primaryPlatformMessageId: 'public-message-id',
+            },
+            messageId: 'public-message-id',
+          },
+        },
+      },
+    }),
+    true,
+  );
+  assert.equal(
+    isRcd2OutboundChannelDeliveryEvent('session.message', {
+      message: {
+        role: 'toolResult',
+        toolName: 'message',
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              result: {
+                receipt: {
+                  primaryPlatformMessageId: 'public-message-id',
+                },
+                messageId: 'public-message-id',
+              },
+            }),
+          },
+        ],
+      },
+    }),
+    true,
+  );
+});
+
+test('R-CD-2 handleSummary derives verdict from proof_failures, not isolated VU state', async () => {
+  const scenario = await readFile(
+    new URL('../../scenarios/r-cd-2-silent-wake.js', import.meta.url),
+    'utf8',
+  );
+
+  assert.match(scenario, /const passed = passRate;/);
+  assert.doesNotMatch(scenario, /finalEvidence/);
+  assert.match(scenario, /postWakeQuietMs < 1000/);
+  assert.match(scenario, /postWakeQuietMs > 30000/);
+});


### PR DESCRIPTION
Closes #408

## Why
R-CD-2 could report `PASS-candidate` after outer `sessions.send` acceptance plus generic delayed session activity even when the dispatching provider turn failed and queued `continue_delegate` was incomplete/replay-unsafe.

## Repair
- requires a fresh disposable session and confirms it has no channel binding before dispatch;
- requires an assistant-only nonce-correlated scheduled receipt;
- requires exact run-ID terminal success, rejecting provider/model-policy errors, replay-invalid, aborted, blocked, and abandoned turns;
- accepts only a nonce-correlated assistant return or `continue_status({notify:false,outcome:"done"})` wake after the delay gate and dispatch completion;
- observes a bounded post-wake quiet window and fails on structured message-tool delivery receipts;
- persists only redacted failure categories, never raw provider error text;
- keeps Tempo receipt ownership in the existing external runner/postprocessor.

## Scope
Docs/proof harness only. No live proof row, OpenClaw runtime change, PR-presentation touch, or provider/model policy change. Current active R-CD-MODEL-TOOL remains `openai/gpt-5.6-luna`.
