### PR TITLE
feat(proofs): validate candidate run result envelope

### DIFF
--- a/RUNBOOKS/project-81/EXECUTABLE-SUITE.md
+++ b/RUNBOOKS/project-81/EXECUTABLE-SUITE.md
@@ -87,7 +87,7 @@ Artifacts are written under `${K6_PROOF_OUT_DIR:-/tmp/k6-proof-runs}`:
 <out-dir>/<candidate-sha>/<ROW>/<seat>/<timestamp-row>/
 ```
 
-Each row emits `row-manifest.json`, `runner-metadata.json`, `k6.log`, `evidence-lines.log`, `evidence.jsonl`, `run-result.json`, metrics files, and summary files when available.
+Each row emits `row-manifest.json`, `runner-metadata.json`, `k6.log`, `evidence-lines.log`, `evidence.jsonl`, `run-result.json`, metrics files, and summary files when available. A review-complete row also emits `candidate-run-result.json` (`openclaw.k6.candidate-run-result.v1`): a public-safe routing envelope that binds the manifest, candidate SHA, docs ref, row, seat, and run identity. It remains candidate-only (`behaviorProof:false`, `canonicalFoldForbidden:true`); review-pending rows deliberately receive no envelope and remain in the review-debt queue.
 
 ## 7. Review before folding
 

--- a/RUNBOOKS/project-81/README.md
+++ b/RUNBOOKS/project-81/README.md
@@ -109,6 +109,7 @@ Rows promoted as static committed-packet validators or honest-limit canaries may
    ├── evidence-lines.log
    ├── evidence.jsonl
    ├── run-result.json
+   ├── candidate-run-result.json  # only when review-complete; never canonical proof
    └── *summary.json
    ```
 

--- a/tools/k6-proofs/scripts/__tests__/candidate-run-result.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/candidate-run-result.test.mjs
@@ -1,0 +1,136 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const runNode = promisify(execFile);
+const script = path.resolve('tools/k6-proofs/scripts/validate-candidate-run-result.mjs');
+const corpusValidator = path.resolve('tools/k6-proofs/scripts/validate-corpus.mjs');
+const sha = 'a'.repeat(40);
+const docsRef = 'b'.repeat(40);
+
+function manifest() {
+  return {
+    schema: 'openclaw.k6.proof-row-manifest.v1',
+    rowId: 'R-CW-TEST',
+    candidateSha: sha,
+    seat: 'cael',
+    scenario: { name: 'r-cw-test' },
+    review: { candidateOnly: true, foldRequiresReview: true },
+    liveRunSafety: { expectedArtifactClass: 'PASS-candidate' },
+  };
+}
+
+function runResult(overrides = {}) {
+  return {
+    effectiveExitCode: 0,
+    verdict: 'PASS-candidate',
+    verdictSource: 'summary-file',
+    candidateOnly: true,
+    foldRequiresReview: true,
+    observability: { traceStatus: 'present', traceId: 'safe-trace-id', correlationReceipt: 'continuation-correlation.json' },
+    review: { status: 'ready-for-human-review', pendingReceipts: [] },
+    ...overrides,
+  };
+}
+
+async function fixture({ result = runResult(), metadata = null } = {}) {
+  const root = await mkdtemp(path.join(tmpdir(), 'candidate-run-result-'));
+  const candidateDir = path.join(root, 'candidate');
+  await mkdir(candidateDir);
+  const manifestPath = path.join(root, 'manifest.json');
+  await writeFile(manifestPath, `${JSON.stringify(manifest(), null, 2)}\n`);
+  await writeFile(path.join(candidateDir, 'runner-metadata.json'), `${JSON.stringify(metadata || {
+    row: 'R-CW-TEST', candidateSha: sha, seat: 'cael', scenario: 'r-cw-test.js',
+  }, null, 2)}\n`);
+  await writeFile(path.join(candidateDir, 'run-result.json'), `${JSON.stringify(result, null, 2)}\n`);
+  return { root, candidateDir, manifestPath };
+}
+
+async function invoke({ manifestPath, candidateDir, out = null }) {
+  const args = [script, '--manifest', manifestPath, '--candidate-dir', candidateDir, '--docs-ref', docsRef];
+  if (out) args.push('--out', out);
+  return runNode(process.execPath, args, { encoding: 'utf8' });
+}
+
+test('emits a public-safe, candidate-only routing envelope for a complete candidate run', async () => {
+  const setup = await fixture();
+  try {
+    const out = path.join(setup.candidateDir, 'candidate-run-result.json');
+    const run = await invoke({ ...setup, out });
+    const result = JSON.parse(run.stdout);
+    assert.equal(result.schema, 'openclaw.k6.candidate-run-result.v1');
+    assert.equal(result.candidate.sha, sha);
+    assert.equal(result.candidate.docsRef, docsRef);
+    assert.equal(result.run.rowId, 'R-CW-TEST');
+    assert.equal(result.result.outcome, 'PASS-candidate');
+    assert.equal(result.result.behaviorProof, false);
+    assert.equal(result.canonicalFoldForbidden, true);
+    assert.equal(result.review.complete, true);
+    assert.equal(result.observability.traceCaptured, true);
+    assert.equal(result.artifacts.correlationReceipt, 'continuation-correlation.json');
+    assert.deepEqual(JSON.parse(await readFile(out, 'utf8')), result);
+  } finally {
+    await rm(setup.root, { recursive: true, force: true });
+  }
+});
+
+test('rejects malformed, identity-mismatched, and review-incomplete candidates', async (t) => {
+  await t.test('malformed run result', async () => {
+    const setup = await fixture();
+    try {
+      await writeFile(path.join(setup.candidateDir, 'run-result.json'), '{bad json');
+      await assert.rejects(invoke(setup), /run result is malformed JSON/);
+    } finally { await rm(setup.root, { recursive: true, force: true }); }
+  });
+  await t.test('metadata mismatch', async () => {
+    const setup = await fixture({ metadata: { row: 'R-OTHER', candidateSha: sha, seat: 'cael', scenario: 'r-cw-test.js' } });
+    try {
+      await assert.rejects(invoke(setup), /row ID mismatch/);
+    } finally { await rm(setup.root, { recursive: true, force: true }); }
+  });
+  await t.test('pending review debt', async () => {
+    const setup = await fixture({ result: runResult({ review: { status: 'review-pending', pendingReceipts: ['tempo-trace-json'] } }) });
+    try {
+      await assert.rejects(invoke(setup), /review-incomplete/);
+    } finally { await rm(setup.root, { recursive: true, force: true }); }
+  });
+});
+
+test('candidate envelope is outside and invisible to canonical corpus validation', async () => {
+  const setup = await fixture();
+  try {
+    const before = await runNode(process.execPath, [corpusValidator, '--index', '--json'], { encoding: 'utf8' });
+    await invoke({ ...setup, out: path.join(setup.candidateDir, 'candidate-run-result.json') });
+    const after = await runNode(process.execPath, [corpusValidator, '--index', '--json'], { encoding: 'utf8' });
+    const normalized = (raw) => {
+      const value = JSON.parse(raw);
+      value.root = '<repo-root>';
+      for (const report of value.reports || []) {
+        if (report.indexPath) report.indexPath = '<repo-root>/PROOFS/INDEX.json';
+        for (const check of report.checks || []) {
+          if (typeof check.detail === 'string') check.detail = check.detail.replaceAll(process.cwd(), '<repo-root>');
+        }
+      }
+      return value;
+    };
+    assert.deepEqual(normalized(after.stdout), normalized(before.stdout));
+  } finally {
+    await rm(setup.root, { recursive: true, force: true });
+  }
+});
+
+test('refuses output outside the candidate directory', async () => {
+  const setup = await fixture();
+  try {
+    await assert.rejects(
+      invoke({ ...setup, out: path.join(setup.root, 'not-a-candidate-envelope.json') }),
+      /output must be candidate-run-result\.json directly inside the candidate directory/,
+    );
+  } finally {
+    await rm(setup.root, { recursive: true, force: true });
+  }
+});

--- a/tools/k6-proofs/scripts/__tests__/report-render.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/report-render.test.mjs
@@ -59,12 +59,22 @@ test('uses candidate-run-result.v1 as the unambiguous review input when present'
   try {
     const runDir = path.join(root, 'candidate', 'R-CW-1', 'cael', 'k6-run-1');
     await mkdir(runDir, { recursive: true });
-    await writeFile(path.join(runDir, 'run-result.json'), `${JSON.stringify({ review: { status: 'review-pending', pendingReceipts: ['tempo-trace-json'] } })}\n`);
+    const sha = 'b40e59f08c7a8997e50a5c8a24b00bc68f653882';
+    await writeFile(path.join(runDir, 'row-manifest.json'), `${JSON.stringify({
+      schema: 'openclaw.k6.proof-row-manifest.v1', rowId: 'R-CW-1', candidateSha: sha,
+      scenario: { name: 'r-cw-1' }, review: { candidateOnly: true, foldRequiresReview: true },
+    })}\n`);
+    await writeFile(path.join(runDir, 'runner-metadata.json'), `${JSON.stringify({ row: 'R-CW-1', candidateSha: sha, seat: 'cael', scenario: 'r-cw-1' })}\n`);
+    await writeFile(path.join(runDir, 'run-result.json'), `${JSON.stringify({
+      candidateOnly: true, foldRequiresReview: true, effectiveExitCode: 0, verdict: 'PASS-candidate', verdictSource: 'k6-summary',
+      review: { status: 'ready-for-human-review', pendingReceipts: [] },
+    })}\n`);
     await writeFile(path.join(runDir, 'candidate-run-result.json'), `${JSON.stringify({
       schema: 'openclaw.k6.candidate-run-result.v1',
-      candidate: { sha: 'b40e59f08c7a8997e50a5c8a24b00bc68f653882' },
-      run: { rowId: 'R-CW-1', seat: 'cael', scenario: 'r-cw-1' },
-      result: { outcome: 'PASS-candidate', behaviorProof: false },
+      candidateOnly: true, foldRequiresReview: true, canonicalFoldForbidden: true,
+      candidate: { sha, docsRef: 'a'.repeat(40) },
+      run: { id: 'k6-run-1', rowId: 'R-CW-1', seat: 'cael', scenario: 'r-cw-1' },
+      result: { outcome: 'PASS-candidate', outcomeSource: 'k6-summary', effectiveExitCode: 0, behaviorProof: false },
       observability: { traceStatus: 'present' },
       review: { status: 'ready-for-human-review', pendingReceipts: [], complete: true },
     }, null, 2)}\n`);
@@ -75,6 +85,31 @@ test('uses candidate-run-result.v1 as the unambiguous review input when present'
     assert.match(html, /R-CW-1/);
     assert.match(html, /ready-for-human-review/);
     assert.doesNotMatch(html, /<td>review-pending<\/td>/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('falls back to the sibling raw result when a sidecar is malformed or unsafe', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'k6-proof-envelope-fallback-'));
+  try {
+    const runDir = path.join(root, 'candidate', 'R-CW-2', 'cael', 'k6-run-2');
+    await mkdir(runDir, { recursive: true });
+    await writeFile(path.join(runDir, 'run-result.json'), `${JSON.stringify({
+      k6ExitCode: 0, candidateOnly: true, foldRequiresReview: true,
+      review: { status: 'review-pending', pendingReceipts: ['tempo-trace-json'] },
+      observability: { traceStatus: 'missing' },
+    })}\n`);
+    await writeFile(path.join(runDir, 'candidate-run-result.json'), `${JSON.stringify({
+      schema: 'openclaw.k6.candidate-run-result.v1', candidateOnly: true, foldRequiresReview: true,
+      canonicalFoldForbidden: true, result: { behaviorProof: true }, review: { status: 'ready-for-human-review', pendingReceipts: [], complete: true },
+    })}\n`);
+    const out = path.join(root, 'report.html');
+    const run = spawnSync(process.execPath, [script, '--root', root, '--out', out], { encoding: 'utf8' });
+    assert.equal(run.status, 0, run.stderr);
+    const html = await readFile(out, 'utf8');
+    assert.match(html, /review-pending/);
+    assert.match(html, /tempo-trace-json: missing/);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/tools/k6-proofs/scripts/__tests__/report-render.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/report-render.test.mjs
@@ -67,6 +67,7 @@ test('uses candidate-run-result.v1 as the unambiguous review input when present'
     await writeFile(path.join(runDir, 'runner-metadata.json'), `${JSON.stringify({ row: 'R-CW-1', candidateSha: sha, seat: 'cael', scenario: 'r-cw-1' })}\n`);
     await writeFile(path.join(runDir, 'run-result.json'), `${JSON.stringify({
       candidateOnly: true, foldRequiresReview: true, effectiveExitCode: 0, verdict: 'PASS-candidate', verdictSource: 'k6-summary',
+      observability: { traceStatus: 'present', traceId: 'safe-trace-id', correlationReceipt: 'continuation-correlation.json' },
       review: { status: 'ready-for-human-review', pendingReceipts: [] },
     })}\n`);
     await writeFile(path.join(runDir, 'candidate-run-result.json'), `${JSON.stringify({
@@ -75,7 +76,7 @@ test('uses candidate-run-result.v1 as the unambiguous review input when present'
       candidate: { sha, docsRef: 'a'.repeat(40) },
       run: { id: 'k6-run-1', rowId: 'R-CW-1', seat: 'cael', scenario: 'r-cw-1' },
       result: { outcome: 'PASS-candidate', outcomeSource: 'k6-summary', effectiveExitCode: 0, behaviorProof: false },
-      observability: { traceStatus: 'present' },
+      observability: { traceStatus: 'present', traceCaptured: true, correlationReceiptPresent: true },
       review: { status: 'ready-for-human-review', pendingReceipts: [], complete: true },
     }, null, 2)}\n`);
     const out = path.join(root, 'report.html');
@@ -108,6 +109,41 @@ test('falls back to the sibling raw result when a sidecar is malformed or unsafe
     const run = spawnSync(process.execPath, [script, '--root', root, '--out', out], { encoding: 'utf8' });
     assert.equal(run.status, 0, run.stderr);
     const html = await readFile(out, 'utf8');
+    assert.match(html, /review-pending/);
+    assert.match(html, /tempo-trace-json: missing/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('falls back to raw trace debt when an identity-valid sidecar forges observability', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'k6-proof-envelope-observability-forgery-'));
+  try {
+    const runDir = path.join(root, 'candidate', 'R-CD-2', 'cael', 'k6-run-2');
+    const sha = 'b40e59f08c7a8997e50a5c8a24b00bc68f653882';
+    await mkdir(runDir, { recursive: true });
+    await writeFile(path.join(runDir, 'row-manifest.json'), `${JSON.stringify({
+      schema: 'openclaw.k6.proof-row-manifest.v1', rowId: 'R-CD-2', candidateSha: sha,
+      scenario: { name: 'r-cd-2' }, review: { candidateOnly: true, foldRequiresReview: true },
+    })}\n`);
+    await writeFile(path.join(runDir, 'runner-metadata.json'), `${JSON.stringify({ row: 'R-CD-2', candidateSha: sha, seat: 'cael', scenario: 'r-cd-2' })}\n`);
+    await writeFile(path.join(runDir, 'run-result.json'), `${JSON.stringify({
+      candidateOnly: true, foldRequiresReview: true, effectiveExitCode: 0, verdict: 'PASS-candidate', verdictSource: 'k6-summary',
+      observability: { traceStatus: 'missing', traceId: null, correlationReceipt: null },
+      review: { status: 'review-pending', pendingReceipts: ['tempo-trace-json'] },
+    })}\n`);
+    await writeFile(path.join(runDir, 'candidate-run-result.json'), `${JSON.stringify({
+      schema: 'openclaw.k6.candidate-run-result.v1', candidateOnly: true, foldRequiresReview: true, canonicalFoldForbidden: true,
+      candidate: { sha, docsRef: 'a'.repeat(40) }, run: { id: 'k6-run-2', rowId: 'R-CD-2', seat: 'cael', scenario: 'r-cd-2' },
+      result: { outcome: 'PASS-candidate', outcomeSource: 'k6-summary', effectiveExitCode: 0, behaviorProof: false },
+      observability: { traceStatus: 'present', traceCaptured: true, correlationReceiptPresent: true },
+      review: { status: 'ready-for-human-review', pendingReceipts: [], complete: true },
+    })}\n`);
+    const out = path.join(root, 'report.html');
+    const run = spawnSync(process.execPath, [script, '--root', root, '--out', out], { encoding: 'utf8' });
+    assert.equal(run.status, 0, run.stderr);
+    const html = await readFile(out, 'utf8');
+    assert.match(html, /trace-missing: 1/);
     assert.match(html, /review-pending/);
     assert.match(html, /tempo-trace-json: missing/);
   } finally {

--- a/tools/k6-proofs/scripts/__tests__/report-render.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/report-render.test.mjs
@@ -53,3 +53,29 @@ test('renders public-safe HTML report from row-list runner artifacts', async () 
     await rm(root, { recursive: true, force: true });
   }
 });
+
+test('uses candidate-run-result.v1 as the unambiguous review input when present', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'k6-proof-envelope-report-'));
+  try {
+    const runDir = path.join(root, 'candidate', 'R-CW-1', 'cael', 'k6-run-1');
+    await mkdir(runDir, { recursive: true });
+    await writeFile(path.join(runDir, 'run-result.json'), `${JSON.stringify({ review: { status: 'review-pending', pendingReceipts: ['tempo-trace-json'] } })}\n`);
+    await writeFile(path.join(runDir, 'candidate-run-result.json'), `${JSON.stringify({
+      schema: 'openclaw.k6.candidate-run-result.v1',
+      candidate: { sha: 'b40e59f08c7a8997e50a5c8a24b00bc68f653882' },
+      run: { rowId: 'R-CW-1', seat: 'cael', scenario: 'r-cw-1' },
+      result: { outcome: 'PASS-candidate', behaviorProof: false },
+      observability: { traceStatus: 'present' },
+      review: { status: 'ready-for-human-review', pendingReceipts: [], complete: true },
+    }, null, 2)}\n`);
+    const out = path.join(root, 'report.html');
+    const run = spawnSync(process.execPath, [script, '--root', root, '--out', out], { encoding: 'utf8' });
+    assert.equal(run.status, 0, run.stderr);
+    const html = await readFile(out, 'utf8');
+    assert.match(html, /R-CW-1/);
+    assert.match(html, /ready-for-human-review/);
+    assert.doesNotMatch(html, /<td>review-pending<\/td>/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/tools/k6-proofs/scripts/__tests__/review-debt.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/review-debt.test.mjs
@@ -32,12 +32,14 @@ async function writeValidatedEnvelopeFixture(root, row) {
   await writeFile(path.join(dir, 'runner-metadata.json'), `${JSON.stringify({ row, candidateSha: sha, seat: 'seat', scenario: 'r-cw-1' })}\n`);
   await writeResult(root, row, {
     candidateOnly: true, foldRequiresReview: true, effectiveExitCode: 0, verdict: 'PASS-candidate', verdictSource: 'k6-summary',
+    observability: { traceStatus: 'present', traceId: 'safe-trace-id', correlationReceipt: 'continuation-correlation.json' },
     review: { status: 'ready-for-human-review', pendingReceipts: [] },
   });
   await writeCandidateResult(root, row, {
     schema: 'openclaw.k6.candidate-run-result.v1', candidateOnly: true, foldRequiresReview: true, canonicalFoldForbidden: true,
     candidate: { sha, docsRef: 'b'.repeat(40) }, run: { id: `run-${row}`, rowId: row, seat: 'seat', scenario: 'r-cw-1' },
     result: { outcome: 'PASS-candidate', outcomeSource: 'k6-summary', effectiveExitCode: 0, behaviorProof: false },
+    observability: { traceStatus: 'present', traceCaptured: true, correlationReceiptPresent: true },
     review: { status: 'ready-for-human-review', pendingReceipts: [], complete: true },
   });
 }
@@ -123,6 +125,34 @@ test('never lets malformed, mismatched, incomplete, or hand-written envelopes su
     assert.equal(summary.totalRows, 4);
     assert.equal(summary.pendingRows, 4);
     assert.equal(summary.byClass['tempo-trace-unfetchable'], 4);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('falls back to raw review debt when an identity-valid sidecar forges trace observability', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'review-debt-envelope-observability-forgery-'));
+  try {
+    const row = 'R-CD-2';
+    await writeValidatedEnvelopeFixture(root, row);
+    const dir = path.join(root, 'candidate-sha', row, 'seat', `run-${row}`);
+    await writeResult(root, row, {
+      candidateOnly: true, foldRequiresReview: true, effectiveExitCode: 0, verdict: 'PASS-candidate', verdictSource: 'k6-summary',
+      observability: { traceStatus: 'missing', traceId: null, correlationReceipt: null },
+      review: { status: 'review-pending', pendingReceipts: ['tempo-trace-json'] },
+    });
+    await writeFile(path.join(dir, 'candidate-run-result.json'), `${JSON.stringify({
+      schema: 'openclaw.k6.candidate-run-result.v1', candidateOnly: true, foldRequiresReview: true, canonicalFoldForbidden: true,
+      candidate: { sha: 'a'.repeat(40), docsRef: 'b'.repeat(40) }, run: { id: `run-${row}`, rowId: row, seat: 'seat', scenario: 'r-cw-1' },
+      result: { outcome: 'PASS-candidate', outcomeSource: 'k6-summary', effectiveExitCode: 0, behaviorProof: false },
+      observability: { traceStatus: 'present', traceCaptured: true, correlationReceiptPresent: true },
+      review: { status: 'ready-for-human-review', pendingReceipts: [], complete: true },
+    }, null, 2)}\n`);
+    const run = await runNode(process.execPath, [script, '--run-root', root, '--json'], { encoding: 'utf8' });
+    const summary = JSON.parse(run.stdout);
+    assert.equal(summary.totalRows, 1);
+    assert.equal(summary.pendingRows, 1);
+    assert.equal(summary.byClass['tempo-trace-unfetchable'], 1);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/tools/k6-proofs/scripts/__tests__/review-debt.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/review-debt.test.mjs
@@ -15,6 +15,12 @@ async function writeResult(root, row, body) {
   await writeFile(path.join(dir, 'run-result.json'), `${JSON.stringify(body, null, 2)}\n`);
 }
 
+async function writeCandidateResult(root, row, body) {
+  const dir = path.join(root, 'candidate-sha', row, 'seat', `run-${row}`);
+  await mkdir(dir, { recursive: true });
+  await writeFile(path.join(dir, 'candidate-run-result.json'), `${JSON.stringify(body, null, 2)}\n`);
+}
+
 test('summarizes trace-missing debt as unfetchable when no trace id exists', async () => {
   const root = await mkdtemp(path.join(tmpdir(), 'review-debt-'));
   try {
@@ -59,6 +65,24 @@ test('renders human-readable review debt table', async () => {
     assert.match(run.stdout, /review-pending rows: 1/);
     assert.match(run.stdout, /tempo-trace-unfetchable: 1/);
     assert.match(run.stdout, /R-OBS-STATUS/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('consumes the versioned candidate envelope without double-counting its legacy run result', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'review-debt-envelope-'));
+  try {
+    await writeResult(root, 'R-CW-1', { review: { status: 'review-pending', pendingReceipts: ['tempo-trace-json'] } });
+    await writeCandidateResult(root, 'R-CW-1', {
+      schema: 'openclaw.k6.candidate-run-result.v1',
+      run: { rowId: 'R-CW-1' },
+      review: { status: 'ready-for-human-review', pendingReceipts: [], complete: true },
+    });
+    const run = await runNode(process.execPath, [script, '--run-root', root, '--json'], { encoding: 'utf8' });
+    const summary = JSON.parse(run.stdout);
+    assert.equal(summary.totalRows, 1);
+    assert.equal(summary.pendingRows, 0);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/tools/k6-proofs/scripts/__tests__/review-debt.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/review-debt.test.mjs
@@ -21,6 +21,27 @@ async function writeCandidateResult(root, row, body) {
   await writeFile(path.join(dir, 'candidate-run-result.json'), `${JSON.stringify(body, null, 2)}\n`);
 }
 
+async function writeValidatedEnvelopeFixture(root, row) {
+  const dir = path.join(root, 'candidate-sha', row, 'seat', `run-${row}`);
+  const sha = 'a'.repeat(40);
+  await mkdir(dir, { recursive: true });
+  await writeFile(path.join(dir, 'row-manifest.json'), `${JSON.stringify({
+    schema: 'openclaw.k6.proof-row-manifest.v1', rowId: row, candidateSha: sha,
+    scenario: { name: 'r-cw-1' }, review: { candidateOnly: true, foldRequiresReview: true },
+  })}\n`);
+  await writeFile(path.join(dir, 'runner-metadata.json'), `${JSON.stringify({ row, candidateSha: sha, seat: 'seat', scenario: 'r-cw-1' })}\n`);
+  await writeResult(root, row, {
+    candidateOnly: true, foldRequiresReview: true, effectiveExitCode: 0, verdict: 'PASS-candidate', verdictSource: 'k6-summary',
+    review: { status: 'ready-for-human-review', pendingReceipts: [] },
+  });
+  await writeCandidateResult(root, row, {
+    schema: 'openclaw.k6.candidate-run-result.v1', candidateOnly: true, foldRequiresReview: true, canonicalFoldForbidden: true,
+    candidate: { sha, docsRef: 'b'.repeat(40) }, run: { id: `run-${row}`, rowId: row, seat: 'seat', scenario: 'r-cw-1' },
+    result: { outcome: 'PASS-candidate', outcomeSource: 'k6-summary', effectiveExitCode: 0, behaviorProof: false },
+    review: { status: 'ready-for-human-review', pendingReceipts: [], complete: true },
+  });
+}
+
 test('summarizes trace-missing debt as unfetchable when no trace id exists', async () => {
   const root = await mkdtemp(path.join(tmpdir(), 'review-debt-'));
   try {
@@ -73,16 +94,35 @@ test('renders human-readable review debt table', async () => {
 test('consumes the versioned candidate envelope without double-counting its legacy run result', async () => {
   const root = await mkdtemp(path.join(tmpdir(), 'review-debt-envelope-'));
   try {
-    await writeResult(root, 'R-CW-1', { review: { status: 'review-pending', pendingReceipts: ['tempo-trace-json'] } });
-    await writeCandidateResult(root, 'R-CW-1', {
-      schema: 'openclaw.k6.candidate-run-result.v1',
-      run: { rowId: 'R-CW-1' },
-      review: { status: 'ready-for-human-review', pendingReceipts: [], complete: true },
-    });
+    await writeValidatedEnvelopeFixture(root, 'R-CW-1');
     const run = await runNode(process.execPath, [script, '--run-root', root, '--json'], { encoding: 'utf8' });
     const summary = JSON.parse(run.stdout);
     assert.equal(summary.totalRows, 1);
     assert.equal(summary.pendingRows, 0);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('never lets malformed, mismatched, incomplete, or hand-written envelopes suppress raw review debt', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'review-debt-envelope-reject-'));
+  try {
+    const cases = [
+      ['R-CW-1', '{not json'],
+      ['R-CW-2', JSON.stringify({ schema: 'openclaw.k6.candidate-run-result.v1', candidateOnly: true, foldRequiresReview: true, canonicalFoldForbidden: true, candidate: { sha: 'f'.repeat(40), docsRef: 'b'.repeat(40) } })],
+      ['R-CW-3', JSON.stringify({ schema: 'openclaw.k6.candidate-run-result.v1', candidateOnly: true, foldRequiresReview: true, canonicalFoldForbidden: true, review: { status: 'review-pending', pendingReceipts: ['tempo-trace-json'], complete: false } })],
+      ['R-CW-4', JSON.stringify({ schema: 'openclaw.k6.candidate-run-result.v1', candidateOnly: true, foldRequiresReview: true, canonicalFoldForbidden: true, result: { behaviorProof: true } })],
+    ];
+    for (const [row, sidecar] of cases) {
+      await writeResult(root, row, { candidateOnly: true, foldRequiresReview: true, review: { status: 'review-pending', pendingReceipts: ['tempo-trace-json'] } });
+      const dir = path.join(root, 'candidate-sha', row, 'seat', `run-${row}`);
+      await writeFile(path.join(dir, 'candidate-run-result.json'), `${sidecar}\n`);
+    }
+    const run = await runNode(process.execPath, [script, '--run-root', root, '--json'], { encoding: 'utf8' });
+    const summary = JSON.parse(run.stdout);
+    assert.equal(summary.totalRows, 4);
+    assert.equal(summary.pendingRows, 4);
+    assert.equal(summary.byClass['tempo-trace-unfetchable'], 4);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/tools/k6-proofs/scripts/candidate-run-result-contract.mjs
+++ b/tools/k6-proofs/scripts/candidate-run-result-contract.mjs
@@ -1,0 +1,43 @@
+import path from 'node:path';
+
+export const CANDIDATE_RUN_RESULT_SCHEMA = 'openclaw.k6.candidate-run-result.v1';
+export const PROOF_ROW_MANIFEST_SCHEMA = 'openclaw.k6.proof-row-manifest.v1';
+
+const SHA = /^[0-9a-f]{40}$/;
+const OUTCOMES = new Set(['PASS-candidate', 'HONEST-LIMIT-candidate', 'PARTIAL-candidate', 'FAIL-candidate', 'construct-only']);
+
+function nonEmptyString(value) {
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function scenarioName(manifest) {
+  return manifest?.scenario?.name || manifest?.scenario?.file?.replace(/\.js$/, '') || null;
+}
+
+// Consumers must use this before a sidecar can replace its sibling raw result.
+// It deliberately proves only candidate-review routing consistency, never a
+// canonical fold or behavioral PASS.
+export function candidateEnvelopeMatchesSiblings({ envelope, manifest, metadata, runResult, runDir }) {
+  if (!envelope || envelope.schema !== CANDIDATE_RUN_RESULT_SCHEMA) return false;
+  if (envelope.candidateOnly !== true || envelope.foldRequiresReview !== true || envelope.canonicalFoldForbidden !== true) return false;
+  if (envelope.result?.behaviorProof !== false || !OUTCOMES.has(envelope.result?.outcome)) return false;
+  if (envelope.result?.effectiveExitCode !== 0) return false;
+  if (envelope.review?.status !== 'ready-for-human-review' || envelope.review?.complete !== true || !Array.isArray(envelope.review?.pendingReceipts) || envelope.review.pendingReceipts.length !== 0) return false;
+
+  if (!manifest || manifest.schema !== PROOF_ROW_MANIFEST_SCHEMA || manifest.review?.candidateOnly !== true || manifest.review?.foldRequiresReview !== true) return false;
+  if (!metadata || !runResult || runResult.candidateOnly !== true || runResult.foldRequiresReview !== true) return false;
+  if (runResult.effectiveExitCode !== 0 || runResult.review?.status !== 'ready-for-human-review' || !Array.isArray(runResult.review?.pendingReceipts) || runResult.review.pendingReceipts.length !== 0) return false;
+
+  const rowId = nonEmptyString(metadata.row);
+  const candidateSha = nonEmptyString(metadata.candidateSha);
+  const seat = nonEmptyString(metadata.seat);
+  const scenario = nonEmptyString(metadata.scenario)?.replace(/\.js$/, '');
+  if (!rowId || !candidateSha || !seat || !scenario || !SHA.test(candidateSha)) return false;
+  if (manifest.rowId !== rowId || scenarioName(manifest) !== scenario) return false;
+  if (manifest.candidateSha && manifest.candidateSha !== candidateSha) return false;
+  if (envelope.candidate?.sha !== candidateSha || !SHA.test(envelope.candidate?.docsRef || '')) return false;
+  if (envelope.run?.id !== path.basename(runDir) || envelope.run?.rowId !== rowId || envelope.run?.seat !== seat || envelope.run?.scenario !== scenario) return false;
+  if (envelope.result?.outcome !== runResult.verdict || envelope.result?.outcomeSource !== runResult.verdictSource) return false;
+  if (manifest.liveRunSafety?.expectedArtifactClass === 'construct-only' && envelope.result.outcome !== 'construct-only') return false;
+  return true;
+}

--- a/tools/k6-proofs/scripts/candidate-run-result-contract.mjs
+++ b/tools/k6-proofs/scripts/candidate-run-result-contract.mjs
@@ -39,5 +39,10 @@ export function candidateEnvelopeMatchesSiblings({ envelope, manifest, metadata,
   if (envelope.run?.id !== path.basename(runDir) || envelope.run?.rowId !== rowId || envelope.run?.seat !== seat || envelope.run?.scenario !== scenario) return false;
   if (envelope.result?.outcome !== runResult.verdict || envelope.result?.outcomeSource !== runResult.verdictSource) return false;
   if (manifest.liveRunSafety?.expectedArtifactClass === 'construct-only' && envelope.result.outcome !== 'construct-only') return false;
+  const rawObservability = runResult.observability;
+  if (!rawObservability || typeof rawObservability.traceStatus !== 'string') return false;
+  if (envelope.observability?.traceStatus !== rawObservability.traceStatus) return false;
+  if (envelope.observability?.traceCaptured !== Boolean(rawObservability.traceId)) return false;
+  if (envelope.observability?.correlationReceiptPresent !== Boolean(rawObservability.correlationReceipt)) return false;
   return true;
 }

--- a/tools/k6-proofs/scripts/render-run-report.mjs
+++ b/tools/k6-proofs/scripts/render-run-report.mjs
@@ -140,6 +140,26 @@ async function rowFromRunResult(root, runResultPath) {
   };
 }
 
+async function rowFromCandidateEnvelope(root, envelopePath) {
+  const envelope = await readJson(envelopePath) || {};
+  if (envelope.schema !== 'openclaw.k6.candidate-run-result.v1') throw new Error(`unsupported candidate result schema: ${envelopePath}`);
+  const rel = path.relative(root, path.dirname(envelopePath)).split(path.sep).join('/');
+  return {
+    rowId: safeText(envelope.run?.rowId),
+    candidateSha: safeText(envelope.candidate?.sha),
+    seat: safeText(envelope.run?.seat),
+    scenario: safeText(envelope.run?.scenario),
+    outcome: safeText(envelope.result?.outcome),
+    reviewStatus: safeText(envelope.review?.status),
+    proofFailures: null,
+    durationMs: null,
+    checksRate: null,
+    traceStatus: safeText(envelope.observability?.traceStatus),
+    receipts: [],
+    rel,
+  };
+}
+
 function render(rows) {
   const generated = new Date().toISOString();
   const totals = rows.reduce((acc, row) => {
@@ -184,9 +204,14 @@ async function main() {
   if (args.help) { usage(); return; }
   if (!args.root) throw new Error('missing --root');
   const root = path.resolve(args.root);
+  const candidateFiles = await walk(root, 'candidate-run-result.json');
+  const candidateDirs = new Set(candidateFiles.map((file) => path.dirname(file)));
   const files = await walk(root, 'run-result.json');
   const rows = [];
-  for (const file of files.sort()) rows.push(await rowFromRunResult(root, file));
+  for (const file of candidateFiles.sort()) rows.push(await rowFromCandidateEnvelope(root, file));
+  for (const file of files.sort()) {
+    if (!candidateDirs.has(path.dirname(file))) rows.push(await rowFromRunResult(root, file));
+  }
   const html = render(rows);
   const out = args.out ? path.resolve(args.out) : path.join(root, 'report.html');
   await writeFile(out, html);

--- a/tools/k6-proofs/scripts/render-run-report.mjs
+++ b/tools/k6-proofs/scripts/render-run-report.mjs
@@ -11,6 +11,7 @@
  */
 import { readdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { candidateEnvelopeMatchesSiblings } from './candidate-run-result-contract.mjs';
 
 function usage() {
   console.error('Usage: node render-run-report.mjs --root <run-out-root> [--out report.html]');
@@ -142,7 +143,13 @@ async function rowFromRunResult(root, runResultPath) {
 
 async function rowFromCandidateEnvelope(root, envelopePath) {
   const envelope = await readJson(envelopePath) || {};
-  if (envelope.schema !== 'openclaw.k6.candidate-run-result.v1') throw new Error(`unsupported candidate result schema: ${envelopePath}`);
+  const runDir = path.dirname(envelopePath);
+  const [manifest, metadata, runResult] = await Promise.all([
+    readJson(path.join(runDir, 'row-manifest.json')),
+    readJson(path.join(runDir, 'runner-metadata.json')),
+    readJson(path.join(runDir, 'run-result.json')),
+  ]);
+  if (!candidateEnvelopeMatchesSiblings({ envelope, manifest, metadata, runResult, runDir })) return null;
   const rel = path.relative(root, path.dirname(envelopePath)).split(path.sep).join('/');
   return {
     rowId: safeText(envelope.run?.rowId),
@@ -204,13 +211,19 @@ async function main() {
   if (args.help) { usage(); return; }
   if (!args.root) throw new Error('missing --root');
   const root = path.resolve(args.root);
-  const candidateFiles = await walk(root, 'candidate-run-result.json');
-  const candidateDirs = new Set(candidateFiles.map((file) => path.dirname(file)));
-  const files = await walk(root, 'run-result.json');
+  const candidateFiles = (await walk(root, 'candidate-run-result.json')).sort();
+  const candidateRows = await Promise.all(candidateFiles.map((file) => rowFromCandidateEnvelope(root, file)));
+  const validCandidateDirs = new Set();
   const rows = [];
-  for (const file of candidateFiles.sort()) rows.push(await rowFromCandidateEnvelope(root, file));
+  for (let index = 0; index < candidateRows.length; index += 1) {
+    const row = candidateRows[index];
+    if (!row) continue;
+    validCandidateDirs.add(path.dirname(candidateFiles[index]));
+    rows.push(row);
+  }
+  const files = await walk(root, 'run-result.json');
   for (const file of files.sort()) {
-    if (!candidateDirs.has(path.dirname(file))) rows.push(await rowFromRunResult(root, file));
+    if (!validCandidateDirs.has(path.dirname(file))) rows.push(await rowFromRunResult(root, file));
   }
   const html = render(rows);
   const out = args.out ? path.resolve(args.out) : path.join(root, 'report.html');

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -13,6 +13,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EVIDENCE_EXTRACTOR="$SCRIPT_DIR/extract-k6-evidence.mjs"
 CONTINUATION_TRACE_COLLECTOR="$SCRIPT_DIR/collect-continuation-trace.mjs"
 ARTIFACT_SANITIZER="$SCRIPT_DIR/sanitize-k6-artifacts.mjs"
+CANDIDATE_RESULT_VALIDATOR="$SCRIPT_DIR/validate-candidate-run-result.mjs"
 PRIVATE_K6_LOG=""
 PRIVATE_EVIDENCE_FILE=""
 PRIVATE_GATEWAY_LOG=""
@@ -509,6 +510,24 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
       --argjson reviewPendingReceipts "$REVIEW_PENDING_RECEIPTS" \
       '{k6ExitCode:$rc, postprocessExitCode:$postprocessRc, effectiveExitCode:$effectiveRc, endedAt:$ended, verdict:(if $verdict == "unknown" then null else $verdict end), verdictSource:$verdictSource, summaryFileVerdict:(if $summaryFileVerdict == "unknown" then null else $summaryFileVerdict end), vuLogVerdict:(if $vuLogVerdict == "" then null else $vuLogVerdict end), summaryFiles:$summaryFiles, evidence:$evidence, candidateOnly:true, foldRequiresReview:true, observability:{traceStatus:$traceStatus, traceId:(if $traceId == "" then null else $traceId end), tempoTraceJson:(if $tempoTraceJson == "" then null else $tempoTraceJson end), correlationReceipt:(if $correlationReceipt == "" then null else $correlationReceipt end), serviceLogStatus:$serviceLogStatus, serviceLog:"gateway-journal.log", serviceLogCapture:"gateway-journal-capture.json", serviceLogRedaction:"gateway-journal-redaction.json"}, review:{status:(if ($reviewPendingReceipts|length)>0 then "review-pending" else "ready-for-human-review" end), pendingReceipts:$reviewPendingReceipts}}' \
       > "$RUN_DIR/run-result.json"
+    # A review-complete candidate can now receive a public-safe routing
+    # envelope. Review-pending runs intentionally remain represented only by
+    # run-result.json so review-debt can route their missing receipts; neither
+    # form is canonical proof or an automatic fold input.
+    DOCS_REF="$(git rev-parse HEAD 2>/dev/null || true)"
+    if [[ "$DOCS_REF" =~ ^[0-9a-f]{40}$ ]] && node "$CANDIDATE_RESULT_VALIDATOR" \
+      --manifest "$MANIFEST_FILE" \
+      --candidate-dir "$RUN_DIR" \
+      --docs-ref "$DOCS_REF" \
+      --out "$RUN_DIR/candidate-run-result.json" \
+      > "$RUN_DIR/candidate-run-result-validation.json" \
+      2> "$RUN_DIR/candidate-run-result-validation.error.log"; then
+      rm -f "$RUN_DIR/candidate-run-result-validation.error.log"
+      echo "[$ROW_ID] CANDIDATE REVIEW ENVELOPE: $RUN_DIR/candidate-run-result.json"
+    else
+      rm -f "$RUN_DIR/candidate-run-result.json"
+      echo "[$ROW_ID] Candidate routing envelope withheld: review is incomplete or its identity contract did not validate." >&2
+    fi
     METRICS_ARGS=(--run-dir "$RUN_DIR" --prometheus-out "$RUN_DIR/openclaw-proofs-k6.prom" --otlp-out "$RUN_DIR/openclaw-proofs-k6.otlp.json")
     if [[ -n "${OPENCLAW_PROOFS_K6_OTLP_ENDPOINT:-}" ]]; then
       METRICS_ARGS+=(--push-otlp "$OPENCLAW_PROOFS_K6_OTLP_ENDPOINT")

--- a/tools/k6-proofs/scripts/summarize-review-debt.mjs
+++ b/tools/k6-proofs/scripts/summarize-review-debt.mjs
@@ -18,11 +18,11 @@ function parseArgs(argv) {
   return args;
 }
 
-async function walk(dir, out = []) {
+async function walk(dir, names, out = []) {
   for (const entry of await readdir(dir, { withFileTypes: true })) {
     const p = path.join(dir, entry.name);
-    if (entry.isDirectory()) await walk(p, out);
-    else if (entry.isFile() && entry.name === 'run-result.json') out.push(p);
+    if (entry.isDirectory()) await walk(p, names, out);
+    else if (entry.isFile() && names.has(entry.name)) out.push(p);
   }
   return out;
 }
@@ -55,9 +55,25 @@ function classifyPending(row, receipt) {
 }
 
 async function loadRows(root) {
-  const files = await walk(root);
+  const candidateFiles = await walk(root, new Set(['candidate-run-result.json']));
+  const candidateDirs = new Set(candidateFiles.map((file) => path.dirname(file)));
+  const files = await walk(root, new Set(['run-result.json']));
   const rows = [];
+  for (const file of candidateFiles.sort()) {
+    const raw = JSON.parse(await readFile(file, 'utf8'));
+    if (raw.schema !== 'openclaw.k6.candidate-run-result.v1') throw new Error(`unsupported candidate result schema: ${file}`);
+    const pendingReceipts = asArray(raw.review?.pendingReceipts);
+    rows.push({
+      rowId: raw.run?.rowId || rowFromPath(file) || 'unknown-row',
+      file: path.relative(root, file),
+      reviewStatus: raw.review?.status || 'unknown',
+      pendingReceipts,
+      traceId: null,
+      pending: pendingReceipts.map((receipt) => classifyPending({ traceId: null }, receipt)),
+    });
+  }
   for (const file of files.sort()) {
+    if (candidateDirs.has(path.dirname(file))) continue;
     const raw = JSON.parse(await readFile(file, 'utf8'));
     const pendingReceipts = asArray(raw.review?.pendingReceipts);
     const rowId = raw.rowId || raw.row || rowFromPath(file) || 'unknown-row';

--- a/tools/k6-proofs/scripts/summarize-review-debt.mjs
+++ b/tools/k6-proofs/scripts/summarize-review-debt.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { readdir, readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
+import { candidateEnvelopeMatchesSiblings } from './candidate-run-result-contract.mjs';
 
 function usage() {
   return `Usage: node tools/k6-proofs/scripts/summarize-review-debt.mjs --run-root <candidate-run-dir> [--json]\n\nScans row run-result.json files and summarizes review-pending receipts.\nFor tempo-trace-json debt, distinguishes fetchable trace ids from trace-missing rows where no Tempo fetch can be attempted.\n`;
@@ -39,6 +40,10 @@ function asArray(value) {
   return Array.isArray(value) ? value : [];
 }
 
+async function readJson(file) {
+  return JSON.parse(await readFile(file, 'utf8'));
+}
+
 function classifyPending(row, receipt) {
   if (receipt !== 'tempo-trace-json') return { receipt, class: 'manual-review', fetchable: null, action: 'supply-or-accept-review-receipt' };
   const traceId = row.traceId || null;
@@ -56,12 +61,25 @@ function classifyPending(row, receipt) {
 
 async function loadRows(root) {
   const candidateFiles = await walk(root, new Set(['candidate-run-result.json']));
-  const candidateDirs = new Set(candidateFiles.map((file) => path.dirname(file)));
   const files = await walk(root, new Set(['run-result.json']));
   const rows = [];
   for (const file of candidateFiles.sort()) {
-    const raw = JSON.parse(await readFile(file, 'utf8'));
-    if (raw.schema !== 'openclaw.k6.candidate-run-result.v1') throw new Error(`unsupported candidate result schema: ${file}`);
+    const dir = path.dirname(file);
+    let raw;
+    let manifest;
+    let metadata;
+    let runResult;
+    try {
+      [raw, manifest, metadata, runResult] = await Promise.all([
+        readJson(file),
+        readJson(path.join(dir, 'row-manifest.json')),
+        readJson(path.join(dir, 'runner-metadata.json')),
+        readJson(path.join(dir, 'run-result.json')),
+      ]);
+    } catch {
+      continue;
+    }
+    if (!candidateEnvelopeMatchesSiblings({ envelope: raw, manifest, metadata, runResult, runDir: dir })) continue;
     const pendingReceipts = asArray(raw.review?.pendingReceipts);
     rows.push({
       rowId: raw.run?.rowId || rowFromPath(file) || 'unknown-row',
@@ -73,8 +91,14 @@ async function loadRows(root) {
     });
   }
   for (const file of files.sort()) {
-    if (candidateDirs.has(path.dirname(file))) continue;
-    const raw = JSON.parse(await readFile(file, 'utf8'));
+    const dir = path.dirname(file);
+    const candidate = await readJson(path.join(dir, 'candidate-run-result.json')).catch(() => null);
+    const [manifest, metadata, raw] = await Promise.all([
+      readJson(path.join(dir, 'row-manifest.json')).catch(() => null),
+      readJson(path.join(dir, 'runner-metadata.json')).catch(() => null),
+      readJson(file),
+    ]);
+    if (candidateEnvelopeMatchesSiblings({ envelope: candidate, manifest, metadata, runResult: raw, runDir: dir })) continue;
     const pendingReceipts = asArray(raw.review?.pendingReceipts);
     const rowId = raw.rowId || raw.row || rowFromPath(file) || 'unknown-row';
     const traceId = raw.observability?.traceId || raw.traceId || null;

--- a/tools/k6-proofs/scripts/validate-candidate-run-result.mjs
+++ b/tools/k6-proofs/scripts/validate-candidate-run-result.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * Validate one candidate run directory and emit its public-safe routing
+ * envelope. This is deliberately a candidate-only boundary: it reads a row
+ * manifest plus one candidate directory and can write only inside that
+ * candidate directory. It never reads or changes canonical PROOFS manifests.
+ */
+import { readFile, writeFile, readdir, realpath } from 'node:fs/promises';
+import path from 'node:path';
+
+const SHA = /^[0-9a-f]{40}$/;
+const OUTCOME = new Set(['PASS-candidate', 'HONEST-LIMIT-candidate', 'PARTIAL-candidate', 'FAIL-candidate', 'construct-only']);
+
+function usage() {
+  console.error('Usage: node validate-candidate-run-result.mjs --manifest <row-manifest.json> --candidate-dir <run-dir> --docs-ref <40-char-sha> [--out <candidate-run-result.json>] [--json]');
+}
+
+function parseArgs(argv) {
+  const args = { json: false };
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--json') { args.json = true; continue; }
+    if (arg === '--help' || arg === '-h') { args.help = true; continue; }
+    if (!['--manifest', '--candidate-dir', '--docs-ref', '--out'].includes(arg)) throw new Error(`unexpected argument: ${arg}`);
+    const value = argv[i + 1];
+    if (!value || value.startsWith('--')) throw new Error(`missing value for ${arg}`);
+    args[arg.slice(2).replaceAll('-', '')] = value;
+    i += 1;
+  }
+  return args;
+}
+
+async function readJson(file, label) {
+  let raw;
+  try { raw = await readFile(file, 'utf8'); }
+  catch (error) { throw new Error(`${label} missing or unreadable: ${error.message}`); }
+  try { return JSON.parse(raw); }
+  catch (error) { throw new Error(`${label} is malformed JSON: ${error.message}`); }
+}
+
+function requireString(value, label) {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${label} must be a non-empty string`);
+  return value;
+}
+
+function requireSha(value, label) {
+  if (!SHA.test(value || '')) throw new Error(`${label} must be a 40-character lowercase SHA`);
+  return value;
+}
+
+function safeRelative(value, label) {
+  if (value == null) return null;
+  if (typeof value !== 'string' || !value || path.isAbsolute(value) || value.split(/[\\/]+/).some((part) => part === '..')) {
+    throw new Error(`${label} must be a safe artifact-relative path`);
+  }
+  return value.replaceAll('\\', '/');
+}
+
+function same(value, expected, label) {
+  if (value !== expected) throw new Error(`${label} mismatch: ${JSON.stringify(value)} != ${JSON.stringify(expected)}`);
+}
+
+function scenarioName(manifest) {
+  return manifest?.scenario?.name || manifest?.scenario?.file?.replace(/\.js$/, '') || null;
+}
+
+function manifestCandidateSha(manifest) {
+  const value = manifest?.candidateSha;
+  return SHA.test(value || '') ? value : null;
+}
+
+async function listSafeArtifacts(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const allowed = new Set([
+    'row-manifest.json', 'runner-metadata.json', 'run-result.json',
+    'candidate-run-result.json', 'seat-readiness.json', 'evidence.jsonl',
+    'evidence-lines.log', 'evidence-redaction.json', 'gateway-journal.log',
+    'gateway-journal-capture.json', 'gateway-journal-redaction.json',
+  ]);
+  return entries
+    .filter((entry) => entry.isFile() && (allowed.has(entry.name) || /(?:^|-)summary\.json$/i.test(entry.name)))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) { usage(); return; }
+  if (!args.manifest || !args.candidatedir || !args.docsref) { usage(); throw new Error('manifest, candidate-dir, and docs-ref are required'); }
+  const docsRef = requireSha(args.docsref, 'docs-ref');
+  const manifestPath = path.resolve(args.manifest);
+  const candidateDir = await realpath(args.candidatedir).catch(() => { throw new Error(`candidate directory does not exist: ${args.candidatedir}`); });
+  const manifest = await readJson(manifestPath, 'manifest');
+  const metadata = await readJson(path.join(candidateDir, 'runner-metadata.json'), 'runner metadata');
+  const runResult = await readJson(path.join(candidateDir, 'run-result.json'), 'run result');
+
+  same(manifest.schema, 'openclaw.k6.proof-row-manifest.v1', 'manifest schema');
+  if (manifest.review?.candidateOnly !== true || manifest.review?.foldRequiresReview !== true) throw new Error('manifest must remain candidateOnly and require human fold review');
+  if (runResult.candidateOnly !== true || runResult.foldRequiresReview !== true) throw new Error('run result must remain candidateOnly and require human fold review');
+  const rowId = requireString(metadata.row, 'runner metadata row');
+  const candidateSha = requireSha(metadata.candidateSha, 'runner metadata candidateSha');
+  const seat = requireString(metadata.seat, 'runner metadata seat');
+  const scenario = requireString(metadata.scenario, 'runner metadata scenario').replace(/\.js$/, '');
+  same(rowId, manifest.rowId, 'row ID');
+  same(scenario, scenarioName(manifest), 'scenario');
+  const declaredSha = manifestCandidateSha(manifest);
+  if (declaredSha) same(candidateSha, declaredSha, 'candidate SHA');
+
+  const verdict = runResult.verdict;
+  if (!OUTCOME.has(verdict)) throw new Error('run result verdict must be an explicit candidate outcome');
+  const expectedArtifactClass = manifest.liveRunSafety?.expectedArtifactClass;
+  if (expectedArtifactClass === 'construct-only' && verdict !== 'construct-only') throw new Error('construct-only manifest cannot emit behavioral candidate evidence');
+  if (runResult.effectiveExitCode !== 0) throw new Error('candidate run is incomplete: effective exit code is non-zero');
+  const review = runResult.review;
+  if (review?.status !== 'ready-for-human-review' || !Array.isArray(review.pendingReceipts) || review.pendingReceipts.length !== 0) {
+    throw new Error('candidate run is review-incomplete: resolve or explicitly classify pending receipts first');
+  }
+
+  const observability = runResult.observability || {};
+  const artifacts = {
+    manifest: 'row-manifest.json',
+    runnerMetadata: 'runner-metadata.json',
+    runResult: 'run-result.json',
+    files: await listSafeArtifacts(candidateDir),
+    tempoTraceJson: safeRelative(observability.tempoTraceJson, 'tempo trace artifact'),
+    correlationReceipt: safeRelative(observability.correlationReceipt, 'correlation receipt artifact'),
+  };
+  const envelope = {
+    schema: 'openclaw.k6.candidate-run-result.v1',
+    candidateOnly: true,
+    foldRequiresReview: true,
+    canonicalFoldForbidden: true,
+    candidate: { sha: candidateSha, docsRef },
+    run: {
+      id: path.basename(candidateDir),
+      rowId,
+      seat,
+      scenario,
+      executionKind: 'row-list-runner',
+    },
+    result: {
+      outcome: verdict,
+      outcomeSource: requireString(runResult.verdictSource, 'run result verdictSource'),
+      effectiveExitCode: runResult.effectiveExitCode,
+      behaviorProof: false,
+    },
+    observability: {
+      traceStatus: requireString(observability.traceStatus, 'observability traceStatus'),
+      traceCaptured: Boolean(observability.traceId),
+      correlationReceiptPresent: Boolean(observability.correlationReceipt),
+    },
+    review: { status: review.status, pendingReceipts: [], complete: true },
+    artifacts,
+  };
+
+  if (args.out) {
+    const outPath = path.resolve(args.out);
+    if (path.dirname(outPath) !== candidateDir || path.basename(outPath) !== 'candidate-run-result.json') {
+      throw new Error('output must be candidate-run-result.json directly inside the candidate directory');
+    }
+    await writeFile(outPath, `${JSON.stringify(envelope, null, 2)}\n`);
+  }
+  process.stdout.write(`${JSON.stringify(envelope, null, 2)}\n`);
+}
+
+main().catch((error) => {
+  console.error(error.message || error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Implements the authorized #106 candidate-result seam.\n\n- Adds public-safe `openclaw.k6.candidate-run-result.v1` validation/emission for review-complete row-list runs.\n- Rejects malformed, identity-mismatched, review-incomplete, and out-of-directory envelopes.\n- Lets report/debt tools prefer the normalized candidate envelope while canonical corpus validation remains blind to it.\n\nNo live run, config/restart/session activity, canonical fold, generated proof publication, or #331/#398/#416/P84 change.\n\nValidation: `node --test tools/k6-proofs/scripts/__tests__/*.test.mjs` (108/108), manifest/alignment checks, `validate-corpus --index`, `bash -n`, and `git diff --check`.