### PR TITLE
proofs: bind R-CD-MODEL-TOOL child receipt to row nonce

### DIFF
--- a/tools/k6-proofs/lib/row-child-correlation.mjs
+++ b/tools/k6-proofs/lib/row-child-correlation.mjs
@@ -1,12 +1,41 @@
+function directStringValues(record) {
+  return Object.values(record).flatMap((value) => {
+    if (typeof value === 'string') return [value];
+    if (Array.isArray(value) && value.every((entry) => typeof entry === 'string')) return value;
+    return [];
+  });
+}
+
+function childKeyBoundToNonce(record, rowNonce) {
+  if (!record || typeof record !== 'object' || Array.isArray(record)) return null;
+  const childSessionKey = typeof record.childSessionKey === 'string' ? record.childSessionKey : null;
+  if (!childSessionKey) return null;
+  return directStringValues(record).some((value) => value.includes(rowNonce)) ? childSessionKey : null;
+}
+
 /**
- * Return a spawned child key only when its event belongs to the proof row.
+ * Return a spawned child key only when the same structured record binds that
+ * key to the proof-row nonce.
  *
- * Gateway subscriptions can contain events from earlier proof work. Requiring
- * the row nonce prevents a stale child session from satisfying a later row's
- * persisted-model receipt.
+ * Gateway subscriptions can contain aggregate events from earlier proof work.
+ * A nonce anywhere in the outer event is not enough: a stale top-level child
+ * key plus an unrelated nested task for the current row must fail closed.
  */
 export function childSessionKeyForRow(eventData, rowNonce) {
-  const event = eventData || {};
-  if (!JSON.stringify(event).includes(rowNonce)) return null;
-  return event.childSessionKey || event.task?.childSessionKey || event.session?.childSessionKey || null;
+  if (!rowNonce || typeof rowNonce !== 'string') return null;
+  const matches = new Set();
+  const seen = new Set();
+
+  function visit(value) {
+    if (!value || typeof value !== 'object' || seen.has(value)) return;
+    seen.add(value);
+    if (!Array.isArray(value)) {
+      const match = childKeyBoundToNonce(value, rowNonce);
+      if (match) matches.add(match);
+    }
+    for (const child of Object.values(value)) visit(child);
+  }
+
+  visit(eventData);
+  return matches.size === 1 ? [...matches][0] : null;
 }

--- a/tools/k6-proofs/lib/row-child-correlation.mjs
+++ b/tools/k6-proofs/lib/row-child-correlation.mjs
@@ -1,0 +1,12 @@
+/**
+ * Return a spawned child key only when its event belongs to the proof row.
+ *
+ * Gateway subscriptions can contain events from earlier proof work. Requiring
+ * the row nonce prevents a stale child session from satisfying a later row's
+ * persisted-model receipt.
+ */
+export function childSessionKeyForRow(eventData, rowNonce) {
+  const event = eventData || {};
+  if (!JSON.stringify(event).includes(rowNonce)) return null;
+  return event.childSessionKey || event.task?.childSessionKey || event.session?.childSessionKey || null;
+}

--- a/tools/k6-proofs/scenarios/r-cd-model-tool.js
+++ b/tools/k6-proofs/scenarios/r-cd-model-tool.js
@@ -4,6 +4,7 @@ import { check } from 'k6';
 import { Counter, Trend } from 'k6/metrics';
 import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+import { childSessionKeyForRow } from '../lib/row-child-correlation.mjs';
 
 export const options = {
   scenarios: { r_cd_model_tool: { executor: 'shared-iterations', vus: 1, iterations: 1, maxDuration: '210s' } },
@@ -167,7 +168,8 @@ export default function() {
         if (classified.kind === 'event') {
           const eventData = classified.data || {}; const eventStr = JSON.stringify(eventData);
           if (eventData.traceId) evidence.trace_id = eventData.traceId;
-          const observedChildSessionKey = eventData.childSessionKey || eventData.task?.childSessionKey || eventData.session?.childSessionKey;
+          const eventBelongsToRow = eventStr.includes(rowNonce);
+          const observedChildSessionKey = childSessionKeyForRow(eventData, rowNonce);
           if (observedChildSessionKey) {
             evidence.child_session_observed = true;
             evidence.child_session_key = observedChildSessionKey;
@@ -176,7 +178,7 @@ export default function() {
               socket.setTimeout(() => tracker.send(socket, 'sessions.list', { limit: 100 }), 500);
             }
           }
-          if (eventStr.includes(rowNonce) && !eventStr.includes(HARNESS_MARKER)) {
+          if (eventBelongsToRow && !eventStr.includes(HARNESS_MARKER)) {
             if (eventStr.includes('MODEL-TOOL-PARENT-SCHEDULED')) {
               evidence.parent_scheduled_sentinel = true;
               console.log('✓ parent scheduled sentinel observed');

--- a/tools/k6-proofs/tests/row-child-correlation.test.mjs
+++ b/tools/k6-proofs/tests/row-child-correlation.test.mjs
@@ -21,3 +21,57 @@ test('accepts only the child key from the current row nonce', () => {
 
   assert.equal(childSessionKeyForRow(rowEvent, 'R-CD-MODEL-TOOL-new'), 'luna-child-for-current-row');
 });
+
+test('rejects a stale outer child key paired with an unrelated nested current-row task', () => {
+  const mixedEvent = {
+    childSessionKey: 'terra-child-from-earlier-row',
+    task: {
+      text: 'Proof nonce R-CD-MODEL-TOOL-new',
+    },
+  };
+
+  assert.equal(childSessionKeyForRow(mixedEvent, 'R-CD-MODEL-TOOL-new'), null);
+});
+
+test('accepts a direct spawn record that binds its child key and task nonce', () => {
+  const spawnEvent = {
+    childSessionKey: 'luna-child-for-current-row',
+    task: 'Proof nonce R-CD-MODEL-TOOL-new',
+  };
+
+  assert.equal(childSessionKeyForRow(spawnEvent, 'R-CD-MODEL-TOOL-new'), 'luna-child-for-current-row');
+});
+
+test('selects the one nested record whose own payload carries the current nonce', () => {
+  const aggregateEvent = {
+    records: [
+      {
+        childSessionKey: 'terra-child-from-earlier-row',
+        task: 'Proof nonce R-CD-MODEL-TOKEN-old',
+      },
+      {
+        childSessionKey: 'luna-child-for-current-row',
+        task: 'Proof nonce R-CD-MODEL-TOOL-new',
+      },
+    ],
+  };
+
+  assert.equal(childSessionKeyForRow(aggregateEvent, 'R-CD-MODEL-TOOL-new'), 'luna-child-for-current-row');
+});
+
+test('fails closed when two different child keys are both bound to the row nonce', () => {
+  const ambiguousEvent = {
+    records: [
+      {
+        childSessionKey: 'luna-child-a',
+        task: 'Proof nonce R-CD-MODEL-TOOL-new',
+      },
+      {
+        childSessionKey: 'luna-child-b',
+        task: 'Proof nonce R-CD-MODEL-TOOL-new',
+      },
+    ],
+  };
+
+  assert.equal(childSessionKeyForRow(ambiguousEvent, 'R-CD-MODEL-TOOL-new'), null);
+});

--- a/tools/k6-proofs/tests/row-child-correlation.test.mjs
+++ b/tools/k6-proofs/tests/row-child-correlation.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { childSessionKeyForRow } from '../lib/row-child-correlation.mjs';
+
+test('rejects an earlier row child even when its event carries a child key', () => {
+  const staleEvent = {
+    childSessionKey: 'terra-child-from-r-cd-model-token',
+    task: { text: 'Proof nonce R-CD-MODEL-TOKEN-old' },
+  };
+
+  assert.equal(childSessionKeyForRow(staleEvent, 'R-CD-MODEL-TOOL-new'), null);
+});
+
+test('accepts only the child key from the current row nonce', () => {
+  const rowEvent = {
+    task: {
+      childSessionKey: 'luna-child-for-current-row',
+      text: 'Proof nonce R-CD-MODEL-TOOL-new',
+    },
+  };
+
+  assert.equal(childSessionKeyForRow(rowEvent, 'R-CD-MODEL-TOOL-new'), 'luna-child-for-current-row');
+});


### PR DESCRIPTION
Addresses #423

Manual exact-SHA validation on `6ee7eca2a4ce1a3e8efa7e51f9dd02d03081741d` proved `continue_delegate(model="openai/gpt-5.6-luna")` persists that model to the row’s own disposable child. The old Terra mismatch was cross-row harness contamination.

This patch gates child-key capture on the row nonce and adds a regression test that rejects a stale Terra-child event while accepting the current Luna-child event.

Verification:
- `node --test tools/k6-proofs/tests/row-child-correlation.test.mjs`
- patched isolated live `R-CD-MODEL-TOOL` run: PASS-candidate; persisted child metadata `openai/gpt-5.6-luna`
- GitNexus exact-candidate index: 558,999 nodes / 1,101,309 edges; trace confirms delegate model forwarding into subagent model resolution and child runtime-model persistence.
