### PR TITLE
proofs: add isolated R-CW-5 cost-cap fixture

### DIFF
--- a/PROOFS/6ee7eca2a4ce1a3e8efa7e51f9dd02d03081741d/R-CW-5/REMEDIATION.md
+++ b/PROOFS/6ee7eca2a4ce1a3e8efa7e51f9dd02d03081741d/R-CW-5/REMEDIATION.md
@@ -1,7 +1,7 @@
 # R-CW-5 remediation receipt — 2026-07-17
 
 - **Candidate:** `6ee7eca2a4ce1a3e8efa7e51f9dd02d03081741d`
-- **Harness change:** docs PR #430 (`92192a712856a056f996a53706868b6d7fa007fe`)
+- **Harness change:** docs PR #430 (`cd7946259c2f97bfb1aa406f9f3da23d4868d3aa`)
 - **Result:** `PASS-candidate` for the isolated typed-tool boundary fixture
 - **Canonical state:** remains `missing` until PR review and an explicit corpus disposition; this receipt does not rewrite the original skipped live run.
 
@@ -12,7 +12,7 @@ The fixture was run from a clean checkout of PR #430 against the exact candidate
 ```text
 node --test tools/k6-proofs/scripts/__tests__/cost-cap-fixture.test.mjs \
   tools/k6-proofs/scripts/__tests__/live-run-guard.test.mjs
-# 9 passed, 0 failed
+# 11 passed, 0 failed
 
 node tools/k6-proofs/scripts/run-cost-cap-fixture.mjs \
   --source-dir <exact-6ee7eca-source> \
@@ -20,6 +20,13 @@ node tools/k6-proofs/scripts/run-cost-cap-fixture.mjs \
   --artifact-dir <temporary-artifact-dir> --cap 100 --json
 # PASS-candidate
 ```
+
+Before executing the production-module matrix and before emitting the final
+cleanup/result receipts, the fixture requires an empty
+`git status --porcelain --untracked-files=no` for the exact candidate source.
+Its regression creates both unstaged and staged edits to a tracked scheduler
+file and proves each is rejected. A matching `HEAD` alone is therefore not
+enough to certify the candidate.
 
 The fixture's required receipt set was complete:
 

--- a/PROOFS/6ee7eca2a4ce1a3e8efa7e51f9dd02d03081741d/R-CW-5/REMEDIATION.md
+++ b/PROOFS/6ee7eca2a4ce1a3e8efa7e51f9dd02d03081741d/R-CW-5/REMEDIATION.md
@@ -1,24 +1,32 @@
 # R-CW-5 remediation receipt — 2026-07-17
 
 - **Candidate:** `6ee7eca2a4ce1a3e8efa7e51f9dd02d03081741d`
-- **Harness change:** docs PR #430 (`77e84659f8e9be9a31469745c43bc36934d2c64d`)
-- **Result:** `PASS-candidate` for the isolated typed-tool boundary fixture
+- **Harness change:** docs PR #430 (pending independent rereview)
+- **Result:** reported local `PASS-candidate` for the isolated typed-tool boundary fixture; this document is not itself a canonical corpus receipt
 - **Canonical state:** remains `missing` until PR review and an explicit corpus disposition; this receipt does not rewrite the original skipped live run.
 
 ## Fresh clean rerun
 
-The fixture was rerun from the clean harness head
-`77e84659f8e9be9a31469745c43bc36934d2c64d` against the exact candidate.
+The fixture was rerun from the clean PR worktree against the exact candidate.
+The final receipt-producing command must be rerun after the PR head is independently
+approved; the local results below are reported evidence, not a corpus fold.
 
 ```text
 node --test tools/k6-proofs/scripts/__tests__/cost-cap-fixture.test.mjs \
   tools/k6-proofs/scripts/__tests__/live-run-guard.test.mjs
-# 11 passed, 0 failed
+# 122 passed, 0 failed (full proof script suite)
 
 node tools/k6-proofs/scripts/run-cost-cap-fixture.mjs \
   --source-dir <exact-6ee7eca-source> \
   --candidate-sha 6ee7eca2a4ce1a3e8efa7e51f9dd02d03081741d \
   --artifact-dir <temporary-artifact-dir> --cap 100 --json
+# PASS-candidate
+
+# non-default-cap regression: the typed surface receives the same cap
+node tools/k6-proofs/scripts/run-cost-cap-fixture.mjs \
+  --source-dir <exact-6ee7eca-source> \
+  --candidate-sha 6ee7eca2a4ce1a3e8efa7e51f9dd02d03081741d \
+  --artifact-dir <temporary-artifact-dir> --cap 200 --json
 # PASS-candidate
 ```
 
@@ -31,12 +39,17 @@ enough to certify the candidate.
 
 The artifact destination is also fail-closed: it rejects an existing receipt,
 an unsafe final directory, and every existing symlink component in its ancestor
-path. The fresh rerun used a new private artifact directory; its readiness
-receipt recorded the exact candidate SHA and no production config/state change.
+path. Public readiness contains only the candidate identity/match booleans,
+tracked-clean status, cap, and no-production-mutation booleans; it never stores
+the private absolute source path. The fixture reuses only a real (non-symlinked)
+pre-existing dependency directory and performs no install. This proves the
+tracked candidate source and the stated local dependency condition, not a
+cryptographically locked dependency provenance claim.
 
 The fixture's required receipt set was complete:
 
-- budget matrix: `99 => allow`, `100 => allow`, `101 => cost-capped`;
+- budget matrix: `<cap - 1> => allow`, `<cap> => allow`, `<cap + 1> => cost-capped`
+  (reported runs covered both `99/100/101` and `199/200/201`);
 - real dispatcher boundary suite: over-cap spawn rejected and the flow marked failed;
 - typed `continue_work` capture: two exhausted elections created zero durable continuation work;
 - cleanup: no production config, gateway state, or candidate-source mutation, and the disposable worktree was removed.

--- a/PROOFS/6ee7eca2a4ce1a3e8efa7e51f9dd02d03081741d/R-CW-5/REMEDIATION.md
+++ b/PROOFS/6ee7eca2a4ce1a3e8efa7e51f9dd02d03081741d/R-CW-5/REMEDIATION.md
@@ -1,13 +1,14 @@
 # R-CW-5 remediation receipt — 2026-07-17
 
 - **Candidate:** `6ee7eca2a4ce1a3e8efa7e51f9dd02d03081741d`
-- **Harness change:** docs PR #430 (`cd7946259c2f97bfb1aa406f9f3da23d4868d3aa`)
+- **Harness change:** docs PR #430 (`77e84659f8e9be9a31469745c43bc36934d2c64d`)
 - **Result:** `PASS-candidate` for the isolated typed-tool boundary fixture
 - **Canonical state:** remains `missing` until PR review and an explicit corpus disposition; this receipt does not rewrite the original skipped live run.
 
 ## Fresh clean rerun
 
-The fixture was run from a clean checkout of PR #430 against the exact candidate.
+The fixture was rerun from the clean harness head
+`77e84659f8e9be9a31469745c43bc36934d2c64d` against the exact candidate.
 
 ```text
 node --test tools/k6-proofs/scripts/__tests__/cost-cap-fixture.test.mjs \
@@ -27,6 +28,11 @@ cleanup/result receipts, the fixture requires an empty
 Its regression creates both unstaged and staged edits to a tracked scheduler
 file and proves each is rejected. A matching `HEAD` alone is therefore not
 enough to certify the candidate.
+
+The artifact destination is also fail-closed: it rejects an existing receipt,
+an unsafe final directory, and every existing symlink component in its ancestor
+path. The fresh rerun used a new private artifact directory; its readiness
+receipt recorded the exact candidate SHA and no production config/state change.
 
 The fixture's required receipt set was complete:
 

--- a/PROOFS/6ee7eca2a4ce1a3e8efa7e51f9dd02d03081741d/R-CW-5/REMEDIATION.md
+++ b/PROOFS/6ee7eca2a4ce1a3e8efa7e51f9dd02d03081741d/R-CW-5/REMEDIATION.md
@@ -1,0 +1,35 @@
+# R-CW-5 remediation receipt — 2026-07-17
+
+- **Candidate:** `6ee7eca2a4ce1a3e8efa7e51f9dd02d03081741d`
+- **Harness change:** docs PR #430 (`92192a712856a056f996a53706868b6d7fa007fe`)
+- **Result:** `PASS-candidate` for the isolated typed-tool boundary fixture
+- **Canonical state:** remains `missing` until PR review and an explicit corpus disposition; this receipt does not rewrite the original skipped live run.
+
+## Fresh clean rerun
+
+The fixture was run from a clean checkout of PR #430 against the exact candidate.
+
+```text
+node --test tools/k6-proofs/scripts/__tests__/cost-cap-fixture.test.mjs \
+  tools/k6-proofs/scripts/__tests__/live-run-guard.test.mjs
+# 9 passed, 0 failed
+
+node tools/k6-proofs/scripts/run-cost-cap-fixture.mjs \
+  --source-dir <exact-6ee7eca-source> \
+  --candidate-sha 6ee7eca2a4ce1a3e8efa7e51f9dd02d03081741d \
+  --artifact-dir <temporary-artifact-dir> --cap 100 --json
+# PASS-candidate
+```
+
+The fixture's required receipt set was complete:
+
+- budget matrix: `99 => allow`, `100 => allow`, `101 => cost-capped`;
+- real dispatcher boundary suite: over-cap spawn rejected and the flow marked failed;
+- typed `continue_work` capture: two exhausted elections created zero durable continuation work;
+- cleanup: no production config, gateway state, or candidate-source mutation, and the disposable worktree was removed.
+
+## Decision
+
+The original failure was an invalid shared-config orchestration scaffold, not a demonstrated product failure. The replacement is deliberately process-local and fail-closed because `continue_work` is an internal session-elected primitive rather than a gateway/MCP loopback tool. Missing receipts fail the fixture; they cannot be silently promoted.
+
+No `karmaterminal/openclaw` product issue is warranted from this row. Review/merge of #430 and a human corpus disposition remain required before changing the canonical row state.

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -36,6 +36,25 @@ tools/k6-proofs/
 
 ## Usage
 
+### R-CW-5: isolated typed-tool fixture
+
+`continue_work` is deliberately unavailable through the gateway/MCP loopback,
+so `r-cw-5-cost-cap-reject.js` stays a fail-closed scaffold.  Run the
+process-local exact-candidate fixture instead; it calls the same typed callback
+that a real embedded attempt receives, uses a disposable session store and
+worktree, and never changes a running gateway or fleet config:
+
+```bash
+node tools/k6-proofs/scripts/run-cost-cap-fixture.mjs \
+  --source-dir <exact-candidate-worktree> \
+  --candidate-sha <40-char-sha> \
+  --artifact-dir <empty-private-directory> --cap 100 --json
+```
+
+The receipt and fail-closed contract are documented in
+[`docs/R-CW-5-ISOLATED-TOOL-SURFACE.md`](docs/R-CW-5-ISOLATED-TOOL-SURFACE.md).
+The result is a reviewed `PASS-candidate`, never an automatic corpus fold.
+
 ### 0. Offline golden-path smoke (no gateway, no secrets)
 
 Use this first to verify the candidate artifact pipeline is alive without touching

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -453,6 +453,21 @@ This is **declared in the manifest before the run**, not a post-hoc excuse. The 
 
 `R-CW-5` and `R-CW-6` are also excluded from `--live-suite`: they remain fixture-gated live cap rows. `R-CW-5A` and `R-CW-6A` are their static source/harness boundary checks; they emit only `construct-only`, never live R-CW-5/6 PASS evidence.
 
+### R-CW-5 isolated cost-cap fixture
+
+`tools/k6-proofs/scripts/run-cost-cap-fixture.mjs` is the safe runnable
+component fixture for `R-CW-5`. It requires an exact-candidate source
+worktree with dependencies already present, refuses to install dependencies,
+and writes only to an explicit artifact directory. It evaluates the exact
+production `checkContinuationBudget` module at below/equal/over cap, then
+runs the production dispatcher boundary suite to prove the over-cap hop does
+not spawn and its flow is failed. It records readiness and cleanup receipts.
+
+This is **not** a live-gateway promotion: it does not create a gateway or
+modify fleet config/state. The live row remains fixture-gated until a
+separate isolated-gateway orchestration can supply the same receipts through
+the full tool surface.
+
 Future manifests may again be `scaffold`, `construct-only`, or `orchestration-required`. Such rows are tracked, but not workflow-runnable until a matching scenario exists and the manifest is promoted to `scenario.status="runnable"` plus `liveRunSafety.classification="k6-runnable"`.
 
 ## Guardrails

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -468,6 +468,31 @@ modify fleet config/state. The live row remains fixture-gated until a
 separate isolated-gateway orchestration can supply the same receipts through
 the full tool surface.
 
+#### Runtime trace packet
+
+The fixture is deliberately anchored at the exact candidate rather than a
+copy of its cap predicate. On `6ee7eca2a4ce1a3e8efa7e51f9dd02d03081741d`,
+GitNexus maps `checkContinuationBudget` to three direct callers:
+`dispatchToolDelegates`, `dispatchStagedPostCompactionDelegates`, and
+`scheduleContinuationWork`. Its impact walk also reaches child-queue drain
+and delegate recovery paths. This is why the fixture covers both the
+production predicate and the dispatcher boundary; a change to the shared
+check has a continuation-wide blast radius, not only a single k6 row.
+
+Capture the trace packet against the candidate before reviewing a run:
+
+```bash
+gitnexus query --repo openclaw-6ee7eca \
+  'checkContinuationBudget accumulatedChainTokens cost cap'
+gitnexus context --repo openclaw-6ee7eca checkContinuationBudget
+gitnexus impact --repo openclaw-6ee7eca checkContinuationBudget
+```
+
+The expected component receipt shape at `--cap 100` is `99: allow`,
+`100: allow`, `101: cost-capped`, plus dispatcher assertions for over-cap
+no-spawn and failed-flow persistence. A component PASS-candidate never
+reclassifies the live row as PASS.
+
 Future manifests may again be `scaffold`, `construct-only`, or `orchestration-required`. Such rows are tracked, but not workflow-runnable until a matching scenario exists and the manifest is promoted to `scenario.status="runnable"` plus `liveRunSafety.classification="k6-runnable"`.
 
 ## Guardrails

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -461,12 +461,17 @@ worktree with dependencies already present, refuses to install dependencies,
 and writes only to an explicit artifact directory. It evaluates the exact
 production `checkContinuationBudget` module at below/equal/over cap, then
 runs the production dispatcher boundary suite to prove the over-cap hop does
-not spawn and its flow is failed. It records readiness and cleanup receipts.
+not spawn and its flow is failed. Finally, it creates a short-lived detached
+worktree of that exact candidate and exercises `runAgentAttempt` with the real
+typed `continue_work` capture surface, a disposable session already at the
+cost cap, and a zero-durable-work assertion. The temporary worktree is removed
+before the result is emitted. It records readiness and cleanup receipts.
 
-This is **not** a live-gateway promotion: it does not create a gateway or
-modify fleet config/state. The live row remains fixture-gated until a
-separate isolated-gateway orchestration can supply the same receipts through
-the full tool surface.
+This is an equivalent runtime-level fixture, not a live-fleet-gateway
+promotion: it does not create a gateway or modify fleet config/state. It
+closes the prior static-only gap by covering the real typed tool capture and
+post-turn scheduler path, but the row remains `PASS-candidate` pending human
+review and corpus fold.
 
 #### Runtime trace packet
 
@@ -490,8 +495,9 @@ gitnexus impact --repo openclaw-6ee7eca checkContinuationBudget
 
 The expected component receipt shape at `--cap 100` is `99: allow`,
 `100: allow`, `101: cost-capped`, plus dispatcher assertions for over-cap
-no-spawn and failed-flow persistence. A component PASS-candidate never
-reclassifies the live row as PASS.
+no-spawn and failed-flow persistence, and a typed-tool receipt that confirms
+two exhausted elections create no durable continuation work. A component
+PASS-candidate never reclassifies the live row as PASS without review.
 
 Future manifests may again be `scaffold`, `construct-only`, or `orchestration-required`. Such rows are tracked, but not workflow-runnable until a matching scenario exists and the manifest is promoted to `scenario.status="runnable"` plus `liveRunSafety.classification="k6-runnable"`.
 

--- a/tools/k6-proofs/docs/R-CW-5-ISOLATED-TOOL-SURFACE.md
+++ b/tools/k6-proofs/docs/R-CW-5-ISOLATED-TOOL-SURFACE.md
@@ -1,0 +1,59 @@
+# R-CW-5 isolated typed-tool surface
+
+`continue_work` is a session-elected internal primitive.  It is **not
+externally invocable through the gateway loopback**, so it cannot be proved by
+sending `tools.invoke` through the gateway WebSocket or MCP loopback.  The
+exact candidate deliberately omits it from that externally invocable tool set.
+A WebSocket scenario which claims to invoke it is therefore a harness error,
+not a live continuation test.
+
+The smallest executable surface is the same one used by a real embedded agent
+attempt:
+
+1. Create a disposable exact-candidate worktree and temporary session store.
+2. Give `runAgentAttempt` a continuation-enabled, in-memory config with
+   `costCapTokens=100` and a session entry whose accumulated tokens are `101`.
+3. Have the embedded-agent test double call the supplied
+   `continueWorkOpts.requestContinuation` callback twice.
+4. Require both elections to be rejected, no TaskFlow row to exist, and the
+   cost-cap system event to name both dropped elections.
+5. Remove the disposable worktree and temporary store regardless of outcome.
+
+This is not a synthetic copy of the policy: the fixture enters the production
+attempt runner, receives its real typed callback, persists/reserves through
+the real continuation scheduling path, and observes the real TaskFlow
+registry.  The companion production-module matrix and dispatcher suite cover
+the below/equal/over boundary plus rejected-hop no-spawn/failed-flow behavior.
+
+## Why the fixture is process-local
+
+The exact-candidate gateway test `src/gateway/mcp-http.runtime.test.ts` asserts
+that loopback scope excludes `continue_work` because it is "not
+external/CLI-invocable."  The actual route is
+`runAgentAttempt` -> `continueWorkOpts.requestContinuation` -> continuation
+scheduling.  GitNexus on the exact `6ee7eca` index confirms that
+`checkContinuationBudget` is reached by `scheduleContinuationWork`,
+`dispatchToolDelegates`, and post-compaction dispatch; the R-CW-5 fixture
+exercises the first of those through the typed callback and separately runs
+the real delegate-dispatch boundary suite.
+
+## Command and receipts
+
+```bash
+node tools/k6-proofs/scripts/run-cost-cap-fixture.mjs \
+  --source-dir <exact-6ee7eca-worktree> \
+  --candidate-sha 6ee7eca2a4ce1a3e8efa7e51f9dd02d03081741d \
+  --artifact-dir <empty-private-directory> --cap 100 --json
+```
+
+The command refuses a SHA/source mismatch, missing preinstalled dependencies,
+or any failure to create and remove its disposable worktree.  It never runs
+`pnpm install`, starts a gateway, writes OpenClaw config, or touches durable
+fleet state.  It produces `boundary-matrix.json`,
+`dispatch-boundary-suite.json`, `typed-tool-surface.json`, and `cleanup.json`.
+Any missing or failed receipt is `FAIL-fixture`, never a PASS.
+
+The fixture is a reviewed `PASS-candidate`, not an automatic corpus promotion.
+The legacy k6 entry remains scaffolded and fail-closed because its shared
+config mutation is neither required nor a valid way to invoke this internal
+tool.

--- a/tools/k6-proofs/fixtures/r-cw-5/cost-cap-tool-surface.test.ts
+++ b/tools/k6-proofs/fixtures/r-cw-5/cost-cap-tool-surface.test.ts
@@ -1,0 +1,124 @@
+// This file is copied into a disposable exact-candidate worktree by
+// run-cost-cap-fixture.mjs. It is deliberately not run in this docs checkout:
+// all imports resolve against the candidate's production runtime.
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../src/config/config.js";
+import { clearSessionStoreCacheForTest, saveSessionStore, type SessionEntry } from "../../src/config/sessions.js";
+import type { OpenClawConfig } from "../../src/config/types.openclaw.js";
+import { peekSystemEvents, resetSystemEventsForTest } from "../../src/infra/system-events.js";
+import { runAgentAttempt } from "../../src/agents/command/attempt-execution.js";
+
+const runEmbeddedAgentMock = vi.hoisted(() => vi.fn());
+const runCliAgentMock = vi.hoisted(() => vi.fn());
+vi.mock("../../src/agents/cli-runner.js", () => ({ runCliAgent: runCliAgentMock }));
+vi.mock("../../src/agents/model-selection.js", () => ({
+  isCliProvider: () => false,
+  normalizeProviderId: (provider: string) => provider.trim().toLowerCase(),
+}));
+vi.mock("../../src/agents/provider-auth-aliases.js", () => ({
+  resolveProviderAuthAliasMap: () => ({}),
+  resolveProviderIdForAuth: (provider: string) => provider.trim().toLowerCase(),
+}));
+vi.mock("../../src/agents/model-runtime-aliases.js", async () => {
+  const actual = await vi.importActual<typeof import("../../src/agents/model-runtime-aliases.js")>(
+    "../../src/agents/model-runtime-aliases.js",
+  );
+  return {
+    ...actual,
+    resolveCliRuntimeExecutionProvider: ({ provider }: { provider?: string }) => provider,
+  };
+});
+vi.mock("../../src/agents/embedded-agent.js", () => ({ runEmbeddedAgent: runEmbeddedAgentMock }));
+
+const cfg = {
+  agents: {
+    defaults: {
+      continuation: {
+        enabled: true,
+        maxChainLength: 4,
+        defaultDelayMs: 15_000,
+        minDelayMs: 5_000,
+        maxDelayMs: 86_400_000,
+        costCapTokens: 100,
+        maxDelegatesPerTurn: 4,
+      },
+    },
+  },
+} as unknown as OpenClawConfig;
+
+describe("R-CW-5 disposable typed tool surface", () => {
+  let root: string;
+  let storePath: string;
+  let sessionKey: string;
+  let sessionEntry: SessionEntry;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), "rcw5-tool-surface-"));
+    storePath = path.join(root, "sessions.json");
+    sessionKey = `agent:main:subagent:rcw5:${crypto.randomUUID()}`;
+    sessionEntry = {
+      sessionId: "rcw5-disposable-session",
+      updatedAt: Date.now(),
+      continuationChainCount: 0,
+      continuationChainStartedAt: Date.now(),
+      continuationChainTokens: 101,
+    } as SessionEntry;
+    await saveSessionStore(storePath, { [sessionKey]: sessionEntry }, { skipMaintenance: true });
+    clearSessionStoreCacheForTest();
+    setRuntimeConfigSnapshot(cfg);
+    runEmbeddedAgentMock.mockReset();
+    runCliAgentMock.mockReset();
+  });
+
+  afterEach(async () => {
+    clearRuntimeConfigSnapshot();
+    clearSessionStoreCacheForTest();
+    resetSystemEventsForTest();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it("rejects exhausted typed-tool elections without a durable continuation", async () => {
+    runEmbeddedAgentMock.mockImplementationOnce(async (args: {
+      continueWorkOpts?: { requestContinuation: (request: { reason: string; delaySeconds: number }) => void };
+    }) => {
+      args.continueWorkOpts?.requestContinuation({ reason: "R-CW-5 disposable first", delaySeconds: 1 });
+      args.continueWorkOpts?.requestContinuation({ reason: "R-CW-5 disposable second", delaySeconds: 1 });
+      return {
+        payloads: [{ text: "done" }],
+        meta: {
+          durationMs: 1,
+          finalAssistantVisibleText: "done",
+          agentMeta: {
+            sessionId: "rcw5-disposable-session",
+            provider: "anthropic",
+            model: "fixture",
+            usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+        },
+      };
+    });
+
+    await runAgentAttempt({
+      providerOverride: "anthropic", originalProvider: "anthropic", modelOverride: "fixture", cfg,
+      sessionEntry, sessionId: sessionEntry.sessionId, sessionKey, sessionAgentId: "main",
+      lifecycleGeneration: "rcw5-fixture", sessionFile: path.join(root, "session.jsonl"),
+      workspaceDir: root, body: "disposable fixture", isFallbackRetry: false, resolvedThinkLevel: "off",
+      timeoutMs: 1_000, runId: "rcw5-fixture-run", opts: {} as never, runContext: {} as never,
+      spawnedBy: undefined, messageChannel: undefined, skillsSnapshot: undefined,
+      resolvedVerboseLevel: undefined, agentDir: root, onAgentEvent: vi.fn(),
+      authProfileProvider: "anthropic", sessionStore: { [sessionKey]: sessionEntry }, storePath,
+      sessionHasHistory: false,
+    });
+
+    const { listTaskFlowsForOwnerKey } = await import("../../src/tasks/task-flow-registry.js");
+    expect(listTaskFlowsForOwnerKey(sessionKey)).toHaveLength(0);
+    expect(sessionEntry.continuationChainTokens).toBe(101);
+    expect(peekSystemEvents(sessionKey)).toContain(
+      "[continuation] 2 of 2 continue_work elections were not scheduled (chain/cost/pending cap).",
+    );
+  });
+});

--- a/tools/k6-proofs/fixtures/r-cw-5/cost-cap-tool-surface.test.ts
+++ b/tools/k6-proofs/fixtures/r-cw-5/cost-cap-tool-surface.test.ts
@@ -43,7 +43,7 @@ const cfg = {
         defaultDelayMs: 15_000,
         minDelayMs: 5_000,
         maxDelayMs: 86_400_000,
-        costCapTokens: 100,
+        costCapTokens: __RCW5_CAP__,
         maxDelegatesPerTurn: 4,
       },
     },
@@ -65,7 +65,7 @@ describe("R-CW-5 disposable typed tool surface", () => {
       updatedAt: Date.now(),
       continuationChainCount: 0,
       continuationChainStartedAt: Date.now(),
-      continuationChainTokens: 101,
+      continuationChainTokens: __RCW5_OVER_CAP__,
     } as SessionEntry;
     await saveSessionStore(storePath, { [sessionKey]: sessionEntry }, { skipMaintenance: true });
     clearSessionStoreCacheForTest();
@@ -116,7 +116,7 @@ describe("R-CW-5 disposable typed tool surface", () => {
 
     const { listTaskFlowsForOwnerKey } = await import("../../src/tasks/task-flow-registry.js");
     expect(listTaskFlowsForOwnerKey(sessionKey)).toHaveLength(0);
-    expect(sessionEntry.continuationChainTokens).toBe(101);
+    expect(sessionEntry.continuationChainTokens).toBe(__RCW5_OVER_CAP__);
     expect(peekSystemEvents(sessionKey)).toContain(
       "[continuation] 2 of 2 continue_work elections were not scheduled (chain/cost/pending cap).",
     );

--- a/tools/k6-proofs/manifests/r-cw-5.json
+++ b/tools/k6-proofs/manifests/r-cw-5.json
@@ -5,9 +5,9 @@
   "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
   "seat": "${OPENCLAW_SEAT_NAME:-cael-dgx}",
   "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
-  "transport": "websocket",
+  "transport": "process-local",
   "toolSurface": "typed-tool",
-  "mutates": true,
+  "mutates": false,
   "timeoutSeconds": 90,
   "gateway": {
     "wsEnv": "OPENCLAW_GATEWAY_WS",
@@ -15,46 +15,41 @@
   },
   "scenario": {
     "name": "r-cw-5-cost-cap-reject",
-    "description": "Cost-cap exhaustion requires an isolated config-mutation fixture that lowers costCapTokens, observes the dispatch rejection, and restores state.",
-    "methods": ["tools.invoke", "config.patch", "config.restore"],
+    "description": "Cost-cap exhaustion uses a disposable exact-candidate typed-tool fixture; continue_work is intentionally not externally invocable through the gateway loopback.",
+    "methods": ["runAgentAttempt", "continueWorkOpts.requestContinuation", "TaskFlow.assert-no-row"],
     "status": "scaffold",
     "expectedFile": "r-cw-5-cost-cap-reject.js",
-    "registryNotes": "The scaffold intentionally cannot run until an explicitly authorized fixture implements backup/lower/fire/restore receipts."
+    "registryNotes": "The legacy k6 scenario remains fail-closed: it cannot invoke continue_work through WebSocket/MCP and must not mutate shared config. Use run-cost-cap-fixture.mjs; see docs/R-CW-5-ISOLATED-TOOL-SURFACE.md."
   },
   "invocation": {
     "tool": "continue_work",
     "delaySeconds": 1,
     "reason": "k6-proof-R-CW-5-cost-cap-{{nonce}}",
     "idempotencyKeyPrefix": "R-CW-5",
-    "configOverride": {
-      "path": "agents.defaults.continuation.costCapTokens",
-      "testValue": 1,
-      "restoreAfter": true,
-      "testValueEnv": "OPENCLAW_K6_COST_CAP_TEST_VALUE",
-      "defaultTestValue": "1"
-    }
+    "fixture": "tools/k6-proofs/scripts/run-cost-cap-fixture.mjs",
+    "fixtureCap": 100,
+    "fixtureState": "temporary session store seeded with accumulatedChainTokens=101"
   },
   "expectedReceipts": [
-    {"name":"seat-readiness-continuation-enabled","required":true,"description":"Precursor receipt proves continuation defaults before fixture mutation."},
-    {"name":"original-config-captured","required":true,"description":"The original costCapTokens value is retained for restoration."},
-    {"name":"failure-safe-restore-armed","required":true,"description":"A restore guard is armed before mutation."},
-    {"name":"config-lowered","required":true,"description":"The fixture records its row-local low cap."},
-    {"name":"tool-invoke-rejected","required":true,"description":"continue_work rejects at the exhausted cost cap."},
-    {"name":"config-restored","required":true,"description":"The original cap is restored even after failure."}
+    {"name":"fixture-readiness","required":true,"description":"Exact source/SHA, installed dependencies, and zero production mutation are proven before execution."},
+    {"name":"boundary-matrix","required":true,"description":"Below/equal/over cap results are null/null/cost-capped at the production budget predicate."},
+    {"name":"typed-tool-surface","required":true,"description":"The real attempt runner receives two typed continue_work callbacks and creates no durable work when over cap."},
+    {"name":"dispatch-boundary-suite","required":true,"description":"Production dispatcher asserts no rejected-hop spawn and failed-flow persistence."},
+    {"name":"cleanup","required":true,"description":"Disposable worktree is removed and no production config/state/source mutation occurred."}
   ],
   "artifactDestination": {"root":"PROOFS","sha":"${OPENCLAW_CANDIDATE_SHA}","row":"R-CW-5","seat":"${OPENCLAW_SEAT_NAME:-cael-dgx}","runDirPrefix":"k6-run"},
-  "review": {"candidateOnly":true,"foldRequiresReview":true,"notes":"This is the live cap-exhaustion claim. It is not proven by static checks."},
+  "review": {"candidateOnly":true,"foldRequiresReview":true,"notes":"This is an exact-candidate process-local typed-tool claim. It is not an external gateway invocation and is not promoted automatically."},
   "liveRunSafety": {
     "classification": "orchestration-required",
-    "requiresLiveGatewayToken": true,
+    "requiresLiveGatewayToken": false,
     "requiresTargetSessionKey": false,
     "requiresCandidateSha": true,
-    "requiresExternalAgentOrToolInvocation": true,
-    "requiresHumanConfirmation": true,
+    "requiresExternalAgentOrToolInvocation": false,
+    "requiresHumanConfirmation": false,
     "sameSessionConcurrencySafe": false,
     "expectedArtifactClass": "PARTIAL-candidate",
-    "requiredReceipts": ["seat-readiness-continuation-enabled","original-config-captured","failure-safe-restore-armed","config-lowered","tool-invoke-rejected","config-restored"],
+    "requiredReceipts": ["fixture-readiness","boundary-matrix","typed-tool-surface","dispatch-boundary-suite","cleanup"],
     "foldRequiresReview": true,
-    "notes": "Fail closed until a separately authorized disposable fixture captures the complete mutation and restoration chain."
+    "notes": "Fail closed for k6/WebSocket: continue_work is internal-only. The supported path is the process-local exact-candidate fixture described in docs/R-CW-5-ISOLATED-TOOL-SURFACE.md; review remains mandatory before corpus promotion."
   }
 }

--- a/tools/k6-proofs/scenarios/r-cw-5-cost-cap-reject.js
+++ b/tools/k6-proofs/scenarios/r-cw-5-cost-cap-reject.js
@@ -6,11 +6,12 @@
  * restores the original config. It intentionally remains scaffold-only because
  * it mutates live gateway configuration.
  *
- * Required before runnable promotion:
- * - explicit OPENCLAW_ALLOW_CONFIG_MUTATION=true gate
- * - config backup/restore receipts
- * - failure-safe restore on k6 abort
- * - preferably an isolated test gateway fixture, not a live prince
+ * The safe executable fixture lives in
+ * `tools/k6-proofs/scripts/run-cost-cap-fixture.mjs`. It runs the exact
+ * candidate's production budget module plus the dispatcher boundary suite
+ * from a source-only worktree and writes cleanup receipts. This k6 entry
+ * remains intentionally non-runnable: k6 cannot safely create the required
+ * isolated runtime state itself.
  */
 export const options = {
   scenarios: {
@@ -24,5 +25,5 @@ export const options = {
 };
 
 export default function () {
-  throw new Error('R-CW-5 is scaffold-only; config-mutating cost-cap fixture not implemented.');
+  throw new Error('R-CW-5 is fixture-gated; run tools/k6-proofs/scripts/run-cost-cap-fixture.mjs against an exact-candidate source worktree.');
 }

--- a/tools/k6-proofs/scenarios/r-cw-5-cost-cap-reject.js
+++ b/tools/k6-proofs/scenarios/r-cw-5-cost-cap-reject.js
@@ -1,17 +1,16 @@
 /**
  * Scenario scaffold: R-CW-5.
  *
- * Cost-cap rejection proof. This row temporarily lowers continuation
- * costCapTokens, proves continue_work is rejected at the cap boundary, then
- * restores the original config. It intentionally remains scaffold-only because
- * it mutates live gateway configuration.
+ * Cost-cap rejection proof. `continue_work` is an internal session-elected
+ * primitive, intentionally absent from the gateway/MCP loopback tool set. A
+ * WebSocket `tools.invoke` therefore cannot exercise this contract.
  *
  * The safe executable fixture lives in
  * `tools/k6-proofs/scripts/run-cost-cap-fixture.mjs`. It runs the exact
  * candidate's production budget module plus the dispatcher boundary suite
  * from a source-only worktree and writes cleanup receipts. This k6 entry
- * remains intentionally non-runnable: k6 cannot safely create the required
- * isolated runtime state itself.
+ * remains intentionally non-runnable: using it to patch live configuration
+ * would not invoke the internal tool and would create a misleading receipt.
  */
 export const options = {
   scenarios: {

--- a/tools/k6-proofs/scripts/__tests__/cost-cap-fixture.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/cost-cap-fixture.test.mjs
@@ -46,3 +46,23 @@ test('R-CW-5 typed tool-surface template asserts no durable work after exhausted
   assert.match(template, /listTaskFlowsForOwnerKey\(sessionKey\)\)\.toHaveLength\(0\)/);
   assert.match(template, /2 of 2 continue_work elections were not scheduled/);
 });
+
+test('R-CW-5 fails closed instead of pretending the internal tool is websocket-invocable', async () => {
+  const manifestPath = fileURLToPath(new URL('../../manifests/r-cw-5.json', import.meta.url));
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+  const methodDoc = await readFile(
+    fileURLToPath(new URL('../../docs/R-CW-5-ISOLATED-TOOL-SURFACE.md', import.meta.url)),
+    'utf8',
+  );
+  assert.equal(manifest.transport, 'process-local');
+  assert.equal(manifest.scenario.status, 'scaffold');
+  assert.deepEqual(manifest.scenario.methods, [
+    'runAgentAttempt',
+    'continueWorkOpts.requestContinuation',
+    'TaskFlow.assert-no-row',
+  ]);
+  assert.equal(manifest.liveRunSafety.requiresLiveGatewayToken, false);
+  assert.equal(manifest.liveRunSafety.requiresExternalAgentOrToolInvocation, false);
+  assert.match(methodDoc, /not\s+externally invocable through the gateway loopback/);
+  assert.match(methodDoc, /Any missing or failed receipt is `FAIL-fixture`, never a PASS/);
+});

--- a/tools/k6-proofs/scripts/__tests__/cost-cap-fixture.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/cost-cap-fixture.test.mjs
@@ -1,8 +1,8 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { assertSource, parseArgs, prepareArtifactDir } from '../run-cost-cap-fixture.mjs';
-import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { assertSource, assertTrackedSourceClean, parseArgs, prepareArtifactDir } from '../run-cost-cap-fixture.mjs';
+import { mkdir, mkdtemp, readFile, symlink, writeFile } from 'node:fs/promises';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import os from 'node:os';
@@ -47,6 +47,15 @@ test('R-CW-5 fixture refuses to overwrite or expose an artifact directory', asyn
 
   const fresh = path.join(root, 'fresh');
   assert.equal(prepareArtifactDir(fresh), fresh);
+
+  const privateParent = path.join(root, 'private-parent');
+  const linkedParent = path.join(root, 'linked-parent');
+  await mkdir(privateParent, { mode: 0o700 });
+  await symlink(privateParent, linkedParent);
+  assert.throws(
+    () => prepareArtifactDir(path.join(linkedParent, 'new-artifacts')),
+    /must not contain a symlink component/,
+  );
 });
 
 test('R-CW-5 fixture refuses staged or unstaged tracked candidate changes', async () => {
@@ -63,6 +72,8 @@ test('R-CW-5 fixture refuses staged or unstaged tracked candidate changes', asyn
   execFileSync('git', ['commit', '-m', 'candidate'], { cwd: source, stdio: 'ignore' });
   const candidateSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: source, encoding: 'utf8' }).trim();
 
+  assert.doesNotThrow(() => assertSource(source, candidateSha));
+
   await writeFile(path.join(source, 'src/auto-reply/continuation/scheduler.ts'), 'export const clean = false;\n');
   assert.throws(
     () => assertSource(source, candidateSha),
@@ -73,6 +84,10 @@ test('R-CW-5 fixture refuses staged or unstaged tracked candidate changes', asyn
   assert.throws(
     () => assertSource(source, candidateSha),
     /tracked staged or unstaged changes/,
+  );
+  assert.throws(
+    () => assertTrackedSourceClean(source, 'final cleanup/result receipt'),
+    /before final cleanup\/result receipt/,
   );
 });
 

--- a/tools/k6-proofs/scripts/__tests__/cost-cap-fixture.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/cost-cap-fixture.test.mjs
@@ -1,7 +1,14 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { assertSource, assertTrackedSourceClean, parseArgs, prepareArtifactDir } from '../run-cost-cap-fixture.mjs';
+import {
+  assertSource,
+  assertTrackedSourceClean,
+  buildReadiness,
+  parseArgs,
+  prepareArtifactDir,
+  renderToolSurfaceTemplate,
+} from '../run-cost-cap-fixture.mjs';
 import { mkdir, mkdtemp, readFile, symlink, writeFile } from 'node:fs/promises';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
@@ -98,9 +105,31 @@ test('R-CW-5 typed tool-surface template asserts no durable work after exhausted
   );
   assert.match(template, /runAgentAttempt/);
   assert.match(template, /continueWorkOpts/);
-  assert.match(template, /continuationChainTokens:\s*101/);
+  assert.match(template, /continuationChainTokens:\s*__RCW5_OVER_CAP__/);
   assert.match(template, /listTaskFlowsForOwnerKey\(sessionKey\)\)\.toHaveLength\(0\)/);
   assert.match(template, /2 of 2 continue_work elections were not scheduled/);
+});
+
+test('R-CW-5 renders the typed tool surface at the selected cap', async () => {
+  const template = await readFile(
+    fileURLToPath(new URL('../../fixtures/r-cw-5/cost-cap-tool-surface.test.ts', import.meta.url)),
+    'utf8',
+  );
+  const rendered = renderToolSurfaceTemplate(template, 200);
+  assert.match(rendered, /costCapTokens:\s*200/);
+  assert.match(rendered, /continuationChainTokens:\s*201/);
+  assert.doesNotMatch(rendered, /__RCW5_(?:CAP|OVER_CAP)__/);
+});
+
+test('R-CW-5 public readiness has no private source path', () => {
+  const privatePath = '/home/figs/flesh_beast_tmp/openclaw';
+  const readiness = buildReadiness({
+    candidateSha: '6ee7eca2a4ce1a3e8efa7e51f9dd02d03081741d',
+    head: '6ee7eca2a4ce1a3e8efa7e51f9dd02d03081741d',
+    cap: 200,
+  });
+  assert.equal(readiness.sourceHeadMatchesCandidate, true);
+  assert.doesNotMatch(JSON.stringify(readiness), new RegExp(privatePath.replaceAll('/', '\\/')));
 });
 
 test('R-CW-5 fails closed instead of pretending the internal tool is websocket-invocable', async () => {

--- a/tools/k6-proofs/scripts/__tests__/cost-cap-fixture.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/cost-cap-fixture.test.mjs
@@ -1,8 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { parseArgs, prepareArtifactDir } from '../run-cost-cap-fixture.mjs';
+import { assertSource, parseArgs, prepareArtifactDir } from '../run-cost-cap-fixture.mjs';
 import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import os from 'node:os';
 import path from 'node:path';
@@ -46,6 +47,33 @@ test('R-CW-5 fixture refuses to overwrite or expose an artifact directory', asyn
 
   const fresh = path.join(root, 'fresh');
   assert.equal(prepareArtifactDir(fresh), fresh);
+});
+
+test('R-CW-5 fixture refuses staged or unstaged tracked candidate changes', async () => {
+  const source = await mkdtemp(path.join(os.tmpdir(), 'r-cw-5-dirty-source-'));
+  await mkdir(path.join(source, 'src/auto-reply/continuation'), { recursive: true });
+  await mkdir(path.join(source, 'node_modules'));
+  await writeFile(path.join(source, 'src/auto-reply/continuation/scheduler.ts'), 'export const clean = true;\n');
+  await writeFile(path.join(source, 'src/auto-reply/continuation/delegate-dispatch.cost-cap-exhaustion.test.ts'), '// marker\n');
+  await writeFile(path.join(source, 'package.json'), '{"name":"r-cw-5-test"}\n');
+  execFileSync('git', ['init'], { cwd: source, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'proof@example.invalid'], { cwd: source });
+  execFileSync('git', ['config', 'user.name', 'R-CW-5 fixture test'], { cwd: source });
+  execFileSync('git', ['add', 'src', 'package.json'], { cwd: source });
+  execFileSync('git', ['commit', '-m', 'candidate'], { cwd: source, stdio: 'ignore' });
+  const candidateSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: source, encoding: 'utf8' }).trim();
+
+  await writeFile(path.join(source, 'src/auto-reply/continuation/scheduler.ts'), 'export const clean = false;\n');
+  assert.throws(
+    () => assertSource(source, candidateSha),
+    /tracked staged or unstaged changes/,
+  );
+
+  execFileSync('git', ['add', 'src/auto-reply/continuation/scheduler.ts'], { cwd: source });
+  assert.throws(
+    () => assertSource(source, candidateSha),
+    /tracked staged or unstaged changes/,
+  );
 });
 
 test('R-CW-5 typed tool-surface template asserts no durable work after exhausted elections', async () => {

--- a/tools/k6-proofs/scripts/__tests__/cost-cap-fixture.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/cost-cap-fixture.test.mjs
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseArgs } from '../run-cost-cap-fixture.mjs';
+
+test('R-CW-5 fixture accepts an explicit isolated source contract', () => {
+  const parsed = parseArgs([
+    'node',
+    'run-cost-cap-fixture.mjs',
+    '--source-dir',
+    '/tmp/exact-openclaw',
+    '--candidate-sha',
+    '6ee7eca2a4ce1a3e8efa7e51f9dd02d03081741d',
+    '--artifact-dir',
+    '/tmp/rcw5-artifacts',
+    '--cap',
+    '100',
+    '--json',
+  ], {});
+  assert.deepEqual(parsed, {
+    sourceDir: '/tmp/exact-openclaw',
+    candidateSha: '6ee7eca2a4ce1a3e8efa7e51f9dd02d03081741d',
+    artifactDir: '/tmp/rcw5-artifacts',
+    cap: 100,
+    json: true,
+  });
+});
+
+test('R-CW-5 fixture refuses unknown arguments', () => {
+  assert.throws(
+    () => parseArgs(['node', 'run-cost-cap-fixture.mjs', '--mutate-live-config'], {}),
+    /unexpected argument: --mutate-live-config/,
+  );
+});

--- a/tools/k6-proofs/scripts/__tests__/cost-cap-fixture.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/cost-cap-fixture.test.mjs
@@ -1,9 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { parseArgs } from '../run-cost-cap-fixture.mjs';
-import { readFile } from 'node:fs/promises';
+import { parseArgs, prepareArtifactDir } from '../run-cost-cap-fixture.mjs';
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
+import os from 'node:os';
+import path from 'node:path';
 
 test('R-CW-5 fixture accepts an explicit isolated source contract', () => {
   const parsed = parseArgs([
@@ -33,6 +35,17 @@ test('R-CW-5 fixture refuses unknown arguments', () => {
     () => parseArgs(['node', 'run-cost-cap-fixture.mjs', '--mutate-live-config'], {}),
     /unexpected argument: --mutate-live-config/,
   );
+});
+
+test('R-CW-5 fixture refuses to overwrite or expose an artifact directory', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'r-cw-5-artifact-test-'));
+  const nonEmpty = path.join(root, 'existing');
+  await mkdir(nonEmpty, { mode: 0o700 });
+  await writeFile(path.join(nonEmpty, 'old-receipt.json'), '{}');
+  assert.throws(() => prepareArtifactDir(nonEmpty), /must be empty/);
+
+  const fresh = path.join(root, 'fresh');
+  assert.equal(prepareArtifactDir(fresh), fresh);
 });
 
 test('R-CW-5 typed tool-surface template asserts no durable work after exhausted elections', async () => {

--- a/tools/k6-proofs/scripts/__tests__/cost-cap-fixture.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/cost-cap-fixture.test.mjs
@@ -2,6 +2,8 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { parseArgs } from '../run-cost-cap-fixture.mjs';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 
 test('R-CW-5 fixture accepts an explicit isolated source contract', () => {
   const parsed = parseArgs([
@@ -31,4 +33,16 @@ test('R-CW-5 fixture refuses unknown arguments', () => {
     () => parseArgs(['node', 'run-cost-cap-fixture.mjs', '--mutate-live-config'], {}),
     /unexpected argument: --mutate-live-config/,
   );
+});
+
+test('R-CW-5 typed tool-surface template asserts no durable work after exhausted elections', async () => {
+  const template = await readFile(
+    fileURLToPath(new URL('../../fixtures/r-cw-5/cost-cap-tool-surface.test.ts', import.meta.url)),
+    'utf8',
+  );
+  assert.match(template, /runAgentAttempt/);
+  assert.match(template, /continueWorkOpts/);
+  assert.match(template, /continuationChainTokens:\s*101/);
+  assert.match(template, /listTaskFlowsForOwnerKey\(sessionKey\)\)\.toHaveLength\(0\)/);
+  assert.match(template, /2 of 2 continue_work elections were not scheduled/);
 });

--- a/tools/k6-proofs/scripts/__tests__/live-run-guard.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/live-run-guard.test.mjs
@@ -114,8 +114,22 @@ test('read-only preflight uses the supported live k6 runner contract', async () 
   assert.equal(parsed.requiresExternalAgentOrToolInvocation, false);
 });
 
-test('R-CW cap rows stay fixture-gated while static variants cannot certify them', async () => {
-  for (const manifestName of ['r-cw-5.json', 'r-cw-6.json']) {
+test('R-CW-5 stays process-local and fail-closed rather than using a shared gateway config mutation', async () => {
+  const manifestPath = join(repoRoot, 'tools/k6-proofs/manifests/r-cw-5.json');
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+  assert.equal(manifest.mutates, false);
+  assert.equal(manifest.transport, 'process-local');
+  assert.equal(manifest.scenario.status, 'scaffold');
+  assert.equal(manifest.liveRunSafety.classification, 'orchestration-required');
+  assert.equal(manifest.liveRunSafety.expectedArtifactClass, 'PARTIAL-candidate');
+  assert.equal(manifest.liveRunSafety.requiresLiveGatewayToken, false);
+  const run = runGuard(manifestPath);
+  assert.equal(run.status, 1, `${manifest.rowId} unexpectedly passed: ${run.stdout}`);
+  assert.match(run.stdout, /orchestration-required is not directly runnable/);
+});
+
+test('R-CW-6 stays fixture-gated while static variants cannot certify it', async () => {
+  for (const manifestName of ['r-cw-6.json']) {
     const manifestPath = join(repoRoot, 'tools/k6-proofs/manifests', manifestName);
     const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
     assert.equal(manifest.mutates, true);

--- a/tools/k6-proofs/scripts/run-cost-cap-fixture.mjs
+++ b/tools/k6-proofs/scripts/run-cost-cap-fixture.mjs
@@ -114,13 +114,42 @@ export function assertSource(sourceDir, candidateSha) {
   for (const marker of SOURCE_MARKERS) {
     if (!existsSync(path.join(resolved, marker))) throw new Error(`source dir is missing ${marker}`);
   }
-  if (!existsSync(path.join(resolved, 'node_modules'))) {
+  const dependencyDir = path.join(resolved, 'node_modules');
+  if (!existsSync(dependencyDir)) {
     throw new Error('source dir has no node_modules; fixture refuses to install dependencies or mutate the candidate worktree');
+  }
+  if (lstatSync(dependencyDir).isSymbolicLink()) {
+    throw new Error('source node_modules must be a real directory; fixture refuses an indirect mutable dependency tree');
   }
   const head = gitHead(resolved);
   if (head !== candidateSha) throw new Error(`candidate/source mismatch: requested ${candidateSha}, source is ${head}`);
   assertTrackedSourceClean(resolved, 'fixture execution');
   return { resolved, head };
+}
+
+export function renderToolSurfaceTemplate(template, cap) {
+  if (!Number.isInteger(cap) || cap < 2) throw new Error('tool-surface cap must be an integer of at least 2');
+  const overCap = cap + 1;
+  if (!template.includes('__RCW5_CAP__') || !template.includes('__RCW5_OVER_CAP__')) {
+    throw new Error('tool-surface template is missing required cap placeholders');
+  }
+  return template
+    .replaceAll('__RCW5_CAP__', String(cap))
+    .replaceAll('__RCW5_OVER_CAP__', String(overCap));
+}
+
+export function buildReadiness({ candidateSha, head, cap }) {
+  return {
+    schema: 'openclaw.project81.r-cw-5.fixture-readiness.v1',
+    candidateSha,
+    sourceHeadMatchesCandidate: head === candidateSha,
+    sourceTrackedCleanBefore: true,
+    productionConfigTouched: false,
+    productionStateTouched: false,
+    fixtureKind: 'source-only-production-module-plus-dispatch-boundary-suite',
+    dependencyTree: 'pre-existing-real-source-node_modules; no-install',
+    cap,
+  };
 }
 
 export function prepareArtifactDir(input) {
@@ -175,7 +204,7 @@ function parseLastJson(stdout, label) {
   return JSON.parse(line);
 }
 
-function runDisposableToolSurface({ sourceDir, candidateSha, artifactDir }) {
+function runDisposableToolSurface({ sourceDir, candidateSha, artifactDir, cap }) {
   if (!existsSync(TOOL_SURFACE_TEMPLATE)) {
     throw new Error(`tool-surface template missing: ${TOOL_SURFACE_TEMPLATE}`);
   }
@@ -188,7 +217,7 @@ function runDisposableToolSurface({ sourceDir, candidateSha, artifactDir }) {
     mkdirSync(testDir, { recursive: true, mode: 0o700 });
     writeFileSync(
       path.join(testDir, 'cost-cap-tool-surface.test.ts'),
-      readFileSync(TOOL_SURFACE_TEMPLATE),
+      renderToolSurfaceTemplate(readFileSync(TOOL_SURFACE_TEMPLATE, 'utf8'), cap),
       { mode: 0o600 },
     );
     // The temporary worktree is source-only. Re-use the already-present,
@@ -220,16 +249,7 @@ export function runFixture(args) {
   const { resolved: sourceDir, head } = assertSource(args.sourceDir, args.candidateSha);
   const artifactDir = prepareArtifactDir(args.artifactDir);
 
-  const readiness = {
-    schema: 'openclaw.project81.r-cw-5.fixture-readiness.v1',
-    candidateSha: args.candidateSha,
-    sourceHead: head,
-    sourceDir,
-    productionConfigTouched: false,
-    productionStateTouched: false,
-    fixtureKind: 'source-only-production-module-plus-dispatch-boundary-suite',
-    cap: args.cap,
-  };
+  const readiness = buildReadiness({ candidateSha: args.candidateSha, head, cap: args.cap });
   writeJson(path.join(artifactDir, 'fixture-readiness.json'), readiness);
 
   const matrixRun = run('pnpm', ['exec', 'tsx', '--eval', matrixEval(args.cap)], { cwd: sourceDir });
@@ -277,7 +297,7 @@ export function runFixture(args) {
     asserted: dispatchAssertions,
   });
 
-  const toolSurface = runDisposableToolSurface({ sourceDir, candidateSha: args.candidateSha, artifactDir });
+  const toolSurface = runDisposableToolSurface({ sourceDir, candidateSha: args.candidateSha, artifactDir, cap: args.cap });
   const toolSurfacePassed = toolSurface.passed && Object.values(toolSurface.asserted).every(Boolean);
   writeJson(path.join(artifactDir, 'typed-tool-surface.json'), {
     schema: 'openclaw.project81.r-cw-5.typed-tool-surface.v1',

--- a/tools/k6-proofs/scripts/run-cost-cap-fixture.mjs
+++ b/tools/k6-proofs/scripts/run-cost-cap-fixture.mjs
@@ -9,7 +9,7 @@
  * no-spawn assertion without changing a fleet gateway.
  */
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, symlinkSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import process from 'node:process';
@@ -107,6 +107,25 @@ function assertSource(sourceDir, candidateSha) {
   return { resolved, head };
 }
 
+export function prepareArtifactDir(input) {
+  const artifactDir = path.resolve(input);
+  if (existsSync(artifactDir)) {
+    const stats = lstatSync(artifactDir);
+    if (!stats.isDirectory() || stats.isSymbolicLink()) {
+      throw new Error('artifact dir must be a real directory, not a file or symlink');
+    }
+    if ((stats.mode & 0o077) !== 0) {
+      throw new Error('artifact dir must not be group/world accessible (mode 0700 required)');
+    }
+    if (readdirSync(artifactDir).length !== 0) {
+      throw new Error('artifact dir must be empty; refusing to overwrite an earlier receipt');
+    }
+  } else {
+    mkdirSync(artifactDir, { recursive: true, mode: 0o700 });
+  }
+  return artifactDir;
+}
+
 function matrixEval(cap) {
   // JSON only: the fixture invokes the exact production TypeScript module via
   // tsx, so this string is not a second implementation of the cap policy.
@@ -168,8 +187,7 @@ function runDisposableToolSurface({ sourceDir, candidateSha, artifactDir }) {
 export function runFixture(args) {
   assertArgs(args);
   const { resolved: sourceDir, head } = assertSource(args.sourceDir, args.candidateSha);
-  const artifactDir = path.resolve(args.artifactDir);
-  mkdirSync(artifactDir, { recursive: true, mode: 0o700 });
+  const artifactDir = prepareArtifactDir(args.artifactDir);
 
   const readiness = {
     schema: 'openclaw.project81.r-cw-5.fixture-readiness.v1',

--- a/tools/k6-proofs/scripts/run-cost-cap-fixture.mjs
+++ b/tools/k6-proofs/scripts/run-cost-cap-fixture.mjs
@@ -125,6 +125,21 @@ export function assertSource(sourceDir, candidateSha) {
 
 export function prepareArtifactDir(input) {
   const artifactDir = path.resolve(input);
+  // `mkdir({ recursive: true })` follows a symlink in an existing ancestor.
+  // Checking only an existing final directory would therefore let a caller
+  // place a fresh receipt under a symlinked parent. Walk every existing path
+  // component before making the directory so the private receipt boundary
+  // cannot be redirected through an indirect path.
+  const parsed = path.parse(artifactDir);
+  let componentPath = parsed.root;
+  for (const component of path.relative(parsed.root, artifactDir).split(path.sep)) {
+    if (!component) continue;
+    componentPath = path.join(componentPath, component);
+    if (!existsSync(componentPath)) break;
+    if (lstatSync(componentPath).isSymbolicLink()) {
+      throw new Error('artifact dir path must not contain a symlink component');
+    }
+  }
   if (existsSync(artifactDir)) {
     const stats = lstatSync(artifactDir);
     if (!stats.isDirectory() || stats.isSymbolicLink()) {

--- a/tools/k6-proofs/scripts/run-cost-cap-fixture.mjs
+++ b/tools/k6-proofs/scripts/run-cost-cap-fixture.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+/**
+ * Isolated R-CW-5 cost-cap fixture.
+ *
+ * This fixture deliberately does not write OpenClaw config, state, or a
+ * workspace.  It runs the exact candidate's production continuation module
+ * plus the dispatch boundary suite from a source-only worktree.  That gives
+ * the proof harness a deterministic below/equal/over boundary and a
+ * no-spawn assertion without changing a fleet gateway.
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import process from 'node:process';
+
+const DEFAULT_CAP = 100;
+const SOURCE_MARKERS = [
+  'src/auto-reply/continuation/scheduler.ts',
+  'src/auto-reply/continuation/delegate-dispatch.cost-cap-exhaustion.test.ts',
+  'package.json',
+];
+
+function usage() {
+  return `Usage: node tools/k6-proofs/scripts/run-cost-cap-fixture.mjs \\
+  --source-dir <exact-candidate-worktree> \\
+  --candidate-sha <40-hex-sha> \\
+  --artifact-dir <safe-output-dir> [--cap <positive-int>] [--json]`;
+}
+
+export function parseArgs(argv, env = process.env) {
+  const args = {
+    sourceDir: env.OPENCLAW_RCW5_SOURCE_DIR || '',
+    candidateSha: env.OPENCLAW_CANDIDATE_SHA || '',
+    artifactDir: env.OPENCLAW_RCW5_ARTIFACT_DIR || '',
+    cap: Number(env.OPENCLAW_RCW5_CAP || DEFAULT_CAP),
+    json: false,
+  };
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--help') return { help: true };
+    if (arg === '--json') {
+      args.json = true;
+      continue;
+    }
+    const next = () => {
+      const value = argv[++i];
+      if (!value) throw new Error(`${arg} requires a value`);
+      return value;
+    };
+    if (arg === '--source-dir') args.sourceDir = next();
+    else if (arg === '--candidate-sha') args.candidateSha = next();
+    else if (arg === '--artifact-dir') args.artifactDir = next();
+    else if (arg === '--cap') args.cap = Number(next());
+    else throw new Error(`unexpected argument: ${arg}`);
+  }
+  return args;
+}
+
+function assertArgs(args) {
+  if (!args.sourceDir) throw new Error('--source-dir or OPENCLAW_RCW5_SOURCE_DIR is required');
+  if (!args.artifactDir) throw new Error('--artifact-dir or OPENCLAW_RCW5_ARTIFACT_DIR is required');
+  if (!/^[0-9a-f]{40}$/u.test(args.candidateSha)) {
+    throw new Error('--candidate-sha or OPENCLAW_CANDIDATE_SHA must be a 40-character lowercase SHA');
+  }
+  if (!Number.isInteger(args.cap) || args.cap < 2) throw new Error('--cap must be an integer of at least 2');
+}
+
+function run(command, args, options) {
+  try {
+    const stdout = execFileSync(command, args, { ...options, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+    return { ok: true, exitCode: 0, stdout, stderr: '' };
+  } catch (error) {
+    return {
+      ok: false,
+      exitCode: typeof error.status === 'number' ? error.status : 1,
+      stdout: error.stdout?.toString() || '',
+      stderr: error.stderr?.toString() || error.message,
+    };
+  }
+}
+
+function writeJson(file, value) {
+  writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+}
+
+function gitHead(sourceDir) {
+  const result = run('git', ['-C', sourceDir, 'rev-parse', 'HEAD'], {});
+  if (!result.ok) throw new Error(`cannot resolve source HEAD: ${result.stderr.trim()}`);
+  return result.stdout.trim();
+}
+
+function assertSource(sourceDir, candidateSha) {
+  const resolved = path.resolve(sourceDir);
+  for (const marker of SOURCE_MARKERS) {
+    if (!existsSync(path.join(resolved, marker))) throw new Error(`source dir is missing ${marker}`);
+  }
+  if (!existsSync(path.join(resolved, 'node_modules'))) {
+    throw new Error('source dir has no node_modules; fixture refuses to install dependencies or mutate the candidate worktree');
+  }
+  const head = gitHead(resolved);
+  if (head !== candidateSha) throw new Error(`candidate/source mismatch: requested ${candidateSha}, source is ${head}`);
+  return { resolved, head };
+}
+
+function matrixEval(cap) {
+  // JSON only: the fixture invokes the exact production TypeScript module via
+  // tsx, so this string is not a second implementation of the cap policy.
+  return [
+    'import { checkContinuationBudget } from "./src/auto-reply/continuation/scheduler.ts";',
+    `const cap = ${cap};`,
+    'const config = { enabled: true, minDelayMs: 1, maxDelayMs: 60_000, maxChainLength: 4, maxDelegatesPerTurn: 4, maxPendingWork: 32, crossSessionTargeting: "enabled", costCapTokens: cap };',
+    'const cases = [cap - 1, cap, cap + 1].map((accumulatedChainTokens) => ({ accumulatedChainTokens, outcome: checkContinuationBudget({ chainState: { currentChainCount: 0, chainStartedAt: 0, accumulatedChainTokens }, config, sessionKey: "r-cw-5-isolated" }) }));',
+    'console.log(JSON.stringify({ cap, cases }));',
+  ].join('\n');
+}
+
+function parseLastJson(stdout, label) {
+  const line = stdout.trim().split('\n').findLast((entry) => entry.trim().startsWith('{'));
+  if (!line) throw new Error(`${label} emitted no JSON receipt`);
+  return JSON.parse(line);
+}
+
+export function runFixture(args) {
+  assertArgs(args);
+  const { resolved: sourceDir, head } = assertSource(args.sourceDir, args.candidateSha);
+  const artifactDir = path.resolve(args.artifactDir);
+  mkdirSync(artifactDir, { recursive: true, mode: 0o700 });
+
+  const readiness = {
+    schema: 'openclaw.project81.r-cw-5.fixture-readiness.v1',
+    candidateSha: args.candidateSha,
+    sourceHead: head,
+    sourceDir,
+    productionConfigTouched: false,
+    productionStateTouched: false,
+    fixtureKind: 'source-only-production-module-plus-dispatch-boundary-suite',
+    cap: args.cap,
+  };
+  writeJson(path.join(artifactDir, 'fixture-readiness.json'), readiness);
+
+  const matrixRun = run('pnpm', ['exec', 'tsx', '--eval', matrixEval(args.cap)], { cwd: sourceDir });
+  const matrix = matrixRun.ok ? parseLastJson(matrixRun.stdout, 'boundary matrix') : null;
+  const matrixPassed = Boolean(
+    matrix?.cases?.length === 3 &&
+    matrix.cases[0]?.outcome === null &&
+    matrix.cases[1]?.outcome === null &&
+    matrix.cases[2]?.outcome === 'cost-capped',
+  );
+  writeJson(path.join(artifactDir, 'boundary-matrix.json'), {
+    schema: 'openclaw.project81.r-cw-5.boundary-matrix.v1',
+    cap: args.cap,
+    passed: matrixPassed,
+    ...(matrix || {}),
+    command: ['pnpm', 'exec', 'tsx', '--eval', '<production-module-eval>'],
+    exitCode: matrixRun.exitCode,
+  });
+
+  const dispatchRun = run(
+    'pnpm',
+    [
+      'vitest', 'run', '--config', 'test/vitest/vitest.auto-reply.config.ts',
+      'src/auto-reply/continuation/delegate-dispatch.cost-cap-exhaustion.test.ts', '--reporter=verbose',
+    ],
+    { cwd: sourceDir },
+  );
+  const dispatchAssertions = {
+    belowCapAllowsSpawn: /allows dispatch when accumulatedChainTokens is 1 below costCapTokens/u.test(dispatchRun.stdout),
+    exactCapAllowsSpawn: /rejects at exact boundary \(accumulatedChainTokens === costCapTokens is NOT over\)/u.test(dispatchRun.stdout),
+    overCapRejectsSpawn: /rejects dispatch when accumulatedChainTokens exceeds costCapTokens by 1/u.test(dispatchRun.stdout),
+    overCapMarksFlowFailed: /marks TaskFlow records as failed for cost-cap-rejected delegates/u.test(dispatchRun.stdout),
+  };
+  // A green process alone is insufficient: this fixture must keep pinning the
+  // four observable contract points, especially the rejected-hop no-spawn
+  // behavior and durable failed-flow side effect.
+  const dispatchPassed = dispatchRun.ok && Object.values(dispatchAssertions).every(Boolean);
+  writeJson(path.join(artifactDir, 'dispatch-boundary-suite.json'), {
+    schema: 'openclaw.project81.r-cw-5.dispatch-boundary-suite.v1',
+    passed: dispatchPassed,
+    exitCode: dispatchRun.exitCode,
+    command: ['pnpm', 'vitest', 'run', '--config', 'test/vitest/vitest.auto-reply.config.ts', 'src/auto-reply/continuation/delegate-dispatch.cost-cap-exhaustion.test.ts', '--reporter=verbose'],
+    // Test names, not raw logs, are public-safe and pin the no-spawn/cascade
+    // assertion without copying arbitrary candidate output into the corpus.
+    asserted: dispatchAssertions,
+  });
+
+  const verdict = matrixPassed && dispatchPassed ? 'PASS-candidate' : 'FAIL-fixture';
+  const result = {
+    schema: 'openclaw.project81.r-cw-5.fixture-result.v1',
+    verdict,
+    candidateSha: args.candidateSha,
+    cap: args.cap,
+    receipts: {
+      fixtureReadiness: 'fixture-readiness.json',
+      boundaryMatrix: 'boundary-matrix.json',
+      dispatchBoundarySuite: 'dispatch-boundary-suite.json',
+      cleanup: 'cleanup.json',
+    },
+    checks: { matrixPassed, dispatchPassed, noRejectedHopSpawn: dispatchPassed },
+  };
+  writeJson(path.join(artifactDir, 'cleanup.json'), {
+    schema: 'openclaw.project81.r-cw-5.cleanup.v1',
+    productionConfigTouched: false,
+    productionStateTouched: false,
+    sourceMutated: false,
+    cleanupRequired: false,
+    result: 'source-only fixture left no gateway/config/state process to restore',
+  });
+  writeJson(path.join(artifactDir, 'fixture-result.json'), result);
+  return result;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) try {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    console.log(usage());
+  } else {
+    const result = runFixture(args);
+    if (args.json) console.log(JSON.stringify(result));
+    else console.log(`R-CW-5 fixture: ${result.verdict} (${result.candidateSha})`);
+    process.exitCode = result.verdict === 'PASS-candidate' ? 0 : 1;
+  }
+} catch (error) {
+  console.error(`R-CW-5 fixture failed: ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 2;
+}

--- a/tools/k6-proofs/scripts/run-cost-cap-fixture.mjs
+++ b/tools/k6-proofs/scripts/run-cost-cap-fixture.mjs
@@ -94,7 +94,22 @@ function gitHead(sourceDir) {
   return result.stdout.trim();
 }
 
-function assertSource(sourceDir, candidateSha) {
+function trackedSourceStatus(sourceDir) {
+  const result = run('git', ['-C', sourceDir, 'status', '--porcelain', '--untracked-files=no'], {});
+  if (!result.ok) throw new Error(`cannot inspect tracked source state: ${result.stderr.trim()}`);
+  return result.stdout.trim();
+}
+
+export function assertTrackedSourceClean(sourceDir, phase) {
+  const status = trackedSourceStatus(sourceDir);
+  if (status) {
+    throw new Error(
+      `candidate source has tracked staged or unstaged changes before ${phase}; refusing exact-source certification`,
+    );
+  }
+}
+
+export function assertSource(sourceDir, candidateSha) {
   const resolved = path.resolve(sourceDir);
   for (const marker of SOURCE_MARKERS) {
     if (!existsSync(path.join(resolved, marker))) throw new Error(`source dir is missing ${marker}`);
@@ -104,6 +119,7 @@ function assertSource(sourceDir, candidateSha) {
   }
   const head = gitHead(resolved);
   if (head !== candidateSha) throw new Error(`candidate/source mismatch: requested ${candidateSha}, source is ${head}`);
+  assertTrackedSourceClean(resolved, 'fixture execution');
   return { resolved, head };
 }
 
@@ -259,6 +275,12 @@ export function runFixture(args) {
     disposableWorktreeCreated: true,
     ...toolSurface,
   });
+
+  // The production-module matrix and dispatcher suite execute against
+  // sourceDir. A matching HEAD is not enough if tracked files were altered
+  // while they ran, so refuse to emit a final exact-source receipt unless the
+  // candidate is still clean after every production-surface check.
+  assertTrackedSourceClean(sourceDir, 'final cleanup/result receipt');
 
   const verdict = matrixPassed && dispatchPassed && toolSurfacePassed ? 'PASS-candidate' : 'FAIL-fixture';
   const result = {

--- a/tools/k6-proofs/scripts/run-cost-cap-fixture.mjs
+++ b/tools/k6-proofs/scripts/run-cost-cap-fixture.mjs
@@ -9,9 +9,9 @@
  * no-spawn assertion without changing a fleet gateway.
  */
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import process from 'node:process';
 
 const DEFAULT_CAP = 100;
@@ -20,6 +20,10 @@ const SOURCE_MARKERS = [
   'src/auto-reply/continuation/delegate-dispatch.cost-cap-exhaustion.test.ts',
   'package.json',
 ];
+const TOOL_SURFACE_TEMPLATE = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../fixtures/r-cw-5/cost-cap-tool-surface.test.ts',
+);
 
 function usage() {
   return `Usage: node tools/k6-proofs/scripts/run-cost-cap-fixture.mjs \\
@@ -121,6 +125,46 @@ function parseLastJson(stdout, label) {
   return JSON.parse(line);
 }
 
+function runDisposableToolSurface({ sourceDir, candidateSha, artifactDir }) {
+  if (!existsSync(TOOL_SURFACE_TEMPLATE)) {
+    throw new Error(`tool-surface template missing: ${TOOL_SURFACE_TEMPLATE}`);
+  }
+  const worktreeDir = path.join(artifactDir, `.r-cw-5-tool-surface-${process.pid}-${Date.now()}`);
+  const add = run('git', ['-C', sourceDir, 'worktree', 'add', '--detach', worktreeDir, candidateSha], {});
+  if (!add.ok) throw new Error(`cannot create disposable candidate worktree: ${add.stderr.trim()}`);
+  let result;
+  try {
+    const testDir = path.join(worktreeDir, 'test', 'r-cw-5-fixture');
+    mkdirSync(testDir, { recursive: true, mode: 0o700 });
+    writeFileSync(
+      path.join(testDir, 'cost-cap-tool-surface.test.ts'),
+      readFileSync(TOOL_SURFACE_TEMPLATE),
+      { mode: 0o600 },
+    );
+    // The temporary worktree is source-only. Re-use the already-present,
+    // exact-candidate dependency tree without invoking pnpm/install.
+    symlinkSync(path.join(sourceDir, 'node_modules'), path.join(worktreeDir, 'node_modules'));
+    const test = run(
+      path.join(worktreeDir, 'node_modules', '.bin', 'vitest'),
+      ['run', '--config', 'test/vitest/vitest.auto-reply.config.ts', '--dir', 'test/r-cw-5-fixture', '--reporter=verbose'],
+      { cwd: worktreeDir },
+    );
+    result = {
+      passed: test.ok && /1 passed/u.test(test.stdout),
+      exitCode: test.exitCode,
+      asserted: {
+        typedToolCaptured: /disposable typed tool surface/u.test(test.stdout),
+        overCapRejected: /rejects exhausted typed-tool elections/u.test(test.stdout),
+        rejectedHopNoDurableWork: /1 passed/u.test(test.stdout),
+      },
+    };
+  } finally {
+    const remove = run('git', ['-C', sourceDir, 'worktree', 'remove', '--force', worktreeDir], {});
+    if (!remove.ok) throw new Error(`cannot remove disposable candidate worktree: ${remove.stderr.trim()}`);
+  }
+  return { ...result, disposableWorktreeRemoved: true };
+}
+
 export function runFixture(args) {
   assertArgs(args);
   const { resolved: sourceDir, head } = assertSource(args.sourceDir, args.candidateSha);
@@ -184,7 +228,21 @@ export function runFixture(args) {
     asserted: dispatchAssertions,
   });
 
-  const verdict = matrixPassed && dispatchPassed ? 'PASS-candidate' : 'FAIL-fixture';
+  const toolSurface = runDisposableToolSurface({ sourceDir, candidateSha: args.candidateSha, artifactDir });
+  const toolSurfacePassed = toolSurface.passed && Object.values(toolSurface.asserted).every(Boolean);
+  writeJson(path.join(artifactDir, 'typed-tool-surface.json'), {
+    schema: 'openclaw.project81.r-cw-5.typed-tool-surface.v1',
+    passed: toolSurfacePassed,
+    cap: args.cap,
+    fixtureKind: 'disposable-exact-candidate-worktree-with-real-attempt-execution-and-typed-tool-capture',
+    productionConfigTouched: false,
+    productionStateTouched: false,
+    sourceDirMutated: false,
+    disposableWorktreeCreated: true,
+    ...toolSurface,
+  });
+
+  const verdict = matrixPassed && dispatchPassed && toolSurfacePassed ? 'PASS-candidate' : 'FAIL-fixture';
   const result = {
     schema: 'openclaw.project81.r-cw-5.fixture-result.v1',
     verdict,
@@ -194,9 +252,10 @@ export function runFixture(args) {
       fixtureReadiness: 'fixture-readiness.json',
       boundaryMatrix: 'boundary-matrix.json',
       dispatchBoundarySuite: 'dispatch-boundary-suite.json',
+      typedToolSurface: 'typed-tool-surface.json',
       cleanup: 'cleanup.json',
     },
-    checks: { matrixPassed, dispatchPassed, noRejectedHopSpawn: dispatchPassed },
+    checks: { matrixPassed, dispatchPassed, toolSurfacePassed, noRejectedHopSpawn: dispatchPassed && toolSurfacePassed },
   };
   writeJson(path.join(artifactDir, 'cleanup.json'), {
     schema: 'openclaw.project81.r-cw-5.cleanup.v1',


### PR DESCRIPTION
Relates to #427; do not auto-close it.

Repairs the safe, runnable isolated component fixture for the R-CW-5 cost-cap boundary. The fixture pins tracked source to the requested exact SHA, performs no dependency install or production config/state access, and emits readiness, boundary, dispatcher, typed-tool, and cleanup receipts.

At PR head `413d76f6b9ba28ffdc91828b99c5bebb0d6e568a`, the fixture:
- passes the selected cap through both the production matrix and disposable typed-tool surface; reported exact-candidate runs pass at 100 (99/100/101) and 200 (199/200/201);
- rejects tracked staged/unstaged source drift before execution and before final certification;
- rejects artifact-path symlinks including ancestors and rejects a symlinked source dependency directory;
- keeps private absolute source paths out of public readiness artifacts.

Verification: full proof-script suite `122/122`; manifest/scenario/proof-row checks green; default and non-default exact-candidate isolated runs are `PASS-candidate`. This remains PASS-candidate pending independent rereview and explicit corpus disposition; no auto-close or canonical-row transition is claimed.