### PR TITLE
fix(proofs): make R-CD-2 lifecycle receipt authoritative

### DIFF
--- a/tools/k6-proofs/lib/gateway-lifecycle.js
+++ b/tools/k6-proofs/lib/gateway-lifecycle.js
@@ -7,3 +7,25 @@ export function gatewayLifecycleRunId(value) {
     ? value.runId
     : null;
 }
+
+// Gateway lifecycle identity lives on the event envelope.  `session.message`
+// is transcript content and deliberately carries no authoritative run id in
+// the deployed protocol.  Keep the distinction explicit so a delayed message
+// can never be promoted into a wake receipt by shape guessing.
+export function gatewayLifecyclePhase(value) {
+  if (!gatewayLifecycleRunId(value)) return null;
+  if (String(value.stream || '').toLowerCase() !== 'lifecycle') return null;
+  const phase = String(value.data?.phase || '').toLowerCase();
+  return phase === 'start' || phase === 'end' ? phase : null;
+}
+
+export function gatewayLifecycleSucceeded(value) {
+  if (gatewayLifecyclePhase(value) !== 'end') return false;
+  const status = String(value.data?.status || value.status || '').toLowerCase();
+  return !['error', 'failed', 'failure', 'aborted'].includes(status) && value.data?.replayInvalid !== true;
+}
+
+export function gatewayWakeRunId(value, acceptedRunId) {
+  const runId = gatewayLifecycleRunId(value);
+  return runId && runId !== acceptedRunId && gatewayLifecyclePhase(value) === 'start' ? runId : null;
+}

--- a/tools/k6-proofs/lib/gateway-lifecycle.js
+++ b/tools/k6-proofs/lib/gateway-lifecycle.js
@@ -1,0 +1,9 @@
+// Gateway agent lifecycle events carry their run identity at the event
+// envelope. sessions.send returns that same `runId` (the idempotency key when
+// supplied). Do not accept lookalike nested IDs: they can belong to a tool,
+// provider attempt, or unrelated turn and would splice evidence across runs.
+export function gatewayLifecycleRunId(value) {
+  return value && typeof value === 'object' && typeof value.runId === 'string' && value.runId.length > 0
+    ? value.runId
+    : null;
+}

--- a/tools/k6-proofs/lib/r-cd-2-authoritative-receipt.mjs
+++ b/tools/k6-proofs/lib/r-cd-2-authoritative-receipt.mjs
@@ -10,6 +10,7 @@ const FAILURE_CATEGORIES = new Set([
   'send-run-mismatch',
   'provider-or-turn-failure',
   'delegate-replay-unsafe',
+  'send-topology-mismatch',
   'missing-continuation-topology',
   'invalid-continuation-topology',
 ]);
@@ -56,7 +57,8 @@ function evidencePasses(evidence) {
     evidence?.dispatch_failure_observed !== true &&
     hex(evidence?.send_run_fingerprint, 16) &&
     evidence.send_run_fingerprint === evidence.terminal_run_fingerprint &&
-    evidence.send_run_fingerprint === evidence.wake_run_fingerprint;
+    evidence.send_run_fingerprint === evidence.wake_run_fingerprint &&
+    hex(evidence?.accepted_send_trace_id, 32);
 }
 
 function topologyPasses(correlation) {
@@ -70,6 +72,12 @@ function topologyPasses(correlation) {
     correlation.dispatchSpanId !== correlation.fireSpanId;
 }
 
+// The accepted sessions.send response is the authority for this row's turn.
+// Do not combine its lifecycle with a separately-valid continuation trace.
+function sameAcceptedTrace(evidence, correlation) {
+  return evidence?.accepted_send_trace_id === correlation?.traceId;
+}
+
 function categoryFor(evidence, correlation) {
   if (evidence?.failureCategory === 'delegate-replay-unsafe') return 'delegate-replay-unsafe';
   if (evidence?.dispatch_failure_observed) return 'provider-or-turn-failure';
@@ -77,6 +85,7 @@ function categoryFor(evidence, correlation) {
     return evidence?.send_run_mismatch ? 'send-run-mismatch' : 'missing-send-run-lifecycle';
   }
   if (!correlation) return 'missing-continuation-topology';
+  if (!sameAcceptedTrace(evidence, correlation)) return 'send-topology-mismatch';
   return 'invalid-continuation-topology';
 }
 
@@ -92,6 +101,7 @@ export function resolveRcd2AuthoritativeReceipt({ evidence, correlation, signing
         send: evidence?.send_run_fingerprint || null,
         terminal: evidence?.terminal_run_fingerprint || null,
         wake: evidence?.wake_run_fingerprint || null,
+        acceptedSendTrace: evidence?.accepted_send_trace_id || null,
         terminalSuccess: evidence?.terminal_success_same_run === true,
         typedDelegate: evidence?.typed_delegate_success_same_run === true,
         quiet: evidence?.post_wake_quiet === true,
@@ -103,11 +113,12 @@ export function resolveRcd2AuthoritativeReceipt({ evidence, correlation, signing
         dispatch: correlation?.dispatchSpanId || null,
         fire: correlation?.fireSpanId || null,
         mode: correlation?.mode || null,
+        acceptedSendTrace: evidence?.accepted_send_trace_id || null,
       }),
     },
   };
 
-  if (!evidencePasses(evidence) || !topologyPasses(correlation)) {
+  if (!evidencePasses(evidence) || !topologyPasses(correlation) || !sameAcceptedTrace(evidence, correlation)) {
     return seal({ ...base, verdict: 'PARTIAL-candidate', failureCategory: categoryFor(evidence, correlation) }, signingKey);
   }
 
@@ -126,6 +137,7 @@ export function resolveRcd2AuthoritativeReceipt({ evidence, correlation, signing
       unboundSessionVerified: true,
       noChannelVerified: true,
       traceFingerprint: fingerprint(correlation.traceId),
+      acceptedSendTraceFingerprint: fingerprint(evidence.accepted_send_trace_id),
       chainFingerprint: fingerprint(correlation.chainId),
       delegateFingerprint: fingerprint(`${correlation.dispatchSpanId}:${correlation.fireSpanId}`),
     },
@@ -145,6 +157,8 @@ export function validateRcd2AuthoritativeReceipt(receipt, signingKey) {
   const life = receipt.lifecycle;
   const pass = receipt.verdict === 'PASS-candidate' && life?.typedTool === 'continue_delegate' && life.mode === 'silent-wake' &&
     ['sameTrace', 'sameChain', 'typedToolObserved', 'dispatchObserved', 'fireObserved', 'terminalSuccessSameRun', 'unboundSessionVerified', 'noChannelVerified'].every((key) => life[key] === true) &&
-    hex(life.traceFingerprint, 16) && hex(life.chainFingerprint, 16) && hex(life.delegateFingerprint, 16);
+    hex(life.traceFingerprint, 16) && hex(life.acceptedSendTraceFingerprint, 16) &&
+    life.traceFingerprint === life.acceptedSendTraceFingerprint &&
+    hex(life.chainFingerprint, 16) && hex(life.delegateFingerprint, 16);
   return pass ? { valid: true, verdict: receipt.verdict } : { valid: false, reason: 'invalid-pass-lifecycle' };
 }

--- a/tools/k6-proofs/lib/r-cd-2-authoritative-receipt.mjs
+++ b/tools/k6-proofs/lib/r-cd-2-authoritative-receipt.mjs
@@ -51,23 +51,24 @@ function evidencePasses(evidence) {
     evidence?.send_run_captured === true &&
     evidence?.terminal_success_same_run === true &&
     evidence?.typed_delegate_success_same_run === true &&
-    evidence?.wake_same_run === true &&
+    evidence?.wake_lifecycle_observed === true &&
     evidence?.post_wake_quiet === true &&
     evidence?.channel_delivery_observed === false &&
     evidence?.dispatch_failure_observed !== true &&
     hex(evidence?.send_run_fingerprint, 16) &&
     hex(evidence?.row_nonce_fingerprint, 16) &&
     evidence.send_run_fingerprint === evidence.terminal_run_fingerprint &&
-    evidence.send_run_fingerprint === evidence.wake_run_fingerprint &&
     hex(evidence?.accepted_send_trace_id, 32);
 }
 
 function topologyPasses(correlation) {
-  return correlation?.tool === 'continue_delegate' &&
-    correlation?.mode === 'silent-wake' &&
-    correlation?.sameTrace === true && correlation?.sameChain === true &&
-    correlation?.typedToolObserved === true &&
-    correlation?.dispatchObserved === true && correlation?.fireObserved === true &&
+  // Consume the collector's public continuation schema directly.  Do not
+  // accept the old, synthetic top-level `tool`/`mode`/boolean projection: a
+  // receipt that the real collector cannot emit must never certify this row.
+  return correlation?.continuation?.tool === 'continue_delegate' &&
+    correlation?.delegate?.mode === 'silent-wake' &&
+    Array.isArray(correlation?.toolSpanIds) && correlation.toolSpanIds.length === 1 &&
+    hex(correlation.toolSpanIds[0], 16) &&
     hex(correlation?.traceId, 32) && typeof correlation?.chainId === 'string' && correlation.chainId.length > 0 &&
     hex(correlation?.dispatchSpanId, 16) && hex(correlation?.fireSpanId, 16) &&
     correlation.dispatchSpanId !== correlation.fireSpanId &&
@@ -96,7 +97,7 @@ function sameRowBinding(evidence, correlation) {
 function categoryFor(evidence, correlation) {
   if (evidence?.failureCategory === 'delegate-replay-unsafe') return 'delegate-replay-unsafe';
   if (evidence?.dispatch_failure_observed) return 'provider-or-turn-failure';
-  if (!evidence?.send_run_captured || !evidence?.terminal_success_same_run || !evidence?.wake_same_run) {
+  if (!evidence?.send_run_captured || !evidence?.terminal_success_same_run || !evidence?.wake_lifecycle_observed) {
     return evidence?.send_run_mismatch ? 'send-run-mismatch' : 'missing-send-run-lifecycle';
   }
   if (!correlation) return 'missing-continuation-topology';
@@ -128,7 +129,7 @@ export function resolveRcd2AuthoritativeReceipt({ evidence, correlation, signing
         chain: correlation?.chainId || null,
         dispatch: correlation?.dispatchSpanId || null,
         fire: correlation?.fireSpanId || null,
-        mode: correlation?.mode || null,
+        mode: correlation?.delegate?.mode || null,
         acceptedSendTrace: evidence?.accepted_send_trace_id || null,
         acceptedSendRun: correlation?.rowBinding?.acceptedSendRunFingerprint || null,
         nonce: correlation?.rowBinding?.nonceFingerprint || null,
@@ -153,6 +154,7 @@ export function resolveRcd2AuthoritativeReceipt({ evidence, correlation, signing
       dispatchObserved: true,
       fireObserved: true,
       terminalSuccessSameRun: true,
+      wakeLifecycleObserved: true,
       unboundSessionVerified: true,
       noChannelVerified: true,
       traceFingerprint: fingerprint(correlation.traceId),
@@ -177,7 +179,7 @@ export function validateRcd2AuthoritativeReceipt(receipt, signingKey) {
     ? { valid: true, verdict: receipt.verdict } : { valid: false, reason: 'invalid-failure-category' };
   const life = receipt.lifecycle;
   const pass = receipt.verdict === 'PASS-candidate' && life?.typedTool === 'continue_delegate' && life.mode === 'silent-wake' &&
-    ['sameTrace', 'sameChain', 'typedToolObserved', 'dispatchObserved', 'fireObserved', 'terminalSuccessSameRun', 'unboundSessionVerified', 'noChannelVerified'].every((key) => life[key] === true) &&
+    ['sameTrace', 'sameChain', 'typedToolObserved', 'dispatchObserved', 'fireObserved', 'terminalSuccessSameRun', 'wakeLifecycleObserved', 'unboundSessionVerified', 'noChannelVerified'].every((key) => life[key] === true) &&
     hex(life.traceFingerprint, 16) && hex(life.acceptedSendTraceFingerprint, 16) &&
     life.traceFingerprint === life.acceptedSendTraceFingerprint &&
     hex(life.acceptedSendRunFingerprint, 16) && hex(life.rowNonceFingerprint, 16) &&

--- a/tools/k6-proofs/lib/r-cd-2-authoritative-receipt.mjs
+++ b/tools/k6-proofs/lib/r-cd-2-authoritative-receipt.mjs
@@ -1,0 +1,150 @@
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
+
+// R-CD-2 has one authority.  The scenario gathers private, nonce-bound
+// acquisition data; this module joins it with the private Tempo topology and
+// emits the only public-safe receipt allowed to promote a candidate verdict.
+export const R_CD_2_AUTHORITATIVE_RECEIPT_SCHEMA = 'openclaw.k6.r-cd-2-authoritative-receipt.v1';
+
+const FAILURE_CATEGORIES = new Set([
+  'missing-send-run-lifecycle',
+  'send-run-mismatch',
+  'provider-or-turn-failure',
+  'delegate-replay-unsafe',
+  'missing-continuation-topology',
+  'invalid-continuation-topology',
+]);
+
+const hex = (value, length) => typeof value === 'string' && new RegExp(`^[a-f0-9]{${length}}$`, 'i').test(value);
+const fingerprint = (value) => createHash('sha256').update(String(value)).digest('hex').slice(0, 16);
+const binding = (value) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
+
+function canonical(receipt) {
+  return JSON.stringify({
+    schema: receipt.schema,
+    row: receipt.row,
+    authoritativeSource: receipt.authoritativeSource,
+    candidateOnly: receipt.candidateOnly,
+    foldRequiresReview: receipt.foldRequiresReview,
+    verdict: receipt.verdict,
+    failureCategory: receipt.failureCategory || null,
+    lifecycle: receipt.lifecycle || null,
+    binding: receipt.binding,
+  });
+}
+
+function seal(receipt, key) {
+  if (typeof key !== 'string' || key.length === 0) throw new Error('missing gateway signing key');
+  return {
+    ...receipt,
+    integrity: {
+      algorithm: 'hmac-sha256-gateway-token-v1',
+      signature: createHmac('sha256', key).update(canonical(receipt)).digest('hex'),
+    },
+  };
+}
+
+function evidencePasses(evidence) {
+  return evidence?.session_created === true &&
+    evidence?.session_unbound_confirmed === true &&
+    evidence?.send_accepted === true &&
+    evidence?.send_run_captured === true &&
+    evidence?.terminal_success_same_run === true &&
+    evidence?.typed_delegate_success_same_run === true &&
+    evidence?.wake_same_run === true &&
+    evidence?.post_wake_quiet === true &&
+    evidence?.channel_delivery_observed === false &&
+    evidence?.dispatch_failure_observed !== true &&
+    hex(evidence?.send_run_fingerprint, 16) &&
+    evidence.send_run_fingerprint === evidence.terminal_run_fingerprint &&
+    evidence.send_run_fingerprint === evidence.wake_run_fingerprint;
+}
+
+function topologyPasses(correlation) {
+  return correlation?.tool === 'continue_delegate' &&
+    correlation?.mode === 'silent-wake' &&
+    correlation?.sameTrace === true && correlation?.sameChain === true &&
+    correlation?.typedToolObserved === true &&
+    correlation?.dispatchObserved === true && correlation?.fireObserved === true &&
+    hex(correlation?.traceId, 32) && typeof correlation?.chainId === 'string' && correlation.chainId.length > 0 &&
+    hex(correlation?.dispatchSpanId, 16) && hex(correlation?.fireSpanId, 16) &&
+    correlation.dispatchSpanId !== correlation.fireSpanId;
+}
+
+function categoryFor(evidence, correlation) {
+  if (evidence?.failureCategory === 'delegate-replay-unsafe') return 'delegate-replay-unsafe';
+  if (evidence?.dispatch_failure_observed) return 'provider-or-turn-failure';
+  if (!evidence?.send_run_captured || !evidence?.terminal_success_same_run || !evidence?.wake_same_run) {
+    return evidence?.send_run_mismatch ? 'send-run-mismatch' : 'missing-send-run-lifecycle';
+  }
+  if (!correlation) return 'missing-continuation-topology';
+  return 'invalid-continuation-topology';
+}
+
+export function resolveRcd2AuthoritativeReceipt({ evidence, correlation, signingKey }) {
+  const base = {
+    schema: R_CD_2_AUTHORITATIVE_RECEIPT_SCHEMA,
+    row: 'R-CD-2',
+    authoritativeSource: 'r-cd-2-row-scoped-resolver',
+    candidateOnly: true,
+    foldRequiresReview: true,
+    binding: {
+      localEvidenceFingerprint: binding({
+        send: evidence?.send_run_fingerprint || null,
+        terminal: evidence?.terminal_run_fingerprint || null,
+        wake: evidence?.wake_run_fingerprint || null,
+        terminalSuccess: evidence?.terminal_success_same_run === true,
+        typedDelegate: evidence?.typed_delegate_success_same_run === true,
+        quiet: evidence?.post_wake_quiet === true,
+        failed: evidence?.dispatch_failure_observed === true,
+      }),
+      topologyFingerprint: binding({
+        trace: correlation?.traceId || null,
+        chain: correlation?.chainId || null,
+        dispatch: correlation?.dispatchSpanId || null,
+        fire: correlation?.fireSpanId || null,
+        mode: correlation?.mode || null,
+      }),
+    },
+  };
+
+  if (!evidencePasses(evidence) || !topologyPasses(correlation)) {
+    return seal({ ...base, verdict: 'PARTIAL-candidate', failureCategory: categoryFor(evidence, correlation) }, signingKey);
+  }
+
+  return seal({
+    ...base,
+    verdict: 'PASS-candidate',
+    lifecycle: {
+      typedTool: 'continue_delegate',
+      mode: 'silent-wake',
+      sameTrace: true,
+      sameChain: true,
+      typedToolObserved: true,
+      dispatchObserved: true,
+      fireObserved: true,
+      terminalSuccessSameRun: true,
+      unboundSessionVerified: true,
+      noChannelVerified: true,
+      traceFingerprint: fingerprint(correlation.traceId),
+      chainFingerprint: fingerprint(correlation.chainId),
+      delegateFingerprint: fingerprint(`${correlation.dispatchSpanId}:${correlation.fireSpanId}`),
+    },
+  }, signingKey);
+}
+
+export function validateRcd2AuthoritativeReceipt(receipt, signingKey) {
+  if (!receipt || receipt.schema !== R_CD_2_AUTHORITATIVE_RECEIPT_SCHEMA || receipt.row !== 'R-CD-2' ||
+      receipt.authoritativeSource !== 'r-cd-2-row-scoped-resolver' || receipt.candidateOnly !== true ||
+      receipt.foldRequiresReview !== true || !hex(receipt.binding?.localEvidenceFingerprint, 64) ||
+      !hex(receipt.binding?.topologyFingerprint, 64) || receipt.integrity?.algorithm !== 'hmac-sha256-gateway-token-v1' ||
+      !hex(receipt.integrity?.signature, 64)) return { valid: false, reason: 'invalid-shape' };
+  const expected = createHmac('sha256', signingKey).update(canonical(receipt)).digest('hex');
+  if (!timingSafeEqual(Buffer.from(expected, 'hex'), Buffer.from(receipt.integrity.signature, 'hex'))) return { valid: false, reason: 'invalid-integrity' };
+  if (receipt.verdict === 'PARTIAL-candidate') return FAILURE_CATEGORIES.has(receipt.failureCategory)
+    ? { valid: true, verdict: receipt.verdict } : { valid: false, reason: 'invalid-failure-category' };
+  const life = receipt.lifecycle;
+  const pass = receipt.verdict === 'PASS-candidate' && life?.typedTool === 'continue_delegate' && life.mode === 'silent-wake' &&
+    ['sameTrace', 'sameChain', 'typedToolObserved', 'dispatchObserved', 'fireObserved', 'terminalSuccessSameRun', 'unboundSessionVerified', 'noChannelVerified'].every((key) => life[key] === true) &&
+    hex(life.traceFingerprint, 16) && hex(life.chainFingerprint, 16) && hex(life.delegateFingerprint, 16);
+  return pass ? { valid: true, verdict: receipt.verdict } : { valid: false, reason: 'invalid-pass-lifecycle' };
+}

--- a/tools/k6-proofs/lib/r-cd-2-authoritative-receipt.mjs
+++ b/tools/k6-proofs/lib/r-cd-2-authoritative-receipt.mjs
@@ -56,6 +56,7 @@ function evidencePasses(evidence) {
     evidence?.channel_delivery_observed === false &&
     evidence?.dispatch_failure_observed !== true &&
     hex(evidence?.send_run_fingerprint, 16) &&
+    hex(evidence?.row_nonce_fingerprint, 16) &&
     evidence.send_run_fingerprint === evidence.terminal_run_fingerprint &&
     evidence.send_run_fingerprint === evidence.wake_run_fingerprint &&
     hex(evidence?.accepted_send_trace_id, 32);
@@ -69,13 +70,27 @@ function topologyPasses(correlation) {
     correlation?.dispatchObserved === true && correlation?.fireObserved === true &&
     hex(correlation?.traceId, 32) && typeof correlation?.chainId === 'string' && correlation.chainId.length > 0 &&
     hex(correlation?.dispatchSpanId, 16) && hex(correlation?.fireSpanId, 16) &&
-    correlation.dispatchSpanId !== correlation.fireSpanId;
+    correlation.dispatchSpanId !== correlation.fireSpanId &&
+    hex(correlation?.rowBinding?.acceptedSendRunFingerprint, 16) &&
+    hex(correlation?.rowBinding?.nonceFingerprint, 16) &&
+    hex(correlation?.rowBinding?.acceptedSendTraceId, 32);
 }
 
 // The accepted sessions.send response is the authority for this row's turn.
 // Do not combine its lifecycle with a separately-valid continuation trace.
 function sameAcceptedTrace(evidence, correlation) {
   return evidence?.accepted_send_trace_id === correlation?.traceId;
+}
+
+// A matching Tempo trace alone is not a sufficient join: a reused/shared
+// trace could otherwise splice one accepted sessions.send lifecycle to a
+// different row's continuation topology. The collector copies only opaque
+// fingerprints from the private row evidence after it validates the trace's
+// nonce-derived reason contract. Require all three identities here.
+function sameRowBinding(evidence, correlation) {
+  return evidence?.send_run_fingerprint === correlation?.rowBinding?.acceptedSendRunFingerprint &&
+    evidence?.row_nonce_fingerprint === correlation?.rowBinding?.nonceFingerprint &&
+    evidence?.accepted_send_trace_id === correlation?.rowBinding?.acceptedSendTraceId;
 }
 
 function categoryFor(evidence, correlation) {
@@ -85,7 +100,7 @@ function categoryFor(evidence, correlation) {
     return evidence?.send_run_mismatch ? 'send-run-mismatch' : 'missing-send-run-lifecycle';
   }
   if (!correlation) return 'missing-continuation-topology';
-  if (!sameAcceptedTrace(evidence, correlation)) return 'send-topology-mismatch';
+  if (!sameAcceptedTrace(evidence, correlation) || !sameRowBinding(evidence, correlation)) return 'send-topology-mismatch';
   return 'invalid-continuation-topology';
 }
 
@@ -102,6 +117,7 @@ export function resolveRcd2AuthoritativeReceipt({ evidence, correlation, signing
         terminal: evidence?.terminal_run_fingerprint || null,
         wake: evidence?.wake_run_fingerprint || null,
         acceptedSendTrace: evidence?.accepted_send_trace_id || null,
+        nonce: evidence?.row_nonce_fingerprint || null,
         terminalSuccess: evidence?.terminal_success_same_run === true,
         typedDelegate: evidence?.typed_delegate_success_same_run === true,
         quiet: evidence?.post_wake_quiet === true,
@@ -114,11 +130,14 @@ export function resolveRcd2AuthoritativeReceipt({ evidence, correlation, signing
         fire: correlation?.fireSpanId || null,
         mode: correlation?.mode || null,
         acceptedSendTrace: evidence?.accepted_send_trace_id || null,
+        acceptedSendRun: correlation?.rowBinding?.acceptedSendRunFingerprint || null,
+        nonce: correlation?.rowBinding?.nonceFingerprint || null,
+        topologyAcceptedSendTrace: correlation?.rowBinding?.acceptedSendTraceId || null,
       }),
     },
   };
 
-  if (!evidencePasses(evidence) || !topologyPasses(correlation) || !sameAcceptedTrace(evidence, correlation)) {
+  if (!evidencePasses(evidence) || !topologyPasses(correlation) || !sameAcceptedTrace(evidence, correlation) || !sameRowBinding(evidence, correlation)) {
     return seal({ ...base, verdict: 'PARTIAL-candidate', failureCategory: categoryFor(evidence, correlation) }, signingKey);
   }
 
@@ -138,6 +157,8 @@ export function resolveRcd2AuthoritativeReceipt({ evidence, correlation, signing
       noChannelVerified: true,
       traceFingerprint: fingerprint(correlation.traceId),
       acceptedSendTraceFingerprint: fingerprint(evidence.accepted_send_trace_id),
+      acceptedSendRunFingerprint: fingerprint(evidence.send_run_fingerprint),
+      rowNonceFingerprint: fingerprint(evidence.row_nonce_fingerprint),
       chainFingerprint: fingerprint(correlation.chainId),
       delegateFingerprint: fingerprint(`${correlation.dispatchSpanId}:${correlation.fireSpanId}`),
     },
@@ -159,6 +180,7 @@ export function validateRcd2AuthoritativeReceipt(receipt, signingKey) {
     ['sameTrace', 'sameChain', 'typedToolObserved', 'dispatchObserved', 'fireObserved', 'terminalSuccessSameRun', 'unboundSessionVerified', 'noChannelVerified'].every((key) => life[key] === true) &&
     hex(life.traceFingerprint, 16) && hex(life.acceptedSendTraceFingerprint, 16) &&
     life.traceFingerprint === life.acceptedSendTraceFingerprint &&
+    hex(life.acceptedSendRunFingerprint, 16) && hex(life.rowNonceFingerprint, 16) &&
     hex(life.chainFingerprint, 16) && hex(life.delegateFingerprint, 16);
   return pass ? { valid: true, verdict: receipt.verdict } : { valid: false, reason: 'invalid-pass-lifecycle' };
 }

--- a/tools/k6-proofs/manifests/r-cd-2.json
+++ b/tools/k6-proofs/manifests/r-cd-2.json
@@ -74,6 +74,11 @@
       "description": "One continue_delegate silent-wake tool execution plus continuation.delegate.dispatch/fire spans share one non-zero trace and chain"
     },
     {
+      "name": "tempo-trace-json",
+      "required": true,
+      "description": "Public-safe Tempo trace projection that carries the same authoritative trace and chain binding as the accepted send lifecycle"
+    },
+    {
       "name": "no-channel-delivery",
       "required": true,
       "description": "Delegate return does NOT produce a channel message (silent mode verified)"

--- a/tools/k6-proofs/manifests/r-cd-2.json
+++ b/tools/k6-proofs/manifests/r-cd-2.json
@@ -18,6 +18,8 @@
     "description": "continue_delegate(mode='silent-wake') full path. Fires a delegate that returns silently and triggers a fresh parent turn without channel output.",
     "methods": [
       "sessions.send",
+      "sessions.create",
+      "sessions.list",
       "sessions.messages.subscribe",
       "tasks.list"
     ],
@@ -41,19 +43,20 @@
     "expectedArtifactClass": "PASS-candidate",
     "requiredReceipts": [
       "seat-readiness",
-      "dispatch-accepted",
-      "parent-wake-event",
+      "send-run-lifecycle",
+      "typed-delegate-topology",
+      "row-scoped-authoritative-receipt",
       "no-channel-delivery",
-      "trace-id"
+      "tempo-trace-json"
     ],
     "foldRequiresReview": true,
     "notes": "Live continuation row. Fail closed when token/session env is missing, serialize per target session, and treat generated output as a PASS-candidate until required receipts are reviewed."
   },
   "expectedReceipts": [
     {
-      "name": "dispatch-accepted",
+      "name": "send-run-lifecycle",
       "required": true,
-      "description": "Gateway accepted the dispatching sessions.send request that asks the agent to call continue_delegate(mode=silent-wake)"
+      "description": "Accepted sessions.send run/turn ID is bound to same-run terminal success and same-run parent wake; generic delayed messages cannot satisfy it"
     },
     {
       "name": "task-ledger-entry",
@@ -66,9 +69,9 @@
       "description": "Child session key from task metadata"
     },
     {
-      "name": "parent-wake-event",
+      "name": "typed-delegate-topology",
       "required": true,
-      "description": "Parent session wakes after silent return (session.message or run event with no channel delivery)"
+      "description": "One continue_delegate silent-wake tool execution plus continuation.delegate.dispatch/fire spans share one non-zero trace and chain"
     },
     {
       "name": "no-channel-delivery",
@@ -76,9 +79,9 @@
       "description": "Delegate return does NOT produce a channel message (silent mode verified)"
     },
     {
-      "name": "trace-id",
+      "name": "row-scoped-authoritative-receipt",
       "required": true,
-      "description": "Trace ID from dispatch response or optional task metadata; Tempo trace JSON must be fetched before folding a PASS."
+      "description": "Validated public-safe R-CD-2 receipt is the sole authority for candidate verdict surfaces"
     }
   ],
   "artifactDestination": {
@@ -91,6 +94,6 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Silent-wake path. PASS-candidate when: (1) dispatching agent turn accepted, (2) parent session emits wake/agent events, (3) NO channel message delivered from the delegate return, and (4) trace/receipt artifacts are fetched for review. A nonce-correlated tasks.list row is optional because continue_delegate uses pending-delegate/subagent surfaces, not the generic task registry."
+    "notes": "Silent-wake path. Only the row-scoped authoritative receipt can produce PASS-candidate: accepted send/turn and terminal/wake must share identity, one typed continue_delegate must complete, Tempo must prove same trace/chain dispatch+fire topology, and no channel delivery may occur."
   }
 }

--- a/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
+++ b/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
@@ -80,12 +80,18 @@ export function isOutboundChannelDeliveryEvent(eventName, eventData) {
   return Boolean(channelTarget) && ['sent', 'delivered', 'completed'].includes(deliveryStatus);
 }
 
+export function lifecycleRunId(value) {
+  if (!value || typeof value !== 'object') return null;
+  return value.runId || value.run_id || value.turnId || value.turn_id ||
+    value.data?.runId || value.data?.run_id || value.data?.turnId || value.data?.turn_id || null;
+}
+
 export default function () {
   const url = __ENV.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
   const token = __ENV.OPENCLAW_GATEWAY_TOKEN;
   const requestedSessionKey = manifest && manifest.sessionKey || __ENV.OPENCLAW_SESSION_KEY || DEFAULTS.sessionKey;
   let sessionKey = requestedSessionKey;
-  const createDisposableSession = (__ENV.OPENCLAW_CREATE_DISPOSABLE_SESSION || '').toLowerCase() === 'true';
+  const createDisposableSession = (__ENV.OPENCLAW_CREATE_DISPOSABLE_SESSION || 'true').toLowerCase() === 'true';
   const seat = manifest && manifest.seat || __ENV.OPENCLAW_SEAT_NAME || DEFAULTS.seat;
   const rowNonce = nonce('R-CD-2');
 
@@ -110,11 +116,25 @@ export default function () {
     sessionKey,
     requestedSessionKey,
     session_created: false,
+    session_unbound_confirmed: false,
     created_session_key: null,
     candidateSha: manifest && manifest.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
     started: new Date().toISOString(),
     // Required receipts
-    tool_accepted: false,
+    // send acceptance is not lifecycle proof; the resolver requires every
+    // same-run field below before it can promote this row.
+    send_accepted: false,
+    send_run_captured: false,
+    send_run_fingerprint: null,
+    terminal_run_fingerprint: null,
+    wake_run_fingerprint: null,
+    terminal_success_same_run: false,
+    typed_delegate_success_same_run: false,
+    wake_same_run: false,
+    post_wake_quiet: false,
+    post_wake_quiet_timer_started: false,
+    dispatch_failure_observed: false,
+    send_run_mismatch: false,
     task_created: false,
     task_mode: null,
     // Silent-wake specific
@@ -125,6 +145,7 @@ export default function () {
     silent_status_record_observed: false,
     dispatch_accepted_at_ms: null,
     wake_gate_ms: Number(__ENV.OPENCLAW_MIN_DELEGATE_DELAY_MS || 5000),
+    post_wake_quiet_ms: Number(__ENV.OPENCLAW_POST_WAKE_QUIET_MS || 5000),
     child_session: null,
     reason_hash: null,
     reason_length: null,
@@ -134,6 +155,7 @@ export default function () {
   };
 
   const started = Date.now();
+  let acceptedRunId = null;
 
   const res = ws.connect(url, {}, (socket) => {
     const tracker = new RequestTracker();
@@ -207,9 +229,24 @@ export default function () {
             evidence.session_created = true;
             evidence.created_session_key = sessionKey;
             console.log(`✓ disposable session created: ${sessionKey}`);
-            startProofFlow(socket);
+            tracker.send(socket, 'sessions.list', { limit: 20 });
           } else {
             console.error(`✗ sessions.create rejected: ${JSON.stringify(classified.error)}`);
+            failures.add(1);
+            socket.close();
+          }
+        }
+
+        if (classified.kind === 'response' && classified.method === 'sessions.list') {
+          const sessions = classified.payload?.sessions || classified.payload?.items || [];
+          const created = sessions.find((session) => session?.key === sessionKey);
+          const bound = Boolean(created?.channelId || created?.channel || created?.deliveryChannel);
+          if (evidence.session_created && created && !bound) {
+            evidence.session_unbound_confirmed = true;
+            startProofFlow(socket);
+          } else {
+            evidence.dispatch_failure_observed = true;
+            console.error('✗ disposable session is missing or bound');
             failures.add(1);
             socket.close();
           }
@@ -218,8 +255,15 @@ export default function () {
         // Check sessions.send accepted (agent turn triggered)
         if (classified.kind === 'response' && classified.method === 'sessions.send') {
           if (classified.ok) {
-            evidence.tool_accepted = true;
+            evidence.send_accepted = true;
             evidence.dispatch_accepted_at_ms = Date.now();
+            acceptedRunId = lifecycleRunId(classified.payload);
+            if (acceptedRunId) {
+              evidence.send_run_captured = true;
+              evidence.send_run_fingerprint = crypto.sha256(String(acceptedRunId), 'hex').slice(0, 16);
+            } else {
+              evidence.dispatch_failure_observed = true;
+            }
             if (classified.payload && classified.payload.traceId) evidence.trace_id = classified.payload.traceId;
             console.log('✓ sessions.send accepted — agent turn triggered for R-CD-2 (mode=silent-wake)');
           } else if (classified.error) {
@@ -253,18 +297,45 @@ export default function () {
           // Some target sessions emit generic agent lifecycle events rather than
           // an early session.message before the delayed wake. Count these as the
           // dispatching agent turn, not as the silent-wake return.
-          if (eventName === 'agent' && evidence.tool_accepted) {
+          if (eventName === 'agent' && evidence.send_accepted) {
             evidence.agent_turn_observed = true;
+            const eventRunId = lifecycleRunId(eventData);
+            const sameRun = Boolean(acceptedRunId && eventRunId === acceptedRunId);
+            const stream = String(eventData.stream || '').toLowerCase();
+            const phase = String(eventData.data?.phase || '').toLowerCase();
+            const status = String(eventData.data?.status || eventData.status || '').toLowerCase();
+            if (stream === 'lifecycle' && phase === 'end') {
+              if (!sameRun) evidence.send_run_mismatch = true;
+              else if (['error', 'failed', 'failure', 'aborted'].includes(status) || eventData.data?.replayInvalid === true) {
+                evidence.dispatch_failure_observed = true;
+                evidence.failureCategory = eventData.data?.replayInvalid === true
+                  ? 'delegate-replay-unsafe' : 'provider-or-turn-failure';
+              } else {
+                evidence.terminal_success_same_run = true;
+                evidence.terminal_run_fingerprint = crypto.sha256(String(eventRunId), 'hex').slice(0, 16);
+              }
+            }
           }
 
           // session.message events immediately after sessions.send are the dispatching
           // agent turn, not the silent-wake return.  The delegate delay is clamped
           // by the gateway, so only count a parent wake after the minimum delay.
-          if (eventName === 'session.message' && evidence.tool_accepted) {
+          if (eventName === 'session.message' && evidence.send_accepted) {
             const elapsed = evidence.dispatch_accepted_at_ms ? Date.now() - evidence.dispatch_accepted_at_ms : 0;
-            if (elapsed >= evidence.wake_gate_ms) {
+            const eventRunId = lifecycleRunId(eventData);
+            const sameRun = Boolean(acceptedRunId && eventRunId === acceptedRunId);
+            if (elapsed >= evidence.wake_gate_ms && sameRun) {
               evidence.parent_wake_observed = true;
               evidence.agent_turn_observed = true;
+              evidence.wake_same_run = true;
+              evidence.wake_run_fingerprint = crypto.sha256(String(eventRunId), 'hex').slice(0, 16);
+              if (!evidence.post_wake_quiet_timer_started) {
+                evidence.post_wake_quiet_timer_started = true;
+                socket.setTimeout(() => {
+                  if (!evidence.channel_message_observed) evidence.post_wake_quiet = true;
+                  socket.close();
+                }, evidence.post_wake_quiet_ms);
+              }
               console.log('✓ delayed session.message event observed (silent-wake return candidate)');
             } else {
               evidence.agent_turn_observed = true;
@@ -279,6 +350,9 @@ export default function () {
           if (eventStr.includes(rowNonce) && eventStr.includes('"notify":false') &&
               eventStr.includes('"outcome":"done"')) {
             evidence.silent_status_record_observed = true;
+            if (acceptedRunId && lifecycleRunId(eventData) === acceptedRunId) {
+              evidence.typed_delegate_success_same_run = true;
+            }
             console.log('ℹ internal continue_status notify:false receipt observed');
           }
 
@@ -301,7 +375,7 @@ export default function () {
         // Early close only after a delayed parent wake candidate is observed; task
         // ledger context remains optional.  Do not close on the initial dispatch
         // agent turn, or this row only proves sessions.send.
-        if (evidence.tool_accepted && evidence.parent_wake_observed) {
+        if (evidence.send_accepted && evidence.parent_wake_observed && evidence.post_wake_quiet) {
           console.log('Primary silent-wake evidence gathered, closing early');
           socket.close();
         }
@@ -329,13 +403,13 @@ export default function () {
   // use their own tracking surface, not the generic task ledger.
   check(res, { 'websocket connected': (r) => r && r.status === 101 });
   check(null, {
-    'agent turn triggered (sessions.send accepted)': () => evidence.tool_accepted,
+    'agent turn triggered (sessions.send accepted)': () => evidence.send_accepted,
     'dispatching agent turn observed': () => evidence.agent_turn_observed,
     'delayed parent wake candidate observed': () => evidence.parent_wake_observed,
     'no channel delivery (silent verified)': () => !evidence.channel_message_observed,
   });
 
-  if (!evidence.tool_accepted || !evidence.agent_turn_observed || !evidence.parent_wake_observed) {
+  if (!evidence.send_accepted || !evidence.agent_turn_observed || !evidence.parent_wake_observed) {
     failures.add(1);
   }
   if (evidence.channel_message_observed) {
@@ -343,40 +417,32 @@ export default function () {
     console.error('FAIL: silent-wake delegate produced channel output');
   }
 
-  // Verdict — PASS when: turn triggered + events flowing + no channel delivery
-  const passed = (!createDisposableSession || evidence.session_created) &&
-    evidence.tool_accepted && evidence.agent_turn_observed &&
-    evidence.parent_wake_observed && !evidence.channel_message_observed;
-
   console.log(`R_CD_2_EVIDENCE ${JSON.stringify(evidence)}`);
   console.log(`\n--- R-CD-2 EVIDENCE SUMMARY ---`);
   console.log(JSON.stringify(evidence, null, 2));
   console.log(`--- END EVIDENCE ---`);
-  console.log(`\n[R-CD-2] VERDICT: ${passed ? 'PASS-candidate' : 'PARTIAL-candidate'}`);
+  // Only the row-scoped resolver may join this private run evidence to the
+  // same-trace/chain tool topology and promote a PASS-candidate.
+  console.log('\n[R-CD-2] VERDICT: PARTIAL-candidate');
 }
 
 export function handleSummary(data) {
   const timestamp = new Date().toISOString();
-  const passRate = data.metrics.proof_failures && data.metrics.proof_failures.values && data.metrics.proof_failures.values.count === 0;
-  const traceId = finalEvidence && finalEvidence.trace_id || null;
   const summary = {
     row: 'R-CD-2',
     sha: __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
     seat: __ENV.OPENCLAW_SEAT_NAME || 'ronan-dgx',
     timestamp,
-    verdict: passRate ? 'PASS-candidate' : 'PARTIAL-candidate',
+    verdict: 'PARTIAL-candidate',
     candidateOnly: true,
     foldRequiresReview: true,
     observability: {
-      traceId,
-      traceJson: traceId ? 'pending-fetch' : 'missing',
+      traceStatus: 'resolved-after-run',
     },
     review: {
-      status: traceId ? 'ready-for-human-review' : 'review-pending',
-      pendingReceipts: traceId ? [] : ['tempo-trace-json'],
-      notes: traceId
-        ? ['Trace id captured; fetch and attach Tempo trace JSON before canonical fold.']
-        : ['No trace_id was emitted by this candidate run; keep PASS-candidate as review-pending until trace JSON is fetched or the fold explicitly accepts trace-missing.'],
+      status: 'review-pending',
+      pendingReceipts: ['r-cd-2-authoritative-receipt'],
+      notes: ['The runner owns final R-CD-2 candidate disposition from its validated row-scoped receipt.'],
     },
     metrics: {
       duration_ms: data.metrics.r_cd_2_duration && data.metrics.r_cd_2_duration.values || null,

--- a/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
+++ b/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
@@ -112,6 +112,7 @@ export default function () {
     row: 'R-CD-2',
     manifest_loaded: !!manifest,
     nonce: rowNonce,
+    row_nonce_fingerprint: crypto.sha256(rowNonce, 'hex').slice(0, 16),
     seat,
     sessionKey,
     requestedSessionKey,

--- a/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
+++ b/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
@@ -23,7 +23,7 @@ import { Counter, Trend } from 'k6/metrics';
 import crypto from 'k6/crypto';
 import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
-import { gatewayLifecycleRunId } from '../lib/gateway-lifecycle.js';
+import { gatewayLifecycleRunId, gatewayLifecyclePhase, gatewayLifecycleSucceeded, gatewayWakeRunId } from '../lib/gateway-lifecycle.js';
 
 export const options = {
   scenarios: {
@@ -130,7 +130,10 @@ export default function () {
     wake_run_fingerprint: null,
     terminal_success_same_run: false,
     typed_delegate_success_same_run: false,
-    wake_same_run: false,
+    // The silent wake is a fresh parent turn.  Its identity is therefore a
+    // distinct top-level gateway lifecycle run, not a field guessed from a
+    // session.message transcript payload.
+    wake_lifecycle_observed: false,
     post_wake_quiet: false,
     post_wake_quiet_timer_started: false,
     dispatch_failure_observed: false,
@@ -305,12 +308,10 @@ export default function () {
             evidence.agent_turn_observed = true;
             const eventRunId = lifecycleRunId(eventData);
             const sameRun = Boolean(acceptedRunId && eventRunId === acceptedRunId);
-            const stream = String(eventData.stream || '').toLowerCase();
-            const phase = String(eventData.data?.phase || '').toLowerCase();
-            const status = String(eventData.data?.status || eventData.status || '').toLowerCase();
-            if (stream === 'lifecycle' && phase === 'end') {
+            const phase = gatewayLifecyclePhase(eventData);
+            if (phase === 'end' && eventRunId === acceptedRunId) {
               if (!sameRun) evidence.send_run_mismatch = true;
-              else if (['error', 'failed', 'failure', 'aborted'].includes(status) || eventData.data?.replayInvalid === true) {
+              else if (!gatewayLifecycleSucceeded(eventData)) {
                 evidence.dispatch_failure_observed = true;
                 evidence.failureCategory = eventData.data?.replayInvalid === true
                   ? 'delegate-replay-unsafe' : 'provider-or-turn-failure';
@@ -319,20 +320,15 @@ export default function () {
                 evidence.terminal_run_fingerprint = crypto.sha256(String(eventRunId), 'hex').slice(0, 16);
               }
             }
-          }
-
-          // session.message events immediately after sessions.send are the dispatching
-          // agent turn, not the silent-wake return.  The delegate delay is clamped
-          // by the gateway, so only count a parent wake after the minimum delay.
-          if (eventName === 'session.message' && evidence.send_accepted) {
+            // The deployed gateway gives agent lifecycle events a top-level
+            // runId.  A later, distinct lifecycle start in this subscribed
+            // parent session is the only authoritative silent-wake receipt.
+            const wakeRunId = gatewayWakeRunId(eventData, acceptedRunId);
             const elapsed = evidence.dispatch_accepted_at_ms ? Date.now() - evidence.dispatch_accepted_at_ms : 0;
-            const eventRunId = lifecycleRunId(eventData);
-            const sameRun = Boolean(acceptedRunId && eventRunId === acceptedRunId);
-            if (elapsed >= evidence.wake_gate_ms && sameRun) {
+            if (wakeRunId && elapsed >= evidence.wake_gate_ms) {
               evidence.parent_wake_observed = true;
-              evidence.agent_turn_observed = true;
-              evidence.wake_same_run = true;
-              evidence.wake_run_fingerprint = crypto.sha256(String(eventRunId), 'hex').slice(0, 16);
+              evidence.wake_lifecycle_observed = true;
+              evidence.wake_run_fingerprint = crypto.sha256(String(wakeRunId), 'hex').slice(0, 16);
               if (!evidence.post_wake_quiet_timer_started) {
                 evidence.post_wake_quiet_timer_started = true;
                 socket.setTimeout(() => {
@@ -340,11 +336,19 @@ export default function () {
                   socket.close();
                 }, evidence.post_wake_quiet_ms);
               }
-              console.log('✓ delayed session.message event observed (silent-wake return candidate)');
-            } else {
-              evidence.agent_turn_observed = true;
-              console.log('✓ initial session.message event observed (dispatching agent turn)');
+              console.log('✓ delayed parent lifecycle wake observed');
             }
+          }
+
+          // session.message events immediately after sessions.send are the dispatching
+          // agent turn, not the silent-wake return.  The delegate delay is clamped
+          // by the gateway, so only count a parent wake after the minimum delay.
+          if (eventName === 'session.message' && evidence.send_accepted) {
+            // session.message carries transcript content but no documented
+            // lifecycle run identity. It is diagnostic only, never a wake
+            // receipt; otherwise a delayed unrelated message could certify.
+            evidence.agent_turn_observed = true;
+            console.log('ℹ session.message observed (non-authoritative for wake identity)');
           }
 
           // continue_status({ notify:false }) is internal completion bookkeeping,

--- a/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
+++ b/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
@@ -23,6 +23,7 @@ import { Counter, Trend } from 'k6/metrics';
 import crypto from 'k6/crypto';
 import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+import { gatewayLifecycleRunId } from '../lib/gateway-lifecycle.js';
 
 export const options = {
   scenarios: {
@@ -81,9 +82,7 @@ export function isOutboundChannelDeliveryEvent(eventName, eventData) {
 }
 
 export function lifecycleRunId(value) {
-  if (!value || typeof value !== 'object') return null;
-  return value.runId || value.run_id || value.turnId || value.turn_id ||
-    value.data?.runId || value.data?.run_id || value.data?.turnId || value.data?.turn_id || null;
+  return gatewayLifecycleRunId(value);
 }
 
 export default function () {

--- a/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
+++ b/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
@@ -151,6 +151,7 @@ export default function () {
     reason_length: null,
     delegate_mode: null,
     trace_id: null,
+    accepted_send_trace_id: null,
     redacted_events: [],
   };
 
@@ -264,7 +265,10 @@ export default function () {
             } else {
               evidence.dispatch_failure_observed = true;
             }
-            if (classified.payload && classified.payload.traceId) evidence.trace_id = classified.payload.traceId;
+            if (classified.payload && classified.payload.traceId) {
+              evidence.accepted_send_trace_id = classified.payload.traceId;
+              evidence.trace_id = classified.payload.traceId;
+            }
             console.log('✓ sessions.send accepted — agent turn triggered for R-CD-2 (mode=silent-wake)');
           } else if (classified.error) {
             console.error(`✗ sessions.send rejected: ${JSON.stringify(classified.error)}`);

--- a/tools/k6-proofs/scripts/__tests__/collect-continuation-trace.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/collect-continuation-trace.test.mjs
@@ -221,12 +221,10 @@ test('R-CD-2 correlation carries only matching opaque send run and nonce binding
     const result = JSON.parse(stdout);
     const receiptText = await readFile(path.join(fixture.dir, result.receiptFile), 'utf8');
     const receipt = JSON.parse(receiptText);
-    assert.equal(receipt.tool, 'continue_delegate');
-    assert.equal(receipt.mode, 'silent-wake');
-    assert.equal(receipt.typedToolObserved, true);
-    assert.equal(receipt.dispatchObserved, true);
-    assert.equal(receipt.fireObserved, true);
-    assert.equal(receipt.sameChain, true);
+    assert.equal(receipt.continuation.tool, 'continue_delegate');
+    assert.equal(receipt.delegate.mode, 'silent-wake');
+    assert.deepEqual(receipt.toolSpanIds, ['aaaaaaaaaaaaaaaa']);
+    assert.equal(receipt.chainId, '11111111-1111-4111-8111-111111111111');
     assert.deepEqual(receipt.rowBinding, {
       acceptedSendRunFingerprint: 'a'.repeat(16),
       nonceFingerprint: createHash('sha256').update(rowNonce).digest('hex').slice(0, 16),
@@ -260,7 +258,7 @@ test('R-CD-2 resolver accepts the collector-shaped receipt, not a synthetic topo
       send_run_captured: true,
       terminal_success_same_run: true,
       typed_delegate_success_same_run: true,
-      wake_same_run: true,
+      wake_lifecycle_observed: true,
       post_wake_quiet: true,
       channel_delivery_observed: false,
       dispatch_failure_observed: false,

--- a/tools/k6-proofs/scripts/__tests__/collect-continuation-trace.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/collect-continuation-trace.test.mjs
@@ -192,6 +192,37 @@ test('correlates a unique trace and validates tool/fire/dispatch topology', asyn
   }
 });
 
+test('rejects duplicate dispatch/fire spans and unrelated causal parents', async () => {
+  const fixture = await fixtureDir();
+  const traceId = '1234567890abcdef1234567890abcdef';
+  const base = traceFixture({ traceId, reasonHash: fixture.reasonHash, reasonLength: fixture.reasonLength });
+  const spans = base.batches[0].scopeSpans[0].spans;
+  const dispatch = spans.find((entry) => entry.name === 'continuation.delegate.dispatch');
+  const fire = spans.find((entry) => entry.name === 'continuation.delegate.fire');
+  const badCases = [
+    ['duplicate-dispatch', { ...dispatch, spanId: b64('9999999999999999') }],
+    ['duplicate-fire', { ...fire, spanId: b64('8888888888888888') }],
+    ['different-parent', { ...fire, parentSpanId: b64('7777777777777777') }],
+  ];
+  for (const [label, extra] of badCases) {
+    const server = await listen((request, response) => {
+      response.setHeader('content-type', 'application/json');
+      response.end(JSON.stringify(new URL(request.url, 'http://localhost').pathname === '/api/search'
+        ? { traces: [{ traceID: traceId }] }
+        : { batches: [{ scopeSpans: [{ spans: label === 'different-parent'
+          ? spans.map((entry) => entry === fire ? extra : entry)
+          : [...spans, extra] }] }] }));
+    });
+    try {
+      await assert.rejects(execFileAsync(process.execPath, [
+        script, '--run-dir', fixture.dir, '--manifest', fixture.manifestPath,
+        '--seat', 'silas-prince', '--tempo-url', server.url, '--timeout-ms', '40', '--poll-ms', '10',
+      ]), new RegExp(label === 'different-parent' ? 'causal parent' : `contains 2 .*${label.slice('duplicate-'.length)}`));
+    } finally { await server.close(); }
+  }
+  await rm(fixture.dir, { recursive: true, force: true });
+});
+
 test('R-CD-2 correlation carries only matching opaque send run and nonce bindings', async () => {
   const rowNonce = 'R-CD-2-example';
   const fixture = await fixtureDir({

--- a/tools/k6-proofs/scripts/__tests__/collect-continuation-trace.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/collect-continuation-trace.test.mjs
@@ -8,6 +8,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import { fileURLToPath } from 'node:url';
+import { resolveRcd2AuthoritativeReceipt } from '../../lib/r-cd-2-authoritative-receipt.mjs';
 
 const execFileAsync = promisify(execFile);
 const script = path.resolve(
@@ -36,7 +37,7 @@ function span(name, traceId, spanId, parentSpanId, attrs = []) {
   };
 }
 
-function traceFixture({ traceId, reasonHash, reasonLength, tool = 'continue_delegate', mode = 'normal' }) {
+function traceFixture({ traceId, reasonHash, reasonLength, tool = 'continue_delegate', mode = 'normal', toolCount = 1 }) {
   const parent = 'dddddddddddddddd';
   const isWork = tool === 'continue_work';
   const acceptSpanName = isWork ? 'continuation.work' : 'continuation.delegate.dispatch';
@@ -51,9 +52,13 @@ function traceFixture({ traceId, reasonHash, reasonLength, tool = 'continue_dele
     batches: [{
       scopeSpans: [{
         spans: [
-          span('openclaw.tool.execution', traceId, 'aaaaaaaaaaaaaaaa', parent, [
-            attr('gen_ai.tool.name', tool),
-          ]),
+          ...Array.from({ length: toolCount }, (_, index) => span(
+            'openclaw.tool.execution',
+            traceId,
+            index === 0 ? 'aaaaaaaaaaaaaaaa' : 'ffffffffffffffff',
+            parent,
+            [attr('gen_ai.tool.name', tool)],
+          )),
           span(fireSpanName, traceId, 'bbbbbbbbbbbbbbbb', parent, continuationAttrs),
           span(acceptSpanName, traceId, 'cccccccccccccccc', parent, continuationAttrs),
           span('openclaw.harness.run', traceId, 'eeeeeeeeeeeeeeee', 'cccccccccccccccc'),
@@ -216,12 +221,101 @@ test('R-CD-2 correlation carries only matching opaque send run and nonce binding
     const result = JSON.parse(stdout);
     const receiptText = await readFile(path.join(fixture.dir, result.receiptFile), 'utf8');
     const receipt = JSON.parse(receiptText);
+    assert.equal(receipt.tool, 'continue_delegate');
+    assert.equal(receipt.mode, 'silent-wake');
+    assert.equal(receipt.typedToolObserved, true);
+    assert.equal(receipt.dispatchObserved, true);
+    assert.equal(receipt.fireObserved, true);
+    assert.equal(receipt.sameChain, true);
     assert.deepEqual(receipt.rowBinding, {
       acceptedSendRunFingerprint: 'a'.repeat(16),
       nonceFingerprint: createHash('sha256').update(rowNonce).digest('hex').slice(0, 16),
       acceptedSendTraceId: traceId,
     });
     assert.doesNotMatch(receiptText, /R-CD-2-example/);
+  } finally {
+    await server.close();
+    await rm(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test('R-CD-2 resolver accepts the collector-shaped receipt, not a synthetic topology', async () => {
+  const rowNonce = 'R-CD-2-resolver-example';
+  const traceId = '2'.repeat(32);
+  const runFingerprint = 'a'.repeat(16);
+  const nonceFingerprint = createHash('sha256').update(rowNonce).digest('hex').slice(0, 16);
+  const fixture = await fixtureDir({
+    rowId: 'R-CD-2',
+    delegateMode: 'silent-wake',
+    nonceOverride: rowNonce,
+    extraEvidence: {
+      send_run_fingerprint: runFingerprint,
+      terminal_run_fingerprint: runFingerprint,
+      wake_run_fingerprint: runFingerprint,
+      row_nonce_fingerprint: nonceFingerprint,
+      accepted_send_trace_id: traceId,
+      session_created: true,
+      session_unbound_confirmed: true,
+      send_accepted: true,
+      send_run_captured: true,
+      terminal_success_same_run: true,
+      typed_delegate_success_same_run: true,
+      wake_same_run: true,
+      post_wake_quiet: true,
+      channel_delivery_observed: false,
+      dispatch_failure_observed: false,
+    },
+  });
+  const server = await listen((request, response) => {
+    response.setHeader('content-type', 'application/json');
+    response.end(JSON.stringify(
+      new URL(request.url, 'http://localhost').pathname === '/api/search'
+        ? { traces: [{ traceID: traceId }] }
+        : traceFixture({ traceId, reasonHash: fixture.reasonHash, reasonLength: fixture.reasonLength, mode: 'silent-wake' }),
+    ));
+  });
+  try {
+    const { stdout } = await execFileAsync(process.execPath, [
+      script, '--run-dir', fixture.dir, '--manifest', fixture.manifestPath,
+      '--seat', 'cael-prince', '--tempo-url', server.url, '--timeout-ms', '100', '--poll-ms', '10',
+    ]);
+    const result = JSON.parse(stdout);
+    const correlation = JSON.parse(await readFile(path.join(fixture.dir, result.receiptFile), 'utf8'));
+    const evidence = JSON.parse(await readFile(path.join(fixture.dir, 'evidence.jsonl'), 'utf8'));
+    const resolved = resolveRcd2AuthoritativeReceipt({
+      evidence,
+      correlation,
+      signingKey: 'collector-shaped-r-cd-2-test-key',
+    });
+    assert.equal(resolved.verdict, 'PASS-candidate');
+  } finally {
+    await server.close();
+    await rm(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test('R-CD-2 collector rejects repeated continue_delegate tool spans', async () => {
+  const fixture = await fixtureDir({ rowId: 'R-CD-2', delegateMode: 'silent-wake' });
+  const traceId = '3'.repeat(32);
+  const server = await listen((request, response) => {
+    response.setHeader('content-type', 'application/json');
+    response.end(JSON.stringify(
+      new URL(request.url, 'http://localhost').pathname === '/api/search'
+        ? { traces: [{ traceID: traceId }] }
+        : traceFixture({ traceId, reasonHash: fixture.reasonHash, reasonLength: fixture.reasonLength, mode: 'silent-wake', toolCount: 2 }),
+    ));
+  });
+  try {
+    await assert.rejects(
+      execFileAsync(process.execPath, [
+        script, '--run-dir', fixture.dir, '--manifest', fixture.manifestPath,
+        '--seat', 'cael-prince', '--tempo-url', server.url, '--timeout-ms', '0', '--poll-ms', '10',
+      ]),
+      (error) => {
+        assert.match(error.stderr, /contains 2 continue_delegate tool spans/);
+        return true;
+      },
+    );
   } finally {
     await server.close();
     await rm(fixture.dir, { recursive: true, force: true });

--- a/tools/k6-proofs/scripts/__tests__/collect-continuation-trace.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/collect-continuation-trace.test.mjs
@@ -36,7 +36,7 @@ function span(name, traceId, spanId, parentSpanId, attrs = []) {
   };
 }
 
-function traceFixture({ traceId, reasonHash, reasonLength, tool = 'continue_delegate' }) {
+function traceFixture({ traceId, reasonHash, reasonLength, tool = 'continue_delegate', mode = 'normal' }) {
   const parent = 'dddddddddddddddd';
   const isWork = tool === 'continue_work';
   const acceptSpanName = isWork ? 'continuation.work' : 'continuation.delegate.dispatch';
@@ -45,7 +45,7 @@ function traceFixture({ traceId, reasonHash, reasonLength, tool = 'continue_dele
     attr('chain.id', '11111111-1111-4111-8111-111111111111'),
     attr('reason.hash', reasonHash),
     attr('reason.length', reasonLength),
-    ...(isWork ? [] : [attr('delegate.mode', 'normal')]),
+    ...(isWork ? [] : [attr('delegate.mode', mode)]),
   ];
   return {
     batches: [{
@@ -93,15 +93,21 @@ async function fixtureDir({
   tool = 'continue_delegate',
   workVariant = 'reason',
   includeNonce = true,
+  rowId,
+  delegateMode,
+  nonceOverride,
+  extraEvidence = {},
 } = {}) {
   const dir = await mkdtemp(path.join(os.tmpdir(), 'continuation-trace-test-'));
   const isWork = tool === 'continue_work';
   const isReasonPrefix = isWork && workVariant === 'reason-prefix';
-  const nonce = isReasonPrefix
+  const resolvedRowId = rowId || (isReasonPrefix ? 'R-CW-3' : isWork ? 'R-CW-1' : 'R-CD-1');
+  const generatedNonce = isReasonPrefix
     ? 'R-CW-3-example'
     : isWork
       ? 'R-CW-1-example'
       : 'R-CD-1-example';
+  const nonce = nonceOverride || generatedNonce;
   const template = isReasonPrefix
     ? 'k6-proof-R-CW-3-redaction RAW-RCW3-{{nonce}}; on continuation wake reply exactly CW3-WOKE {{nonce}}'
     : isWork
@@ -111,10 +117,10 @@ async function fixtureDir({
   const reason = templatedReason;
   const reasonHash = createHash('sha256').update(reason).digest('hex').slice(0, 16);
   const manifest = {
-    rowId: isReasonPrefix ? 'R-CW-3' : isWork ? 'R-CW-1' : 'R-CD-1',
+    rowId: resolvedRowId,
     invocation: isWork
       ? { tool, reason: template }
-      : { tool, mode: 'normal', promptTemplate: template },
+      : { tool, mode: delegateMode || 'normal', promptTemplate: template },
   };
   const evidence = {
     row: manifest.rowId,
@@ -123,7 +129,8 @@ async function fixtureDir({
     dispatch_accepted_at_ms: Date.parse('2026-07-12T22:15:10.000Z'),
     reason_hash: reasonHash,
     reason_length: reason.length,
-    ...(isWork ? {} : { delegate_mode: 'normal' }),
+    ...(isWork ? {} : { delegate_mode: delegateMode || 'normal' }),
+    ...extraEvidence,
   };
   const manifestPath = path.join(dir, 'manifest.json');
   await writeFile(manifestPath, JSON.stringify(manifest));
@@ -174,6 +181,47 @@ test('correlates a unique trace and validates tool/fire/dispatch topology', asyn
     }]);
     assert.match(observedQuery, new RegExp(`reason\\.hash="${fixture.reasonHash}"`));
     assert.doesNotMatch(JSON.stringify(receipt), /Proof nonce/);
+  } finally {
+    await server.close();
+    await rm(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test('R-CD-2 correlation carries only matching opaque send run and nonce bindings', async () => {
+  const rowNonce = 'R-CD-2-example';
+  const fixture = await fixtureDir({
+    rowId: 'R-CD-2',
+    delegateMode: 'silent-wake',
+    nonceOverride: rowNonce,
+    extraEvidence: {
+      send_run_fingerprint: 'a'.repeat(16),
+      row_nonce_fingerprint: createHash('sha256').update(rowNonce).digest('hex').slice(0, 16),
+      accepted_send_trace_id: '1'.repeat(32),
+    },
+  });
+  const traceId = '1'.repeat(32);
+  const server = await listen((request, response) => {
+    response.setHeader('content-type', 'application/json');
+    response.end(JSON.stringify(
+      new URL(request.url, 'http://localhost').pathname === '/api/search'
+        ? { traces: [{ traceID: traceId }] }
+        : traceFixture({ traceId, reasonHash: fixture.reasonHash, reasonLength: fixture.reasonLength, mode: 'silent-wake' }),
+    ));
+  });
+  try {
+    const { stdout } = await execFileAsync(process.execPath, [
+      script, '--run-dir', fixture.dir, '--manifest', fixture.manifestPath,
+      '--seat', 'cael-prince', '--tempo-url', server.url, '--timeout-ms', '100', '--poll-ms', '10',
+    ]);
+    const result = JSON.parse(stdout);
+    const receiptText = await readFile(path.join(fixture.dir, result.receiptFile), 'utf8');
+    const receipt = JSON.parse(receiptText);
+    assert.deepEqual(receipt.rowBinding, {
+      acceptedSendRunFingerprint: 'a'.repeat(16),
+      nonceFingerprint: createHash('sha256').update(rowNonce).digest('hex').slice(0, 16),
+      acceptedSendTraceId: traceId,
+    });
+    assert.doesNotMatch(receiptText, /R-CD-2-example/);
   } finally {
     await server.close();
     await rm(fixture.dir, { recursive: true, force: true });

--- a/tools/k6-proofs/scripts/__tests__/continuation-row-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/continuation-row-contract.test.mjs
@@ -88,3 +88,10 @@ test('row runner keeps private acquisition transient and publishes sanitized evi
   assert.doesNotMatch(runner, /gateway-journal\.private/);
   assert.doesNotMatch(runner, /sessionKey:\$session/);
 });
+
+test('R-CD-2 row-list runner declares the signed receipt that candidate routing validates', async () => {
+  const runner = await readFile(path.join(repoRoot, 'tools/k6-proofs/scripts/run-proofs.sh'), 'utf8');
+  assert.match(runner, /R_CD_2_RECEIPT_SHA256/);
+  assert.match(runner, /createHash\("sha256"\)/);
+  assert.match(runner, /authoritativeReceipt:\(if \$authoritativeReceiptSha256 == "" then null else \{file:"r-cd-2-authoritative-receipt\.json", sha256:\$authoritativeReceiptSha256, validated:true/);
+});

--- a/tools/k6-proofs/scripts/__tests__/continuation-row-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/continuation-row-contract.test.mjs
@@ -1,12 +1,128 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { readdir, readFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { createServer } from 'node:http';
+import { execFile } from 'node:child_process';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
 const manifestsDir = path.join(repoRoot, 'tools/k6-proofs/manifests');
 const scenariosDir = path.join(repoRoot, 'tools/k6-proofs/scenarios');
+const run = promisify(execFile);
+
+const candidateSha = 'a'.repeat(40);
+const traceId = '1'.repeat(32);
+const dispatchSpanId = '2'.repeat(16);
+const fireSpanId = '3'.repeat(16);
+const toolSpanId = '4'.repeat(16);
+const sharedParentSpanId = '5'.repeat(16);
+const chainId = '12345678-1234-4123-8123-123456789abc';
+
+function attr(key, value) {
+  return { key, value: typeof value === 'number' ? { intValue: String(value) } : { stringValue: String(value) } };
+}
+
+function rcd2Trace({ reasonHash, reasonLength }) {
+  const continuationAttrs = [
+    attr('reason.hash', reasonHash),
+    attr('reason.length', reasonLength),
+    attr('delegate.mode', 'silent-wake'),
+    attr('chain.id', chainId),
+  ];
+  return {
+    batches: [{ scopeSpans: [{ spans: [
+      { name: 'continuation.delegate.dispatch', traceId, spanId: dispatchSpanId, parentSpanId: sharedParentSpanId, status: { code: 1 }, attributes: continuationAttrs },
+      { name: 'continuation.delegate.fire', traceId, spanId: fireSpanId, parentSpanId: sharedParentSpanId, status: { code: 1 }, attributes: continuationAttrs },
+      { name: 'openclaw.tool.execution', traceId, spanId: toolSpanId, parentSpanId: sharedParentSpanId, status: { code: 1 }, attributes: [attr('gen_ai.tool.name', 'continue_delegate')] },
+    ] }] }],
+  };
+}
+
+async function listen(handler) {
+  const server = createServer(handler);
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  return { server, baseUrl: `http://127.0.0.1:${address.port}` };
+}
+
+async function writeExecutable(file, source) {
+  await writeFile(file, source, { mode: 0o755 });
+  await chmod(file, 0o755);
+}
+
+async function runRcd2RunnerFixture({ tamper = false } = {}) {
+  const root = await mkdtemp(path.join(tmpdir(), 'r-cd-2-runner-contract-'));
+  const bin = path.join(root, 'bin');
+  const out = path.join(root, 'out');
+  await Promise.all([mkdir(bin, { recursive: true }), mkdir(out, { recursive: true })]);
+
+  const manifest = JSON.parse(await readFile(path.join(manifestsDir, 'r-cd-2.json'), 'utf8'));
+  const nonce = 'RCD2-RUNNER-CONTRACT-NONCE';
+  const reason = manifest.invocation.promptTemplate.replaceAll('{{nonce}}', nonce);
+  const reasonHash = createHash('sha256').update(reason).digest('hex').slice(0, 16);
+  const now = new Date().toISOString();
+  const evidence = {
+    row: 'R-CD-2', nonce, started: now, ended: now, dispatch_accepted_at_ms: Date.now(),
+    delegate_mode: 'silent-wake', reason_hash: reasonHash, reason_length: reason.length,
+    session_created: true, session_unbound_confirmed: true, send_accepted: true,
+    send_run_captured: true, terminal_success_same_run: true, typed_delegate_success_same_run: true,
+    wake_lifecycle_observed: true, post_wake_quiet: true, channel_delivery_observed: false,
+    dispatch_failure_observed: false, send_run_fingerprint: 'a'.repeat(16),
+    terminal_run_fingerprint: 'a'.repeat(16), wake_run_fingerprint: 'a'.repeat(16),
+    row_nonce_fingerprint: 'b'.repeat(16), accepted_send_trace_id: traceId,
+  };
+  const trace = rcd2Trace({ reasonHash, reasonLength: reason.length });
+  const tempo = await listen((req, res) => {
+    if (req.url.startsWith('/health') || req.url.startsWith('/status')) {
+      res.writeHead(200).end('{}');
+    } else if (req.url.startsWith('/api/search')) {
+      res.writeHead(200, { 'content-type': 'application/json' }).end(JSON.stringify({ traces: [{ traceID: traceId }] }));
+    } else if (req.url.startsWith(`/api/traces/${traceId}`)) {
+      res.writeHead(200, { 'content-type': 'application/json' }).end(JSON.stringify(trace));
+    } else {
+      res.writeHead(404).end();
+    }
+  });
+
+  try {
+    await writeExecutable(path.join(bin, 'openclaw'), '#!/bin/sh\nprintf \'%s\\n\' \'{"enabled":true,"maxChainLength":3,"maxDelegatesPerTurn":3,"costCapTokens":3}\'\n');
+    await writeExecutable(path.join(bin, 'hostname'), '#!/bin/sh\nprintf \'%s\\n\' cael-dgx\n');
+    await writeExecutable(path.join(bin, 'journalctl'), '#!/bin/sh\ncase " $* " in *" --show-cursor "*) printf \'%s\\n\' \'-- cursor: runner-contract\' ;; esac\n');
+    await writeExecutable(path.join(bin, 'k6'), `#!/bin/sh\nif [ "${'${1:-}'}" = version ]; then printf '%s\\n' 'k6 v2.0.0'; exit 0; fi\nprintf '%s %s\\n' '=== K6-PROOF-EVIDENCE ===' '${JSON.stringify(evidence)}'\n`);
+    if (tamper) {
+      await writeExecutable(path.join(bin, 'node'), `#!/bin/sh\ncase "$*" in *validate-candidate-run-result.mjs*) receipt=$(find "${out}" -name r-cd-2-authoritative-receipt.json -print -quit); [ -n "$receipt" ] && printf ' ' >> "$receipt" ;; esac\nexec "${process.execPath}" "$@"\n`);
+    }
+    const env = {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH}`,
+      ...(tamper ? { REAL_NODE: process.execPath } : {}),
+      K6_BIN: path.join(bin, 'k6'),
+      OPENCLAW_GATEWAY_TOKEN: 'runner-contract-token',
+      OPENCLAW_GATEWAY_WS: tempo.baseUrl.replace(/^http/, 'ws'),
+      OPENCLAW_PROOFS_TEMPO_BASE_URL: tempo.baseUrl,
+      OPENCLAW_CANDIDATE_SHA: candidateSha,
+      OPENCLAW_RUNTIME_BUILD_SHA: candidateSha,
+      OPENCLAW_SESSION_KEY: 'main',
+      OPENCLAW_SEAT_NAME: 'cael-dgx',
+    };
+    const result = await run('bash', ['scripts/run-proofs.sh', '--live', '--out-dir', out, 'R-CD-2', candidateSha], {
+      cwd: path.join(repoRoot, 'tools/k6-proofs'), env, timeout: 30_000,
+    });
+    const runBase = path.join(out, candidateSha, 'R-CD-2', 'cael-dgx');
+    const [runId] = await readdir(runBase);
+    const runDir = path.join(runBase, runId);
+    return { root, out, runDir, result };
+  } catch (error) {
+    await rm(root, { recursive: true, force: true });
+    throw error;
+  } finally {
+    await new Promise((resolve) => tempo.server.close(resolve));
+  }
+}
 
 test('every trace-required continue_delegate row persists the safe fingerprint contract', async () => {
   const files = (await readdir(manifestsDir)).filter((name) => name.endsWith('.json'));
@@ -94,4 +210,33 @@ test('R-CD-2 row-list runner declares the signed receipt that candidate routing 
   assert.match(runner, /R_CD_2_RECEIPT_SHA256/);
   assert.match(runner, /createHash\("sha256"\)/);
   assert.match(runner, /authoritativeReceipt:\(if \$authoritativeReceiptSha256 == "" then null else \{file:"r-cd-2-authoritative-receipt\.json", sha256:\$authoritativeReceiptSha256, validated:true/);
+});
+
+test('R-CD-2 live runner emits an envelope only for an untampered authoritative receipt', async (t) => {
+  await t.test('valid signed receipt produces a candidate envelope through run-proofs.sh', async () => {
+    const fixture = await runRcd2RunnerFixture();
+    try {
+      const envelope = JSON.parse(await readFile(path.join(fixture.runDir, 'candidate-run-result.json'), 'utf8'));
+      const result = JSON.parse(await readFile(path.join(fixture.runDir, 'run-result.json'), 'utf8'));
+      assert.equal(result.authoritativeReceipt.file, 'r-cd-2-authoritative-receipt.json');
+      assert.match(result.authoritativeReceipt.sha256, /^[a-f0-9]{64}$/);
+      assert.equal(envelope.result.outcome, 'PASS-candidate');
+      assert.equal(envelope.authoritativeReceipt.sha256, result.authoritativeReceipt.sha256);
+      assert.match(fixture.result.stdout, /CANDIDATE REVIEW ENVELOPE/);
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+    }
+  });
+
+  await t.test('tampered receipt is withheld by the live runner before it can emit an envelope', async () => {
+    const fixture = await runRcd2RunnerFixture({ tamper: true });
+    try {
+      await assert.rejects(readFile(path.join(fixture.runDir, 'candidate-run-result.json'), 'utf8'), /ENOENT/);
+      const validationError = await readFile(path.join(fixture.runDir, 'candidate-run-result-validation.error.log'), 'utf8');
+      assert.match(validationError, /authoritative receipt digest mismatch/);
+      assert.match(fixture.result.stderr, /Candidate routing envelope withheld/);
+    } finally {
+      await rm(fixture.root, { recursive: true, force: true });
+    }
+  });
 });

--- a/tools/k6-proofs/scripts/__tests__/gateway-lifecycle.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/gateway-lifecycle.test.mjs
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { gatewayLifecycleRunId } from '../../lib/gateway-lifecycle.js';
+
+test('R-CD-2 accepts only the documented top-level gateway lifecycle runId', () => {
+  assert.equal(gatewayLifecycleRunId({ runId: 'send-run-1', stream: 'lifecycle' }), 'send-run-1');
+  for (const value of [
+    {},
+    { run_id: 'legacy-looking' },
+    { turnId: 'tool-turn' },
+    { data: { runId: 'nested-attempt' } },
+    { runId: '' },
+  ]) {
+    assert.equal(gatewayLifecycleRunId(value), null);
+  }
+});

--- a/tools/k6-proofs/scripts/__tests__/gateway-lifecycle.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/gateway-lifecycle.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { gatewayLifecycleRunId } from '../../lib/gateway-lifecycle.js';
+import { gatewayLifecyclePhase, gatewayLifecycleRunId, gatewayLifecycleSucceeded, gatewayWakeRunId } from '../../lib/gateway-lifecycle.js';
 
 test('R-CD-2 accepts only the documented top-level gateway lifecycle runId', () => {
   assert.equal(gatewayLifecycleRunId({ runId: 'send-run-1', stream: 'lifecycle' }), 'send-run-1');
@@ -13,4 +13,14 @@ test('R-CD-2 accepts only the documented top-level gateway lifecycle runId', () 
   ]) {
     assert.equal(gatewayLifecycleRunId(value), null);
   }
+});
+
+test('uses only top-level lifecycle envelopes for terminal and wake identity', () => {
+  const terminal = { runId: 'send-run-1', stream: 'lifecycle', data: { phase: 'end', status: 'ok' } };
+  const wake = { runId: 'wake-run-2', stream: 'lifecycle', data: { phase: 'start' } };
+  assert.equal(gatewayLifecyclePhase(terminal), 'end');
+  assert.equal(gatewayLifecycleSucceeded(terminal), true);
+  assert.equal(gatewayWakeRunId(wake, 'send-run-1'), 'wake-run-2');
+  assert.equal(gatewayWakeRunId({ stream: 'lifecycle', data: { phase: 'start', runId: 'nested' } }, 'send-run-1'), null);
+  assert.equal(gatewayWakeRunId({ runId: 'send-run-1', stream: 'lifecycle', data: { phase: 'start' } }, 'send-run-1'), null);
 });

--- a/tools/k6-proofs/scripts/__tests__/r-cd-2-authoritative-receipt.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cd-2-authoritative-receipt.test.mjs
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  resolveRcd2AuthoritativeReceipt,
+  validateRcd2AuthoritativeReceipt,
+} from '../../lib/r-cd-2-authoritative-receipt.mjs';
+
+const signingKey = 'r-cd-2-authoritative-receipt-test-key';
+const run = 'a'.repeat(16);
+
+function evidence(overrides = {}) {
+  return {
+    session_created: true, session_unbound_confirmed: true,
+    send_accepted: true, send_run_captured: true,
+    terminal_success_same_run: true, typed_delegate_success_same_run: true,
+    wake_same_run: true, post_wake_quiet: true,
+    channel_delivery_observed: false, dispatch_failure_observed: false,
+    send_run_fingerprint: run, terminal_run_fingerprint: run, wake_run_fingerprint: run,
+    ...overrides,
+  };
+}
+
+function correlation(overrides = {}) {
+  return {
+    tool: 'continue_delegate', mode: 'silent-wake', sameTrace: true, sameChain: true,
+    typedToolObserved: true, dispatchObserved: true, fireObserved: true,
+    traceId: 'b'.repeat(32), chainId: 'private-chain-id',
+    dispatchSpanId: 'c'.repeat(16), fireSpanId: 'd'.repeat(16),
+    ...overrides,
+  };
+}
+
+test('R-CD-2 promotes only a same-run typed silent-wake topology', () => {
+  const receipt = resolveRcd2AuthoritativeReceipt({ evidence: evidence(), correlation: correlation(), signingKey });
+  assert.equal(receipt.verdict, 'PASS-candidate');
+  assert.equal(validateRcd2AuthoritativeReceipt(receipt, signingKey).valid, true);
+  assert.doesNotMatch(JSON.stringify(receipt), /private-chain-id|bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/);
+});
+
+test('R-CD-2 rejects outer-send acceptance plus an unrelated delayed message', () => {
+  const receipt = resolveRcd2AuthoritativeReceipt({
+    evidence: evidence({ terminal_success_same_run: false, wake_same_run: false, send_run_mismatch: true }),
+    correlation: correlation(), signingKey,
+  });
+  assert.deepEqual([receipt.verdict, receipt.failureCategory], ['PARTIAL-candidate', 'send-run-mismatch']);
+});
+
+test('R-CD-2 rejects replay failure, wrong mode, and mismatched trace topology', () => {
+  const replay = resolveRcd2AuthoritativeReceipt({
+    evidence: evidence({ dispatch_failure_observed: true, failureCategory: 'delegate-replay-unsafe' }),
+    correlation: correlation(), signingKey,
+  });
+  assert.equal(replay.failureCategory, 'delegate-replay-unsafe');
+  for (const bad of [correlation({ mode: 'normal' }), correlation({ sameTrace: false })]) {
+    const receipt = resolveRcd2AuthoritativeReceipt({ evidence: evidence(), correlation: bad, signingKey });
+    assert.deepEqual([receipt.verdict, receipt.failureCategory], ['PARTIAL-candidate', 'invalid-continuation-topology']);
+  }
+});

--- a/tools/k6-proofs/scripts/__tests__/r-cd-2-authoritative-receipt.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cd-2-authoritative-receipt.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import path from 'node:path';
@@ -23,7 +23,7 @@ function evidence(overrides = {}) {
     session_created: true, session_unbound_confirmed: true,
     send_accepted: true, send_run_captured: true,
     terminal_success_same_run: true, typed_delegate_success_same_run: true,
-    wake_same_run: true, post_wake_quiet: true,
+    wake_lifecycle_observed: true, post_wake_quiet: true,
     channel_delivery_observed: false, dispatch_failure_observed: false,
     send_run_fingerprint: run, terminal_run_fingerprint: run, wake_run_fingerprint: run,
     row_nonce_fingerprint: 'e'.repeat(16),
@@ -34,8 +34,8 @@ function evidence(overrides = {}) {
 
 function correlation(overrides = {}) {
   return {
-    tool: 'continue_delegate', mode: 'silent-wake', sameTrace: true, sameChain: true,
-    typedToolObserved: true, dispatchObserved: true, fireObserved: true,
+    continuation: { tool: 'continue_delegate' }, delegate: { mode: 'silent-wake' },
+    sameTrace: true, sameChain: true, toolSpanIds: ['a'.repeat(16)],
     traceId: 'b'.repeat(32), chainId: 'private-chain-id',
     dispatchSpanId: 'c'.repeat(16), fireSpanId: 'd'.repeat(16),
     rowBinding: {
@@ -56,7 +56,7 @@ test('R-CD-2 promotes only a same-run typed silent-wake topology', () => {
 
 test('R-CD-2 rejects outer-send acceptance plus an unrelated delayed message', () => {
   const receipt = resolveRcd2AuthoritativeReceipt({
-    evidence: evidence({ terminal_success_same_run: false, wake_same_run: false, send_run_mismatch: true }),
+    evidence: evidence({ terminal_success_same_run: false, wake_lifecycle_observed: false, send_run_mismatch: true }),
     correlation: correlation(), signingKey,
   });
   assert.deepEqual([receipt.verdict, receipt.failureCategory], ['PARTIAL-candidate', 'send-run-mismatch']);
@@ -92,7 +92,7 @@ test('R-CD-2 rejects replay failure, wrong mode, and mismatched trace topology',
     correlation: correlation(), signingKey,
   });
   assert.equal(replay.failureCategory, 'delegate-replay-unsafe');
-  for (const bad of [correlation({ mode: 'normal' }), correlation({ sameTrace: false })]) {
+  for (const bad of [correlation({ delegate: { mode: 'normal' } }), correlation({ toolSpanIds: ['a'.repeat(16), 'b'.repeat(16)] })]) {
     const receipt = resolveRcd2AuthoritativeReceipt({ evidence: evidence(), correlation: bad, signingKey });
     assert.deepEqual([receipt.verdict, receipt.failureCategory], ['PARTIAL-candidate', 'invalid-continuation-topology']);
   }
@@ -114,11 +114,14 @@ test('R-CD-2 writer and postprocessor accept only the authoritative receipt', as
     const writerResult = JSON.parse(await readFile(path.join(dir, writerDir, 'row-result.json'), 'utf8'));
     assert.equal(writerResult.outcome, 'PASS-candidate');
     assert.equal(writerResult.verdictSource, 'r-cd-2-authoritative-receipt');
+    assert.equal(writerResult.authoritativeReceipt.validated, true);
+    await access(path.join(dir, writerDir, 'r-cd-2-authoritative-receipt.json'));
     const post = await execFileAsync(process.execPath, [postprocessorPath, '--manifest', manifestPath, '--summary', summaryPath, '--out-root', path.join(dir, 'post'), '--run-id', 'unit', '--authoritative-receipt', receiptPath], { cwd: dir, env });
     const postDir = JSON.parse(post.stdout).runDir;
     const postResult = JSON.parse(await readFile(path.join(postDir, 'row-result.json'), 'utf8'));
     assert.equal(postResult.outcome, 'PASS-candidate');
     assert.equal(postResult.verdictSource, 'r-cd-2-authoritative-receipt');
+    assert.equal(postResult.authoritativeReceipt.validated, true);
     await assert.rejects(execFileAsync(process.execPath, [writerPath, '--input', logPath, '--row', 'R-CD-2', '--seat', 'unit', '--sha', 'a'.repeat(40)], { cwd: dir, env }));
   } finally {
     await rm(dir, { recursive: true, force: true });

--- a/tools/k6-proofs/scripts/__tests__/r-cd-2-authoritative-receipt.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cd-2-authoritative-receipt.test.mjs
@@ -26,6 +26,7 @@ function evidence(overrides = {}) {
     wake_same_run: true, post_wake_quiet: true,
     channel_delivery_observed: false, dispatch_failure_observed: false,
     send_run_fingerprint: run, terminal_run_fingerprint: run, wake_run_fingerprint: run,
+    row_nonce_fingerprint: 'e'.repeat(16),
     accepted_send_trace_id: 'b'.repeat(32),
     ...overrides,
   };
@@ -37,6 +38,11 @@ function correlation(overrides = {}) {
     typedToolObserved: true, dispatchObserved: true, fireObserved: true,
     traceId: 'b'.repeat(32), chainId: 'private-chain-id',
     dispatchSpanId: 'c'.repeat(16), fireSpanId: 'd'.repeat(16),
+    rowBinding: {
+      acceptedSendRunFingerprint: run,
+      nonceFingerprint: 'e'.repeat(16),
+      acceptedSendTraceId: 'b'.repeat(32),
+    },
     ...overrides,
   };
 }
@@ -64,6 +70,20 @@ test('R-CD-2 rejects individually valid lifecycle and topology receipts from dif
   });
   assert.deepEqual([receipt.verdict, receipt.failureCategory], ['PARTIAL-candidate', 'send-topology-mismatch']);
   assert.equal(validateRcd2AuthoritativeReceipt(receipt, signingKey).valid, true);
+});
+
+test('R-CD-2 rejects a same-trace/chain topology with another row run or nonce', () => {
+  for (const rowBinding of [
+    { acceptedSendRunFingerprint: 'f'.repeat(16), nonceFingerprint: 'e'.repeat(16), acceptedSendTraceId: 'b'.repeat(32) },
+    { acceptedSendRunFingerprint: run, nonceFingerprint: 'f'.repeat(16), acceptedSendTraceId: 'b'.repeat(32) },
+  ]) {
+    const receipt = resolveRcd2AuthoritativeReceipt({
+      evidence: evidence(),
+      correlation: correlation({ rowBinding }),
+      signingKey,
+    });
+    assert.deepEqual([receipt.verdict, receipt.failureCategory], ['PARTIAL-candidate', 'send-topology-mismatch']);
+  }
 });
 
 test('R-CD-2 rejects replay failure, wrong mode, and mismatched trace topology', () => {

--- a/tools/k6-proofs/scripts/__tests__/r-cd-2-authoritative-receipt.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cd-2-authoritative-receipt.test.mjs
@@ -26,6 +26,7 @@ function evidence(overrides = {}) {
     wake_same_run: true, post_wake_quiet: true,
     channel_delivery_observed: false, dispatch_failure_observed: false,
     send_run_fingerprint: run, terminal_run_fingerprint: run, wake_run_fingerprint: run,
+    accepted_send_trace_id: 'b'.repeat(32),
     ...overrides,
   };
 }
@@ -53,6 +54,16 @@ test('R-CD-2 rejects outer-send acceptance plus an unrelated delayed message', (
     correlation: correlation(), signingKey,
   });
   assert.deepEqual([receipt.verdict, receipt.failureCategory], ['PARTIAL-candidate', 'send-run-mismatch']);
+});
+
+test('R-CD-2 rejects individually valid lifecycle and topology receipts from different traces', () => {
+  const receipt = resolveRcd2AuthoritativeReceipt({
+    evidence: evidence({ accepted_send_trace_id: 'e'.repeat(32) }),
+    correlation: correlation({ traceId: 'b'.repeat(32) }),
+    signingKey,
+  });
+  assert.deepEqual([receipt.verdict, receipt.failureCategory], ['PARTIAL-candidate', 'send-topology-mismatch']);
+  assert.equal(validateRcd2AuthoritativeReceipt(receipt, signingKey).valid, true);
 });
 
 test('R-CD-2 rejects replay failure, wrong mode, and mismatched trace topology', () => {

--- a/tools/k6-proofs/scripts/__tests__/r-cd-2-authoritative-receipt.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cd-2-authoritative-receipt.test.mjs
@@ -1,5 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
 import {
   resolveRcd2AuthoritativeReceipt,
   validateRcd2AuthoritativeReceipt,
@@ -7,6 +12,11 @@ import {
 
 const signingKey = 'r-cd-2-authoritative-receipt-test-key';
 const run = 'a'.repeat(16);
+const execFileAsync = promisify(execFile);
+const repoRoot = path.resolve(import.meta.dirname, '../..');
+const manifestPath = path.join(repoRoot, 'manifests/r-cd-2.json');
+const writerPath = path.join(repoRoot, 'scripts/evidence-writer.mjs');
+const postprocessorPath = path.join(repoRoot, 'scripts/postprocess-k6-summary.mjs');
 
 function evidence(overrides = {}) {
   return {
@@ -54,5 +64,32 @@ test('R-CD-2 rejects replay failure, wrong mode, and mismatched trace topology',
   for (const bad of [correlation({ mode: 'normal' }), correlation({ sameTrace: false })]) {
     const receipt = resolveRcd2AuthoritativeReceipt({ evidence: evidence(), correlation: bad, signingKey });
     assert.deepEqual([receipt.verdict, receipt.failureCategory], ['PARTIAL-candidate', 'invalid-continuation-topology']);
+  }
+});
+
+test('R-CD-2 writer and postprocessor accept only the authoritative receipt', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'r-cd-2-authoritative-'));
+  try {
+    const receipt = resolveRcd2AuthoritativeReceipt({ evidence: evidence(), correlation: correlation(), signingKey });
+    const receiptPath = path.join(dir, 'receipt.json');
+    const logPath = path.join(dir, 'k6.log');
+    const summaryPath = path.join(dir, 'summary.json');
+    await writeFile(receiptPath, JSON.stringify(receipt));
+    await writeFile(logPath, '--- R-CD-2 EVIDENCE SUMMARY ---\n{"row":"R-CD-2","redacted_events":[]}\n--- END EVIDENCE ---\n');
+    await writeFile(summaryPath, JSON.stringify({ metrics: { proof_failures: { values: { count: 0 } }, checks: { values: { rate: 1 } } } }));
+    const env = { ...process.env, OPENCLAW_GATEWAY_TOKEN: signingKey };
+    const writer = await execFileAsync(process.execPath, [writerPath, '--input', logPath, '--row', 'R-CD-2', '--seat', 'unit', '--sha', 'a'.repeat(40), '--manifest', manifestPath, '--authoritative-receipt', receiptPath], { cwd: dir, env });
+    const writerDir = JSON.parse(writer.stdout).runDir;
+    const writerResult = JSON.parse(await readFile(path.join(dir, writerDir, 'row-result.json'), 'utf8'));
+    assert.equal(writerResult.outcome, 'PASS-candidate');
+    assert.equal(writerResult.verdictSource, 'r-cd-2-authoritative-receipt');
+    const post = await execFileAsync(process.execPath, [postprocessorPath, '--manifest', manifestPath, '--summary', summaryPath, '--out-root', path.join(dir, 'post'), '--run-id', 'unit', '--authoritative-receipt', receiptPath], { cwd: dir, env });
+    const postDir = JSON.parse(post.stdout).runDir;
+    const postResult = JSON.parse(await readFile(path.join(postDir, 'row-result.json'), 'utf8'));
+    assert.equal(postResult.outcome, 'PASS-candidate');
+    assert.equal(postResult.verdictSource, 'r-cd-2-authoritative-receipt');
+    await assert.rejects(execFileAsync(process.execPath, [writerPath, '--input', logPath, '--row', 'R-CD-2', '--seat', 'unit', '--sha', 'a'.repeat(40)], { cwd: dir, env }));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
   }
 });

--- a/tools/k6-proofs/scripts/__tests__/report-render.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/report-render.test.mjs
@@ -46,7 +46,9 @@ test('renders public-safe HTML report from row-list runner artifacts', async () 
     const html = await readFile(out, 'utf8');
     assert.match(html, /Project 81 k6 PROOFS report/);
     assert.match(html, /R-CD-2/);
-    assert.match(html, /PASS-candidate/);
+    // A k6 summary cannot promote R-CD-2 without the signed row authority.
+    assert.match(html, /PARTIAL-candidate/);
+    assert.doesNotMatch(html, /<td>PASS-candidate<\/td>/);
     assert.match(html, /trace-id: missing|tempo-trace-json: missing/);
     assert.doesNotMatch(html, /agent:main|secret/);
   } finally {

--- a/tools/k6-proofs/scripts/candidate-run-result-contract.mjs
+++ b/tools/k6-proofs/scripts/candidate-run-result-contract.mjs
@@ -1,5 +1,7 @@
 import path from 'node:path';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { validateRcd2AuthoritativeReceipt } from '../lib/r-cd-2-authoritative-receipt.mjs';
 
 export const CANDIDATE_RUN_RESULT_SCHEMA = 'openclaw.k6.candidate-run-result.v1';
 export const PROOF_ROW_MANIFEST_SCHEMA = 'openclaw.k6.proof-row-manifest.v1';
@@ -45,6 +47,20 @@ export function candidateEnvelopeMatchesSiblings({ envelope, manifest, metadata,
   if (envelope.candidate?.sha !== candidateSha || !SHA.test(envelope.candidate?.docsRef || '')) return false;
   if (envelope.run?.id !== path.basename(runDir) || envelope.run?.rowId !== rowId || envelope.run?.seat !== seat || envelope.run?.scenario !== scenario) return false;
   if (envelope.result?.outcome !== runResult.verdict || envelope.result?.outcomeSource !== runResult.verdictSource) return false;
+  if (rowId === 'R-CD-2') {
+    const declared = runResult.authoritativeReceipt;
+    if (declared?.validated !== true || declared?.source !== 'r-cd-2-row-scoped-resolver' ||
+        envelope.authoritativeReceipt?.file !== 'r-cd-2-authoritative-receipt.json' ||
+        envelope.authoritativeReceipt?.sha256 !== declared?.sha256 ||
+        !/^[a-f0-9]{64}$/iu.test(declared?.sha256 || '')) return false;
+    try {
+      const raw = readFileSync(path.join(runDir, declared.file));
+      if (createHash('sha256').update(raw).digest('hex') !== declared.sha256) return false;
+      const receipt = JSON.parse(raw.toString('utf8'));
+      const integrity = validateRcd2AuthoritativeReceipt(receipt, process.env.OPENCLAW_GATEWAY_TOKEN);
+      if (!integrity.valid || integrity.verdict !== runResult.verdict) return false;
+    } catch { return false; }
+  }
   if (manifest.liveRunSafety?.expectedArtifactClass === 'construct-only' && envelope.result.outcome !== 'construct-only') return false;
   const rawObservability = runResult.observability;
   if (!rawObservability || typeof rawObservability.traceStatus !== 'string') return false;

--- a/tools/k6-proofs/scripts/candidate-run-result-contract.mjs
+++ b/tools/k6-proofs/scripts/candidate-run-result-contract.mjs
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { existsSync } from 'node:fs';
 
 export const CANDIDATE_RUN_RESULT_SCHEMA = 'openclaw.k6.candidate-run-result.v1';
 export const PROOF_ROW_MANIFEST_SCHEMA = 'openclaw.k6.proof-row-manifest.v1';
@@ -33,6 +34,12 @@ export function candidateEnvelopeMatchesSiblings({ envelope, manifest, metadata,
   const seat = nonEmptyString(metadata.seat);
   const scenario = nonEmptyString(metadata.scenario)?.replace(/\.js$/, '');
   if (!rowId || !candidateSha || !seat || !scenario || !SHA.test(candidateSha)) return false;
+  if (rowId === 'R-CD-2' && (
+    runResult.verdictSource !== 'r-cd-2-authoritative-receipt' ||
+    runResult.authoritativeReceipt?.validated !== true ||
+    runResult.authoritativeReceipt?.source !== 'r-cd-2-row-scoped-resolver' ||
+    !existsSync(path.join(runDir, 'r-cd-2-authoritative-receipt.json'))
+  )) return false;
   if (manifest.rowId !== rowId || scenarioName(manifest) !== scenario) return false;
   if (manifest.candidateSha && manifest.candidateSha !== candidateSha) return false;
   if (envelope.candidate?.sha !== candidateSha || !SHA.test(envelope.candidate?.docsRef || '')) return false;

--- a/tools/k6-proofs/scripts/collect-continuation-trace.mjs
+++ b/tools/k6-proofs/scripts/collect-continuation-trace.mjs
@@ -220,8 +220,12 @@ function validateTrace(trace, expected) {
     return span.name === 'openclaw.tool.execution' &&
       attrs.get('gen_ai.tool.name') === expected.tool;
   });
-  if (tools.length === 0) {
-    throw new Error(`matched trace lacks the originating ${expected.tool} tool span`);
+  if (tools.length !== 1) {
+    throw new Error(
+      tools.length === 0
+        ? `matched trace lacks the originating ${expected.tool} tool span`
+        : `matched trace contains ${tools.length} ${expected.tool} tool spans`,
+    );
   }
 
   const traceId = idHex(accept.traceId, 16, 'trace id');
@@ -429,6 +433,15 @@ async function main() {
           // reason hash; retain only fingerprints, never raw run IDs/nonces.
           ...(evidence.row === 'R-CD-2'
             ? {
+                // This is deliberately the collector's native continuation
+                // shape. The R-CD-2 resolver consumes these exact fields; it
+                // must not rely on a separately invented topology fixture.
+                tool: contract.tool,
+                mode: contract.mode,
+                typedToolObserved: topology.toolSpanIds.length === 1,
+                dispatchObserved: Boolean(topology.dispatchSpanId),
+                fireObserved: Boolean(topology.fireSpanId),
+                sameChain: true,
                 rowBinding: {
                   acceptedSendRunFingerprint: evidence.send_run_fingerprint || null,
                   nonceFingerprint: evidence.row_nonce_fingerprint || null,

--- a/tools/k6-proofs/scripts/collect-continuation-trace.mjs
+++ b/tools/k6-proofs/scripts/collect-continuation-trace.mjs
@@ -198,22 +198,32 @@ function matchesContinuationSpan(span, expected, name) {
 
 function validateTrace(trace, expected) {
   const spans = allSpans(trace);
-  const accept = spans.find((span) =>
+  const accepts = spans.filter((span) =>
     matchesContinuationSpan(span, expected, expected.acceptSpanName));
-  if (!accept) throw new Error(`matched trace lacks the expected ${expected.acceptSpanName} span`);
+  if (accepts.length !== 1) {
+    throw new Error(accepts.length === 0
+      ? `matched trace lacks the expected ${expected.acceptSpanName} span`
+      : `matched trace contains ${accepts.length} ${expected.acceptSpanName} spans`);
+  }
+  const accept = accepts[0];
   const acceptAttrs = attributes(accept);
   const chainId = String(acceptAttrs.get('chain.id') || '');
   if (!/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu.test(chainId)) {
     throw new Error(`${expected.acceptSpanName} span lacks a public-safe UUIDv4 chain.id`);
   }
 
-  const fire = spans.find((span) => {
+  const fires = spans.filter((span) => {
     const attrs = attributes(span);
     return matchesContinuationSpan(span, expected, expected.fireSpanName) &&
       attrs.get('chain.id') === chainId &&
       (expected.mode === undefined || attrs.get('delegate.mode') === expected.mode);
   });
-  if (!fire) throw new Error(`matched trace lacks the expected ${expected.fireSpanName} span`);
+  if (fires.length !== 1) {
+    throw new Error(fires.length === 0
+      ? `matched trace lacks the expected ${expected.fireSpanName} span`
+      : `matched trace contains ${fires.length} ${expected.fireSpanName} spans`);
+  }
+  const fire = fires[0];
 
   const tools = spans.filter((span) => {
     const attrs = attributes(span);
@@ -237,6 +247,12 @@ function validateTrace(trace, expected) {
 
   const acceptSpanId = idHex(accept.spanId, 8, 'accept span id');
   const fireSpanId = idHex(fire.spanId, 8, 'fire span id');
+  const acceptParentSpanId = idHex(accept.parentSpanId, 8, 'dispatch parent span id');
+  const fireParentSpanId = idHex(fire.parentSpanId, 8, 'fire parent span id');
+  const toolParentSpanIds = tools.map((span) => idHex(span.parentSpanId, 8, 'tool parent span id'));
+  if (fireParentSpanId !== acceptParentSpanId || toolParentSpanIds.some((value) => value !== acceptParentSpanId)) {
+    throw new Error('tool/fire/dispatch do not share one causal parent');
+  }
   const toolSpanIds = tools.map((span) => idHex(span.spanId, 8, 'tool span id'));
   if (acceptSpanId === fireSpanId ||
       toolSpanIds.includes(acceptSpanId) ||
@@ -255,14 +271,14 @@ function validateTrace(trace, expected) {
     chainId,
     toolSpanIds,
     fireSpanId,
-    fireParentSpanId: idHex(fire.parentSpanId, 8, 'fire parent span id'),
+    fireParentSpanId,
     childSpans,
   };
   if (expected.tool === 'continue_delegate') {
     return {
       ...topology,
       dispatchSpanId: acceptSpanId,
-      dispatchParentSpanId: idHex(accept.parentSpanId, 8, 'dispatch parent span id'),
+      dispatchParentSpanId: acceptParentSpanId,
     };
   }
   return {

--- a/tools/k6-proofs/scripts/collect-continuation-trace.mjs
+++ b/tools/k6-proofs/scripts/collect-continuation-trace.mjs
@@ -423,6 +423,19 @@ async function main() {
             acceptSpan: contract.acceptSpanName,
             fireSpan: contract.fireSpanName,
           },
+          // R-CD-2's row resolver needs the same opaque row identity on both
+          // the accepted sessions.send lifecycle and the Tempo topology. The
+          // trace has already been selected by this evidence's nonce-derived
+          // reason hash; retain only fingerprints, never raw run IDs/nonces.
+          ...(evidence.row === 'R-CD-2'
+            ? {
+                rowBinding: {
+                  acceptedSendRunFingerprint: evidence.send_run_fingerprint || null,
+                  nonceFingerprint: evidence.row_nonce_fingerprint || null,
+                  acceptedSendTraceId: evidence.accepted_send_trace_id || null,
+                },
+              }
+            : {}),
           ...(contract.mode === undefined ? {} : { delegate: { mode: contract.mode } }),
           sameTrace: true,
           distinctSpans: true,

--- a/tools/k6-proofs/scripts/collect-continuation-trace.mjs
+++ b/tools/k6-proofs/scripts/collect-continuation-trace.mjs
@@ -433,15 +433,10 @@ async function main() {
           // reason hash; retain only fingerprints, never raw run IDs/nonces.
           ...(evidence.row === 'R-CD-2'
             ? {
-                // This is deliberately the collector's native continuation
-                // shape. The R-CD-2 resolver consumes these exact fields; it
-                // must not rely on a separately invented topology fixture.
-                tool: contract.tool,
-                mode: contract.mode,
-                typedToolObserved: topology.toolSpanIds.length === 1,
-                dispatchObserved: Boolean(topology.dispatchSpanId),
-                fireObserved: Boolean(topology.fireSpanId),
-                sameChain: true,
+                // The resolver consumes the native continuation/delegate
+                // shape emitted below plus topology.toolSpanIds.  Keep the
+                // row binding public-safe and opaque, but never manufacture
+                // a second top-level topology schema for a fixture to fake.
                 rowBinding: {
                   acceptedSendRunFingerprint: evidence.send_run_fingerprint || null,
                   nonceFingerprint: evidence.row_nonce_fingerprint || null,

--- a/tools/k6-proofs/scripts/evidence-writer.mjs
+++ b/tools/k6-proofs/scripts/evidence-writer.mjs
@@ -26,6 +26,7 @@
 import { copyFileSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { sanitizeEvidenceRecords } from './sanitize-k6-artifacts.mjs';
+import { validateRcd2AuthoritativeReceipt } from '../lib/r-cd-2-authoritative-receipt.mjs';
 
 function parseArgs(argv) {
   const out = {};
@@ -106,6 +107,16 @@ try {
   process.exit(1);
 }
 
+let authoritativeReceipt = null;
+if (args.row === 'R-CD-2') {
+  if (!args['authoritative-receipt']) {
+    throw new Error('R-CD-2 requires --authoritative-receipt; generic evidence cannot promote this row');
+  }
+  authoritativeReceipt = JSON.parse(readFileSync(args['authoritative-receipt'], 'utf8'));
+  const validation = validateRcd2AuthoritativeReceipt(authoritativeReceipt, process.env.OPENCLAW_GATEWAY_TOKEN);
+  if (!validation.valid) throw new Error(`R-CD-2 authoritative receipt rejected: ${validation.reason}`);
+}
+
 // --- REDACTION BOUNDARY ---
 // Refuse to write if evidence has raw 'events' but no 'redacted_events'
 if (evidence.events && !evidence.redacted_events) {
@@ -144,9 +155,9 @@ writeFileSync(join(outDir, 'evidence-redaction.json'), JSON.stringify({
 }, null, 2) + '\n');
 
 // Determine verdict
-const verdict = evidence.tool_accepted || evidence.prompt_sent
+const verdict = authoritativeReceipt ? authoritativeReceipt.verdict : (evidence.tool_accepted || evidence.prompt_sent
   ? (evidence.task_created || evidence.child_spawned ? 'PASS-candidate' : 'PARTIAL-candidate')
-  : 'FAIL-candidate';
+  : 'FAIL-candidate');
 
 // Write row-result.json
 const result = {
@@ -157,6 +168,7 @@ const result = {
   candidateSha: args.sha,
   seat: args.seat,
   outcome: verdict,
+  verdictSource: authoritativeReceipt ? 'r-cd-2-authoritative-receipt' : 'generic-evidence',
   liveRunSafety: manifest?.liveRunSafety ? {
     classification: manifest.liveRunSafety.classification,
     requiresLiveGatewayToken: Boolean(manifest.liveRunSafety.requiresLiveGatewayToken),

--- a/tools/k6-proofs/scripts/evidence-writer.mjs
+++ b/tools/k6-proofs/scripts/evidence-writer.mjs
@@ -138,6 +138,11 @@ mkdirSync(join(outDir, 'artifacts'), { recursive: true });
 if (args['seat-readiness']) {
   copyFileSync(args['seat-readiness'], join(outDir, 'seat-readiness.json'));
 }
+if (authoritativeReceipt) {
+  // Carry the signed authority alongside every public candidate surface so a
+  // report/envelope cannot cite an uninspectable generic PASS.
+  copyFileSync(args['authoritative-receipt'], join(outDir, 'r-cd-2-authoritative-receipt.json'));
+}
 
 // Write k6-summary.json through the same public-safe boundary as run-proofs.sh.
 writeFileSync(join(outDir, 'k6-summary.json'), JSON.stringify(summary, null, 2) + '\n');
@@ -169,6 +174,13 @@ const result = {
   seat: args.seat,
   outcome: verdict,
   verdictSource: authoritativeReceipt ? 'r-cd-2-authoritative-receipt' : 'generic-evidence',
+  ...(authoritativeReceipt ? {
+    authoritativeReceipt: {
+      schema: authoritativeReceipt.schema,
+      validated: true,
+      source: 'r-cd-2-row-scoped-resolver',
+    },
+  } : {}),
   liveRunSafety: manifest?.liveRunSafety ? {
     classification: manifest.liveRunSafety.classification,
     requiresLiveGatewayToken: Boolean(manifest.liveRunSafety.requiresLiveGatewayToken),

--- a/tools/k6-proofs/scripts/evidence-writer.mjs
+++ b/tools/k6-proofs/scripts/evidence-writer.mjs
@@ -24,6 +24,7 @@
  */
 
 import { copyFileSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import { join } from 'node:path';
 import { sanitizeEvidenceRecords } from './sanitize-k6-artifacts.mjs';
 import { validateRcd2AuthoritativeReceipt } from '../lib/r-cd-2-authoritative-receipt.mjs';
@@ -135,6 +136,13 @@ const runId = `k6-run-${stamp()}`;
 const outDir = join('PROOFS', args.sha, args.row, args.seat, runId);
 mkdirSync(join(outDir, 'artifacts'), { recursive: true });
 
+let authoritativeReceiptDigest = null;
+if (authoritativeReceipt) {
+  const raw = readFileSync(args['authoritative-receipt']);
+  authoritativeReceiptDigest = createHash('sha256').update(raw).digest('hex');
+  writeFileSync(join(outDir, 'r-cd-2-authoritative-receipt.json'), raw);
+}
+
 if (args['seat-readiness']) {
   copyFileSync(args['seat-readiness'], join(outDir, 'seat-readiness.json'));
 }
@@ -174,13 +182,10 @@ const result = {
   seat: args.seat,
   outcome: verdict,
   verdictSource: authoritativeReceipt ? 'r-cd-2-authoritative-receipt' : 'generic-evidence',
-  ...(authoritativeReceipt ? {
-    authoritativeReceipt: {
-      schema: authoritativeReceipt.schema,
-      validated: true,
-      source: 'r-cd-2-row-scoped-resolver',
-    },
-  } : {}),
+  ...(authoritativeReceiptDigest ? { authoritativeReceipt: {
+    schema: authoritativeReceipt.schema, validated: true, source: 'r-cd-2-row-scoped-resolver',
+    file: 'r-cd-2-authoritative-receipt.json', sha256: authoritativeReceiptDigest,
+  } } : {}),
   liveRunSafety: manifest?.liveRunSafety ? {
     classification: manifest.liveRunSafety.classification,
     requiresLiveGatewayToken: Boolean(manifest.liveRunSafety.requiresLiveGatewayToken),

--- a/tools/k6-proofs/scripts/postprocess-k6-summary.mjs
+++ b/tools/k6-proofs/scripts/postprocess-k6-summary.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
 import path from 'node:path';
 import { readFileSync } from 'node:fs';
 import { validateRcd2AuthoritativeReceipt } from '../lib/r-cd-2-authoritative-receipt.mjs';
@@ -186,19 +187,19 @@ async function main() {
   const expectedArtifactClass = manifest.liveRunSafety?.expectedArtifactClass;
   let outcome = outcomeFromSummary(summary, expectedArtifactClass);
   let verdictSource = 'k6-summary';
+  let authoritativeReceiptDigest = null;
+  let authoritativeReceiptRaw = null;
   let authoritativeReceipt = null;
   if (manifest.rowId === 'R-CD-2') {
     if (!args['authoritative-receipt']) throw new Error('R-CD-2 requires --authoritative-receipt');
-    const receipt = JSON.parse(readFileSync(args['authoritative-receipt'], 'utf8'));
+    authoritativeReceiptRaw = readFileSync(args['authoritative-receipt']);
+    const receipt = JSON.parse(authoritativeReceiptRaw.toString('utf8'));
     const validation = validateRcd2AuthoritativeReceipt(receipt, process.env.OPENCLAW_GATEWAY_TOKEN);
     if (!validation.valid) throw new Error(`R-CD-2 authoritative receipt rejected: ${validation.reason}`);
     outcome = receipt.verdict;
     verdictSource = 'r-cd-2-authoritative-receipt';
-    authoritativeReceipt = {
-      schema: receipt.schema,
-      validated: true,
-      source: 'r-cd-2-row-scoped-resolver',
-    };
+    authoritativeReceiptDigest = createHash('sha256').update(authoritativeReceiptRaw).digest('hex');
+    authoritativeReceipt = { schema: receipt.schema, validated: true, source: 'r-cd-2-row-scoped-resolver' };
   }
   const failures = requiredMetric(summary, 'proof_failures');
   const failureCount = failures ? Number(failures.count || 0) : 0;
@@ -222,7 +223,7 @@ async function main() {
     transport: manifest.transport,
     outcome,
     verdictSource,
-    ...(authoritativeReceipt ? { authoritativeReceipt } : {}),
+    ...(authoritativeReceiptDigest ? { authoritativeReceipt: { ...authoritativeReceipt, file: 'r-cd-2-authoritative-receipt.json', sha256: authoritativeReceiptDigest } } : {}),
     metrics: {
       proofFailures: failureCount,
       checksRate: checkRate,
@@ -255,10 +256,8 @@ async function main() {
   await mkdir(path.join(runDir, 'artifacts'), { recursive: true });
   await writeFile(path.join(runDir, 'row-manifest.json'), JSON.stringify(manifest, null, 2) + '\n');
   await writeFile(path.join(runDir, 'k6-summary.json'), JSON.stringify(summary, null, 2) + '\n');
-  if (authoritativeReceipt) {
-    await writeFile(path.join(runDir, 'r-cd-2-authoritative-receipt.json'), JSON.stringify(authoritativeReceipt, null, 2) + '\n');
-  }
   await writeFile(path.join(runDir, 'row-result.json'), JSON.stringify(result, null, 2) + '\n');
+  if (authoritativeReceiptRaw) await writeFile(path.join(runDir, 'r-cd-2-authoritative-receipt.json'), authoritativeReceiptRaw);
   await writeFile(path.join(runDir, 'EVIDENCE.md'), evidenceDraft({ manifest, summary, result }));
 
   console.log(JSON.stringify({ runDir, outcome, rowId: manifest.rowId, candidateOnly: true }, null, 2));

--- a/tools/k6-proofs/scripts/postprocess-k6-summary.mjs
+++ b/tools/k6-proofs/scripts/postprocess-k6-summary.mjs
@@ -186,6 +186,7 @@ async function main() {
   const expectedArtifactClass = manifest.liveRunSafety?.expectedArtifactClass;
   let outcome = outcomeFromSummary(summary, expectedArtifactClass);
   let verdictSource = 'k6-summary';
+  let authoritativeReceipt = null;
   if (manifest.rowId === 'R-CD-2') {
     if (!args['authoritative-receipt']) throw new Error('R-CD-2 requires --authoritative-receipt');
     const receipt = JSON.parse(readFileSync(args['authoritative-receipt'], 'utf8'));
@@ -193,6 +194,11 @@ async function main() {
     if (!validation.valid) throw new Error(`R-CD-2 authoritative receipt rejected: ${validation.reason}`);
     outcome = receipt.verdict;
     verdictSource = 'r-cd-2-authoritative-receipt';
+    authoritativeReceipt = {
+      schema: receipt.schema,
+      validated: true,
+      source: 'r-cd-2-row-scoped-resolver',
+    };
   }
   const failures = requiredMetric(summary, 'proof_failures');
   const failureCount = failures ? Number(failures.count || 0) : 0;
@@ -216,6 +222,7 @@ async function main() {
     transport: manifest.transport,
     outcome,
     verdictSource,
+    ...(authoritativeReceipt ? { authoritativeReceipt } : {}),
     metrics: {
       proofFailures: failureCount,
       checksRate: checkRate,
@@ -248,6 +255,9 @@ async function main() {
   await mkdir(path.join(runDir, 'artifacts'), { recursive: true });
   await writeFile(path.join(runDir, 'row-manifest.json'), JSON.stringify(manifest, null, 2) + '\n');
   await writeFile(path.join(runDir, 'k6-summary.json'), JSON.stringify(summary, null, 2) + '\n');
+  if (authoritativeReceipt) {
+    await writeFile(path.join(runDir, 'r-cd-2-authoritative-receipt.json'), JSON.stringify(authoritativeReceipt, null, 2) + '\n');
+  }
   await writeFile(path.join(runDir, 'row-result.json'), JSON.stringify(result, null, 2) + '\n');
   await writeFile(path.join(runDir, 'EVIDENCE.md'), evidenceDraft({ manifest, summary, result }));
 

--- a/tools/k6-proofs/scripts/postprocess-k6-summary.mjs
+++ b/tools/k6-proofs/scripts/postprocess-k6-summary.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { readFileSync } from 'node:fs';
+import { validateRcd2AuthoritativeReceipt } from '../lib/r-cd-2-authoritative-receipt.mjs';
 
 function usage() {
   console.error(`Usage: node tools/k6-proofs/scripts/postprocess-k6-summary.mjs \\
@@ -182,7 +184,16 @@ async function main() {
   const runDir = path.join(outRoot, sha, row, seat, runId);
 
   const expectedArtifactClass = manifest.liveRunSafety?.expectedArtifactClass;
-  const outcome = outcomeFromSummary(summary, expectedArtifactClass);
+  let outcome = outcomeFromSummary(summary, expectedArtifactClass);
+  let verdictSource = 'k6-summary';
+  if (manifest.rowId === 'R-CD-2') {
+    if (!args['authoritative-receipt']) throw new Error('R-CD-2 requires --authoritative-receipt');
+    const receipt = JSON.parse(readFileSync(args['authoritative-receipt'], 'utf8'));
+    const validation = validateRcd2AuthoritativeReceipt(receipt, process.env.OPENCLAW_GATEWAY_TOKEN);
+    if (!validation.valid) throw new Error(`R-CD-2 authoritative receipt rejected: ${validation.reason}`);
+    outcome = receipt.verdict;
+    verdictSource = 'r-cd-2-authoritative-receipt';
+  }
   const failures = requiredMetric(summary, 'proof_failures');
   const failureCount = failures ? Number(failures.count || 0) : 0;
   const checks = requiredMetric(summary, 'checks');
@@ -204,6 +215,7 @@ async function main() {
     toolSurface: manifest.toolSurface,
     transport: manifest.transport,
     outcome,
+    verdictSource,
     metrics: {
       proofFailures: failureCount,
       checksRate: checkRate,

--- a/tools/k6-proofs/scripts/render-run-report.mjs
+++ b/tools/k6-proofs/scripts/render-run-report.mjs
@@ -124,7 +124,16 @@ async function rowFromRunResult(root, runResultPath) {
   const evidenceRows = files.includes('evidence.jsonl') ? await readEvidenceJsonl(path.join(runDir, 'evidence.jsonl')) : [];
   const rel = path.relative(root, runDir).split(path.sep).join('/');
   const proofFailures = Number(summary?.metrics?.failures ?? runResult.proofFailures ?? (runResult.k6ExitCode === 0 ? 0 : 1));
-  const outcome = safeText(summary?.verdict || (runResult.k6ExitCode === 0 ? 'PASS-candidate' : 'FAIL-candidate'));
+  // R-CD-2 has one authority: its signed row-scoped receipt, carried by the
+  // normalized run result. A generic k6 summary cannot override that result.
+  const outcome = safeText(
+    manifest?.rowId === 'R-CD-2' && (
+      runResult?.verdictSource !== 'r-cd-2-authoritative-receipt' ||
+      runResult?.authoritativeReceipt?.validated !== true
+    )
+      ? 'PARTIAL-candidate'
+      : (runResult?.outcome || summary?.verdict || (runResult.k6ExitCode === 0 ? 'PASS-candidate' : 'FAIL-candidate')),
+  );
   return {
     rowId: safeText(metadata?.row || manifest?.rowId),
     candidateSha: safeText(metadata?.candidateSha || manifest?.candidateSha || summary?.sha),

--- a/tools/k6-proofs/scripts/render-run-report.mjs
+++ b/tools/k6-proofs/scripts/render-run-report.mjs
@@ -11,7 +11,9 @@
  */
 import { readdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { createHash } from 'node:crypto';
 import { candidateEnvelopeMatchesSiblings } from './candidate-run-result-contract.mjs';
+import { validateRcd2AuthoritativeReceipt } from '../lib/r-cd-2-authoritative-receipt.mjs';
 
 function usage() {
   console.error('Usage: node render-run-report.mjs --root <run-out-root> [--out report.html]');
@@ -124,16 +126,21 @@ async function rowFromRunResult(root, runResultPath) {
   const evidenceRows = files.includes('evidence.jsonl') ? await readEvidenceJsonl(path.join(runDir, 'evidence.jsonl')) : [];
   const rel = path.relative(root, runDir).split(path.sep).join('/');
   const proofFailures = Number(summary?.metrics?.failures ?? runResult.proofFailures ?? (runResult.k6ExitCode === 0 ? 0 : 1));
-  // R-CD-2 has one authority: its signed row-scoped receipt, carried by the
-  // normalized run result. A generic k6 summary cannot override that result.
-  const outcome = safeText(
-    manifest?.rowId === 'R-CD-2' && (
-      runResult?.verdictSource !== 'r-cd-2-authoritative-receipt' ||
-      runResult?.authoritativeReceipt?.validated !== true
-    )
-      ? 'PARTIAL-candidate'
-      : (runResult?.outcome || summary?.verdict || (runResult.k6ExitCode === 0 ? 'PASS-candidate' : 'FAIL-candidate')),
-  );
+  let outcome = safeText(summary?.verdict || (runResult.k6ExitCode === 0 ? 'PASS-candidate' : 'FAIL-candidate'));
+  if ((metadata?.row || manifest?.rowId) === 'R-CD-2') {
+    const declared = runResult.authoritativeReceipt;
+    try {
+      if (runResult.verdictSource !== 'r-cd-2-authoritative-receipt' || declared?.file !== 'r-cd-2-authoritative-receipt.json' || !/^[a-f0-9]{64}$/iu.test(declared?.sha256 || '')) throw new Error('missing authoritative receipt declaration');
+      const raw = await readFile(path.join(runDir, declared.file));
+      if (createHash('sha256').update(raw).digest('hex') !== declared.sha256) throw new Error('authoritative receipt digest mismatch');
+      const receipt = JSON.parse(raw.toString('utf8'));
+      const integrity = validateRcd2AuthoritativeReceipt(receipt, process.env.OPENCLAW_GATEWAY_TOKEN);
+      if (!integrity.valid || integrity.verdict !== runResult.verdict) throw new Error('authoritative receipt invalid');
+      outcome = safeText(receipt.verdict);
+    } catch {
+      outcome = 'PARTIAL-candidate';
+    }
+  }
   return {
     rowId: safeText(metadata?.row || manifest?.rowId),
     candidateSha: safeText(metadata?.candidateSha || manifest?.candidateSha || summary?.sha),

--- a/tools/k6-proofs/scripts/resolve-r-cd-2-authoritative-receipt.mjs
+++ b/tools/k6-proofs/scripts/resolve-r-cd-2-authoritative-receipt.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { resolveRcd2AuthoritativeReceipt } from '../lib/r-cd-2-authoritative-receipt.mjs';
+
+function args(argv) {
+  const out = {};
+  for (let i = 2; i < argv.length; i += 2) {
+    if (!argv[i]?.startsWith('--') || !argv[i + 1]) throw new Error('usage: --run-dir <dir> --evidence <private-json> [--correlation <private-json>]');
+    out[argv[i].slice(2)] = argv[i + 1];
+  }
+  if (!out['run-dir'] || !out.evidence) throw new Error('run-dir and evidence are required');
+  return out;
+}
+
+async function readJson(file) {
+  try { return JSON.parse(await readFile(file, 'utf8')); }
+  catch { return null; }
+}
+
+async function main() {
+  const input = args(process.argv);
+  const runDir = path.resolve(input['run-dir']);
+  const evidence = await readJson(input.evidence);
+  const correlation = await readJson(input.correlation || path.join(runDir, 'continuation-trace-correlation.json'));
+  const receipt = resolveRcd2AuthoritativeReceipt({ evidence, correlation, signingKey: process.env.OPENCLAW_GATEWAY_TOKEN });
+  const target = path.join(runDir, 'r-cd-2-authoritative-receipt.json');
+  await writeFile(target, `${JSON.stringify(receipt, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify({ verdict: receipt.verdict, receipt: path.basename(target) })}\n`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`R-CD-2 authoritative receipt failed: ${error.message}\n`);
+  process.exitCode = 1;
+});

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -452,6 +452,7 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
     # emits PARTIAL; only this resolver may join its private accepted-run
     # lifecycle with the matching continuation trace/chain receipt.
     R_CD_2_RECEIPT=""
+    R_CD_2_RECEIPT_SHA256=""
     if [[ "$ROW_ID" == "R-CD-2" ]]; then
       R_CD_2_RECEIPT="r-cd-2-authoritative-receipt.json"
       RESOLVER_ARGS=(--run-dir "$RUN_DIR" --evidence "$PRIVATE_EVIDENCE_FILE")
@@ -459,6 +460,10 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
         RESOLVER_ARGS+=(--correlation "$CORRELATION_RECEIPT_PATH")
       fi
       if node "$R_CD_2_RECEIPT_RESOLVER" "${RESOLVER_ARGS[@]}" > "$RUN_DIR/r-cd-2-authoritative-resolution.json"; then
+        # The row-list runner itself—not only the writer/postprocessor path—must
+        # carry the signed receipt declaration into run-result.json.  Candidate
+        # routing verifies this digest before it can publish an R-CD-2 envelope.
+        R_CD_2_RECEIPT_SHA256="$(node --input-type=module -e 'import { createHash } from "node:crypto"; import { readFileSync } from "node:fs"; process.stdout.write(createHash("sha256").update(readFileSync(process.argv[1])).digest("hex"));' "$RUN_DIR/$R_CD_2_RECEIPT")"
         SUMMARY_VERDICT="$(jq -r '.verdict // "PARTIAL-candidate"' "$RUN_DIR/$R_CD_2_RECEIPT")"
         SUMMARY_VERDICT_SOURCE="r-cd-2-authoritative-receipt"
         SUMMARY_FILE_VERDICT="$SUMMARY_VERDICT"
@@ -540,6 +545,7 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
       --arg tempoTraceJson "$TEMPO_TRACE_JSON" \
       --arg correlationReceipt "$CORRELATION_RECEIPT" \
       --arg lifecycleReceipt "$R_CD_2_RECEIPT" \
+      --arg authoritativeReceiptSha256 "$R_CD_2_RECEIPT_SHA256" \
       --arg serviceLogStatus "$GATEWAY_JOURNAL_STATUS" \
       --arg verdict "$SUMMARY_VERDICT" \
       --arg verdictSource "$SUMMARY_VERDICT_SOURCE" \
@@ -548,7 +554,7 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
       --argjson summaryFiles "$SUMMARY_FILES_JSON" \
       --argjson evidence "$EVIDENCE_JSON" \
       --argjson reviewPendingReceipts "$REVIEW_PENDING_RECEIPTS" \
-      '{k6ExitCode:$rc, postprocessExitCode:$postprocessRc, effectiveExitCode:$effectiveRc, endedAt:$ended, verdict:(if $verdict == "unknown" then null else $verdict end), verdictSource:$verdictSource, summaryFileVerdict:(if $summaryFileVerdict == "unknown" then null else $summaryFileVerdict end), vuLogVerdict:(if $vuLogVerdict == "" then null else $vuLogVerdict end), summaryFiles:$summaryFiles, evidence:$evidence, candidateOnly:true, foldRequiresReview:true, observability:{traceStatus:$traceStatus, traceId:(if $traceId == "" then null else $traceId end), tempoTraceJson:(if $tempoTraceJson == "" then null else $tempoTraceJson end), correlationReceipt:(if $correlationReceipt == "" then null else $correlationReceipt end), lifecycleReceipt:(if $lifecycleReceipt == "" then null else $lifecycleReceipt end), serviceLogStatus:$serviceLogStatus, serviceLog:"gateway-journal.log", serviceLogCapture:"gateway-journal-capture.json", serviceLogRedaction:"gateway-journal-redaction.json"}, review:{status:(if ($reviewPendingReceipts|length)>0 then "review-pending" else "ready-for-human-review" end), pendingReceipts:$reviewPendingReceipts}}' \
+      '{k6ExitCode:$rc, postprocessExitCode:$postprocessRc, effectiveExitCode:$effectiveRc, endedAt:$ended, verdict:(if $verdict == "unknown" then null else $verdict end), verdictSource:$verdictSource, summaryFileVerdict:(if $summaryFileVerdict == "unknown" then null else $summaryFileVerdict end), vuLogVerdict:(if $vuLogVerdict == "" then null else $vuLogVerdict end), summaryFiles:$summaryFiles, evidence:$evidence, candidateOnly:true, foldRequiresReview:true, authoritativeReceipt:(if $authoritativeReceiptSha256 == "" then null else {file:"r-cd-2-authoritative-receipt.json", sha256:$authoritativeReceiptSha256, validated:true, source:"r-cd-2-row-scoped-resolver"} end), observability:{traceStatus:$traceStatus, traceId:(if $traceId == "" then null else $traceId end), tempoTraceJson:(if $tempoTraceJson == "" then null else $tempoTraceJson end), correlationReceipt:(if $correlationReceipt == "" then null else $correlationReceipt end), lifecycleReceipt:(if $lifecycleReceipt == "" then null else $lifecycleReceipt end), serviceLogStatus:$serviceLogStatus, serviceLog:"gateway-journal.log", serviceLogCapture:"gateway-journal-capture.json", serviceLogRedaction:"gateway-journal-redaction.json"}, review:{status:(if ($reviewPendingReceipts|length)>0 then "review-pending" else "ready-for-human-review" end), pendingReceipts:$reviewPendingReceipts}}' \
       > "$RUN_DIR/run-result.json"
     # A review-complete candidate can now receive a public-safe routing
     # envelope. Review-pending runs intentionally remain represented only by

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EVIDENCE_EXTRACTOR="$SCRIPT_DIR/extract-k6-evidence.mjs"
 CONTINUATION_TRACE_COLLECTOR="$SCRIPT_DIR/collect-continuation-trace.mjs"
+R_CD_2_RECEIPT_RESOLVER="$SCRIPT_DIR/resolve-r-cd-2-authoritative-receipt.mjs"
 ARTIFACT_SANITIZER="$SCRIPT_DIR/sanitize-k6-artifacts.mjs"
 CANDIDATE_RESULT_VALIDATOR="$SCRIPT_DIR/validate-candidate-run-result.mjs"
 PRIVATE_K6_LOG=""
@@ -447,6 +448,28 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
       )"
     fi
 
+    # R-CD-2 owns one candidate verdict surface.  Its scenario deliberately
+    # emits PARTIAL; only this resolver may join its private accepted-run
+    # lifecycle with the matching continuation trace/chain receipt.
+    R_CD_2_RECEIPT=""
+    if [[ "$ROW_ID" == "R-CD-2" ]]; then
+      R_CD_2_RECEIPT="r-cd-2-authoritative-receipt.json"
+      RESOLVER_ARGS=(--run-dir "$RUN_DIR" --evidence "$PRIVATE_EVIDENCE_FILE")
+      if [[ -n "$CORRELATION_RECEIPT_PATH" && -f "$CORRELATION_RECEIPT_PATH" ]]; then
+        RESOLVER_ARGS+=(--correlation "$CORRELATION_RECEIPT_PATH")
+      fi
+      if node "$R_CD_2_RECEIPT_RESOLVER" "${RESOLVER_ARGS[@]}" > "$RUN_DIR/r-cd-2-authoritative-resolution.json"; then
+        SUMMARY_VERDICT="$(jq -r '.verdict // "PARTIAL-candidate"' "$RUN_DIR/$R_CD_2_RECEIPT")"
+        SUMMARY_VERDICT_SOURCE="r-cd-2-authoritative-receipt"
+        SUMMARY_FILE_VERDICT="$SUMMARY_VERDICT"
+        VU_LOG_VERDICT=""
+      else
+        SUMMARY_VERDICT="PARTIAL-candidate"
+        SUMMARY_VERDICT_SOURCE="r-cd-2-authoritative-receipt-missing"
+        POSTPROCESS_RC=1
+      fi
+    fi
+
     if ! node "$ARTIFACT_SANITIZER" \
       --input "$PRIVATE_EVIDENCE_FILE" \
       --out "$RUN_DIR/evidence.jsonl" \
@@ -471,6 +494,22 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
       [[ -f "$RUN_DIR/evidence-lines.log" ]] || : > "$RUN_DIR/evidence-lines.log"
     else
       rm -f "$RUN_DIR/evidence-redaction.error.log"
+    fi
+    if [[ "$ROW_ID" == "R-CD-2" && -f "$RUN_DIR/$R_CD_2_RECEIPT" ]]; then
+      # Provider/RPC/journal capture remains private for this row.  The signed,
+      # allowlisted receipt is the sole public candidate evidence and the sole
+      # verdict authority; raw trace and correlation inputs are not exported.
+      jq -cn --arg verdict "$SUMMARY_VERDICT" --arg receipt "$R_CD_2_RECEIPT" \
+        '{row:"R-CD-2", verdict:$verdict, authoritativeReceipt:$receipt}' > "$RUN_DIR/evidence.jsonl"
+      printf '%s\n' 'R-CD-2 private acquisition withheld; inspect the authoritative receipt.' > "$RUN_DIR/evidence-lines.log"
+      printf '%s\n' 'R-CD-2 private k6 acquisition withheld; inspect the authoritative receipt.' > "$RUN_DIR/k6.log"
+      printf '%s\n' 'R-CD-2 private gateway acquisition withheld; inspect the authoritative receipt.' > "$RUN_DIR/gateway-journal.log"
+      rm -f "$TEMPO_TRACE_PATH" "$CORRELATION_RECEIPT_PATH"
+      TRACE_ID=""
+      TEMPO_TRACE_JSON=""
+      CORRELATION_RECEIPT=""
+      CORRELATION_RECEIPT_PATH=""
+      TRACE_STATUS="r-cd-2-authoritative-receipt"
     fi
     cat "$RUN_DIR/k6.log"
     rm -f "$PRIVATE_K6_LOG" "$PRIVATE_EVIDENCE_FILE" "$PRIVATE_GATEWAY_LOG"
@@ -500,6 +539,7 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
       --arg traceId "$TRACE_ID" \
       --arg tempoTraceJson "$TEMPO_TRACE_JSON" \
       --arg correlationReceipt "$CORRELATION_RECEIPT" \
+      --arg lifecycleReceipt "$R_CD_2_RECEIPT" \
       --arg serviceLogStatus "$GATEWAY_JOURNAL_STATUS" \
       --arg verdict "$SUMMARY_VERDICT" \
       --arg verdictSource "$SUMMARY_VERDICT_SOURCE" \
@@ -508,7 +548,7 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
       --argjson summaryFiles "$SUMMARY_FILES_JSON" \
       --argjson evidence "$EVIDENCE_JSON" \
       --argjson reviewPendingReceipts "$REVIEW_PENDING_RECEIPTS" \
-      '{k6ExitCode:$rc, postprocessExitCode:$postprocessRc, effectiveExitCode:$effectiveRc, endedAt:$ended, verdict:(if $verdict == "unknown" then null else $verdict end), verdictSource:$verdictSource, summaryFileVerdict:(if $summaryFileVerdict == "unknown" then null else $summaryFileVerdict end), vuLogVerdict:(if $vuLogVerdict == "" then null else $vuLogVerdict end), summaryFiles:$summaryFiles, evidence:$evidence, candidateOnly:true, foldRequiresReview:true, observability:{traceStatus:$traceStatus, traceId:(if $traceId == "" then null else $traceId end), tempoTraceJson:(if $tempoTraceJson == "" then null else $tempoTraceJson end), correlationReceipt:(if $correlationReceipt == "" then null else $correlationReceipt end), serviceLogStatus:$serviceLogStatus, serviceLog:"gateway-journal.log", serviceLogCapture:"gateway-journal-capture.json", serviceLogRedaction:"gateway-journal-redaction.json"}, review:{status:(if ($reviewPendingReceipts|length)>0 then "review-pending" else "ready-for-human-review" end), pendingReceipts:$reviewPendingReceipts}}' \
+      '{k6ExitCode:$rc, postprocessExitCode:$postprocessRc, effectiveExitCode:$effectiveRc, endedAt:$ended, verdict:(if $verdict == "unknown" then null else $verdict end), verdictSource:$verdictSource, summaryFileVerdict:(if $summaryFileVerdict == "unknown" then null else $summaryFileVerdict end), vuLogVerdict:(if $vuLogVerdict == "" then null else $vuLogVerdict end), summaryFiles:$summaryFiles, evidence:$evidence, candidateOnly:true, foldRequiresReview:true, observability:{traceStatus:$traceStatus, traceId:(if $traceId == "" then null else $traceId end), tempoTraceJson:(if $tempoTraceJson == "" then null else $tempoTraceJson end), correlationReceipt:(if $correlationReceipt == "" then null else $correlationReceipt end), lifecycleReceipt:(if $lifecycleReceipt == "" then null else $lifecycleReceipt end), serviceLogStatus:$serviceLogStatus, serviceLog:"gateway-journal.log", serviceLogCapture:"gateway-journal-capture.json", serviceLogRedaction:"gateway-journal-redaction.json"}, review:{status:(if ($reviewPendingReceipts|length)>0 then "review-pending" else "ready-for-human-review" end), pendingReceipts:$reviewPendingReceipts}}' \
       > "$RUN_DIR/run-result.json"
     # A review-complete candidate can now receive a public-safe routing
     # envelope. Review-pending runs intentionally remain represented only by

--- a/tools/k6-proofs/scripts/validate-candidate-run-result.mjs
+++ b/tools/k6-proofs/scripts/validate-candidate-run-result.mjs
@@ -7,6 +7,8 @@
  */
 import { readFile, writeFile, readdir, realpath } from 'node:fs/promises';
 import path from 'node:path';
+import { createHash } from 'node:crypto';
+import { validateRcd2AuthoritativeReceipt } from '../lib/r-cd-2-authoritative-receipt.mjs';
 
 const SHA = /^[0-9a-f]{40}$/;
 const OUTCOME = new Set(['PASS-candidate', 'HONEST-LIMIT-candidate', 'PARTIAL-candidate', 'FAIL-candidate', 'construct-only']);
@@ -74,6 +76,7 @@ async function listSafeArtifacts(dir) {
   const allowed = new Set([
     'row-manifest.json', 'runner-metadata.json', 'run-result.json',
     'candidate-run-result.json', 'seat-readiness.json', 'evidence.jsonl',
+    'r-cd-2-authoritative-receipt.json',
     'evidence-lines.log', 'evidence-redaction.json', 'gateway-journal.log',
     'gateway-journal-capture.json', 'gateway-journal-redaction.json',
   ]);
@@ -117,6 +120,18 @@ async function main() {
   }
 
   const observability = runResult.observability || {};
+  let authoritativeReceipt = null;
+  if (rowId === 'R-CD-2') {
+    const declared = runResult.authoritativeReceipt;
+    if (runResult.verdictSource !== 'r-cd-2-authoritative-receipt' || declared?.file !== 'r-cd-2-authoritative-receipt.json' || !/^[a-f0-9]{64}$/iu.test(declared?.sha256 || '')) {
+      throw new Error('R-CD-2 candidate requires a declared authoritative receipt digest');
+    }
+    const raw = await readFile(path.join(candidateDir, declared.file));
+    if (createHash('sha256').update(raw).digest('hex') !== declared.sha256) throw new Error('R-CD-2 authoritative receipt digest mismatch');
+    authoritativeReceipt = JSON.parse(raw);
+    const integrity = validateRcd2AuthoritativeReceipt(authoritativeReceipt, process.env.OPENCLAW_GATEWAY_TOKEN);
+    if (!integrity.valid || integrity.verdict !== runResult.verdict) throw new Error(`R-CD-2 authoritative receipt invalid: ${integrity.reason || 'verdict mismatch'}`);
+  }
   const artifacts = {
     manifest: 'row-manifest.json',
     runnerMetadata: 'runner-metadata.json',
@@ -149,6 +164,7 @@ async function main() {
       traceCaptured: Boolean(observability.traceId),
       correlationReceiptPresent: Boolean(observability.correlationReceipt),
     },
+    ...(authoritativeReceipt ? { authoritativeReceipt: { file: 'r-cd-2-authoritative-receipt.json', sha256: runResult.authoritativeReceipt.sha256 } } : {}),
     review: { status: review.status, pendingReceipts: [], complete: true },
     artifacts,
   };


### PR DESCRIPTION
Addresses #408.

Fresh current-main redo from `main@0ada205c`.

- binds accepted `sessions.send` run/turn to terminal success and parent wake
- requires exactly one typed `continue_delegate` silent-wake execution plus same trace/chain dispatch/fire topology
- collector and resolver use the same row-scoped public-safe topology receipt; raw provider/RPC/journal acquisition stays private
- fails closed for provider/replay failure, run/nonce/trace mismatch, wrong mode, missing protocol run ID, and repeated tool execution

Validation at `a667aed9`:
- `node --test tools/k6-proofs/scripts/__tests__/*.test.mjs` — 146/146 PASS
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs` — PASS
- `node tools/k6-proofs/scripts/check-scenario-alignment.mjs` — PASS
- `k6 inspect tools/k6-proofs/scenarios/r-cd-2-silent-wake.js` — PASS
- `bash -n tools/k6-proofs/scripts/run-proofs.sh` and `git diff --check` — PASS

No live row refire, core change, or presentation movement.