### PR TITLE
fix(proofs): make Tempo correlation receipts deterministic

### DIFF
--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -232,8 +232,9 @@ successful proof with missing artifacts. Trace and correlation paths in
 ## Tempo trace receipts
 
 When a live row emits a `trace_id`, `run-proofs.sh` attempts to fetch the
-matching Tempo JSON from `OPENCLAW_PROOFS_TEMPO_BASE_URL` / `TEMPO_BASE_URL` (fleet default `http://tempo.dandelion.cult`)
-and saves it beside the candidate run artifacts as `tempo-trace-<trace>.json`.
+matching Tempo trace from `OPENCLAW_PROOFS_TEMPO_BASE_URL` / `TEMPO_BASE_URL` (fleet default `http://tempo.dandelion.cult`)
+and saves only its public-safe projection beside the candidate run artifacts
+as `tempo-trace-<trace>.json`; raw Tempo/OTLP responses are never public proof artifacts.
 For trace-required tool rows whose primary `trace_id` is null, the collector
 instead searches by seat service, tool fingerprint, and an evidence-derived
 bounded dispatch window. It accepts exactly one candidate, fails closed on
@@ -250,7 +251,7 @@ from the committed prompt template and evidence nonce, searches Tempo by
 `reason.hash` + `reason.length` + delegate mode, requires exactly one trace,
 and validates that the originating `continue_delegate` tool span plus
 `continuation.delegate.fire` and `continuation.delegate.dispatch` share valid,
-distinct IDs and one chain. The raw trace and
+distinct IDs and one chain. The public-safe trace projection and
 `continuation-trace-correlation.json` are saved beside the row artifacts; raw
 task text and `traceparent` are not persisted in the correlation receipt.
 

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -237,7 +237,8 @@ and saves it beside the candidate run artifacts as `tempo-trace-<trace>.json`.
 For trace-required tool rows whose primary `trace_id` is null, the collector
 instead searches by seat service, tool fingerprint, and an evidence-derived
 bounded dispatch window. It accepts exactly one candidate, fails closed on
-zero or multiple candidates, and saves the same public-safe Tempo JSON plus a
+zero or multiple candidates, and saves a public-safe projection containing
+only proof topology plus allowlisted telemetry attributes, together with a
 deterministic correlation receipt containing the exact query window. Fetch or
 correlation failures are kept non-fatal by default and leave
 `tempo-trace-json` review-pending. Set `OPENCLAW_PROOFS_K6_TEMPO_REQUIRED=true`

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -231,13 +231,17 @@ successful proof with missing artifacts. Trace and correlation paths in
 
 ## Tempo trace receipts
 
-When a live row emits a `trace_id`, `run-proofs.sh` now attempts to fetch the
+When a live row emits a `trace_id`, `run-proofs.sh` attempts to fetch the
 matching Tempo JSON from `OPENCLAW_PROOFS_TEMPO_BASE_URL` / `TEMPO_BASE_URL` (fleet default `http://tempo.dandelion.cult`)
 and saves it beside the candidate run artifacts as `tempo-trace-<trace>.json`.
-The fetch receipt is stored in `tempo-trace-receipt.json`; fetch failures are
-kept non-fatal by default and leave `tempo-trace-json` review-pending. Set
-`OPENCLAW_PROOFS_K6_TEMPO_REQUIRED=true` only when a missing trace JSON should
-fail the run.
+For trace-required tool rows whose primary `trace_id` is null, the collector
+instead searches by seat service, tool fingerprint, and an evidence-derived
+bounded dispatch window. It accepts exactly one candidate, fails closed on
+zero or multiple candidates, and saves the same public-safe Tempo JSON plus a
+deterministic correlation receipt containing the exact query window. Fetch or
+correlation failures are kept non-fatal by default and leave
+`tempo-trace-json` review-pending. Set `OPENCLAW_PROOFS_K6_TEMPO_REQUIRED=true`
+only when a missing trace JSON should fail the run.
 
 For trace-required `continue_delegate` rows, the runner does not trust a
 missing or first-match trace ID. It derives the public-safe runtime fingerprint

--- a/tools/k6-proofs/k6-proofs-pipeline.xml
+++ b/tools/k6-proofs/k6-proofs-pipeline.xml
@@ -48,7 +48,7 @@
     </Step>
     <Step order="3" id="evidence-capture">
       <Action>Grep journal for nonce; pull Tempo trace; query Loki</Action>
-      <Artifacts>EVIDENCE.md + raw trace JSON + summary JSON</Artifacts>
+      <Artifacts>EVIDENCE.md + public-safe trace projection JSON + summary JSON</Artifacts>
       <Destination>PROOFS/{SHA}/R-{ROW-NAME}/</Destination>
     </Step>
     <Step order="4" id="commit">

--- a/tools/k6-proofs/lib/public-tempo-trace.mjs
+++ b/tools/k6-proofs/lib/public-tempo-trace.mjs
@@ -1,0 +1,104 @@
+const PUBLIC_TRACE_ATTRIBUTE_KEYS = new Set([
+  'chain.id',
+  'delegate.mode',
+  'gen_ai.tool.name',
+  'openclaw.toolName',
+  'reason.hash',
+  'reason.length',
+  'reason.present',
+]);
+
+export function tempoAttributeValue(attribute) {
+  const value = attribute?.value || {};
+  return value.stringValue ?? value.intValue ?? value.boolValue ?? value.doubleValue ?? null;
+}
+
+export function allTempoSpans(trace) {
+  if (Array.isArray(trace?.batches)) {
+    return trace.batches.flatMap((batch) =>
+      (batch.scopeSpans || batch.instrumentationLibrarySpans || []).flatMap((scope) => scope.spans || []));
+  }
+  if (Array.isArray(trace?.trace?.spans)) return trace.trace.spans;
+  return [];
+}
+
+function safeHex(value, length) {
+  const text = String(value ?? '').toLowerCase();
+  return new RegExp(`^[0-9a-f]{${length}}$`).test(text) && !/^0+$/.test(text) ? text : null;
+}
+
+function safeSpanId(value, bytes) {
+  if (!value) return null;
+  const text = String(value);
+  if (text.length === bytes * 2 && /^[0-9a-f]+$/i.test(text)) return safeHex(text, bytes * 2);
+  try {
+    const decoded = Buffer.from(text, 'base64');
+    return decoded.length === bytes ? safeHex(decoded.toString('hex'), bytes * 2) : null;
+  } catch {
+    return null;
+  }
+}
+
+function publicTraceAttribute(attribute) {
+  if (!attribute || !PUBLIC_TRACE_ATTRIBUTE_KEYS.has(attribute.key)) return null;
+  const value = tempoAttributeValue(attribute);
+  if (value === undefined || value === null) return null;
+
+  if (attribute.key === 'reason.hash' && !/^[0-9a-f]{16}$/iu.test(String(value))) return null;
+  if (attribute.key === 'reason.length' && !Number.isInteger(Number(value))) return null;
+  if (attribute.key === 'reason.present' && value !== true && value !== false && value !== 'true' && value !== 'false') return null;
+  if (attribute.key === 'delegate.mode' && !['normal', 'silent', 'silent-wake', 'post-compaction'].includes(String(value))) return null;
+  if (['gen_ai.tool.name', 'openclaw.toolName'].includes(attribute.key) &&
+      !['continue_delegate', 'continue_work', 'request_compaction'].includes(String(value))) return null;
+  if (attribute.key === 'chain.id' &&
+      !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu.test(String(value))) return null;
+
+  if (typeof value === 'boolean') return { key: attribute.key, value: { boolValue: value } };
+  if (typeof value === 'number' || attribute.key === 'reason.length') {
+    return { key: attribute.key, value: { intValue: String(value) } };
+  }
+  return { key: attribute.key, value: { stringValue: String(value) } };
+}
+
+export function publicTempoStatusCode(value) {
+  if (value === 0 || value === 'UNSET') return 'UNSET';
+  if (value === 1 || value === 'OK') return 'OK';
+  if (value === 2 || value === 'ERROR') return 'ERROR';
+  return 'UNSET';
+}
+
+export function publicTempoSpanName(value) {
+  return typeof value === 'string' && /^(?:openclaw|continuation)\.[A-Za-z0-9._:-]{1,150}$/u.test(value)
+    ? value
+    : null;
+}
+
+/**
+ * Convert a private Tempo/OTLP response into the only trace shape permitted in
+ * public proof-run artifacts. Arbitrary resource/span attributes, events,
+ * links, status messages, task text, and credentials are intentionally absent.
+ */
+export function projectPublicTempoTrace(trace, traceId) {
+  const spans = allTempoSpans(trace).flatMap((span) => {
+    const name = publicTempoSpanName(span.name);
+    if (!name) return [];
+    const spanId = safeSpanId(span.spanId, 8);
+    if (!spanId) return [];
+    const parentSpanId = safeSpanId(span.parentSpanId, 8);
+    return [{
+      name,
+      traceId,
+      spanId,
+      parentSpanId,
+      status: { code: publicTempoStatusCode(span.status?.code) },
+      attributes: (Array.isArray(span.attributes) ? span.attributes : [])
+        .map(publicTraceAttribute)
+        .filter(Boolean),
+    }];
+  });
+  return {
+    schema: 'openclaw.k6.public-tempo-trace.v1',
+    traceId,
+    spans,
+  };
+}

--- a/tools/k6-proofs/manifests/r-cw-1.json
+++ b/tools/k6-proofs/manifests/r-cw-1.json
@@ -30,7 +30,7 @@
     { "name": "tool-invoke-accepted", "required": true, "description": "Gateway accepted the continue_work tool invocation" },
     { "name": "continue-work-tool-result-scheduled", "required": true, "description": "Post-dispatch non-harness event includes explicit CW-SCHEDULED sentinel emitted after continue_work tool result reports scheduled" },
     { "name": "work-woke-event", "required": true, "description": "Session wake event delivered after delaySeconds" },
-    { "name": "trace-id", "required": true, "description": "Unique safe-fingerprint correlation to raw Tempo JSON containing same-trace continue_work tool, continuation.work, and continuation.work.fire spans" }
+    { "name": "trace-id", "required": true, "description": "Unique safe-fingerprint correlation to a public-safe Tempo projection containing same-trace continue_work tool, continuation.work, and continuation.work.fire spans" }
   ],
   "artifactDestination": {
     "root": "PROOFS",

--- a/tools/k6-proofs/manifests/r-rc-2.json
+++ b/tools/k6-proofs/manifests/r-rc-2.json
@@ -52,7 +52,7 @@
     {
       "name": "trace-id",
       "required": true,
-      "description": "Unique safe-fingerprint correlation to raw Tempo JSON containing same-trace continue_delegate tool, fire, and dispatch spans"
+      "description": "Unique safe-fingerprint correlation to a public-safe Tempo projection containing same-trace continue_delegate tool, fire, and dispatch spans"
     }
   ],
   "artifactDestination": {

--- a/tools/k6-proofs/scripts/__tests__/collect-continuation-trace.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/collect-continuation-trace.test.mjs
@@ -42,7 +42,7 @@ function traceFixture({ traceId, reasonHash, reasonLength, tool = 'continue_dele
   const acceptSpanName = isWork ? 'continuation.work' : 'continuation.delegate.dispatch';
   const fireSpanName = isWork ? 'continuation.work.fire' : 'continuation.delegate.fire';
   const continuationAttrs = [
-    attr('chain.id', 'chain-example'),
+    attr('chain.id', '11111111-1111-4111-8111-111111111111'),
     attr('reason.hash', reasonHash),
     attr('reason.length', reasonLength),
     ...(isWork ? [] : [attr('delegate.mode', 'normal')]),
@@ -376,6 +376,71 @@ test('uses a fixed dispatch-only window when evidence has no ended time', async 
   }
 });
 
+test('persists a public trace projection without private Tempo attributes or status messages', async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'tool-trace-public-projection-test-'));
+  const manifestPath = path.join(dir, 'manifest.json');
+  const traceId = '77777777777777777777777777777777';
+  const sessionKey = 'agent:main:private-session-key-not-in-evidence';
+  const authorization = 'Bearer private-tempo-credential';
+  const statusMessage = 'private backend status text';
+  await writeFile(manifestPath, JSON.stringify({
+    rowId: 'R-RC-1',
+    invocation: { tool: 'request_compaction' },
+  }));
+  await writeFile(path.join(dir, 'evidence.jsonl'), `${JSON.stringify({
+    row: 'R-RC-1',
+    started: '2026-07-13T03:20:19.504Z',
+    ended: '2026-07-13T03:20:53.324Z',
+  })}\n`);
+
+  const unsafePrivateTrace = toolTraceFixture({ traceId, tool: 'request_compaction' });
+  const toolSpan = unsafePrivateTrace.batches[0].scopeSpans[0].spans[0];
+  toolSpan.attributes.push(
+    attr('session.key', sessionKey),
+    attr('authorization', authorization),
+  );
+  toolSpan.status = { code: 'ERROR', message: statusMessage };
+
+  const server = await listen((request, response) => {
+    const url = new URL(request.url, 'http://localhost');
+    response.setHeader('content-type', 'application/json');
+    response.end(JSON.stringify(
+      url.pathname === '/api/search'
+        ? { traces: [{ traceID: traceId }] }
+        : unsafePrivateTrace,
+    ));
+  });
+
+  try {
+    const { stdout } = await execFileAsync(process.execPath, [
+      script,
+      '--run-dir', dir,
+      '--manifest', manifestPath,
+      '--seat', 'ronan-dgx',
+      '--tempo-url', server.url,
+      '--timeout-ms', '100',
+      '--poll-ms', '10',
+    ]);
+    const result = JSON.parse(stdout);
+    const traceText = await readFile(path.join(dir, result.traceFile), 'utf8');
+    const receiptText = await readFile(path.join(dir, result.receiptFile), 'utf8');
+    const publicTrace = JSON.parse(traceText);
+    const receipt = JSON.parse(receiptText);
+
+    assert.equal(publicTrace.schema, 'openclaw.k6.public-tempo-trace.v1');
+    assert.equal(publicTrace.traceId, traceId);
+    assert.match(traceText, /gen_ai\.tool\.name/);
+    for (const privateValue of [sessionKey, authorization, statusMessage]) {
+      assert.doesNotMatch(traceText, new RegExp(privateValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+      assert.doesNotMatch(receiptText, new RegExp(privateValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    }
+    assert.deepEqual(receipt.tool.status, { code: 'ERROR' });
+  } finally {
+    await server.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('correlates continue_work tool/accept/fire topology by safe reason fingerprint', async () => {
   const fixture = await fixtureDir({ tool: 'continue_work' });
   const traceId = '33333333333333333333333333333333';
@@ -453,9 +518,14 @@ test('reconstructs deterministic R-CW-3 reason telemetry without persisting the 
     ]);
     const result = JSON.parse(stdout);
     const receipt = JSON.parse(await readFile(path.join(fixture.dir, result.receiptFile), 'utf8'));
+    const publicTraceText = await readFile(path.join(fixture.dir, result.traceFile), 'utf8');
 
     assert.equal(receipt.row, 'R-CW-3');
     assert.equal(receipt.reason.hash, fixture.reasonHash);
+    assert.match(publicTraceText, /reason\.hash/);
+    assert.match(publicTraceText, new RegExp(fixture.reasonHash));
+    assert.match(publicTraceText, /reason\.length/);
+    assert.doesNotMatch(publicTraceText, /RAW-RCW3/);
     assert.doesNotMatch(JSON.stringify(receipt), /RAW-RCW3/);
   } finally {
     await server.close();

--- a/tools/k6-proofs/scripts/__tests__/collect-continuation-trace.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/collect-continuation-trace.test.mjs
@@ -302,10 +302,74 @@ test('recovers a unique non-continuation tool trace by seat, tool, and evidence 
     assert.equal(receipt.tool.spanId, 'aaaaaaaaaaaaaaaa');
     assert.equal(receipt.tool.status.code, 'UNSET');
     assert.equal(receipt.uniqueTrace, true);
+    assert.equal('generatedAt' in receipt, false);
+    assert.deepEqual(receipt.searchWindow, {
+      startUnixSeconds: Math.floor(Date.parse('2026-07-13T03:20:19.504Z') / 1000) - 60,
+      endUnixSeconds: Math.floor(Date.parse('2026-07-13T03:20:53.324Z') / 1000) + 60,
+      paddingSeconds: 60,
+      source: 'dispatch-and-evidence-ended',
+    });
     assert.match(observedQuery, /service\.name="ronan-prince"/);
     assert.match(observedQuery, /gen_ai\.tool\.name="request_compaction"/);
     assert.equal(observedStart, String(Math.floor(Date.parse('2026-07-13T03:20:19.504Z') / 1000) - 60));
     assert.equal(observedEnd, String(Math.floor(Date.parse('2026-07-13T03:20:53.324Z') / 1000) + 60));
+  } finally {
+    await server.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('uses a fixed dispatch-only window when evidence has no ended time', async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'tool-trace-window-test-'));
+  const manifestPath = path.join(dir, 'manifest.json');
+  const traceId = '66666666666666666666666666666666';
+  const dispatchedAt = '2026-07-13T03:20:19.504Z';
+  await writeFile(manifestPath, JSON.stringify({
+    rowId: 'R-RC-1',
+    invocation: { tool: 'request_compaction' },
+  }));
+  await writeFile(path.join(dir, 'evidence.jsonl'), `${JSON.stringify({
+    row: 'R-RC-1',
+    started: dispatchedAt,
+  })}\n`);
+  let observedEnd = '';
+  const server = await listen((request, response) => {
+    const url = new URL(request.url, 'http://localhost');
+    response.setHeader('content-type', 'application/json');
+    if (url.pathname === '/api/search') {
+      observedEnd = url.searchParams.get('end') || '';
+      response.end(JSON.stringify({ traces: [{ traceID: traceId }] }));
+      return;
+    }
+    response.end(JSON.stringify(toolTraceFixture({ traceId, tool: 'request_compaction' })));
+  });
+
+  try {
+    const args = [
+      script,
+      '--run-dir', dir,
+      '--manifest', manifestPath,
+      '--seat', 'ronan-dgx',
+      '--tempo-url', server.url,
+      '--timeout-ms', '100',
+      '--poll-ms', '10',
+    ];
+    const { stdout } = await execFileAsync(process.execPath, args);
+    const result = JSON.parse(stdout);
+    const receiptPath = path.join(dir, result.receiptFile);
+    const firstReceipt = await readFile(receiptPath, 'utf8');
+    await execFileAsync(process.execPath, args);
+    assert.equal(await readFile(receiptPath, 'utf8'), firstReceipt);
+
+    const dispatchSeconds = Math.floor(Date.parse(dispatchedAt) / 1000);
+    const receipt = JSON.parse(firstReceipt);
+    assert.equal(observedEnd, String(dispatchSeconds + 60));
+    assert.deepEqual(receipt.searchWindow, {
+      startUnixSeconds: dispatchSeconds - 60,
+      endUnixSeconds: dispatchSeconds + 60,
+      paddingSeconds: 60,
+      source: 'dispatch-only',
+    });
   } finally {
     await server.close();
     await rm(dir, { recursive: true, force: true });

--- a/tools/k6-proofs/scripts/__tests__/tempo-fetch.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/tempo-fetch.test.mjs
@@ -21,13 +21,25 @@ async function withServer(handler, fn) {
   }
 }
 
-test('fetches Tempo trace JSON by trace id and writes receipt', async () => {
+test('fetches and projects Tempo trace JSON by trace id without persisting private fields', async () => {
   const root = await mkdtemp(path.join(tmpdir(), 'tempo-fetch-'));
   try {
     await withServer((req, res) => {
       assert.equal(req.url, '/api/traces/0123456789abcdef');
       res.setHeader('content-type', 'application/json');
-      res.end(JSON.stringify({ batches: [{ scopeSpans: [{ spans: [{ traceId: '0123456789abcdef', spanId: 'abc' }] }] }] }));
+      res.end(JSON.stringify({ batches: [{ resource: { attributes: [{ key: 'host.secret', value: { stringValue: 'private-resource' } }] }, scopeSpans: [{ spans: [{
+        traceId: '0123456789abcdef',
+        spanId: '0123456789abcdef',
+        name: 'openclaw.tool',
+        status: { code: 2, message: 'private status text' },
+        attributes: [
+          { key: 'openclaw.toolName', value: { stringValue: 'continue_work' } },
+          { key: 'session.key', value: { stringValue: 'agent:private:session' } },
+          { key: 'authorization', value: { stringValue: 'Bearer private-token' } },
+          { key: 'task.text', value: { stringValue: 'private task prompt' } },
+        ],
+        events: [{ name: 'private event', attributes: [{ key: 'prompt', value: { stringValue: 'private prompt' } }] }],
+      }] }] }] }));
     }, async (baseUrl) => {
       const out = path.join(root, 'trace.json');
       const run = await runNode(process.execPath, [script, '--trace-id', '0123456789abcdef', '--tempo-url', baseUrl, '--out', out], { encoding: 'utf8' });
@@ -37,7 +49,17 @@ test('fetches Tempo trace JSON by trace id and writes receipt', async () => {
       assert.equal(receipt.spans, 1);
       assert.equal(receipt.tempoUrl.includes('0123456789abcdef'), false);
       const body = JSON.parse(await readFile(out, 'utf8'));
-      assert.equal(body.batches[0].scopeSpans[0].spans.length, 1);
+      assert.equal(body.schema, 'openclaw.k6.public-tempo-trace.v1');
+      assert.equal(body.spans.length, 1);
+      assert.equal(body.spans[0].name, 'openclaw.tool');
+      assert.deepEqual(body.spans[0].status, { code: 'ERROR' });
+      assert.deepEqual(body.spans[0].attributes, [
+        { key: 'openclaw.toolName', value: { stringValue: 'continue_work' } },
+      ]);
+      const serialized = JSON.stringify({ body, receipt });
+      for (const forbidden of ['session.key', 'authorization', 'agent:private:session', 'private-token', 'private status text', 'private-resource', 'private task prompt', 'private prompt']) {
+        assert.equal(serialized.includes(forbidden), false, `leaked ${forbidden}`);
+      }
     });
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -53,7 +75,7 @@ test('can discover trace id from run-dir evidence.jsonl', async () => {
     await withServer((req, res) => {
       assert.equal(req.url, '/api/traces/abcdef0123456789');
       res.setHeader('content-type', 'application/json');
-      res.end(JSON.stringify({ trace: { spans: [{ spanId: 'abc' }] } }));
+      res.end(JSON.stringify({ trace: { spans: [{ spanId: '0123456789abcdef', name: 'continuation.work' }] } }));
     }, async (baseUrl) => {
       const run = await runNode(process.execPath, [script, '--run-dir', runDir, '--tempo-url', baseUrl], { encoding: 'utf8' });
       const receipt = JSON.parse(run.stdout);
@@ -78,7 +100,10 @@ test('can discover trace id from Tempo TraceQL search', async () => {
       }
       assert.equal(req.url, '/api/traces/fedcba9876543210');
       res.setHeader('content-type', 'application/json');
-      res.end(JSON.stringify({ trace: { spans: [{ spanId: 'abc' }, { spanId: 'def' }] } }));
+      res.end(JSON.stringify({ trace: { spans: [
+        { spanId: '0123456789abcdef', name: 'continuation.work' },
+        { spanId: 'fedcba9876543210', name: 'continuation.work.fire' },
+      ] } }));
     }, async (baseUrl) => {
       const out = path.join(root, 'trace.json');
       const run = await runNode(process.execPath, [script, '--traceql', '{ .chain.id = "chain-1" }', '--tempo-url', baseUrl, '--start', '1783518200', '--end', '1783518400', '--out', out], { encoding: 'utf8' });
@@ -87,7 +112,7 @@ test('can discover trace id from Tempo TraceQL search', async () => {
       assert.equal(receipt.traceId, 'fedcba9876543210');
       assert.equal(receipt.spans, 2);
       const body = JSON.parse(await readFile(out, 'utf8'));
-      assert.equal(body.trace.spans.length, 2);
+      assert.equal(body.spans.length, 2);
     });
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -100,7 +125,7 @@ test('uses OPENCLAW_PROOFS_TEMPO_BASE_URL when --tempo-url is omitted', async ()
     await withServer((req, res) => {
       assert.equal(req.url, '/api/traces/1111222233334444');
       res.setHeader('content-type', 'application/json');
-      res.end(JSON.stringify({ trace: { spans: [{ spanId: 'env' }] } }));
+      res.end(JSON.stringify({ trace: { spans: [{ spanId: '0123456789abcdef', name: 'continuation.work' }] } }));
     }, async (baseUrl) => {
       const out = path.join(root, 'trace.json');
       const run = await runNode(process.execPath, [script, '--trace-id', '1111222233334444', '--out', out], {

--- a/tools/k6-proofs/scripts/collect-continuation-trace.mjs
+++ b/tools/k6-proofs/scripts/collect-continuation-trace.mjs
@@ -6,6 +6,7 @@ import { pathToFileURL } from 'node:url';
 import { sanitizeEvidenceRecords } from './sanitize-k6-artifacts.mjs';
 
 const DEFAULT_TEMPO_BASE_URL = 'http://tempo.dandelion.cult';
+const CORRELATION_WINDOW_PADDING_SECONDS = 60;
 
 function usage() {
   console.error(`Usage: node collect-continuation-trace.mjs \\
@@ -335,10 +336,13 @@ async function main() {
     : `{ resource.service.name="${serviceName}" && name="openclaw.tool.execution" && .gen_ai.tool.name="${contract.tool}" }`;
   const dispatchMs = Number(evidence.dispatch_accepted_at_ms || Date.parse(evidence.started));
   if (!Number.isFinite(dispatchMs)) throw new Error('evidence lacks a valid dispatch/start time');
-  const start = Math.floor(dispatchMs / 1000) - 60;
+  const dispatchSeconds = Math.floor(dispatchMs / 1000);
+  const start = dispatchSeconds - CORRELATION_WINDOW_PADDING_SECONDS;
   const evidenceEndMs = Date.parse(evidence.ended);
-  const searchEndMs = Number.isFinite(evidenceEndMs) ? evidenceEndMs : Date.now();
-  const end = Math.floor(searchEndMs / 1000) + 60;
+  const evidenceEndSeconds = Number.isFinite(evidenceEndMs)
+    ? Math.floor(evidenceEndMs / 1000)
+    : dispatchSeconds;
+  const end = Math.max(dispatchSeconds, evidenceEndSeconds) + CORRELATION_WINDOW_PADDING_SECONDS;
   const deadline = Date.now() + args.timeoutMs;
   let candidates = [];
   let traceId = '';
@@ -398,11 +402,16 @@ async function main() {
     schema: contract.kind === 'continuation'
       ? 'openclaw.k6.continuation-trace-correlation.v1'
       : 'openclaw.k6.tool-trace-correlation.v1',
-    generatedAt: new Date().toISOString(),
     row: evidence.row || manifest.rowId,
     seat: args.seat,
     attribution: contract.attribution,
     query,
+    searchWindow: {
+      startUnixSeconds: start,
+      endUnixSeconds: end,
+      paddingSeconds: CORRELATION_WINDOW_PADDING_SECONDS,
+      source: Number.isFinite(evidenceEndMs) ? 'dispatch-and-evidence-ended' : 'dispatch-only',
+    },
     traceJson: path.basename(traceOut),
     ...topology,
     ...(contract.kind === 'continuation'

--- a/tools/k6-proofs/scripts/collect-continuation-trace.mjs
+++ b/tools/k6-proofs/scripts/collect-continuation-trace.mjs
@@ -174,6 +174,90 @@ function assertTraceIsPublicSafe(trace, evidence, reason) {
   }
 }
 
+const PUBLIC_TRACE_ATTRIBUTE_KEYS = new Set([
+  'chain.id',
+  'delegate.mode',
+  'gen_ai.tool.name',
+  'openclaw.toolName',
+  'reason.hash',
+  'reason.length',
+  'reason.present',
+]);
+
+function publicTraceAttribute(attribute) {
+  if (!attribute || !PUBLIC_TRACE_ATTRIBUTE_KEYS.has(attribute.key)) return null;
+  const value = attributeValue(attribute);
+  if (value === undefined || value === null) return null;
+
+  if (attribute.key === 'reason.hash' && !/^[0-9a-f]{16}$/iu.test(String(value))) return null;
+  if (attribute.key === 'reason.length' && !Number.isInteger(Number(value))) return null;
+  if (attribute.key === 'reason.present' && value !== true && value !== false && value !== 'true' && value !== 'false') return null;
+  if (attribute.key === 'delegate.mode' && !['normal', 'silent', 'silent-wake', 'post-compaction'].includes(String(value))) return null;
+  if (['gen_ai.tool.name', 'openclaw.toolName'].includes(attribute.key) &&
+      !['continue_delegate', 'continue_work', 'request_compaction'].includes(String(value))) return null;
+  if (attribute.key === 'chain.id' &&
+      !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu.test(String(value))) return null;
+
+  if (typeof value === 'boolean') return { key: attribute.key, value: { boolValue: value } };
+  if (typeof value === 'number' || attribute.key === 'reason.length') {
+    return { key: attribute.key, value: { intValue: String(value) } };
+  }
+  return { key: attribute.key, value: { stringValue: String(value) } };
+}
+
+function safePublicSpanId(value, bytes) {
+  if (!value) return null;
+  try {
+    return idHex(value, bytes, 'public trace span id');
+  } catch {
+    return null;
+  }
+}
+
+function publicStatusCode(value) {
+  if (value === 0 || value === 'UNSET') return 'UNSET';
+  if (value === 1 || value === 'OK') return 'OK';
+  if (value === 2 || value === 'ERROR') return 'ERROR';
+  return 'UNSET';
+}
+
+function publicSpanName(value) {
+  return typeof value === 'string' && /^(?:openclaw|continuation)\.[A-Za-z0-9._:-]{1,150}$/u.test(value)
+    ? value
+    : null;
+}
+
+/**
+ * Persist only the topology and telemetry attributes needed for proof review.
+ * Tempo's raw OTLP response may contain session keys, credentials, task text,
+ * or status messages that are valid for the private backend but forbidden in
+ * the public proof corpus.
+ */
+function publicTraceProjection(trace, traceId) {
+  const spans = allSpans(trace).flatMap((span) => {
+    const name = publicSpanName(span.name);
+    if (!name) return [];
+    const spanId = safePublicSpanId(span.spanId, 8);
+    if (!spanId) return [];
+    const parentSpanId = safePublicSpanId(span.parentSpanId, 8);
+    return [{
+      name,
+      traceId,
+      spanId,
+      parentSpanId,
+      status: { code: publicStatusCode(span.status?.code) },
+      attributes: (Array.isArray(span.attributes) ? span.attributes : [])
+        .map(publicTraceAttribute)
+        .filter(Boolean),
+    }];
+  });
+  return {
+    schema: 'openclaw.k6.public-tempo-trace.v1',
+    traceId,
+    spans,
+  };
+}
+
 async function tempoSearch(baseUrl, query, start, end) {
   const root = String(baseUrl).replace(/\/+$/, '');
   const params = new URLSearchParams({ q: query, start: String(start), end: String(end), limit: '20' });
@@ -209,7 +293,9 @@ function validateTrace(trace, expected) {
   if (!accept) throw new Error(`matched trace lacks the expected ${expected.acceptSpanName} span`);
   const acceptAttrs = attributes(accept);
   const chainId = String(acceptAttrs.get('chain.id') || '');
-  if (!chainId) throw new Error(`${expected.acceptSpanName} span lacks chain.id`);
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu.test(chainId)) {
+    throw new Error(`${expected.acceptSpanName} span lacks a public-safe UUIDv4 chain.id`);
+  }
 
   const fire = spans.find((span) => {
     const attrs = attributes(span);
@@ -247,7 +333,8 @@ function validateTrace(trace, expected) {
   const childSpans = spans
     .filter((span) =>
       span.parentSpanId && idHex(span.parentSpanId, 8, 'parent span id') === acceptSpanId)
-    .map((span) => ({ name: span.name, spanId: idHex(span.spanId, 8, 'child span id') }));
+    .map((span) => ({ name: publicSpanName(span.name), spanId: idHex(span.spanId, 8, 'child span id') }))
+    .filter((span) => span.name !== null);
 
   const topology = {
     traceId,
@@ -295,10 +382,8 @@ function validateToolTrace(trace, expected) {
       ? idHex(tool.parentSpanId, 8, 'tool parent span id')
       : null,
     status: {
-      code: tool.status?.code ?? 'UNSET',
-      message: tool.status?.message ?? null,
+      code: publicStatusCode(tool.status?.code),
     },
-    errorType: attrs.get('error.type') ?? attrs.get('exception.type') ?? null,
   };
 }
 
@@ -389,6 +474,7 @@ async function main() {
     throw new Error(`no Tempo trace matched ${fingerprint} before timeout`);
   }
   assertTraceIsPublicSafe(trace, evidence, contract);
+  const publicTrace = publicTraceProjection(trace, traceId);
 
   const traceOut = path.join(runDir, `tempo-trace-${traceId.slice(0, 12)}.json`);
   const receiptOut = path.join(
@@ -397,7 +483,7 @@ async function main() {
       ? 'continuation-trace-correlation.json'
       : 'tool-trace-correlation.json',
   );
-  await writeFile(traceOut, JSON.stringify(trace, null, 2) + '\n');
+  await writeFile(traceOut, JSON.stringify(publicTrace, null, 2) + '\n');
   const receipt = {
     schema: contract.kind === 'continuation'
       ? 'openclaw.k6.continuation-trace-correlation.v1'
@@ -437,7 +523,6 @@ async function main() {
             spanId: topology.toolSpanId,
             parentSpanId: topology.toolParentSpanId,
             status: topology.status,
-            errorType: topology.errorType,
           },
           uniqueTrace: true,
         }),

--- a/tools/k6-proofs/scripts/collect-continuation-trace.mjs
+++ b/tools/k6-proofs/scripts/collect-continuation-trace.mjs
@@ -3,6 +3,13 @@ import { createHash } from 'node:crypto';
 import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import {
+  allTempoSpans as allSpans,
+  projectPublicTempoTrace,
+  publicTempoSpanName as publicSpanName,
+  publicTempoStatusCode as publicStatusCode,
+  tempoAttributeValue as attributeValue,
+} from '../lib/public-tempo-trace.mjs';
 import { sanitizeEvidenceRecords } from './sanitize-k6-artifacts.mjs';
 
 const DEFAULT_TEMPO_BASE_URL = 'http://tempo.dandelion.cult';
@@ -58,22 +65,8 @@ function idHex(value, bytes, label) {
   return safeHex(decoded.toString('hex'), bytes * 2, label);
 }
 
-function attributeValue(attribute) {
-  const value = attribute?.value || {};
-  return value.stringValue ?? value.intValue ?? value.boolValue ?? value.doubleValue ?? null;
-}
-
 function attributes(span) {
   return new Map((span?.attributes || []).map((attribute) => [attribute.key, attributeValue(attribute)]));
-}
-
-function allSpans(trace) {
-  if (Array.isArray(trace?.batches)) {
-    return trace.batches.flatMap((batch) =>
-      (batch.scopeSpans || batch.instrumentationLibrarySpans || []).flatMap((scope) => scope.spans || []));
-  }
-  if (Array.isArray(trace?.trace?.spans)) return trace.trace.spans;
-  return [];
 }
 
 async function readEvidence(evidencePath) {
@@ -174,96 +167,13 @@ function assertTraceIsPublicSafe(trace, evidence, reason) {
   }
 }
 
-const PUBLIC_TRACE_ATTRIBUTE_KEYS = new Set([
-  'chain.id',
-  'delegate.mode',
-  'gen_ai.tool.name',
-  'openclaw.toolName',
-  'reason.hash',
-  'reason.length',
-  'reason.present',
-]);
-
-function publicTraceAttribute(attribute) {
-  if (!attribute || !PUBLIC_TRACE_ATTRIBUTE_KEYS.has(attribute.key)) return null;
-  const value = attributeValue(attribute);
-  if (value === undefined || value === null) return null;
-
-  if (attribute.key === 'reason.hash' && !/^[0-9a-f]{16}$/iu.test(String(value))) return null;
-  if (attribute.key === 'reason.length' && !Number.isInteger(Number(value))) return null;
-  if (attribute.key === 'reason.present' && value !== true && value !== false && value !== 'true' && value !== 'false') return null;
-  if (attribute.key === 'delegate.mode' && !['normal', 'silent', 'silent-wake', 'post-compaction'].includes(String(value))) return null;
-  if (['gen_ai.tool.name', 'openclaw.toolName'].includes(attribute.key) &&
-      !['continue_delegate', 'continue_work', 'request_compaction'].includes(String(value))) return null;
-  if (attribute.key === 'chain.id' &&
-      !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu.test(String(value))) return null;
-
-  if (typeof value === 'boolean') return { key: attribute.key, value: { boolValue: value } };
-  if (typeof value === 'number' || attribute.key === 'reason.length') {
-    return { key: attribute.key, value: { intValue: String(value) } };
-  }
-  return { key: attribute.key, value: { stringValue: String(value) } };
-}
-
-function safePublicSpanId(value, bytes) {
-  if (!value) return null;
-  try {
-    return idHex(value, bytes, 'public trace span id');
-  } catch {
-    return null;
-  }
-}
-
-function publicStatusCode(value) {
-  if (value === 0 || value === 'UNSET') return 'UNSET';
-  if (value === 1 || value === 'OK') return 'OK';
-  if (value === 2 || value === 'ERROR') return 'ERROR';
-  return 'UNSET';
-}
-
-function publicSpanName(value) {
-  return typeof value === 'string' && /^(?:openclaw|continuation)\.[A-Za-z0-9._:-]{1,150}$/u.test(value)
-    ? value
-    : null;
-}
-
-/**
- * Persist only the topology and telemetry attributes needed for proof review.
- * Tempo's raw OTLP response may contain session keys, credentials, task text,
- * or status messages that are valid for the private backend but forbidden in
- * the public proof corpus.
- */
-function publicTraceProjection(trace, traceId) {
-  const spans = allSpans(trace).flatMap((span) => {
-    const name = publicSpanName(span.name);
-    if (!name) return [];
-    const spanId = safePublicSpanId(span.spanId, 8);
-    if (!spanId) return [];
-    const parentSpanId = safePublicSpanId(span.parentSpanId, 8);
-    return [{
-      name,
-      traceId,
-      spanId,
-      parentSpanId,
-      status: { code: publicStatusCode(span.status?.code) },
-      attributes: (Array.isArray(span.attributes) ? span.attributes : [])
-        .map(publicTraceAttribute)
-        .filter(Boolean),
-    }];
-  });
-  return {
-    schema: 'openclaw.k6.public-tempo-trace.v1',
-    traceId,
-    spans,
-  };
-}
 
 async function tempoSearch(baseUrl, query, start, end) {
   const root = String(baseUrl).replace(/\/+$/, '');
   const params = new URLSearchParams({ q: query, start: String(start), end: String(end), limit: '20' });
   const response = await fetch(`${root}/api/search?${params}`, { headers: { accept: 'application/json' } });
   const text = await response.text();
-  if (!response.ok) throw new Error(`Tempo search failed: HTTP ${response.status} ${text.slice(0, 240)}`);
+  if (!response.ok) throw new Error(`Tempo search failed: HTTP ${response.status} ${response.statusText}`.trim());
   const json = JSON.parse(text);
   return json.traces || [];
 }
@@ -274,7 +184,7 @@ async function fetchTrace(baseUrl, traceId) {
     headers: { accept: 'application/json' },
   });
   const text = await response.text();
-  if (!response.ok) throw new Error(`Tempo trace fetch failed: HTTP ${response.status} ${text.slice(0, 240)}`);
+  if (!response.ok) throw new Error(`Tempo trace fetch failed: HTTP ${response.status} ${response.statusText}`.trim());
   return JSON.parse(text);
 }
 
@@ -474,7 +384,7 @@ async function main() {
     throw new Error(`no Tempo trace matched ${fingerprint} before timeout`);
   }
   assertTraceIsPublicSafe(trace, evidence, contract);
-  const publicTrace = publicTraceProjection(trace, traceId);
+  const publicTrace = projectPublicTempoTrace(trace, traceId);
 
   const traceOut = path.join(runDir, `tempo-trace-${traceId.slice(0, 12)}.json`);
   const receiptOut = path.join(

--- a/tools/k6-proofs/scripts/fetch-tempo-trace.mjs
+++ b/tools/k6-proofs/scripts/fetch-tempo-trace.mjs
@@ -3,12 +3,13 @@
  * Fetch a Tempo trace JSON receipt for a Project 81 k6 proof candidate run.
  *
  * The script accepts either --trace-id directly or --run-dir containing
- * evidence.jsonl. It writes the raw Tempo JSON response to --out (or
+ * evidence.jsonl. It writes a public-safe Tempo trace projection to --out (or
  * <run-dir>/tempo-trace-<trace-id>.json) and prints a compact public-safe
  * receipt to stdout.
  */
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { projectPublicTempoTrace } from '../lib/public-tempo-trace.mjs';
 
 const DEFAULT_TEMPO_BASE_URL = 'http://tempo.dandelion.cult';
 
@@ -72,7 +73,7 @@ async function traceIdFromTraceql(baseUrl, traceql, { start, end } = {}) {
   const url = `${root}/api/search?${new URLSearchParams(params)}`;
   const response = await fetch(url, { headers: { accept: 'application/json' } });
   const text = await response.text();
-  if (!response.ok) throw new Error(`Tempo search failed: HTTP ${response.status} ${response.statusText} ${text.slice(0, 240)}`.trim());
+  if (!response.ok) throw new Error(`Tempo search failed: HTTP ${response.status} ${response.statusText}`.trim());
   let json;
   try { json = JSON.parse(text); }
   catch { throw new Error(`Tempo search did not return JSON for query ${query}`); }
@@ -86,11 +87,16 @@ async function fetchTrace(baseUrl, traceId) {
   const url = `${root}/api/traces/${encodeURIComponent(traceId)}`;
   const response = await fetch(url, { headers: { accept: 'application/json' } });
   const text = await response.text();
-  if (!response.ok) throw new Error(`Tempo trace fetch failed: HTTP ${response.status} ${response.statusText} ${text.slice(0, 240)}`.trim());
+  if (!response.ok) throw new Error(`Tempo trace fetch failed: HTTP ${response.status} ${response.statusText}`.trim());
   let json;
   try { json = JSON.parse(text); }
   catch { throw new Error(`Tempo trace fetch did not return JSON for ${traceId}`); }
   return { url, json };
+}
+
+function publicTempoUrl(url) {
+  const parsed = new URL(url);
+  return `${parsed.origin}/api/traces/<trace-id>`;
 }
 
 async function main() {
@@ -102,18 +108,16 @@ async function main() {
     ? path.resolve(args.out)
     : path.join(path.resolve(args.runDir || process.cwd()), `tempo-trace-${traceId.slice(0, 12)}.json`);
   const { url, json } = await fetchTrace(args.tempoUrl, traceId);
+  const publicTrace = projectPublicTempoTrace(json, traceId);
   await mkdir(path.dirname(out), { recursive: true });
-  await writeFile(out, `${JSON.stringify(json, null, 2)}\n`);
-  const spans = Array.isArray(json?.batches)
-    ? json.batches.reduce((sum, batch) => sum + (batch?.scopeSpans || batch?.instrumentationLibrarySpans || []).reduce((s, scope) => s + (scope?.spans || []).length, 0), 0)
-    : Array.isArray(json?.trace?.spans) ? json.trace.spans.length : null;
+  await writeFile(out, `${JSON.stringify(publicTrace, null, 2)}\n`);
   console.log(JSON.stringify({
     schema: 'openclaw.k6.tempo-trace-fetch.v1',
     traceId,
     out: path.basename(out),
-    tempoUrl: url.replace(traceId, '<trace-id>'),
+    tempoUrl: publicTempoUrl(url),
     fetched: true,
-    spans,
+    spans: publicTrace.spans.length,
   }, null, 2));
 }
 

--- a/tools/k6-proofs/skill/SKILL.md
+++ b/tools/k6-proofs/skill/SKILL.md
@@ -10,7 +10,7 @@ Build, run, and maintain k6 proof-row scenarios for the OpenClaw continuation fe
 - **Prometheus** — metrics store for candidate rows; set `OPENCLAW_PROOFS_PROMETHEUS_BASE_URL` / `OPENCLAW_PROOFS_PROMETHEUS_RW_URL` for non-fleet runs (fleet default: `prometheus.dandelion.cult`).
 - **Grafana** — dashboards (contract in `tools/k6-proofs/METRICS.md`; JSON in `tools/k6-proofs/dashboards/k6-proofs.json`).
 - **Loki** — log aggregation for nonce-correlated journal receipts; set `OPENCLAW_PROOFS_LOKI_BASE_URL` for non-fleet runs.
-- **Tempo** — distributed tracing; raw trace JSON is the proof surface for continuation spans; set `OPENCLAW_PROOFS_TEMPO_BASE_URL` for non-fleet runs.
+- **Tempo** — distributed tracing; a public-safe trace projection is the proof surface for continuation spans; set `OPENCLAW_PROOFS_TEMPO_BASE_URL` for non-fleet runs.
 - **Alloy / OTel Collector** — forwards logs and traces from seats into Loki/Tempo.
 
 ### Repo Structure
@@ -146,7 +146,7 @@ node tools/k6-proofs/scripts/evidence-writer.mjs \
   --row R-CD-2 \
   --seat <seat> \
   --sha <40-char-sha>
-# Review the candidate run directory, add raw trace/log receipts, then fold intentionally.
+# Review the candidate run directory, add public-safe trace/log receipts, then fold intentionally.
 ```
 
 ## Key Patterns
@@ -154,7 +154,7 @@ node tools/k6-proofs/scripts/evidence-writer.mjs \
 ### Evidence Correlation
 The gateway doesn't expose a REST API for delegate dispatch — delegates fire via the agent's tool surface. The k6 harness verifies infrastructure readiness and captures evidence post-run:
 1. **Journal/Loki grep** — query the gateway journal or Loki for the nonce window; do not commit secrets.
-2. **Tempo trace pull** — export raw trace JSON for the trace id; summarize span tree separately.
+2. **Tempo trace pull** — export the public-safe trace projection for the trace id; summarize span tree separately.
 3. **Session/event receipt** — use redacted `sessions.messages.subscribe` / response receipts where the row depends on session delivery.
 
 ### Both-Forms Mandate


### PR DESCRIPTION
## Summary

Repairs the remaining determinism gap in the R-RC-1 Tempo fallback collector described by issue 400.

The core null-`trace_id` recovery path was already present: correlate by seat/service, `request_compaction` tool fingerprint, and a bounded dispatch window; require exactly one candidate; export only public-safe trace material. This patch makes the correlation receipt and search window reproducible:

- derives the no-`ended` upper bound from evidence instead of wall-clock `Date.now()`;
- removes wall-clock `generatedAt` from the receipt;
- records the exact evidence-derived search window and source;
- adds a dispatch-only double-run regression proving byte-identical receipts;
- preserves fail-closed zero/multiple-candidate behavior and private-material rejection.

## Verification

- `node --test tools/k6-proofs/scripts/__tests__/collect-continuation-trace.test.mjs` — **10 passed, 0 failed**
- `node tools/k6-proofs/scripts/check-proof-row-manifests.mjs` — **passed** (35 rows, 38 manifest entries, 0 missing)
- `node tools/k6-proofs/scripts/validate-corpus.mjs --current` — **4 passed, 0 failed**
- `git diff --check HEAD^ HEAD` — **passed**

No proof refire is required by the issue contract.

Related issue: https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/400

Issue 400 remains open for explicit reviewer disposition.
