### PR TITLE
fix(proofs): make R-CD-2 lifecycle receipt authoritative

### DIFF
--- a/tools/k6-proofs/lib/r-cd-2-lifecycle.js
+++ b/tools/k6-proofs/lib/r-cd-2-lifecycle.js
@@ -1,0 +1,312 @@
+const SCHEDULED_SENTINEL_PREFIX = 'RCD2-DELEGATE-SCHEDULED';
+
+function eventText(eventData) {
+  try {
+    return JSON.stringify(eventData || {});
+  } catch {
+    return '';
+  }
+}
+
+function transcriptMessageText(eventName, eventData) {
+  if (eventName !== 'session.message' || eventData?.message?.role !== 'assistant') {
+    return '';
+  }
+  const content = eventData?.message?.content;
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  const texts = [];
+  for (const block of content) {
+    if (typeof block === 'string') {
+      texts.push(block);
+    } else if (
+      block &&
+      typeof block === 'object' &&
+      ['text', 'output_text'].includes(block.type) &&
+      typeof block.text === 'string'
+    ) {
+      texts.push(block.text);
+    }
+  }
+  return texts.join('\n');
+}
+
+function hasCorrelatedSilentStatusReceipt(eventName, eventData, rowNonce) {
+  if (eventName !== 'session.message' || eventData?.message?.role !== 'assistant') {
+    return false;
+  }
+  const content = eventData?.message?.content;
+  if (!Array.isArray(content)) return false;
+  for (const block of content) {
+    if (!block || typeof block !== 'object') continue;
+    const name = block.name || block.toolName;
+    if (name !== 'continue_status') continue;
+    const args = block.arguments || block.input || block.args;
+    if (!args || typeof args !== 'object') continue;
+    if (
+      args.notify === false &&
+      args.outcome === 'done' &&
+      eventText(args).includes(rowNonce)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isMatchingDispatchLifecycle(eventName, eventData, dispatchRunId) {
+  return Boolean(
+    eventName === 'agent' &&
+      dispatchRunId &&
+      eventData?.runId === dispatchRunId,
+  );
+}
+
+function redactedFailureReceipt(eventName, eventData, dispatchRunId, observedAtMs) {
+  const text = eventText(eventData).toLowerCase();
+  const matchingLifecycle = isMatchingDispatchLifecycle(
+    eventName,
+    eventData,
+    dispatchRunId,
+  );
+  const stream = String(eventData?.stream || '').toLowerCase();
+  const phase = String(eventData?.data?.phase || '').toLowerCase();
+  const livenessState = String(eventData?.data?.livenessState || '').toLowerCase();
+  const status = String(
+    eventData?.status ||
+      eventData?.state ||
+      eventData?.outcome ||
+      eventData?.data?.status ||
+      '',
+  ).toLowerCase();
+  const lifecycleFailed =
+    matchingLifecycle &&
+    (stream === 'error' ||
+      (stream === 'lifecycle' && ['error', 'failed', 'failure'].includes(phase)) ||
+      (stream === 'lifecycle' &&
+        phase === 'end' &&
+        ['error', 'failed', 'failure'].includes(status)) ||
+      (stream === 'lifecycle' &&
+        phase === 'end' &&
+        (eventData?.data?.replayInvalid === true ||
+          eventData?.data?.aborted === true ||
+          ['blocked', 'abandoned'].includes(livenessState))));
+
+  if (lifecycleFailed) {
+    let kind = 'dispatching-turn-failed';
+    if (eventData?.data?.replayInvalid === true) {
+      kind = 'dispatching-turn-replay-invalid';
+    } else if (eventData?.data?.aborted === true) {
+      kind = 'dispatching-turn-aborted';
+    } else if (['blocked', 'abandoned'].includes(livenessState)) {
+      kind = 'dispatching-turn-not-live';
+    } else if (
+      text.includes('continue_delegate') &&
+      (text.includes('replay-unsafe') || text.includes('enclosing turn was incomplete'))
+    ) {
+      kind = 'delegate-replay-unsafe';
+    } else if (text.includes('model override') && text.includes('not allowed')) {
+      kind = 'model-policy-rejected';
+    } else if (
+      (text.includes('provider') || text.includes('openai responses')) &&
+      (text.includes('transport error') ||
+        text.includes('request failed') ||
+        text.includes('connection error'))
+    ) {
+      kind = 'provider-transport-error';
+    }
+    return {
+      kind,
+      sourceEvent: eventName || 'unknown',
+      correlation: 'dispatch-run-id',
+      observedAtMs,
+    };
+  }
+
+  if (eventName !== 'session.message') return null;
+
+  const messageText = transcriptMessageText(eventName, eventData).toLowerCase();
+  let kind = null;
+  if (
+    messageText.includes('continue_delegate') &&
+    (messageText.includes('replay-unsafe') ||
+      messageText.includes('enclosing turn was incomplete'))
+  ) {
+    kind = 'delegate-replay-unsafe';
+  } else if (
+    messageText.includes('model override') &&
+    messageText.includes('not allowed')
+  ) {
+    kind = 'model-policy-rejected';
+  } else if (
+    (messageText.includes('provider') || messageText.includes('openai responses')) &&
+    (messageText.includes('transport error') ||
+      messageText.includes('request failed') ||
+      messageText.includes('connection error'))
+  ) {
+    kind = 'provider-transport-error';
+  }
+  if (kind) {
+    return {
+      kind,
+      sourceEvent: eventName || 'unknown',
+      correlation: 'subscribed-session-after-dispatch',
+      observedAtMs,
+    };
+  }
+
+  return null;
+}
+
+export function rCd2ScheduledSentinel(rowNonce) {
+  return `${SCHEDULED_SENTINEL_PREFIX} ${rowNonce}`;
+}
+
+export function isRcd2OutboundChannelDeliveryEvent(eventName, eventData) {
+  const lowerName = String(eventName || '').toLowerCase();
+  const namedDelivery =
+    lowerName.includes('delivery') &&
+    (lowerName.includes('channel') ||
+      lowerName.includes('message') ||
+      lowerName.includes('outbound'));
+  if (namedDelivery) return true;
+  if (!eventData || typeof eventData !== 'object') return false;
+
+  const channelTarget =
+    eventData.channelId ||
+    eventData.channel_id ||
+    eventData.targetChannel ||
+    eventData.deliveryChannel;
+  const deliveryStatus = String(
+    eventData.deliveryStatus ||
+      eventData.delivery_state ||
+      eventData.deliveryState ||
+      '',
+  ).toLowerCase();
+  if (Boolean(channelTarget) && ['sent', 'delivered', 'completed'].includes(deliveryStatus)) {
+    return true;
+  }
+
+  const message = eventData.message;
+  if (!message || typeof message !== 'object') return false;
+  const isMessageToolResult =
+    ['tool', 'toolResult'].includes(message.role) && message.toolName === 'message';
+  if (
+    isMessageToolResult &&
+    message.details &&
+    typeof message.details === 'object' &&
+    message.details.result &&
+    typeof message.details.result === 'object' &&
+    (typeof message.details.result.messageId === 'string' ||
+      (message.details.result.receipt &&
+        typeof message.details.result.receipt === 'object'))
+  ) {
+    return true;
+  }
+  if (isMessageToolResult && Array.isArray(message.content)) {
+    for (const block of message.content) {
+      if (!block || typeof block !== 'object' || typeof block.text !== 'string') continue;
+      try {
+        const parsed = JSON.parse(block.text);
+        const result = parsed && typeof parsed === 'object' ? parsed.result : null;
+        if (
+          result &&
+          typeof result === 'object' &&
+          (typeof result.messageId === 'string' ||
+            (result.receipt && typeof result.receipt === 'object'))
+        ) {
+          return true;
+        }
+      } catch {
+        // Non-JSON tool result text cannot prove delivery.
+      }
+    }
+  }
+  const statuses = [];
+  const appendStatus = (value) => {
+    if (typeof value === 'string') statuses.push(value.toLowerCase());
+  };
+  appendStatus(message.details?.deliveryStatus);
+  appendStatus(message.details?.delivery?.status);
+  if (Array.isArray(message.content)) {
+    for (const block of message.content) {
+      if (!block || typeof block !== 'object') continue;
+      appendStatus(block.details?.deliveryStatus);
+      appendStatus(block.result?.deliveryStatus);
+      appendStatus(block.result?.details?.deliveryStatus);
+    }
+  }
+  return statuses.some((value) => ['sent', 'delivered', 'completed'].includes(value));
+}
+
+export function classifyRcd2LifecycleEvent({
+  eventName,
+  eventData,
+  rowNonce,
+  harnessMarker,
+  toolAccepted,
+  dispatchRunId,
+  delegateScheduledAtMs,
+  dispatchTurnCompletedAtMs,
+  wakeGateMs,
+  nowMs,
+}) {
+  const messageText = transcriptMessageText(eventName, eventData);
+  const harnessEcho = messageText.includes(harnessMarker);
+  const scheduledSentinel = messageText.includes(rCd2ScheduledSentinel(rowNonce));
+  const correlatedReturn =
+    !scheduledSentinel &&
+    (messageText.includes(rowNonce) ||
+      hasCorrelatedSilentStatusReceipt(eventName, eventData, rowNonce));
+  const dispatchTurnCompleted =
+    isMatchingDispatchLifecycle(eventName, eventData, dispatchRunId) &&
+    String(eventData?.stream || '').toLowerCase() === 'lifecycle' &&
+    String(eventData?.data?.phase || '').toLowerCase() === 'end' &&
+    eventData?.data?.willRetry !== true &&
+    eventData?.data?.completed !== false &&
+    eventData?.data?.replayInvalid !== true &&
+    eventData?.data?.aborted !== true &&
+    !['blocked', 'abandoned'].includes(
+      String(eventData?.data?.livenessState || '').toLowerCase(),
+    );
+  const delegateScheduledReceipt =
+    toolAccepted &&
+    !harnessEcho &&
+    messageText.includes(rCd2ScheduledSentinel(rowNonce));
+  const parentWakeObserved =
+    toolAccepted &&
+    !harnessEcho &&
+    correlatedReturn &&
+    delegateScheduledAtMs !== null &&
+    dispatchTurnCompletedAtMs !== null &&
+    eventName === 'session.message' &&
+    nowMs >= delegateScheduledAtMs + wakeGateMs &&
+    nowMs >= dispatchTurnCompletedAtMs;
+  const failureReceipt =
+    toolAccepted && !harnessEcho
+      ? redactedFailureReceipt(eventName, eventData, dispatchRunId, nowMs)
+      : null;
+
+  return {
+    delegateScheduledReceipt,
+    parentWakeObserved,
+    dispatchTurnCompleted,
+    failureReceipt,
+  };
+}
+
+export function isRcd2LifecyclePass(evidence) {
+  return Boolean(
+    evidence &&
+      evidence.disposable_session_required &&
+      evidence.session_created &&
+      evidence.session_unbound_confirmed &&
+      evidence.tool_accepted &&
+      evidence.delegate_scheduled_receipt &&
+      evidence.dispatch_turn_completed &&
+      evidence.parent_wake_observed &&
+      evidence.post_wake_quiet_completed &&
+      !evidence.dispatch_failure_observed &&
+      !evidence.channel_message_observed,
+  );
+}

--- a/tools/k6-proofs/lib/r-cd-2-lifecycle.js
+++ b/tools/k6-proofs/lib/r-cd-2-lifecycle.js
@@ -90,7 +90,8 @@ function redactedFailureReceipt(eventName, eventData, dispatchRunId, observedAtM
         phase === 'end' &&
         (eventData?.data?.replayInvalid === true ||
           eventData?.data?.aborted === true ||
-          ['blocked', 'abandoned'].includes(livenessState))));
+          ['blocked', 'abandoned'].includes(livenessState))) ||
+      (stream === 'item' && ['error', 'failed', 'failure', 'aborted'].includes(status)));
 
   if (lifecycleFailed) {
     let kind = 'dispatching-turn-failed';
@@ -295,7 +296,7 @@ export function classifyRcd2LifecycleEvent({
   };
 }
 
-export function isRcd2LifecyclePass(evidence) {
+export function hasRcd2LocalEvidence(evidence) {
   return Boolean(
     evidence &&
       evidence.disposable_session_required &&
@@ -308,5 +309,17 @@ export function isRcd2LifecyclePass(evidence) {
       evidence.post_wake_quiet_completed &&
       !evidence.dispatch_failure_observed &&
       !evidence.channel_message_observed,
+  );
+}
+
+export function isRcd2LifecyclePass(evidence) {
+  return Boolean(
+    hasRcd2LocalEvidence(evidence) &&
+      evidence.authoritative_lifecycle_receipt === true &&
+      evidence.observed_delegate_mode === 'silent-wake' &&
+      typeof evidence.observed_trace_id === 'string' && evidence.observed_trace_id.length === 32 &&
+      typeof evidence.observed_chain_id === 'string' && evidence.observed_chain_id.length > 0 &&
+      typeof evidence.observed_delegate_id === 'string' && evidence.observed_delegate_id.length > 0 &&
+      evidence.child_fire_or_completion_observed === true,
   );
 }

--- a/tools/k6-proofs/manifests/r-cd-2.json
+++ b/tools/k6-proofs/manifests/r-cd-2.json
@@ -19,6 +19,7 @@
     "methods": [
       "sessions.send",
       "sessions.messages.subscribe",
+      "sessions.list",
       "tasks.list"
     ],
     "status": "runnable",
@@ -34,15 +35,19 @@
   "liveRunSafety": {
     "classification": "k6-runnable",
     "requiresLiveGatewayToken": true,
-    "requiresTargetSessionKey": true,
+    "requiresTargetSessionKey": false,
     "requiresCandidateSha": true,
     "requiresExternalAgentOrToolInvocation": true,
     "sameSessionConcurrencySafe": false,
     "expectedArtifactClass": "PASS-candidate",
     "requiredReceipts": [
       "seat-readiness",
+      "unbound-disposable-session",
       "dispatch-accepted",
+      "delegate-scheduled-receipt",
+      "dispatch-turn-completed",
       "parent-wake-event",
+      "post-wake-no-delivery-window",
       "no-channel-delivery",
       "trace-id"
     ],
@@ -50,6 +55,11 @@
     "notes": "Live continuation row. Fail closed when token/session env is missing, serialize per target session, and treat generated output as a PASS-candidate until required receipts are reviewed."
   },
   "expectedReceipts": [
+    {
+      "name": "unbound-disposable-session",
+      "required": true,
+      "description": "Fresh disposable session created and confirmed through sessions.list with no channel delivery binding"
+    },
     {
       "name": "dispatch-accepted",
       "required": true,
@@ -59,6 +69,26 @@
       "name": "task-ledger-entry",
       "required": false,
       "description": "Optional extra context from the generic TaskFlow task ledger; continue_delegate does not reliably write here"
+    },
+    {
+      "name": "delegate-scheduled-receipt",
+      "required": true,
+      "description": "Nonce-correlated parent receipt emitted only after the continue_delegate tool result reports scheduled"
+    },
+    {
+      "name": "dispatch-failure-receipt",
+      "required": false,
+      "description": "Redacted fail-closed classification when the provider/agent turn fails or queued continue_delegate is incomplete/replay-unsafe"
+    },
+    {
+      "name": "dispatch-turn-completed",
+      "required": true,
+      "description": "Run-ID-correlated terminal lifecycle success for the dispatching parent turn"
+    },
+    {
+      "name": "post-wake-no-delivery-window",
+      "required": true,
+      "description": "Bounded observation window after the correlated parent wake with no outbound channel-delivery event"
     },
     {
       "name": "child-session-key",
@@ -91,6 +121,6 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Silent-wake path. PASS-candidate when: (1) dispatching agent turn accepted, (2) parent session emits wake/agent events, (3) NO channel message delivered from the delegate return, and (4) trace/receipt artifacts are fetched for review. A nonce-correlated tasks.list row is optional because continue_delegate uses pending-delegate/subagent surfaces, not the generic task registry."
+    "notes": "Silent-wake path. PASS-candidate requires: (1) a fresh disposable session confirmed to have no channel binding, (2) dispatching agent turn accepted, (3) nonce-correlated delegate-scheduled receipt, (4) run-ID-correlated terminal success for the dispatching turn, (5) nonce-correlated delayed parent wake after scheduling, (6) a bounded post-wake window with no explicit message-tool delivery receipt, and (7) trace/receipt artifacts fetched for review. Provider/turn failure or incomplete/replay-unsafe delegate rejection is fail-closed PARTIAL-candidate. Bound live sessions are intentionally unsupported because the subscribed Gateway stream does not expose a reliable normal channel-delivery receipt."
   }
 }

--- a/tools/k6-proofs/manifests/r-cd-2.json
+++ b/tools/k6-proofs/manifests/r-cd-2.json
@@ -49,6 +49,7 @@
       "parent-wake-event",
       "post-wake-no-delivery-window",
       "no-channel-delivery",
+      "continuation-lifecycle-receipt",
       "trace-id"
     ],
     "foldRequiresReview": true,
@@ -104,6 +105,11 @@
       "name": "no-channel-delivery",
       "required": true,
       "description": "Delegate return does NOT produce a channel message (silent mode verified)"
+    },
+    {
+      "name": "continuation-lifecycle-receipt",
+      "required": true,
+      "description": "Row-scoped public-safe verdict from the strict typed-tool/dispatch/fire same-trace, same-chain silent-wake correlation"
     },
     {
       "name": "trace-id",

--- a/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
+++ b/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
@@ -26,8 +26,8 @@ import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js
 import { closeSocketAfterDelay } from '../lib/socket-close.js';
 import {
   classifyRcd2LifecycleEvent,
+  hasRcd2LocalEvidence,
   isRcd2OutboundChannelDeliveryEvent,
-  isRcd2LifecyclePass,
   rCd2ScheduledSentinel,
 } from '../lib/r-cd-2-lifecycle.js';
 
@@ -48,6 +48,12 @@ export const options = {
 
 const failures = new Counter('proof_failures');
 const duration = new Trend('r_cd_2_duration');
+
+function safeRpcFailureCategory(method) {
+  // RPC payloads can contain provider details, prompts, or identifiers.  Public
+  // proof output records only this opaque method/category pair.
+  return `${method}-rejected`;
+}
 
 // --- Manifest-driven config ---
 const manifest = loadManifestFromEnv();
@@ -261,7 +267,7 @@ export default function () {
             console.log(`✓ disposable session created: ${sessionKey}`);
             tracker.send(socket, 'sessions.list', { limit: 10, search: sessionKey });
           } else {
-            console.error(`✗ sessions.create rejected: ${JSON.stringify(classified.error)}`);
+            console.error(`✗ ${safeRpcFailureCategory('sessions.create')}`);
             failures.add(1);
             socket.close();
           }
@@ -269,7 +275,7 @@ export default function () {
 
         if (classified.kind === 'response' && classified.method === 'sessions.list') {
           if (!classified.ok) {
-            console.error(`✗ sessions.list rejected: ${JSON.stringify(classified.error)}`);
+            console.error(`✗ ${safeRpcFailureCategory('sessions.list')}`);
             failures.add(1);
             socket.close();
           } else {
@@ -308,7 +314,7 @@ export default function () {
             if (classified.payload && classified.payload.traceId) evidence.trace_id = classified.payload.traceId;
             console.log('✓ sessions.send accepted — agent turn triggered for R-CD-2 (mode=silent-wake)');
           } else if (classified.error) {
-            console.error(`✗ sessions.send rejected: ${JSON.stringify(classified.error)}`);
+            console.error(`✗ ${safeRpcFailureCategory('sessions.send')}`);
             failures.add(1);
           }
         }
@@ -408,13 +414,13 @@ export default function () {
         }
 
         maybeScheduleSuccessClose();
-      } catch (e) {
-        console.warn(`parse error: ${e}`);
+      } catch {
+        console.warn('gateway-frame-parse-failed');
       }
     });
 
-    socket.on('error', (e) => {
-      console.error(`ws error: ${e && e.error ? e.error() : e}`);
+    socket.on('error', () => {
+      console.error('gateway-websocket-error');
       failures.add(1);
     });
   });
@@ -442,8 +448,8 @@ export default function () {
     'no channel delivery (silent verified)': () => !evidence.channel_message_observed,
   });
 
-  const passed = isRcd2LifecyclePass(evidence);
-  if (!passed && !evidence.dispatch_failure_observed) {
+  const localEvidenceComplete = hasRcd2LocalEvidence(evidence);
+  if (!localEvidenceComplete && !evidence.dispatch_failure_observed) {
     failures.add(1);
   }
   if (evidence.channel_message_observed) {
@@ -455,28 +461,32 @@ export default function () {
   console.log(`\n--- R-CD-2 EVIDENCE SUMMARY ---`);
   console.log(JSON.stringify(evidence, null, 2));
   console.log(`--- END EVIDENCE ---`);
-  console.log(`\n[R-CD-2] VERDICT: ${passed ? 'PASS-candidate' : 'PARTIAL-candidate'}`);
+  // Only run-proofs.sh may promote this row after the strict trace correlator
+  // writes r-cd-2-lifecycle-receipt.json.  The VU has useful local evidence,
+  // but cannot itself attest same-trace/chain/mode topology.
+  console.log('\n[R-CD-2] VERDICT: PARTIAL-candidate');
 }
 
 export function handleSummary(data) {
   const timestamp = new Date().toISOString();
-  const passRate = data.metrics.proof_failures && data.metrics.proof_failures.values && data.metrics.proof_failures.values.count === 0;
-  const passed = passRate;
   const summary = {
     row: 'R-CD-2',
     sha: __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
     seat: __ENV.OPENCLAW_SEAT_NAME || 'ronan-dgx',
     timestamp,
-    verdict: passed ? 'PASS-candidate' : 'PARTIAL-candidate',
+    verdict: 'PARTIAL-candidate',
+    lifecycleReceipt: {
+      path: 'r-cd-2-lifecycle-receipt.json',
+      verdict: 'PENDING',
+      authority: 'strict-continuation-correlation',
+    },
     candidateOnly: true,
     foldRequiresReview: true,
     review: {
       status: 'review-pending',
       receiptSource: 'run-proofs evidence extraction and Tempo postprocessing',
       notes: [
-        passed
-          ? 'VU lifecycle checks passed; external postprocessing must still attach the required Tempo trace before folding.'
-          : 'No successful correlated continuation lifecycle was proven; retain the redacted failure receipt and do not fold as PASS.',
+        'The VU cannot establish same-trace/chain/mode topology. run-proofs must replace this provisional verdict with r-cd-2-lifecycle-receipt.json before any PASS-candidate exists.',
       ],
     },
     metrics: {

--- a/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
+++ b/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
@@ -23,6 +23,13 @@ import { Counter, Trend } from 'k6/metrics';
 import crypto from 'k6/crypto';
 import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+import { closeSocketAfterDelay } from '../lib/socket-close.js';
+import {
+  classifyRcd2LifecycleEvent,
+  isRcd2OutboundChannelDeliveryEvent,
+  isRcd2LifecyclePass,
+  rCd2ScheduledSentinel,
+} from '../lib/r-cd-2-lifecycle.js';
 
 export const options = {
   scenarios: {
@@ -41,7 +48,6 @@ export const options = {
 
 const failures = new Counter('proof_failures');
 const duration = new Trend('r_cd_2_duration');
-let finalEvidence = null;
 
 // --- Manifest-driven config ---
 const manifest = loadManifestFromEnv();
@@ -65,32 +71,38 @@ function invocationCfg() {
   };
 }
 
-export function isOutboundChannelDeliveryEvent(eventName, eventData) {
-  const lowerName = String(eventName || '').toLowerCase();
-  const namedDelivery = lowerName.includes('delivery') &&
-    (lowerName.includes('channel') || lowerName.includes('message') || lowerName.includes('outbound'));
-  if (namedDelivery) return true;
-  if (!eventData || typeof eventData !== 'object') return false;
-
-  const channelTarget = eventData.channelId || eventData.channel_id ||
-    eventData.targetChannel || eventData.deliveryChannel;
-  const deliveryStatus = String(
-    eventData.deliveryStatus || eventData.delivery_state || eventData.deliveryState || '',
-  ).toLowerCase();
-  return Boolean(channelTarget) && ['sent', 'delivered', 'completed'].includes(deliveryStatus);
-}
-
 export default function () {
   const url = __ENV.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
   const token = __ENV.OPENCLAW_GATEWAY_TOKEN;
   const requestedSessionKey = manifest && manifest.sessionKey || __ENV.OPENCLAW_SESSION_KEY || DEFAULTS.sessionKey;
   let sessionKey = requestedSessionKey;
-  const createDisposableSession = (__ENV.OPENCLAW_CREATE_DISPOSABLE_SESSION || '').toLowerCase() === 'true';
+  const disposableEnv =
+    __ENV.OPENCLAW_CREATE_DISPOSABLE_SESSION ||
+    __ENV.OPENCLAW_CREATE_DISPOSABLE_SESSIONS ||
+    'true';
+  const createDisposableSession = disposableEnv.toLowerCase() === 'true';
   const seat = manifest && manifest.seat || __ENV.OPENCLAW_SEAT_NAME || DEFAULTS.seat;
   const rowNonce = nonce('R-CD-2');
+  const postWakeQuietMs = Number(__ENV.OPENCLAW_R_CD_2_POST_WAKE_QUIET_MS || 5000);
 
   if (!token) {
     console.error('OPENCLAW_GATEWAY_TOKEN is required');
+    failures.add(1);
+    return;
+  }
+  if (!createDisposableSession) {
+    console.error('R-CD-2 requires an unbound disposable session for no-channel proof');
+    failures.add(1);
+    return;
+  }
+  if (
+    !Number.isFinite(postWakeQuietMs) ||
+    postWakeQuietMs < 1000 ||
+    postWakeQuietMs > 30000
+  ) {
+    console.error(
+      'OPENCLAW_R_CD_2_POST_WAKE_QUIET_MS must be a finite value from 1000 through 30000',
+    );
     failures.add(1);
     return;
   }
@@ -110,11 +122,15 @@ export default function () {
     sessionKey,
     requestedSessionKey,
     session_created: false,
+    session_unbound_confirmed: false,
     created_session_key: null,
     candidateSha: manifest && manifest.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
     started: new Date().toISOString(),
+    disposable_session_required: createDisposableSession,
     // Required receipts
     tool_accepted: false,
+    delegate_scheduled_receipt: false,
+    delegate_scheduled_at_ms: null,
     task_created: false,
     task_mode: null,
     // Silent-wake specific
@@ -124,12 +140,20 @@ export default function () {
     channel_message_observed: false, // MUST stay false for PASS
     silent_status_record_observed: false,
     dispatch_accepted_at_ms: null,
+    dispatch_run_id: null,
+    dispatch_turn_completed: false,
+    dispatch_turn_completed_at_ms: null,
     wake_gate_ms: Number(__ENV.OPENCLAW_MIN_DELEGATE_DELAY_MS || 5000),
+    parent_wake_observed_at_ms: null,
+    post_wake_quiet_ms: postWakeQuietMs,
+    post_wake_quiet_completed: false,
     child_session: null,
     reason_hash: null,
     reason_length: null,
     delegate_mode: null,
     trace_id: null,
+    dispatch_failure_observed: false,
+    failure_receipt: null,
     redacted_events: [],
   };
 
@@ -137,8 +161,35 @@ export default function () {
 
   const res = ws.connect(url, {}, (socket) => {
     const tracker = new RequestTracker();
+    let successCloseScheduled = false;
+    let proofFlowStarted = false;
+
+    function maybeScheduleSuccessClose() {
+      if (
+        successCloseScheduled ||
+        !evidence.delegate_scheduled_receipt ||
+        !evidence.dispatch_turn_completed ||
+        !evidence.parent_wake_observed ||
+        evidence.dispatch_failure_observed ||
+        evidence.channel_message_observed
+      ) {
+        return;
+      }
+      const closeAfterMs =
+        evidence.parent_wake_observed_at_ms + evidence.post_wake_quiet_ms;
+      const remainingMs = Math.max(0, closeAfterMs - Date.now());
+      successCloseScheduled = true;
+      closeSocketAfterDelay(socket, remainingMs, () => {
+        if (!evidence.dispatch_failure_observed && !evidence.channel_message_observed) {
+          evidence.post_wake_quiet_completed = true;
+          console.log('✓ bounded post-wake no-delivery window completed');
+        }
+      });
+    }
 
     function startProofFlow(socket) {
+      if (proofFlowStarted) return;
+      proofFlowStarted = true;
       // Subscribe to parent session messages to detect wake + verify no channel delivery.
       // Protocol: sessions.messages.subscribe uses 'key' not 'sessionKey'.
       tracker.send(socket, 'sessions.messages.subscribe', { key: sessionKey });
@@ -153,7 +204,10 @@ export default function () {
         evidence.reason_hash = crypto.sha256(prompt, 'hex').slice(0, 16);
         evidence.reason_length = prompt.length;
         evidence.delegate_mode = inv.mode;
-        const agentInstruction = `[k6-proof-harness] Call continue_delegate with: task="${prompt}", mode="${inv.mode}", delaySeconds=${inv.delaySeconds}. This is a proof run — execute the tool call immediately, no other action needed.`;
+        const agentInstruction =
+          `[k6-proof-harness] Call continue_delegate with: task="${prompt}", mode="${inv.mode}", delaySeconds=${inv.delaySeconds}. ` +
+          `After the continue_delegate tool result reports scheduled, reply exactly ${rCd2ScheduledSentinel(rowNonce)}. ` +
+          `This is a proof run — execute the tool call immediately, no other action needed.`;
         tracker.send(socket, 'sessions.send', {
           key: sessionKey,
           message: agentInstruction,
@@ -181,8 +235,6 @@ export default function () {
             label: `k6 R-CD-2 ${rowNonce}`,
           });
         }, 250);
-      } else {
-        socket.setTimeout(() => startProofFlow(socket), 500);
       }
     });
 
@@ -207,11 +259,43 @@ export default function () {
             evidence.session_created = true;
             evidence.created_session_key = sessionKey;
             console.log(`✓ disposable session created: ${sessionKey}`);
-            startProofFlow(socket);
+            tracker.send(socket, 'sessions.list', { limit: 10, search: sessionKey });
           } else {
             console.error(`✗ sessions.create rejected: ${JSON.stringify(classified.error)}`);
             failures.add(1);
             socket.close();
+          }
+        }
+
+        if (classified.kind === 'response' && classified.method === 'sessions.list') {
+          if (!classified.ok) {
+            console.error(`✗ sessions.list rejected: ${JSON.stringify(classified.error)}`);
+            failures.add(1);
+            socket.close();
+          } else {
+            const sessions = Array.isArray(classified.payload && classified.payload.sessions)
+              ? classified.payload.sessions
+              : [];
+            const created = sessions.find((session) => session && session.key === sessionKey);
+            const deliveryContext = created && created.deliveryContext || {};
+            const hasChannelBinding = Boolean(
+              created &&
+                (created.lastChannel ||
+                  created.lastTo ||
+                  created.lastAccountId ||
+                  deliveryContext.channel ||
+                  deliveryContext.to ||
+                  deliveryContext.accountId),
+            );
+            if (!created || hasChannelBinding) {
+              console.error('✗ disposable session is missing or has a channel delivery binding');
+              failures.add(1);
+              socket.close();
+            } else {
+              evidence.session_unbound_confirmed = true;
+              console.log('✓ disposable session has no channel delivery binding');
+              startProofFlow(socket);
+            }
           }
         }
 
@@ -220,6 +304,7 @@ export default function () {
           if (classified.ok) {
             evidence.tool_accepted = true;
             evidence.dispatch_accepted_at_ms = Date.now();
+            evidence.dispatch_run_id = classified.payload && classified.payload.runId || null;
             if (classified.payload && classified.payload.traceId) evidence.trace_id = classified.payload.traceId;
             console.log('✓ sessions.send accepted — agent turn triggered for R-CD-2 (mode=silent-wake)');
           } else if (classified.error) {
@@ -249,6 +334,18 @@ export default function () {
           const eventName = classified.event || '';
           const eventData = classified.data || {};
           const eventStr = JSON.stringify(eventData);
+          const lifecycle = classifyRcd2LifecycleEvent({
+            eventName,
+            eventData,
+            rowNonce,
+            harnessMarker: '[k6-proof-harness]',
+            toolAccepted: evidence.tool_accepted,
+            dispatchRunId: evidence.dispatch_run_id,
+            delegateScheduledAtMs: evidence.delegate_scheduled_at_ms,
+            dispatchTurnCompletedAtMs: evidence.dispatch_turn_completed_at_ms,
+            wakeGateMs: evidence.wake_gate_ms,
+            nowMs: Date.now(),
+          });
 
           // Some target sessions emit generic agent lifecycle events rather than
           // an early session.message before the delayed wake. Count these as the
@@ -257,19 +354,36 @@ export default function () {
             evidence.agent_turn_observed = true;
           }
 
-          // session.message events immediately after sessions.send are the dispatching
-          // agent turn, not the silent-wake return.  The delegate delay is clamped
-          // by the gateway, so only count a parent wake after the minimum delay.
-          if (eventName === 'session.message' && evidence.tool_accepted) {
-            const elapsed = evidence.dispatch_accepted_at_ms ? Date.now() - evidence.dispatch_accepted_at_ms : 0;
-            if (elapsed >= evidence.wake_gate_ms) {
-              evidence.parent_wake_observed = true;
-              evidence.agent_turn_observed = true;
-              console.log('✓ delayed session.message event observed (silent-wake return candidate)');
-            } else {
-              evidence.agent_turn_observed = true;
-              console.log('✓ initial session.message event observed (dispatching agent turn)');
-            }
+          if (lifecycle.delegateScheduledReceipt) {
+            evidence.delegate_scheduled_receipt = true;
+            evidence.delegate_scheduled_at_ms = Date.now();
+            evidence.agent_turn_observed = true;
+            console.log('✓ correlated continue_delegate scheduled receipt observed');
+          }
+
+          if (lifecycle.dispatchTurnCompleted) {
+            evidence.dispatch_turn_completed = true;
+            evidence.dispatch_turn_completed_at_ms = Date.now();
+            console.log('✓ dispatching agent turn completed successfully');
+          }
+
+          if (lifecycle.parentWakeObserved) {
+            evidence.parent_wake_observed = true;
+            evidence.parent_wake_observed_at_ms =
+              evidence.parent_wake_observed_at_ms || Date.now();
+            evidence.agent_turn_observed = true;
+            console.log('✓ correlated delayed parent wake observed after delegate scheduling receipt');
+          } else if (eventName === 'session.message' && evidence.tool_accepted) {
+            evidence.agent_turn_observed = true;
+            console.log('ℹ session.message observed without qualified continuation wake');
+          }
+
+          if (lifecycle.failureReceipt && !evidence.dispatch_failure_observed) {
+            evidence.dispatch_failure_observed = true;
+            evidence.failure_receipt = lifecycle.failureReceipt;
+            failures.add(1);
+            console.warn(`✗ dispatching turn failed: ${lifecycle.failureReceipt.kind}`);
+            socket.close();
           }
 
           // continue_status({ notify:false }) is internal completion bookkeeping,
@@ -285,26 +399,15 @@ export default function () {
           // Negative check: only an explicit outbound-delivery-shaped event counts.
           // Generic agent/chat events can contain the full transcript plus routing
           // metadata, so substring checks for "channel" and "deliver" are unsafe.
-          if (eventStr.includes(rowNonce) &&
-              isOutboundChannelDeliveryEvent(eventName, eventData)) {
-            if (eventStr.includes('[k6-proof-harness]')) {
-              evidence.dispatch_channel_message_observed = true;
-              console.log('ℹ dispatch instruction channel event observed (not delegate return)');
-            } else {
-              evidence.channel_message_observed = true;
-              console.warn('✗ Delegate channel delivery detected — silent mode violated!');
-              failures.add(1);
-            }
+          if (isRcd2OutboundChannelDeliveryEvent(eventName, eventData)) {
+            evidence.channel_message_observed = true;
+            console.warn('✗ Outbound channel delivery detected — silent mode violated!');
+            failures.add(1);
+            socket.close();
           }
         }
 
-        // Early close only after a delayed parent wake candidate is observed; task
-        // ledger context remains optional.  Do not close on the initial dispatch
-        // agent turn, or this row only proves sessions.send.
-        if (evidence.tool_accepted && evidence.parent_wake_observed) {
-          console.log('Primary silent-wake evidence gathered, closing early');
-          socket.close();
-        }
+        maybeScheduleSuccessClose();
       } catch (e) {
         console.warn(`parse error: ${e}`);
       }
@@ -318,7 +421,6 @@ export default function () {
 
   evidence.ended = new Date().toISOString();
   evidence.duration_ms = Date.now() - started;
-  finalEvidence = evidence;
   duration.add(evidence.duration_ms);
 
   // Checks — core evidence for silent-wake proof:
@@ -329,24 +431,25 @@ export default function () {
   // use their own tracking surface, not the generic task ledger.
   check(res, { 'websocket connected': (r) => r && r.status === 101 });
   check(null, {
+    'unbound disposable session confirmed': () => evidence.session_unbound_confirmed,
     'agent turn triggered (sessions.send accepted)': () => evidence.tool_accepted,
     'dispatching agent turn observed': () => evidence.agent_turn_observed,
-    'delayed parent wake candidate observed': () => evidence.parent_wake_observed,
+    'correlated delegate scheduled receipt observed': () => evidence.delegate_scheduled_receipt,
+    'dispatching agent turn completed successfully': () => evidence.dispatch_turn_completed,
+    'correlated delayed parent wake observed after scheduling': () => evidence.parent_wake_observed,
+    'post-wake no-delivery window completed': () => evidence.post_wake_quiet_completed,
+    'dispatching turn stayed successful': () => !evidence.dispatch_failure_observed,
     'no channel delivery (silent verified)': () => !evidence.channel_message_observed,
   });
 
-  if (!evidence.tool_accepted || !evidence.agent_turn_observed || !evidence.parent_wake_observed) {
+  const passed = isRcd2LifecyclePass(evidence);
+  if (!passed && !evidence.dispatch_failure_observed) {
     failures.add(1);
   }
   if (evidence.channel_message_observed) {
     failures.add(1);
     console.error('FAIL: silent-wake delegate produced channel output');
   }
-
-  // Verdict — PASS when: turn triggered + events flowing + no channel delivery
-  const passed = (!createDisposableSession || evidence.session_created) &&
-    evidence.tool_accepted && evidence.agent_turn_observed &&
-    evidence.parent_wake_observed && !evidence.channel_message_observed;
 
   console.log(`R_CD_2_EVIDENCE ${JSON.stringify(evidence)}`);
   console.log(`\n--- R-CD-2 EVIDENCE SUMMARY ---`);
@@ -358,25 +461,23 @@ export default function () {
 export function handleSummary(data) {
   const timestamp = new Date().toISOString();
   const passRate = data.metrics.proof_failures && data.metrics.proof_failures.values && data.metrics.proof_failures.values.count === 0;
-  const traceId = finalEvidence && finalEvidence.trace_id || null;
+  const passed = passRate;
   const summary = {
     row: 'R-CD-2',
     sha: __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
     seat: __ENV.OPENCLAW_SEAT_NAME || 'ronan-dgx',
     timestamp,
-    verdict: passRate ? 'PASS-candidate' : 'PARTIAL-candidate',
+    verdict: passed ? 'PASS-candidate' : 'PARTIAL-candidate',
     candidateOnly: true,
     foldRequiresReview: true,
-    observability: {
-      traceId,
-      traceJson: traceId ? 'pending-fetch' : 'missing',
-    },
     review: {
-      status: traceId ? 'ready-for-human-review' : 'review-pending',
-      pendingReceipts: traceId ? [] : ['tempo-trace-json'],
-      notes: traceId
-        ? ['Trace id captured; fetch and attach Tempo trace JSON before canonical fold.']
-        : ['No trace_id was emitted by this candidate run; keep PASS-candidate as review-pending until trace JSON is fetched or the fold explicitly accepts trace-missing.'],
+      status: 'review-pending',
+      receiptSource: 'run-proofs evidence extraction and Tempo postprocessing',
+      notes: [
+        passed
+          ? 'VU lifecycle checks passed; external postprocessing must still attach the required Tempo trace before folding.'
+          : 'No successful correlated continuation lifecycle was proven; retain the redacted failure receipt and do not fold as PASS.',
+      ],
     },
     metrics: {
       duration_ms: data.metrics.r_cd_2_duration && data.metrics.r_cd_2_duration.values || null,

--- a/tools/k6-proofs/scripts/__tests__/r-cd-2-lifecycle-authority.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cd-2-lifecycle-authority.test.mjs
@@ -1,0 +1,142 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { resolveRcd2LifecycleReceipt } from '../resolve-r-cd-2-lifecycle-receipt.mjs';
+
+const execFileAsync = promisify(execFile);
+const repoRoot = path.resolve(import.meta.dirname, '../..');
+const manifest = path.join(repoRoot, 'manifests/r-cd-2.json');
+const writer = path.join(repoRoot, 'scripts/evidence-writer.mjs');
+const postprocess = path.join(repoRoot, 'scripts/postprocess-k6-summary.mjs');
+const sha = 'a'.repeat(40);
+
+function validCorrelation(overrides = {}) {
+  return {
+    continuation: {
+      tool: 'continue_delegate',
+      acceptSpan: 'continuation.delegate.dispatch',
+      fireSpan: 'continuation.delegate.fire',
+    },
+    delegate: { mode: 'silent-wake' },
+    sameTrace: true,
+    distinctSpans: true,
+    traceId: '1'.repeat(32),
+    chainId: 'test-chain-001',
+    dispatchSpanId: '2'.repeat(16),
+    fireSpanId: '3'.repeat(16),
+    toolSpanIds: ['4'.repeat(16)],
+    ...overrides,
+  };
+}
+
+test('R-CD-2 lifecycle authority is fail-closed for July, provider, and wrong-topology shapes', () => {
+  assert.deepEqual(
+    resolveRcd2LifecycleReceipt({ collectorPresent: false, correlation: null }),
+    {
+      schema: 'openclaw.k6.r-cd-2-lifecycle-receipt.v1',
+      row: 'R-CD-2',
+      authoritativeSource: 'continuation-trace-correlation',
+      candidateOnly: true,
+      foldRequiresReview: true,
+      verdict: 'PARTIAL-candidate',
+      failureCategory: 'missing-lifecycle-correlation',
+    },
+  );
+  assert.equal(
+    resolveRcd2LifecycleReceipt({
+      collectorPresent: false,
+      correlation: null,
+      failureReceipt: { kind: 'delegate-replay-unsafe' },
+    }).failureCategory,
+    'delegate-replay-unsafe',
+  );
+  assert.equal(
+    resolveRcd2LifecycleReceipt({
+      correlation: validCorrelation({ delegate: { mode: 'normal' } }),
+    }).failureCategory,
+    'invalid-lifecycle-topology',
+  );
+  assert.equal(
+    resolveRcd2LifecycleReceipt({
+      correlation: validCorrelation({ sameTrace: false }),
+    }).failureCategory,
+    'invalid-lifecycle-topology',
+  );
+});
+
+test('R-CD-2 lifecycle authority accepts only the complete same-chain silent-wake topology', () => {
+  const result = resolveRcd2LifecycleReceipt({ correlation: validCorrelation() });
+  assert.equal(result.verdict, 'PASS-candidate');
+  assert.equal(result.lifecycle.typedTool, 'continue_delegate');
+  assert.equal(result.lifecycle.observedMode, 'silent-wake');
+  assert.equal(result.lifecycle.sameTrace, true);
+  assert.equal(result.lifecycle.toolSpanCount, 1);
+  for (const field of ['traceHash', 'chainHash', 'dispatchSpanHash', 'fireSpanHash']) {
+    assert.match(result.lifecycle[field], /^[a-f0-9]{16}$/);
+  }
+  assert.equal(JSON.stringify(result).includes('test-chain-001'), false);
+});
+
+async function runWriters(receipt) {
+  const dir = await mkdtemp(path.join(tmpdir(), 'r-cd-2-authority-'));
+  const receiptPath = path.join(dir, 'r-cd-2-lifecycle-receipt.json');
+  const inputPath = path.join(dir, 'k6.log');
+  const summaryPath = path.join(dir, 'summary.json');
+  await writeFile(receiptPath, `${JSON.stringify(receipt)}\n`);
+  await writeFile(inputPath, [
+    '--- R-CD-2 EVIDENCE SUMMARY ---',
+    JSON.stringify({ row: 'R-CD-2', tool_accepted: true, task_created: true, redacted_events: [] }),
+    '--- END EVIDENCE ---',
+  ].join('\n'));
+  await writeFile(summaryPath, JSON.stringify({
+    metrics: {
+      proof_failures: { values: { count: 0 } },
+      checks: { values: { rate: 1 } },
+    },
+  }));
+  const writerRun = await execFileAsync(process.execPath, [writer, '--input', inputPath, '--row', 'R-CD-2', '--seat', 'test', '--sha', sha, '--manifest', manifest, '--lifecycle-receipt', receiptPath], { cwd: dir });
+  const postRun = await execFileAsync(process.execPath, [postprocess, '--manifest', manifest, '--summary', summaryPath, '--out-root', path.join(dir, 'post'), '--run-id', 'test', '--lifecycle-receipt', receiptPath], { cwd: dir });
+  const writerDir = JSON.parse(writerRun.stdout).runDir;
+  const postDir = JSON.parse(postRun.stdout).runDir;
+  return {
+    writerResult: JSON.parse(await readFile(path.join(dir, writerDir, 'row-result.json'), 'utf8')),
+    postResult: JSON.parse(await readFile(path.join(postDir, 'row-result.json'), 'utf8')),
+  };
+}
+
+test('shared artifact writers require the same R-CD-2 lifecycle verdict', async () => {
+  // Test the public contract directly: both scripts reject a missing receipt,
+  // so outer acceptance/check metrics cannot create a R-CD-2 PASS on either path.
+  const dir = await mkdtemp(path.join(tmpdir(), 'r-cd-2-writers-'));
+  const input = path.join(dir, 'k6.log');
+  const summary = path.join(dir, 'summary.json');
+  await writeFile(input, '--- R-CD-2 EVIDENCE SUMMARY ---\n{"tool_accepted":true,"task_created":true,"redacted_events":[]}\n--- END EVIDENCE ---\n');
+  await writeFile(summary, JSON.stringify({ metrics: { proof_failures: { values: { count: 0 } }, checks: { values: { rate: 1 } } } }));
+  await assert.rejects(
+    execFileAsync(process.execPath, [writer, '--input', input, '--row', 'R-CD-2', '--seat', 'test', '--sha', sha, '--manifest', manifest], { cwd: dir }),
+  );
+  await assert.rejects(
+    execFileAsync(process.execPath, [postprocess, '--manifest', manifest, '--summary', summary, '--out-root', path.join(dir, 'post')], { cwd: dir }),
+  );
+});
+
+test('shared artifact writers agree on partial and complete lifecycle fixtures', async () => {
+  const july = resolveRcd2LifecycleReceipt({
+    collectorPresent: false,
+    correlation: null,
+    failureReceipt: { kind: 'provider-transport-error' },
+  });
+  const julyResults = await runWriters(july);
+  assert.equal(julyResults.writerResult.outcome, 'PARTIAL-candidate');
+  assert.equal(julyResults.postResult.outcome, 'PARTIAL-candidate');
+  assert.equal(julyResults.writerResult.lifecycleReceipt.failureCategory, 'provider-transport-error');
+
+  const complete = resolveRcd2LifecycleReceipt({ correlation: validCorrelation() });
+  const completeResults = await runWriters(complete);
+  assert.equal(completeResults.writerResult.outcome, 'PASS-candidate');
+  assert.equal(completeResults.postResult.outcome, 'PASS-candidate');
+});

--- a/tools/k6-proofs/scripts/__tests__/r-cd-2-lifecycle.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cd-2-lifecycle.test.mjs
@@ -1,0 +1,424 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import {
+  classifyRcd2LifecycleEvent,
+  isRcd2OutboundChannelDeliveryEvent,
+  isRcd2LifecyclePass,
+  rCd2ScheduledSentinel,
+} from '../../lib/r-cd-2-lifecycle.js';
+
+const rowNonce = 'R-CD-2-fixture';
+const harnessMarker = '[k6-proof-harness]';
+
+function classify(overrides) {
+  return classifyRcd2LifecycleEvent({
+    eventName: 'session.message',
+    eventData: {},
+    rowNonce,
+    harnessMarker,
+    toolAccepted: true,
+    dispatchRunId: 'dispatch-run',
+    delegateScheduledAtMs: null,
+    dispatchTurnCompletedAtMs: 500,
+    wakeGateMs: 5000,
+    nowMs: 10000,
+    ...overrides,
+  });
+}
+
+test('R-CD-2 does not treat a generic delayed message after scheduling as a continuation wake', () => {
+  const event = classify({
+    eventData: {
+      sessionKey: `r-cd-2-${rowNonce}`,
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'unrelated activity' }],
+        metadata: { continuation: rowNonce },
+      },
+    },
+    delegateScheduledAtMs: 1000,
+  });
+
+  assert.equal(event.delegateScheduledReceipt, false);
+  assert.equal(event.parentWakeObserved, false);
+  assert.equal(
+    isRcd2LifecyclePass({
+      disposable_session_required: true,
+      session_created: true,
+      session_unbound_confirmed: true,
+      tool_accepted: true,
+      delegate_scheduled_receipt: false,
+      dispatch_turn_completed: true,
+      parent_wake_observed: true,
+      post_wake_quiet_completed: true,
+      dispatch_failure_observed: false,
+      channel_message_observed: false,
+    }),
+    false,
+  );
+});
+
+test('R-CD-2 ignores nonce-bearing tool-call arguments when correlating the wake', () => {
+  const event = classify({
+    eventData: {
+      message: {
+        role: 'assistant',
+        content: [
+          {
+            type: 'toolCall',
+            name: 'continue_delegate',
+            arguments: { task: `reply DONE ${rowNonce}` },
+          },
+        ],
+      },
+    },
+    delegateScheduledAtMs: 1000,
+  });
+
+  assert.equal(event.delegateScheduledReceipt, false);
+  assert.equal(event.parentWakeObserved, false);
+});
+
+test('R-CD-2 rejects user-authored lifecycle sentinels', () => {
+  const event = classify({
+    eventData: {
+      message: {
+        role: 'user',
+        content: [{ type: 'text', text: rCd2ScheduledSentinel(rowNonce) }],
+      },
+    },
+    delegateScheduledAtMs: 1000,
+  });
+
+  assert.equal(event.delegateScheduledReceipt, false);
+  assert.equal(event.parentWakeObserved, false);
+});
+
+test('R-CD-2 does not reuse a repeated scheduled sentinel as the delayed wake', () => {
+  const event = classify({
+    eventData: {
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: rCd2ScheduledSentinel(rowNonce) }],
+      },
+    },
+    delegateScheduledAtMs: 1000,
+    dispatchTurnCompletedAtMs: 2000,
+  });
+
+  assert.equal(event.delegateScheduledReceipt, true);
+  assert.equal(event.parentWakeObserved, false);
+});
+
+test('R-CD-2 accepts a correlated assistant continue_status receipt as the silent wake', () => {
+  const event = classify({
+    eventData: {
+      message: {
+        role: 'assistant',
+        content: [
+          {
+            type: 'toolCall',
+            name: 'continue_status',
+            arguments: {
+              notify: false,
+              outcome: 'done',
+              status: `completed ${rowNonce}`,
+            },
+          },
+        ],
+      },
+    },
+    delegateScheduledAtMs: 1000,
+  });
+
+  assert.equal(event.parentWakeObserved, true);
+});
+
+test('R-CD-2 accepts a wake only after the correlated scheduled receipt and delay gate', () => {
+  const scheduledAtMs = 1000;
+  const scheduled = classify({
+    eventData: {
+      sessionKey: `r-cd-2-${rowNonce}`,
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: rCd2ScheduledSentinel(rowNonce) }],
+      },
+    },
+    nowMs: scheduledAtMs,
+  });
+  const wake = classify({
+    eventData: {
+      sessionKey: `r-cd-2-${rowNonce}`,
+      message: { role: 'assistant', content: [{ type: 'text', text: `DONE ${rowNonce}` }] },
+    },
+    delegateScheduledAtMs: scheduledAtMs,
+    nowMs: scheduledAtMs + 5000,
+  });
+
+  assert.equal(scheduled.delegateScheduledReceipt, true);
+  assert.equal(wake.parentWakeObserved, true);
+  assert.equal(
+    isRcd2LifecyclePass({
+      disposable_session_required: true,
+      session_created: true,
+      session_unbound_confirmed: true,
+      tool_accepted: true,
+      delegate_scheduled_receipt: true,
+      dispatch_turn_completed: true,
+      parent_wake_observed: true,
+      post_wake_quiet_completed: true,
+      dispatch_failure_observed: false,
+      channel_message_observed: false,
+    }),
+    true,
+  );
+});
+
+test('R-CD-2 emits redacted failure receipts for rejected dispatching turns', () => {
+  const providerFailure = classify({
+    eventData: {
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'OpenAI Responses transport error' }],
+      },
+    },
+  });
+  const replayUnsafe = classify({
+    eventData: {
+      message: {
+        role: 'assistant',
+        content: [
+          {
+            type: 'text',
+            text: 'Failed 1 queued continue_delegate election(s) because the enclosing turn was incomplete and replay-unsafe',
+          },
+        ],
+      },
+    },
+  });
+
+  assert.deepEqual(providerFailure.failureReceipt, {
+    kind: 'provider-transport-error',
+    sourceEvent: 'session.message',
+    correlation: 'subscribed-session-after-dispatch',
+    observedAtMs: 10000,
+  });
+  assert.deepEqual(replayUnsafe.failureReceipt, {
+    kind: 'delegate-replay-unsafe',
+    sourceEvent: 'session.message',
+    correlation: 'subscribed-session-after-dispatch',
+    observedAtMs: 10000,
+  });
+  assert.equal(JSON.stringify(replayUnsafe.failureReceipt).includes('continue_delegate'), false);
+});
+
+test('R-CD-2 classifies standard dispatch lifecycle errors and requires terminal success', () => {
+  const lifecycleError = classify({
+    eventName: 'agent',
+    eventData: {
+      runId: 'dispatch-run',
+      stream: 'lifecycle',
+      data: { phase: 'error', error: 'private provider details' },
+    },
+  });
+  const lifecycleEnd = classify({
+    eventName: 'agent',
+    eventData: {
+      runId: 'dispatch-run',
+      stream: 'lifecycle',
+      data: { phase: 'end' },
+    },
+  });
+
+  assert.deepEqual(lifecycleError.failureReceipt, {
+    kind: 'dispatching-turn-failed',
+    sourceEvent: 'agent',
+    correlation: 'dispatch-run-id',
+    observedAtMs: 10000,
+  });
+  assert.equal(lifecycleEnd.dispatchTurnCompleted, true);
+  assert.equal(
+    classify({
+      eventName: 'agent',
+      eventData: {
+        runId: 'dispatch-run',
+        stream: 'lifecycle',
+        data: { phase: 'start', status: 'failed' },
+      },
+    }).failureReceipt,
+    null,
+  );
+  assert.equal(
+    classify({
+      eventName: 'agent',
+      eventData: {
+        runId: 'dispatch-run',
+        stream: 'item',
+        data: { status: 'failed' },
+      },
+    }).failureReceipt,
+    null,
+  );
+  assert.equal(
+    classify({
+      eventName: 'agent',
+      eventData: {
+        runId: 'another-run',
+        stream: 'lifecycle',
+        data: { phase: 'error', error: 'OpenAI Responses transport error' },
+      },
+    }).failureReceipt,
+    null,
+  );
+  assert.equal(
+    isRcd2LifecyclePass({
+      disposable_session_required: true,
+      session_created: true,
+      session_unbound_confirmed: true,
+      tool_accepted: true,
+      delegate_scheduled_receipt: true,
+      dispatch_turn_completed: false,
+      parent_wake_observed: true,
+      post_wake_quiet_completed: true,
+      dispatch_failure_observed: false,
+      channel_message_observed: false,
+    }),
+    false,
+  );
+});
+
+test('R-CD-2 does not pass before the bounded post-wake quiet window completes', () => {
+  assert.equal(
+    isRcd2LifecyclePass({
+      disposable_session_required: true,
+      session_created: true,
+      session_unbound_confirmed: true,
+      tool_accepted: true,
+      delegate_scheduled_receipt: true,
+      dispatch_turn_completed: true,
+      parent_wake_observed: true,
+      post_wake_quiet_completed: false,
+      dispatch_failure_observed: false,
+      channel_message_observed: false,
+    }),
+    false,
+  );
+});
+
+test('R-CD-2 cannot pass without an unbound disposable session receipt', () => {
+  assert.equal(
+    isRcd2LifecyclePass({
+      disposable_session_required: true,
+      session_created: true,
+      session_unbound_confirmed: false,
+      tool_accepted: true,
+      delegate_scheduled_receipt: true,
+      dispatch_turn_completed: true,
+      parent_wake_observed: true,
+      post_wake_quiet_completed: true,
+      dispatch_failure_observed: false,
+      channel_message_observed: false,
+    }),
+    false,
+  );
+});
+
+test('R-CD-2 rejects replay-invalid or abandoned terminal lifecycle events', () => {
+  const invalidEnd = classify({
+    eventName: 'agent',
+    eventData: {
+      runId: 'dispatch-run',
+      stream: 'lifecycle',
+      data: {
+        phase: 'end',
+        replayInvalid: true,
+        aborted: true,
+        livenessState: 'abandoned',
+      },
+    },
+  });
+
+  assert.equal(invalidEnd.dispatchTurnCompleted, false);
+  assert.deepEqual(invalidEnd.failureReceipt, {
+    kind: 'dispatching-turn-replay-invalid',
+    sourceEvent: 'agent',
+    correlation: 'dispatch-run-id',
+    observedAtMs: 10000,
+  });
+});
+
+test('R-CD-2 recognizes status-only outbound delivery receipts', () => {
+  assert.equal(
+    isRcd2OutboundChannelDeliveryEvent('channel.delivery', {
+      channelId: 'proof-channel',
+      deliveryStatus: 'delivered',
+    }),
+    true,
+  );
+  assert.equal(
+    isRcd2OutboundChannelDeliveryEvent('session.message', {
+      message: {
+        role: 'tool',
+        content: [
+          {
+            type: 'toolResult',
+            result: { details: { deliveryStatus: 'sent' } },
+          },
+        ],
+      },
+    }),
+    true,
+  );
+  assert.equal(
+    isRcd2OutboundChannelDeliveryEvent('session.message', {
+      message: {
+        role: 'toolResult',
+        toolName: 'message',
+        details: {
+          result: {
+            receipt: {
+              primaryPlatformMessageId: 'public-message-id',
+            },
+            messageId: 'public-message-id',
+          },
+        },
+      },
+    }),
+    true,
+  );
+  assert.equal(
+    isRcd2OutboundChannelDeliveryEvent('session.message', {
+      message: {
+        role: 'toolResult',
+        toolName: 'message',
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              result: {
+                receipt: {
+                  primaryPlatformMessageId: 'public-message-id',
+                },
+                messageId: 'public-message-id',
+              },
+            }),
+          },
+        ],
+      },
+    }),
+    true,
+  );
+});
+
+test('R-CD-2 handleSummary derives verdict from proof_failures, not isolated VU state', async () => {
+  const scenario = await readFile(
+    new URL('../../scenarios/r-cd-2-silent-wake.js', import.meta.url),
+    'utf8',
+  );
+
+  assert.match(scenario, /const passed = passRate;/);
+  assert.doesNotMatch(scenario, /finalEvidence/);
+  assert.match(scenario, /postWakeQuietMs < 1000/);
+  assert.match(scenario, /postWakeQuietMs > 30000/);
+});

--- a/tools/k6-proofs/scripts/__tests__/r-cd-2-lifecycle.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cd-2-lifecycle.test.mjs
@@ -42,7 +42,7 @@ test('R-CD-2 does not treat a generic delayed message after scheduling as a cont
 
   assert.equal(event.delegateScheduledReceipt, false);
   assert.equal(event.parentWakeObserved, false);
-  assert.equal(
+  assert.deepEqual(
     isRcd2LifecyclePass({
       disposable_session_required: true,
       session_created: true,
@@ -170,6 +170,12 @@ test('R-CD-2 accepts a wake only after the correlated scheduled receipt and dela
       post_wake_quiet_completed: true,
       dispatch_failure_observed: false,
       channel_message_observed: false,
+      authoritative_lifecycle_receipt: true,
+      observed_delegate_mode: 'silent-wake',
+      observed_trace_id: 'a'.repeat(32),
+      observed_chain_id: 'test-chain',
+      observed_delegate_id: 'delegate-1',
+      child_fire_or_completion_observed: true,
     }),
     true,
   );
@@ -249,7 +255,7 @@ test('R-CD-2 classifies standard dispatch lifecycle errors and requires terminal
     }).failureReceipt,
     null,
   );
-  assert.equal(
+  assert.deepEqual(
     classify({
       eventName: 'agent',
       eventData: {
@@ -258,7 +264,12 @@ test('R-CD-2 classifies standard dispatch lifecycle errors and requires terminal
         data: { status: 'failed' },
       },
     }).failureReceipt,
-    null,
+    {
+      kind: 'dispatching-turn-failed',
+      sourceEvent: 'agent',
+      correlation: 'dispatch-run-id',
+      observedAtMs: 10000,
+    },
   );
   assert.equal(
     classify({
@@ -411,13 +422,14 @@ test('R-CD-2 recognizes status-only outbound delivery receipts', () => {
   );
 });
 
-test('R-CD-2 handleSummary derives verdict from proof_failures, not isolated VU state', async () => {
+test('R-CD-2 handleSummary stays provisional until the strict lifecycle receipt resolves it', async () => {
   const scenario = await readFile(
     new URL('../../scenarios/r-cd-2-silent-wake.js', import.meta.url),
     'utf8',
   );
 
-  assert.match(scenario, /const passed = passRate;/);
+  assert.match(scenario, /verdict: 'PARTIAL-candidate'/);
+  assert.match(scenario, /r-cd-2-lifecycle-receipt\.json/);
   assert.doesNotMatch(scenario, /finalEvidence/);
   assert.match(scenario, /postWakeQuietMs < 1000/);
   assert.match(scenario, /postWakeQuietMs > 30000/);

--- a/tools/k6-proofs/scripts/evidence-writer.mjs
+++ b/tools/k6-proofs/scripts/evidence-writer.mjs
@@ -46,8 +46,27 @@ function stamp() {
 }
 
 function usage() {
-  console.error(`Usage: node evidence-writer.mjs --input <k6-output> --row <ROW> --seat <SEAT> --sha <SHA> [--manifest <row-manifest.json>]`);
+  console.error(`Usage: node evidence-writer.mjs --input <k6-output> --row <ROW> --seat <SEAT> --sha <SHA> [--manifest <row-manifest.json>] [--lifecycle-receipt <r-cd-2-lifecycle-receipt.json>]`);
   process.exit(2);
+}
+
+function rcd2LifecycleVerdict(args, row) {
+  if (row !== 'R-CD-2') return null;
+  if (!args['lifecycle-receipt']) {
+    throw new Error('R-CD-2 requires --lifecycle-receipt from the strict continuation correlator');
+  }
+  const receipt = JSON.parse(readFileSync(args['lifecycle-receipt'], 'utf8'));
+  if (receipt?.schema !== 'openclaw.k6.r-cd-2-lifecycle-receipt.v1') {
+    throw new Error('R-CD-2 lifecycle receipt has an unsupported schema');
+  }
+  if (!['PASS-candidate', 'PARTIAL-candidate'].includes(receipt.verdict)) {
+    throw new Error('R-CD-2 lifecycle receipt has an invalid verdict');
+  }
+  const serialized = JSON.stringify(receipt).toLowerCase();
+  if (/(traceparent|reason|prompt|sessionkey|token|rpc error)/.test(serialized)) {
+    throw new Error('R-CD-2 lifecycle receipt contains forbidden public material');
+  }
+  return receipt;
 }
 
 // --- Main ---
@@ -118,6 +137,7 @@ if (evidence.events && !evidence.redacted_events) {
 const events = evidence.redacted_events || [];
 const { sanitized: [summary], orderedTokens } = sanitizeEvidenceRecords([evidence]);
 const { sanitized: safeEvents } = sanitizeEvidenceRecords(events, orderedTokens);
+const lifecycleReceipt = rcd2LifecycleVerdict(args, args.row);
 
 // Build output directory
 const runId = `k6-run-${stamp()}`;
@@ -126,6 +146,9 @@ mkdirSync(join(outDir, 'artifacts'), { recursive: true });
 
 if (args['seat-readiness']) {
   copyFileSync(args['seat-readiness'], join(outDir, 'seat-readiness.json'));
+}
+if (lifecycleReceipt) {
+  copyFileSync(args['lifecycle-receipt'], join(outDir, 'r-cd-2-lifecycle-receipt.json'));
 }
 
 // Write k6-summary.json through the same public-safe boundary as run-proofs.sh.
@@ -144,9 +167,9 @@ writeFileSync(join(outDir, 'evidence-redaction.json'), JSON.stringify({
 }, null, 2) + '\n');
 
 // Determine verdict
-const verdict = evidence.tool_accepted || evidence.prompt_sent
+const verdict = lifecycleReceipt?.verdict || (evidence.tool_accepted || evidence.prompt_sent
   ? (evidence.task_created || evidence.child_spawned ? 'PASS-candidate' : 'PARTIAL-candidate')
-  : 'FAIL-candidate';
+  : 'FAIL-candidate');
 
 // Write row-result.json
 const result = {
@@ -157,6 +180,13 @@ const result = {
   candidateSha: args.sha,
   seat: args.seat,
   outcome: verdict,
+  ...(lifecycleReceipt ? {
+    lifecycleReceipt: {
+      schema: lifecycleReceipt.schema,
+      verdict: lifecycleReceipt.verdict,
+      ...(lifecycleReceipt.failureCategory ? { failureCategory: lifecycleReceipt.failureCategory } : {}),
+    },
+  } : {}),
   liveRunSafety: manifest?.liveRunSafety ? {
     classification: manifest.liveRunSafety.classification,
     requiresLiveGatewayToken: Boolean(manifest.liveRunSafety.requiresLiveGatewayToken),
@@ -201,6 +231,7 @@ const md = `# ${args.row} — ${args.seat} — ${verdict}
 | Parent return observed | ${evidence.parent_return ? '✓' : '✗'} |
 | Safe reason fingerprint | \`${summary.reason_hash || 'N/A'}\` / length \`${summary.reason_length || 'N/A'}\` |
 | Manifest loaded | ${evidence.manifest_loaded ? '✓' : '✗ (defaults used)'} |
+${lifecycleReceipt ? `| R-CD-2 lifecycle authority | ${lifecycleReceipt.verdict === 'PASS-candidate' ? '✓' : '✗'} (${lifecycleReceipt.failureCategory || 'verified'}) |` : ''}
 
 ## Artifacts
 
@@ -208,6 +239,7 @@ const md = `# ${args.row} — ${args.seat} — ${verdict}
 - \`gateway-events.ndjson\` — redacted WS frames (${safeEvents.length} captured)
 - \`evidence-redaction.json\` — public-safe redaction receipt
 - \`row-result.json\` — normalized outcome
+${lifecycleReceipt ? '- `r-cd-2-lifecycle-receipt.json` — authoritative row-scoped lifecycle verdict\n' : ''}
 - \`seat-readiness.json\` — public-safe seat/tooling preflight (${args['seat-readiness'] ? 'captured' : 'not supplied to writer'})
 - \`artifacts/\` — optional copied receipts (Tempo trace, logs)
 

--- a/tools/k6-proofs/scripts/postprocess-k6-summary.mjs
+++ b/tools/k6-proofs/scripts/postprocess-k6-summary.mjs
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { copyFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 function usage() {
   console.error(`Usage: node tools/k6-proofs/scripts/postprocess-k6-summary.mjs \\
   --manifest tools/k6-proofs/manifests/preflight.example.json \\
   --summary /tmp/k6-summary.json \\
-  [--out-root PROOFS] [--run-id k6-run-YYYYMMDDTHHMMSSZ]`);
+  [--out-root PROOFS] [--run-id k6-run-YYYYMMDDTHHMMSSZ] \\
+  [--lifecycle-receipt r-cd-2-lifecycle-receipt.json]`);
 }
 
 function parseArgs(argv) {
@@ -83,7 +84,11 @@ function receiptStatusFromName(name, summary) {
   }
 }
 
-function outcomeFromSummary(summary) {
+function outcomeFromSummary(summary, rowId, lifecycleReceipt) {
+  if (rowId === 'R-CD-2') {
+    if (!lifecycleReceipt) return 'PARTIAL-candidate';
+    return lifecycleReceipt.verdict;
+  }
   const failures = requiredMetric(summary, 'proof_failures');
   const failureCount = failures ? Number(failures.count || 0) : 0;
   const checks = requiredMetric(summary, 'checks');
@@ -92,6 +97,22 @@ function outcomeFromSummary(summary) {
   if (failureCount > 0) return 'FAIL-candidate';
   if (checkRate !== null && checkRate < 1) return 'HONEST-LIMIT-candidate';
   return 'PASS-candidate';
+}
+
+async function readRcd2LifecycleReceipt(args, rowId) {
+  if (rowId !== 'R-CD-2') return null;
+  if (!args['lifecycle-receipt']) {
+    throw new Error('R-CD-2 requires --lifecycle-receipt from the strict continuation correlator');
+  }
+  const receipt = JSON.parse(await readFile(args['lifecycle-receipt'], 'utf8'));
+  if (receipt?.schema !== 'openclaw.k6.r-cd-2-lifecycle-receipt.v1' ||
+      !['PASS-candidate', 'PARTIAL-candidate'].includes(receipt.verdict)) {
+    throw new Error('R-CD-2 lifecycle receipt is invalid');
+  }
+  if (/(traceparent|reason|prompt|sessionkey|token|rpc error)/.test(JSON.stringify(receipt).toLowerCase())) {
+    throw new Error('R-CD-2 lifecycle receipt contains forbidden public material');
+  }
+  return receipt;
 }
 
 function evidenceDraft({ manifest, summary, result }) {
@@ -176,8 +197,9 @@ async function main() {
   const seat = dest.seat || manifest.seat;
   const runId = args['run-id'] || `${dest.runDirPrefix || 'k6-run'}-${stamp()}`;
   const runDir = path.join(outRoot, sha, row, seat, runId);
+  const lifecycleReceipt = await readRcd2LifecycleReceipt(args, manifest.rowId);
 
-  const outcome = outcomeFromSummary(summary);
+  const outcome = outcomeFromSummary(summary, manifest.rowId, lifecycleReceipt);
   const failures = requiredMetric(summary, 'proof_failures');
   const failureCount = failures ? Number(failures.count || 0) : 0;
   const checks = requiredMetric(summary, 'checks');
@@ -217,7 +239,18 @@ async function main() {
       foldRequiresReview: manifest.liveRunSafety.foldRequiresReview === true,
     } : null,
     failureClass,
-    reason: outcome === 'FAIL-candidate'
+    ...(lifecycleReceipt ? {
+      lifecycleReceipt: {
+        schema: lifecycleReceipt.schema,
+        verdict: lifecycleReceipt.verdict,
+        ...(lifecycleReceipt.failureCategory ? { failureCategory: lifecycleReceipt.failureCategory } : {}),
+      },
+    } : {}),
+    reason: lifecycleReceipt
+      ? (lifecycleReceipt.verdict === 'PASS-candidate'
+        ? 'strict row-scoped lifecycle receipt verified the required topology'
+        : `strict row-scoped lifecycle receipt is non-pass: ${lifecycleReceipt.failureCategory || 'unknown'}`)
+      : outcome === 'FAIL-candidate'
       ? 'k6 proof_failures metric is non-zero'
       : outcome === 'HONEST-LIMIT-candidate'
         ? 'k6 checks did not all pass; classify for human review'
@@ -230,6 +263,9 @@ async function main() {
   await writeFile(path.join(runDir, 'row-manifest.json'), JSON.stringify(manifest, null, 2) + '\n');
   await writeFile(path.join(runDir, 'k6-summary.json'), JSON.stringify(summary, null, 2) + '\n');
   await writeFile(path.join(runDir, 'row-result.json'), JSON.stringify(result, null, 2) + '\n');
+  if (lifecycleReceipt) {
+    await copyFile(args['lifecycle-receipt'], path.join(runDir, 'r-cd-2-lifecycle-receipt.json'));
+  }
   await writeFile(path.join(runDir, 'EVIDENCE.md'), evidenceDraft({ manifest, summary, result }));
 
   console.log(JSON.stringify({ runDir, outcome, rowId: manifest.rowId, candidateOnly: true }, null, 2));

--- a/tools/k6-proofs/scripts/resolve-r-cd-2-lifecycle-receipt.mjs
+++ b/tools/k6-proofs/scripts/resolve-r-cd-2-lifecycle-receipt.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/**
+ * Resolve R-CD-2's only pass authority from the strict continuation trace
+ * correlation receipt.  This deliberately does not inspect prompts, RPC
+ * errors, session keys, or raw event payloads.
+ */
+import { createHash } from 'node:crypto';
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+function safeText(value, max = 128) {
+  return typeof value === 'string' && value.length > 0 && value.length <= max;
+}
+
+function safeHex(value, length) {
+  return typeof value === 'string' && new RegExp(`^[a-f0-9]{${length}}$`, 'i').test(value);
+}
+
+function opaqueHash(value) {
+  return createHash('sha256').update(value).digest('hex').slice(0, 16);
+}
+
+/**
+ * Return a public-safe R-CD-2 verdict.  The correlation receipt is written by
+ * collect-continuation-trace.mjs only after it has proved one trace containing
+ * the typed tool span plus matching dispatch and fire spans.
+ */
+const SAFE_FAILURE_CATEGORIES = new Set([
+  'provider-transport-error',
+  'model-policy-rejected',
+  'delegate-replay-unsafe',
+  'dispatching-turn-failed',
+  'dispatching-turn-replay-invalid',
+  'dispatching-turn-aborted',
+  'dispatching-turn-not-live',
+]);
+
+export function resolveRcd2LifecycleReceipt({ correlation, collectorPresent = true, failureReceipt = null }) {
+  const base = {
+    schema: 'openclaw.k6.r-cd-2-lifecycle-receipt.v1',
+    row: 'R-CD-2',
+    authoritativeSource: 'continuation-trace-correlation',
+    candidateOnly: true,
+    foldRequiresReview: true,
+  };
+  if (!collectorPresent || !correlation || typeof correlation !== 'object') {
+    const failureCategory = SAFE_FAILURE_CATEGORIES.has(failureReceipt?.kind)
+      ? failureReceipt.kind
+      : 'missing-lifecycle-correlation';
+    return { ...base, verdict: 'PARTIAL-candidate', failureCategory };
+  }
+
+  const continuation = correlation.continuation || {};
+  const delegate = correlation.delegate || {};
+  const hasTopology =
+    continuation.tool === 'continue_delegate' &&
+    continuation.acceptSpan === 'continuation.delegate.dispatch' &&
+    continuation.fireSpan === 'continuation.delegate.fire' &&
+    delegate.mode === 'silent-wake' &&
+    correlation.sameTrace === true &&
+    correlation.distinctSpans === true &&
+    safeHex(correlation.traceId, 32) &&
+    safeText(correlation.chainId) &&
+    safeHex(correlation.dispatchSpanId, 16) &&
+    safeHex(correlation.fireSpanId, 16) &&
+    Array.isArray(correlation.toolSpanIds) &&
+    correlation.toolSpanIds.length >= 1 &&
+    correlation.toolSpanIds.every((id) => safeHex(id, 16));
+
+  if (!hasTopology) {
+    return { ...base, verdict: 'PARTIAL-candidate', failureCategory: 'invalid-lifecycle-topology' };
+  }
+
+  // Keep only hashes of opaque identifiers and observed topology facts.  In
+  // particular, never copy query text, raw trace/chain/span IDs, reason data,
+  // prompt text, errors, or a traceparent into the public row receipt.
+  return {
+    ...base,
+    verdict: 'PASS-candidate',
+    lifecycle: {
+      typedTool: 'continue_delegate',
+      observedMode: 'silent-wake',
+      sameTrace: true,
+      traceHash: opaqueHash(correlation.traceId.toLowerCase()),
+      chainHash: opaqueHash(correlation.chainId),
+      dispatchSpanHash: opaqueHash(correlation.dispatchSpanId.toLowerCase()),
+      fireSpanHash: opaqueHash(correlation.fireSpanId.toLowerCase()),
+      toolSpanCount: correlation.toolSpanIds.length,
+    },
+  };
+}
+
+async function main() {
+  const args = Object.fromEntries(process.argv.slice(2).reduce((pairs, arg, index, all) => {
+    if (arg.startsWith('--')) pairs.push([arg.slice(2), all[index + 1]]);
+    return pairs;
+  }, []));
+  if (!args['run-dir']) throw new Error('usage: --run-dir <row-run-dir> [--correlation <receipt>]');
+  const runDir = path.resolve(args['run-dir']);
+  const correlationPath = args.correlation
+    ? path.resolve(args.correlation)
+    : path.join(runDir, 'continuation-trace-correlation.json');
+  let correlation = null;
+  let failureReceipt = null;
+  let collectorPresent = true;
+  try {
+    correlation = JSON.parse(await readFile(correlationPath, 'utf8'));
+  } catch {
+    collectorPresent = false;
+  }
+  if (args.evidence) {
+    try {
+      const evidence = JSON.parse(await readFile(args.evidence, 'utf8'));
+      failureReceipt = evidence?.failure_receipt || null;
+    } catch {
+      // The absence of parseable local evidence is itself non-authoritative;
+      // do not surface parsing details in the public lifecycle receipt.
+    }
+  }
+  const result = resolveRcd2LifecycleReceipt({ correlation, collectorPresent, failureReceipt });
+  result.generatedAt = new Date().toISOString();
+  await writeFile(path.join(runDir, 'r-cd-2-lifecycle-receipt.json'), `${JSON.stringify(result, null, 2)}\n`);
+  console.log(JSON.stringify(result));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    // Do not print an underlying private collector/RPC error into a public
+    // artifact or caller log.  The row receipt carries only safe categories.
+    console.error(`R-CD-2 lifecycle receipt failed: ${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EVIDENCE_EXTRACTOR="$SCRIPT_DIR/extract-k6-evidence.mjs"
 CONTINUATION_TRACE_COLLECTOR="$SCRIPT_DIR/collect-continuation-trace.mjs"
+RCD2_LIFECYCLE_RESOLVER="$SCRIPT_DIR/resolve-r-cd-2-lifecycle-receipt.mjs"
 ARTIFACT_SANITIZER="$SCRIPT_DIR/sanitize-k6-artifacts.mjs"
 PRIVATE_K6_LOG=""
 PRIVATE_EVIDENCE_FILE=""
@@ -368,6 +369,7 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
     TEMPO_TRACE_JSON=""
     CORRELATION_RECEIPT_PATH=""
     CORRELATION_RECEIPT=""
+    RCD2_LIFECYCLE_RECEIPT=""
     REVIEW_PENDING_RECEIPTS='[]'
     if [[ "$GATEWAY_JOURNAL_STATUS" != "captured" ]]; then
       REVIEW_PENDING_RECEIPTS='["gateway-journal"]'
@@ -446,6 +448,42 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
       )"
     fi
 
+    # R-CD-2 has one pass authority: the strict collector's row-scoped,
+    # public-safe lifecycle receipt.  A sessions.send acceptance, a generic
+    # delayed event, a VU log, and a k6 check rate are all non-authoritative.
+    if [[ "$ROW_ID" == "R-CD-2" ]]; then
+      if node "$RCD2_LIFECYCLE_RESOLVER" --run-dir "$RUN_DIR" --evidence "$PRIVATE_EVIDENCE_FILE" \
+        > "$RUN_DIR/r-cd-2-lifecycle-receipt.stdout.json"; then
+        RCD2_LIFECYCLE_RECEIPT="r-cd-2-lifecycle-receipt.json"
+        SUMMARY_VERDICT="$(jq -r '.verdict' "$RUN_DIR/$RCD2_LIFECYCLE_RECEIPT")"
+        SUMMARY_VERDICT_SOURCE="r-cd-2-lifecycle-receipt"
+        # k6's handleSummary necessarily runs before trace correlation.  Replace
+        # its provisional row summary only after the authoritative receipt is
+        # available, retaining the original value for audit.  This gives the
+        # scenario summary the same R-CD-2 authority as the artifact writers.
+        while IFS= read -r -d '' SUMMARY_PATH; do
+          SUMMARY_TMP="$SUMMARY_PATH.lifecycle-authority.tmp"
+          jq --arg verdict "$SUMMARY_VERDICT" \
+            --arg receipt "$RCD2_LIFECYCLE_RECEIPT" \
+            --arg source "$SUMMARY_VERDICT_SOURCE" \
+            '.scenarioProvisionalVerdict = (.verdict // null) |
+             .verdict = $verdict |
+             .lifecycleReceipt = {path:$receipt, verdict:$verdict, authority:$source}' \
+            "$SUMMARY_PATH" > "$SUMMARY_TMP" && mv "$SUMMARY_TMP" "$SUMMARY_PATH"
+        done < <(find "$RUN_DIR" -maxdepth 1 -type f -name '*summary.json' -print0)
+        SUMMARY_FILE_VERDICT="$SUMMARY_VERDICT"
+        if [[ "$SUMMARY_VERDICT" != "PASS-candidate" ]]; then
+          POSTPROCESS_RC=1
+        fi
+      else
+        # Resolver failures must not preserve a VU-log or summary-file PASS.
+        RCD2_LIFECYCLE_RECEIPT="r-cd-2-lifecycle-receipt.json"
+        SUMMARY_VERDICT="PARTIAL-candidate"
+        SUMMARY_VERDICT_SOURCE="r-cd-2-lifecycle-receipt"
+        POSTPROCESS_RC=1
+      fi
+    fi
+
     if ! node "$ARTIFACT_SANITIZER" \
       --input "$PRIVATE_EVIDENCE_FILE" \
       --out "$RUN_DIR/evidence.jsonl" \
@@ -499,6 +537,7 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
       --arg traceId "$TRACE_ID" \
       --arg tempoTraceJson "$TEMPO_TRACE_JSON" \
       --arg correlationReceipt "$CORRELATION_RECEIPT" \
+      --arg rcd2LifecycleReceipt "$RCD2_LIFECYCLE_RECEIPT" \
       --arg serviceLogStatus "$GATEWAY_JOURNAL_STATUS" \
       --arg verdict "$SUMMARY_VERDICT" \
       --arg verdictSource "$SUMMARY_VERDICT_SOURCE" \
@@ -507,7 +546,7 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
       --argjson summaryFiles "$SUMMARY_FILES_JSON" \
       --argjson evidence "$EVIDENCE_JSON" \
       --argjson reviewPendingReceipts "$REVIEW_PENDING_RECEIPTS" \
-      '{k6ExitCode:$rc, postprocessExitCode:$postprocessRc, effectiveExitCode:$effectiveRc, endedAt:$ended, verdict:(if $verdict == "unknown" then null else $verdict end), verdictSource:$verdictSource, summaryFileVerdict:(if $summaryFileVerdict == "unknown" then null else $summaryFileVerdict end), vuLogVerdict:(if $vuLogVerdict == "" then null else $vuLogVerdict end), summaryFiles:$summaryFiles, evidence:$evidence, candidateOnly:true, foldRequiresReview:true, observability:{traceStatus:$traceStatus, traceId:(if $traceId == "" then null else $traceId end), tempoTraceJson:(if $tempoTraceJson == "" then null else $tempoTraceJson end), correlationReceipt:(if $correlationReceipt == "" then null else $correlationReceipt end), serviceLogStatus:$serviceLogStatus, serviceLog:"gateway-journal.log", serviceLogCapture:"gateway-journal-capture.json", serviceLogRedaction:"gateway-journal-redaction.json"}, review:{status:(if ($reviewPendingReceipts|length)>0 then "review-pending" else "ready-for-human-review" end), pendingReceipts:$reviewPendingReceipts}}' \
+      '{k6ExitCode:$rc, postprocessExitCode:$postprocessRc, effectiveExitCode:$effectiveRc, endedAt:$ended, verdict:(if $verdict == "unknown" then null else $verdict end), verdictSource:$verdictSource, summaryFileVerdict:(if $summaryFileVerdict == "unknown" then null else $summaryFileVerdict end), vuLogVerdict:(if $vuLogVerdict == "" then null else $vuLogVerdict end), summaryFiles:$summaryFiles, evidence:$evidence, candidateOnly:true, foldRequiresReview:true, lifecycleReceipt:(if $rcd2LifecycleReceipt == "" then null else $rcd2LifecycleReceipt end), observability:{traceStatus:$traceStatus, traceId:(if $traceId == "" then null else $traceId end), tempoTraceJson:(if $tempoTraceJson == "" then null else $tempoTraceJson end), correlationReceipt:(if $correlationReceipt == "" then null else $correlationReceipt end), serviceLogStatus:$serviceLogStatus, serviceLog:"gateway-journal.log", serviceLogCapture:"gateway-journal-capture.json", serviceLogRedaction:"gateway-journal-redaction.json"}, review:{status:(if ($reviewPendingReceipts|length)>0 then "review-pending" else "ready-for-human-review" end), pendingReceipts:$reviewPendingReceipts}}' \
       > "$RUN_DIR/run-result.json"
     METRICS_ARGS=(--run-dir "$RUN_DIR" --prometheus-out "$RUN_DIR/openclaw-proofs-k6.prom" --otlp-out "$RUN_DIR/openclaw-proofs-k6.otlp.json")
     if [[ -n "${OPENCLAW_PROOFS_K6_OTLP_ENDPOINT:-}" ]]; then


### PR DESCRIPTION
## Scope

Docs-harness-only repair for #411. No live row, collector, core, Tempo-service, assembly, or presentation change.

- R-CD-2 PASS now comes only from a public-safe lifecycle receipt resolved from strict typed continue_delegate correlation: observed silent-wake, one trace/chain, dispatch and fire topology.
- The runner replaces the scenario provisional result with that receipt; evidence-writer.mjs and postprocess-k6-summary.mjs require and consume the same row-scoped receipt. Other rows retain their existing paths.
- Provider/replay/failed-item, missing/malformed, wrong-mode, and mismatched topology are non-pass categories. The scenario no longer prints raw RPC errors; the receipt contains categories and opaque hashes only.
- Focused fixtures cover July false-green, provider/replay failure, complete silent-wake topology, and wrong mode/mismatched trace.

## Validation

- R-CD-2 focused tests: 17/17
- Full docs harness: 115/115
- Manifest coverage, scenario registry, scenario alignment, bash syntax, and diff check passed.

No canary or refire was run.