### PR TITLE
fix(proofs): verify R-CW-5 lockfile dependencies

### DIFF
--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -518,9 +518,10 @@ This is **declared in the manifest before the run**, not a post-hoc excuse. The 
 ### R-CW-5 isolated cost-cap fixture
 
 `tools/k6-proofs/scripts/run-cost-cap-fixture.mjs` is the safe runnable
-component fixture for `R-CW-5`. It requires an exact-candidate source
-worktree with dependencies already present, refuses to install dependencies,
-and writes only to an explicit artifact directory. It evaluates the exact
+component fixture for `R-CW-5`. It requires a clean exact-candidate source
+worktree and its committed `pnpm-lock.yaml`, then creates a disposable
+candidate worktree and runs `pnpm install --frozen-lockfile --prefer-offline`
+there. It never trusts or mutates source `node_modules`, and writes only to an explicit artifact directory. It evaluates the exact
 production `checkContinuationBudget` module at below/equal/over cap, then
 runs the production dispatcher boundary suite to prove the over-cap hop does
 not spawn and its flow is failed. Finally, it creates a short-lived detached

--- a/tools/k6-proofs/docs/R-CW-5-ISOLATED-TOOL-SURFACE.md
+++ b/tools/k6-proofs/docs/R-CW-5-ISOLATED-TOOL-SURFACE.md
@@ -46,10 +46,11 @@ node tools/k6-proofs/scripts/run-cost-cap-fixture.mjs \
   --artifact-dir <empty-private-directory> --cap 100 --json
 ```
 
-The command refuses a SHA/source mismatch, missing preinstalled dependencies,
-or any failure to create and remove its disposable worktree.  It never runs
-`pnpm install`, starts a gateway, writes OpenClaw config, or touches durable
-fleet state.  It produces `boundary-matrix.json`,
+The command refuses a SHA/source mismatch, a missing or altered candidate
+lockfile, or any failure to create and remove its disposable worktree. It runs
+`pnpm install --frozen-lockfile --prefer-offline` only in that disposable
+worktree, never trusts or mutates source `node_modules`, starts a gateway,
+writes OpenClaw config, or touches durable fleet state. It produces `boundary-matrix.json`,
 `dispatch-boundary-suite.json`, `typed-tool-surface.json`, and `cleanup.json`.
 Any missing or failed receipt is `FAIL-fixture`, never a PASS.
 

--- a/tools/k6-proofs/scripts/__tests__/cost-cap-fixture.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/cost-cap-fixture.test.mjs
@@ -3,13 +3,15 @@ import assert from 'node:assert/strict';
 
 import {
   assertSource,
+  assertCandidateWorktreeIntegrity,
   assertTrackedSourceClean,
   buildReadiness,
   parseArgs,
   prepareArtifactDir,
+  resolvePinnedPnpm,
   renderToolSurfaceTemplate,
 } from '../run-cost-cap-fixture.mjs';
-import { mkdir, mkdtemp, readFile, symlink, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, symlink, writeFile } from 'node:fs/promises';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import os from 'node:os';
@@ -99,6 +101,44 @@ test('R-CW-5 fixture refuses staged or unstaged tracked candidate changes', asyn
   );
 });
 
+test('R-CW-5 fixture rechecks committed candidate files after disposable worktree mutation', async () => {
+  const worktree = await mkdtemp(path.join(os.tmpdir(), 'r-cw-5-worktree-integrity-'));
+  await writeFile(path.join(worktree, 'package.json'), '{"packageManager":"pnpm@11.2.2"}\n');
+  await writeFile(path.join(worktree, 'pnpm-lock.yaml'), 'lockfileVersion: "9.0"\n');
+  execFileSync('git', ['init'], { cwd: worktree, stdio: 'ignore' });
+  execFileSync('git', ['config', 'user.email', 'proof@example.invalid'], { cwd: worktree });
+  execFileSync('git', ['config', 'user.name', 'R-CW-5 fixture test'], { cwd: worktree });
+  execFileSync('git', ['add', 'package.json', 'pnpm-lock.yaml'], { cwd: worktree });
+  execFileSync('git', ['commit', '-m', 'candidate'], { cwd: worktree, stdio: 'ignore' });
+  const candidateSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: worktree, encoding: 'utf8' }).trim();
+
+  assert.doesNotThrow(() => assertCandidateWorktreeIntegrity(worktree, candidateSha, 'proof execution after install'));
+  await writeFile(path.join(worktree, 'package.json'), '{"packageManager":"pnpm@0.0.0"}\n');
+  assert.throws(
+    () => assertCandidateWorktreeIntegrity(worktree, candidateSha, 'final receipt emission'),
+    /tracked staged or unstaged changes|differs from committed/,
+  );
+});
+
+test('R-CW-5 fixture ignores a fake PATH pnpm and verifies the committed pin', async () => {
+  const worktree = await mkdtemp(path.join(os.tmpdir(), 'r-cw-5-pinned-pnpm-'));
+  const actualVersion = execFileSync('pnpm', ['--version'], { encoding: 'utf8' }).trim();
+  await writeFile(path.join(worktree, 'package.json'), `{"packageManager":"pnpm@${actualVersion}"}\n`);
+  const fakeBin = await mkdtemp(path.join(os.tmpdir(), 'r-cw-5-fake-pnpm-'));
+  const fakePnpm = path.join(fakeBin, 'pnpm');
+  await writeFile(fakePnpm, '#!/bin/sh\necho FAKE-PNPM-RAN >&2\nexit 97\n');
+  await chmod(fakePnpm, 0o700);
+  const priorPath = process.env.PATH;
+  try {
+    process.env.PATH = fakeBin;
+    const pinned = resolvePinnedPnpm(worktree);
+    assert.equal(pinned.pnpmVersion, actualVersion);
+    assert.match(pinned.packageManager, new RegExp(`^pnpm@${actualVersion.replaceAll('.', '\\.')}`));
+  } finally {
+    process.env.PATH = priorPath;
+  }
+});
+
 test('R-CW-5 typed tool-surface template asserts no durable work after exhausted elections', async () => {
   const template = await readFile(
     fileURLToPath(new URL('../../fixtures/r-cw-5/cost-cap-tool-surface.test.ts', import.meta.url)),
@@ -141,7 +181,13 @@ test('R-CW-5 executes only in a disposable frozen-lockfile dependency tree', asy
     fileURLToPath(new URL('../run-cost-cap-fixture.mjs', import.meta.url)),
     'utf8',
   );
-  assert.match(runner, /pnpm', \['install', '--frozen-lockfile', '--prefer-offline'\]/);
+  assert.match(runner, /resolvePinnedPnpm/);
+  assert.match(runner, /--ignore-scripts/);
+  assert.match(runner, /resolveCandidateLocalExecutable\(worktreeDir, 'tsx'\)/);
+  assert.match(runner, /resolveCandidateLocalExecutable\(worktreeDir, 'vitest'\)/);
+  assert.match(runner, /assertCandidateWorktreeIntegrity\(worktreeDir, candidateSha, 'proof execution after install'\)/);
+  assert.match(runner, /assertCandidateWorktreeIntegrity\(worktreeDir, candidateSha, 'final receipt emission'\)/);
+  assert.doesNotMatch(runner, /run\('pnpm'/);
   assert.match(runner, /sourceNodeModulesTrusted: false/);
   assert.doesNotMatch(runner, /symlinkSync\(path\.join\(sourceDir, 'node_modules'\)/);
 });

--- a/tools/k6-proofs/scripts/__tests__/cost-cap-fixture.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/cost-cap-fixture.test.mjs
@@ -72,10 +72,11 @@ test('R-CW-5 fixture refuses staged or unstaged tracked candidate changes', asyn
   await writeFile(path.join(source, 'src/auto-reply/continuation/scheduler.ts'), 'export const clean = true;\n');
   await writeFile(path.join(source, 'src/auto-reply/continuation/delegate-dispatch.cost-cap-exhaustion.test.ts'), '// marker\n');
   await writeFile(path.join(source, 'package.json'), '{"name":"r-cw-5-test"}\n');
+  await writeFile(path.join(source, 'pnpm-lock.yaml'), 'lockfileVersion: "9.0"\n');
   execFileSync('git', ['init'], { cwd: source, stdio: 'ignore' });
   execFileSync('git', ['config', 'user.email', 'proof@example.invalid'], { cwd: source });
   execFileSync('git', ['config', 'user.name', 'R-CW-5 fixture test'], { cwd: source });
-  execFileSync('git', ['add', 'src', 'package.json'], { cwd: source });
+  execFileSync('git', ['add', 'src', 'package.json', 'pnpm-lock.yaml'], { cwd: source });
   execFileSync('git', ['commit', '-m', 'candidate'], { cwd: source, stdio: 'ignore' });
   const candidateSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: source, encoding: 'utf8' }).trim();
 
@@ -127,9 +128,22 @@ test('R-CW-5 public readiness has no private source path', () => {
     candidateSha: '6ee7eca2a4ce1a3e8efa7e51f9dd02d03081741d',
     head: '6ee7eca2a4ce1a3e8efa7e51f9dd02d03081741d',
     cap: 200,
+    lockfileSha256: 'a'.repeat(64),
   });
   assert.equal(readiness.sourceHeadMatchesCandidate, true);
+  assert.equal(readiness.lockfileSha256, 'a'.repeat(64));
+  assert.match(readiness.dependencyTree, /frozen-lockfile/);
   assert.doesNotMatch(JSON.stringify(readiness), new RegExp(privatePath.replaceAll('/', '\\/')));
+});
+
+test('R-CW-5 executes only in a disposable frozen-lockfile dependency tree', async () => {
+  const runner = await readFile(
+    fileURLToPath(new URL('../run-cost-cap-fixture.mjs', import.meta.url)),
+    'utf8',
+  );
+  assert.match(runner, /pnpm', \['install', '--frozen-lockfile', '--prefer-offline'\]/);
+  assert.match(runner, /sourceNodeModulesTrusted: false/);
+  assert.doesNotMatch(runner, /symlinkSync\(path\.join\(sourceDir, 'node_modules'\)/);
 });
 
 test('R-CW-5 fails closed instead of pretending the internal tool is websocket-invocable', async () => {

--- a/tools/k6-proofs/scripts/run-cost-cap-fixture.mjs
+++ b/tools/k6-proofs/scripts/run-cost-cap-fixture.mjs
@@ -10,7 +10,7 @@
  */
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, realpathSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import process from 'node:process';
@@ -100,6 +100,51 @@ function fileSha256(file) {
   return createHash('sha256').update(readFileSync(file)).digest('hex');
 }
 
+function isInside(child, parent) {
+  const relative = path.relative(parent, child);
+  return relative !== '' && !relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative);
+}
+
+function requireCandidatePackageManager(worktreeDir) {
+  const packageJson = JSON.parse(readFileSync(path.join(worktreeDir, 'package.json'), 'utf8'));
+  const packageManager = packageJson?.packageManager;
+  const match = typeof packageManager === 'string' && /^pnpm@(\d+\.\d+\.\d+)(?:\+sha512\.[a-f0-9]+)?$/u.exec(packageManager);
+  if (!match) throw new Error('candidate package.json must pin pnpm with an exact packageManager version');
+  return { packageManager, pnpmVersion: match[1] };
+}
+
+// The fixture must not let a caller-provided PATH substitute its package
+// manager.  pnpm is installed alongside this Node runtime in our supported
+// runner image; invoke that immutable script through process.execPath and
+// compare its version with the candidate's committed packageManager pin.
+export function resolvePinnedPnpm(worktreeDir) {
+  const { packageManager, pnpmVersion } = requireCandidatePackageManager(worktreeDir);
+  const nodePrefix = path.resolve(path.dirname(process.execPath), '..');
+  const pnpmScript = path.join(nodePrefix, 'lib', 'node_modules', 'pnpm', 'bin', 'pnpm.cjs');
+  if (!existsSync(pnpmScript) || !lstatSync(pnpmScript).isFile() || lstatSync(pnpmScript).isSymbolicLink()) {
+    throw new Error('runner has no real Node-local pnpm script for the candidate packageManager pin');
+  }
+  const resolvedPnpmScript = realpathSync(pnpmScript);
+  const versionResult = run(process.execPath, [resolvedPnpmScript, '--version'], { cwd: worktreeDir });
+  if (!versionResult.ok) throw new Error(`cannot execute Node-local pnpm for candidate packageManager pin: ${versionResult.stderr.trim()}`);
+  const version = versionResult.stdout.trim();
+  if (version !== pnpmVersion) {
+    throw new Error(`runner pnpm version ${version || '<missing>'} does not match candidate pin ${pnpmVersion}`);
+  }
+  return { packageManager, pnpmVersion, pnpmScript: resolvedPnpmScript };
+}
+
+function resolveCandidateLocalExecutable(worktreeDir, name) {
+  const nodeModules = realpathSync(path.join(worktreeDir, 'node_modules'));
+  const bin = path.join(worktreeDir, 'node_modules', '.bin', name);
+  if (!existsSync(bin)) throw new Error(`candidate-local ${name} executable is missing after frozen install`);
+  const executable = realpathSync(bin);
+  if (!isInside(executable, nodeModules)) {
+    throw new Error(`candidate-local ${name} executable resolves outside disposable node_modules`);
+  }
+  return executable;
+}
+
 function trackedSourceStatus(sourceDir) {
   const result = run('git', ['-C', sourceDir, 'status', '--porcelain', '--untracked-files=no'], {});
   if (!result.ok) throw new Error(`cannot inspect tracked source state: ${result.stderr.trim()}`);
@@ -113,6 +158,25 @@ export function assertTrackedSourceClean(sourceDir, phase) {
       `candidate source has tracked staged or unstaged changes before ${phase}; refusing exact-source certification`,
     );
   }
+}
+
+export function assertCandidateWorktreeIntegrity(worktreeDir, candidateSha, phase) {
+  const head = gitHead(worktreeDir);
+  if (head !== candidateSha) {
+    throw new Error(`disposable candidate HEAD changed before ${phase}: expected ${candidateSha}, found ${head}`);
+  }
+  assertTrackedSourceClean(worktreeDir, phase);
+  const candidateFiles = ['package.json', 'pnpm-lock.yaml'];
+  const fileHashes = {};
+  for (const file of candidateFiles) {
+    const actual = fileSha256(path.join(worktreeDir, file));
+    const committed = run('git', ['-C', worktreeDir, 'show', `${candidateSha}:${file}`], {});
+    if (!committed.ok) throw new Error(`cannot read committed ${file} from candidate ${candidateSha}`);
+    const expected = createHash('sha256').update(committed.stdout).digest('hex');
+    if (actual !== expected) throw new Error(`disposable candidate ${file} differs from committed ${candidateSha} before ${phase}`);
+    fileHashes[file] = actual;
+  }
+  return { head, trackedClean: true, candidateFileSha256: fileHashes };
 }
 
 export function assertSource(sourceDir, candidateSha) {
@@ -208,7 +272,7 @@ function parseLastJson(stdout, label) {
   return JSON.parse(line);
 }
 
-function runToolSurface({ worktreeDir, cap }) {
+function runToolSurface({ worktreeDir, cap, vitestExecutable }) {
   if (!existsSync(TOOL_SURFACE_TEMPLATE)) {
     throw new Error(`tool-surface template missing: ${TOOL_SURFACE_TEMPLATE}`);
   }
@@ -220,8 +284,8 @@ function runToolSurface({ worktreeDir, cap }) {
     { mode: 0o600 },
   );
   const test = run(
-    path.join(worktreeDir, 'node_modules', '.bin', 'vitest'),
-    ['run', '--config', 'test/vitest/vitest.auto-reply.config.ts', '--dir', 'test/r-cw-5-fixture', '--reporter=verbose'],
+    process.execPath,
+    [vitestExecutable, 'run', '--config', 'test/vitest/vitest.auto-reply.config.ts', '--dir', 'test/r-cw-5-fixture', '--reporter=verbose'],
     { cwd: worktreeDir },
   );
   return {
@@ -237,44 +301,67 @@ function runToolSurface({ worktreeDir, cap }) {
 
 function runVerifiedCandidateWorktree({ sourceDir, candidateSha, artifactDir, cap, sourceLockfileSha256 }) {
   const worktreeDir = path.join(artifactDir, `.r-cw-5-verified-${process.pid}-${Date.now()}`);
+  const cleanup = { disposableWorktreeCreated: false, disposableWorktreeRemoved: false };
   const add = run('git', ['-C', sourceDir, 'worktree', 'add', '--detach', worktreeDir, candidateSha], {});
   if (!add.ok) throw new Error(`cannot create disposable candidate worktree: ${add.stderr.trim()}`);
+  cleanup.disposableWorktreeCreated = true;
   try {
-    const lockfileSha256 = fileSha256(path.join(worktreeDir, 'pnpm-lock.yaml'));
+    const beforeInstall = assertCandidateWorktreeIntegrity(worktreeDir, candidateSha, 'dependency install');
+    const lockfileSha256 = beforeInstall.candidateFileSha256['pnpm-lock.yaml'];
     if (lockfileSha256 !== sourceLockfileSha256) {
       throw new Error('disposable candidate lockfile does not match the verified source lockfile');
     }
-    const install = run('pnpm', ['install', '--frozen-lockfile', '--prefer-offline'], { cwd: worktreeDir });
+    const packageManager = resolvePinnedPnpm(worktreeDir);
+    const install = run(
+      process.execPath,
+      [packageManager.pnpmScript, 'install', '--frozen-lockfile', '--prefer-offline', '--ignore-scripts'],
+      { cwd: worktreeDir },
+    );
     if (!install.ok) throw new Error(`frozen-lockfile install failed: ${install.stderr.trim()}`);
     const dependencyDir = path.join(worktreeDir, 'node_modules');
     if (!existsSync(dependencyDir) || !lstatSync(dependencyDir).isDirectory() || lstatSync(dependencyDir).isSymbolicLink()) {
       throw new Error('frozen-lockfile install did not create a real disposable node_modules directory');
     }
-    const matrixRun = run('pnpm', ['exec', 'tsx', '--eval', matrixEval(cap)], { cwd: worktreeDir });
+    const virtualStoreLock = path.join(worktreeDir, 'node_modules', '.pnpm', 'lock.yaml');
+    if (!existsSync(virtualStoreLock) || fileSha256(virtualStoreLock) !== lockfileSha256) {
+      throw new Error('disposable pnpm virtual-store lock does not byte-match the committed candidate lockfile');
+    }
+    const afterInstall = assertCandidateWorktreeIntegrity(worktreeDir, candidateSha, 'proof execution after install');
+    const tsxExecutable = resolveCandidateLocalExecutable(worktreeDir, 'tsx');
+    const vitestExecutable = resolveCandidateLocalExecutable(worktreeDir, 'vitest');
+    const matrixRun = run(process.execPath, [tsxExecutable, '--eval', matrixEval(cap)], { cwd: worktreeDir });
     const matrix = matrixRun.ok ? parseLastJson(matrixRun.stdout, 'boundary matrix') : null;
     const dispatchRun = run(
-      'pnpm',
+      process.execPath,
       [
-        'vitest', 'run', '--config', 'test/vitest/vitest.auto-reply.config.ts',
+        vitestExecutable, 'run', '--config', 'test/vitest/vitest.auto-reply.config.ts',
         'src/auto-reply/continuation/delegate-dispatch.cost-cap-exhaustion.test.ts', '--reporter=verbose',
       ],
       { cwd: worktreeDir },
     );
+    const afterExecution = assertCandidateWorktreeIntegrity(worktreeDir, candidateSha, 'final receipt emission');
     return {
       matrixRun,
       matrix,
       dispatchRun,
-      toolSurface: runToolSurface({ worktreeDir, cap }),
+      toolSurface: runToolSurface({ worktreeDir, cap, vitestExecutable }),
       dependency: {
-        installCommand: ['pnpm', 'install', '--frozen-lockfile', '--prefer-offline'],
+        packageManager: packageManager.packageManager,
+        pnpmVersion: packageManager.pnpmVersion,
+        installCommand: ['node', '<node-local-pnpm>', 'install', '--frozen-lockfile', '--prefer-offline', '--ignore-scripts'],
         lockfileSha256,
+        virtualStoreLockSha256: fileSha256(virtualStoreLock),
         frozenLockfileVerified: true,
         sourceNodeModulesTrusted: false,
+        executionWorktreeIntegrity: { beforeInstall, afterInstall, afterExecution },
+        cleanup,
       },
     };
   } finally {
     const remove = run('git', ['-C', sourceDir, 'worktree', 'remove', '--force', worktreeDir], {});
     if (!remove.ok) throw new Error(`cannot remove disposable candidate worktree: ${remove.stderr.trim()}`);
+    if (existsSync(worktreeDir)) throw new Error('disposable candidate worktree still exists after cleanup');
+    cleanup.disposableWorktreeRemoved = true;
   }
 }
 
@@ -305,7 +392,7 @@ export function runFixture(args) {
     cap: args.cap,
     passed: matrixPassed,
     ...(matrix || {}),
-    command: ['pnpm', 'exec', 'tsx', '--eval', '<production-module-eval>'],
+    command: ['node', '<candidate-local-tsx>', '--eval', '<production-module-eval>'],
     exitCode: matrixRun.exitCode,
     dependency: verified.dependency,
   });
@@ -324,7 +411,7 @@ export function runFixture(args) {
     schema: 'openclaw.project81.r-cw-5.dispatch-boundary-suite.v1',
     passed: dispatchPassed,
     exitCode: dispatchRun.exitCode,
-    command: ['pnpm', 'vitest', 'run', '--config', 'test/vitest/vitest.auto-reply.config.ts', 'src/auto-reply/continuation/delegate-dispatch.cost-cap-exhaustion.test.ts', '--reporter=verbose'],
+    command: ['node', '<candidate-local-vitest>', 'run', '--config', 'test/vitest/vitest.auto-reply.config.ts', 'src/auto-reply/continuation/delegate-dispatch.cost-cap-exhaustion.test.ts', '--reporter=verbose'],
     // Test names, not raw logs, are public-safe and pin the no-spawn/cascade
     // assertion without copying arbitrary candidate output into the corpus.
     asserted: dispatchAssertions,
@@ -350,7 +437,7 @@ export function runFixture(args) {
   // sourceDir. A matching HEAD is not enough if tracked files were altered
   // while they ran, so refuse to emit a final exact-source receipt unless the
   // candidate is still clean after every production-surface check.
-  assertTrackedSourceClean(sourceDir, 'final cleanup/result receipt');
+  const finalSource = assertSource(sourceDir, args.candidateSha);
 
   const verdict = matrixPassed && dispatchPassed && toolSurfacePassed ? 'PASS-candidate' : 'FAIL-fixture';
   const result = {
@@ -372,6 +459,10 @@ export function runFixture(args) {
     productionConfigTouched: false,
     productionStateTouched: false,
     sourceMutated: false,
+    sourceHeadMatchesCandidateAfter: finalSource.head === args.candidateSha,
+    sourceTrackedCleanAfter: true,
+    executionWorktreeIntegrity: verified.dependency.executionWorktreeIntegrity,
+    disposableWorktreeRemoved: verified.dependency.cleanup.disposableWorktreeRemoved,
     cleanupRequired: false,
     result: 'source-only fixture left no gateway/config/state process to restore',
   });

--- a/tools/k6-proofs/scripts/run-cost-cap-fixture.mjs
+++ b/tools/k6-proofs/scripts/run-cost-cap-fixture.mjs
@@ -9,7 +9,8 @@
  * no-spawn assertion without changing a fleet gateway.
  */
 import { execFileSync } from 'node:child_process';
-import { existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, symlinkSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import process from 'node:process';
@@ -19,6 +20,7 @@ const SOURCE_MARKERS = [
   'src/auto-reply/continuation/scheduler.ts',
   'src/auto-reply/continuation/delegate-dispatch.cost-cap-exhaustion.test.ts',
   'package.json',
+  'pnpm-lock.yaml',
 ];
 const TOOL_SURFACE_TEMPLATE = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -94,6 +96,10 @@ function gitHead(sourceDir) {
   return result.stdout.trim();
 }
 
+function fileSha256(file) {
+  return createHash('sha256').update(readFileSync(file)).digest('hex');
+}
+
 function trackedSourceStatus(sourceDir) {
   const result = run('git', ['-C', sourceDir, 'status', '--porcelain', '--untracked-files=no'], {});
   if (!result.ok) throw new Error(`cannot inspect tracked source state: ${result.stderr.trim()}`);
@@ -114,17 +120,14 @@ export function assertSource(sourceDir, candidateSha) {
   for (const marker of SOURCE_MARKERS) {
     if (!existsSync(path.join(resolved, marker))) throw new Error(`source dir is missing ${marker}`);
   }
-  const dependencyDir = path.join(resolved, 'node_modules');
-  if (!existsSync(dependencyDir)) {
-    throw new Error('source dir has no node_modules; fixture refuses to install dependencies or mutate the candidate worktree');
-  }
-  if (lstatSync(dependencyDir).isSymbolicLink()) {
-    throw new Error('source node_modules must be a real directory; fixture refuses an indirect mutable dependency tree');
+  const lockfile = path.join(resolved, 'pnpm-lock.yaml');
+  if (!lstatSync(lockfile).isFile() || lstatSync(lockfile).isSymbolicLink()) {
+    throw new Error('candidate pnpm-lock.yaml must be a real regular file');
   }
   const head = gitHead(resolved);
   if (head !== candidateSha) throw new Error(`candidate/source mismatch: requested ${candidateSha}, source is ${head}`);
   assertTrackedSourceClean(resolved, 'fixture execution');
-  return { resolved, head };
+  return { resolved, head, lockfileSha256: fileSha256(lockfile) };
 }
 
 export function renderToolSurfaceTemplate(template, cap) {
@@ -138,7 +141,7 @@ export function renderToolSurfaceTemplate(template, cap) {
     .replaceAll('__RCW5_OVER_CAP__', String(overCap));
 }
 
-export function buildReadiness({ candidateSha, head, cap }) {
+export function buildReadiness({ candidateSha, head, cap, lockfileSha256 }) {
   return {
     schema: 'openclaw.project81.r-cw-5.fixture-readiness.v1',
     candidateSha,
@@ -147,7 +150,8 @@ export function buildReadiness({ candidateSha, head, cap }) {
     productionConfigTouched: false,
     productionStateTouched: false,
     fixtureKind: 'source-only-production-module-plus-dispatch-boundary-suite',
-    dependencyTree: 'pre-existing-real-source-node_modules; no-install',
+    lockfileSha256,
+    dependencyTree: 'fresh-disposable-pnpm-install-frozen-lockfile; source node_modules never trusted',
     cap,
   };
 }
@@ -204,56 +208,92 @@ function parseLastJson(stdout, label) {
   return JSON.parse(line);
 }
 
-function runDisposableToolSurface({ sourceDir, candidateSha, artifactDir, cap }) {
+function runToolSurface({ worktreeDir, cap }) {
   if (!existsSync(TOOL_SURFACE_TEMPLATE)) {
     throw new Error(`tool-surface template missing: ${TOOL_SURFACE_TEMPLATE}`);
   }
-  const worktreeDir = path.join(artifactDir, `.r-cw-5-tool-surface-${process.pid}-${Date.now()}`);
+  const testDir = path.join(worktreeDir, 'test', 'r-cw-5-fixture');
+  mkdirSync(testDir, { recursive: true, mode: 0o700 });
+  writeFileSync(
+    path.join(testDir, 'cost-cap-tool-surface.test.ts'),
+    renderToolSurfaceTemplate(readFileSync(TOOL_SURFACE_TEMPLATE, 'utf8'), cap),
+    { mode: 0o600 },
+  );
+  const test = run(
+    path.join(worktreeDir, 'node_modules', '.bin', 'vitest'),
+    ['run', '--config', 'test/vitest/vitest.auto-reply.config.ts', '--dir', 'test/r-cw-5-fixture', '--reporter=verbose'],
+    { cwd: worktreeDir },
+  );
+  return {
+    passed: test.ok && /1 passed/u.test(test.stdout),
+    exitCode: test.exitCode,
+    asserted: {
+      typedToolCaptured: /disposable typed tool surface/u.test(test.stdout),
+      overCapRejected: /rejects exhausted typed-tool elections/u.test(test.stdout),
+      rejectedHopNoDurableWork: /1 passed/u.test(test.stdout),
+    },
+  };
+}
+
+function runVerifiedCandidateWorktree({ sourceDir, candidateSha, artifactDir, cap, sourceLockfileSha256 }) {
+  const worktreeDir = path.join(artifactDir, `.r-cw-5-verified-${process.pid}-${Date.now()}`);
   const add = run('git', ['-C', sourceDir, 'worktree', 'add', '--detach', worktreeDir, candidateSha], {});
   if (!add.ok) throw new Error(`cannot create disposable candidate worktree: ${add.stderr.trim()}`);
-  let result;
   try {
-    const testDir = path.join(worktreeDir, 'test', 'r-cw-5-fixture');
-    mkdirSync(testDir, { recursive: true, mode: 0o700 });
-    writeFileSync(
-      path.join(testDir, 'cost-cap-tool-surface.test.ts'),
-      renderToolSurfaceTemplate(readFileSync(TOOL_SURFACE_TEMPLATE, 'utf8'), cap),
-      { mode: 0o600 },
-    );
-    // The temporary worktree is source-only. Re-use the already-present,
-    // exact-candidate dependency tree without invoking pnpm/install.
-    symlinkSync(path.join(sourceDir, 'node_modules'), path.join(worktreeDir, 'node_modules'));
-    const test = run(
-      path.join(worktreeDir, 'node_modules', '.bin', 'vitest'),
-      ['run', '--config', 'test/vitest/vitest.auto-reply.config.ts', '--dir', 'test/r-cw-5-fixture', '--reporter=verbose'],
+    const lockfileSha256 = fileSha256(path.join(worktreeDir, 'pnpm-lock.yaml'));
+    if (lockfileSha256 !== sourceLockfileSha256) {
+      throw new Error('disposable candidate lockfile does not match the verified source lockfile');
+    }
+    const install = run('pnpm', ['install', '--frozen-lockfile', '--prefer-offline'], { cwd: worktreeDir });
+    if (!install.ok) throw new Error(`frozen-lockfile install failed: ${install.stderr.trim()}`);
+    const dependencyDir = path.join(worktreeDir, 'node_modules');
+    if (!existsSync(dependencyDir) || !lstatSync(dependencyDir).isDirectory() || lstatSync(dependencyDir).isSymbolicLink()) {
+      throw new Error('frozen-lockfile install did not create a real disposable node_modules directory');
+    }
+    const matrixRun = run('pnpm', ['exec', 'tsx', '--eval', matrixEval(cap)], { cwd: worktreeDir });
+    const matrix = matrixRun.ok ? parseLastJson(matrixRun.stdout, 'boundary matrix') : null;
+    const dispatchRun = run(
+      'pnpm',
+      [
+        'vitest', 'run', '--config', 'test/vitest/vitest.auto-reply.config.ts',
+        'src/auto-reply/continuation/delegate-dispatch.cost-cap-exhaustion.test.ts', '--reporter=verbose',
+      ],
       { cwd: worktreeDir },
     );
-    result = {
-      passed: test.ok && /1 passed/u.test(test.stdout),
-      exitCode: test.exitCode,
-      asserted: {
-        typedToolCaptured: /disposable typed tool surface/u.test(test.stdout),
-        overCapRejected: /rejects exhausted typed-tool elections/u.test(test.stdout),
-        rejectedHopNoDurableWork: /1 passed/u.test(test.stdout),
+    return {
+      matrixRun,
+      matrix,
+      dispatchRun,
+      toolSurface: runToolSurface({ worktreeDir, cap }),
+      dependency: {
+        installCommand: ['pnpm', 'install', '--frozen-lockfile', '--prefer-offline'],
+        lockfileSha256,
+        frozenLockfileVerified: true,
+        sourceNodeModulesTrusted: false,
       },
     };
   } finally {
     const remove = run('git', ['-C', sourceDir, 'worktree', 'remove', '--force', worktreeDir], {});
     if (!remove.ok) throw new Error(`cannot remove disposable candidate worktree: ${remove.stderr.trim()}`);
   }
-  return { ...result, disposableWorktreeRemoved: true };
 }
 
 export function runFixture(args) {
   assertArgs(args);
-  const { resolved: sourceDir, head } = assertSource(args.sourceDir, args.candidateSha);
+  const { resolved: sourceDir, head, lockfileSha256 } = assertSource(args.sourceDir, args.candidateSha);
   const artifactDir = prepareArtifactDir(args.artifactDir);
 
-  const readiness = buildReadiness({ candidateSha: args.candidateSha, head, cap: args.cap });
+  const readiness = buildReadiness({ candidateSha: args.candidateSha, head, cap: args.cap, lockfileSha256 });
   writeJson(path.join(artifactDir, 'fixture-readiness.json'), readiness);
 
-  const matrixRun = run('pnpm', ['exec', 'tsx', '--eval', matrixEval(args.cap)], { cwd: sourceDir });
-  const matrix = matrixRun.ok ? parseLastJson(matrixRun.stdout, 'boundary matrix') : null;
+  const verified = runVerifiedCandidateWorktree({
+    sourceDir,
+    candidateSha: args.candidateSha,
+    artifactDir,
+    cap: args.cap,
+    sourceLockfileSha256: lockfileSha256,
+  });
+  const { matrixRun, matrix, dispatchRun, toolSurface } = verified;
   const matrixPassed = Boolean(
     matrix?.cases?.length === 3 &&
     matrix.cases[0]?.outcome === null &&
@@ -267,16 +307,9 @@ export function runFixture(args) {
     ...(matrix || {}),
     command: ['pnpm', 'exec', 'tsx', '--eval', '<production-module-eval>'],
     exitCode: matrixRun.exitCode,
+    dependency: verified.dependency,
   });
 
-  const dispatchRun = run(
-    'pnpm',
-    [
-      'vitest', 'run', '--config', 'test/vitest/vitest.auto-reply.config.ts',
-      'src/auto-reply/continuation/delegate-dispatch.cost-cap-exhaustion.test.ts', '--reporter=verbose',
-    ],
-    { cwd: sourceDir },
-  );
   const dispatchAssertions = {
     belowCapAllowsSpawn: /allows dispatch when accumulatedChainTokens is 1 below costCapTokens/u.test(dispatchRun.stdout),
     exactCapAllowsSpawn: /rejects at exact boundary \(accumulatedChainTokens === costCapTokens is NOT over\)/u.test(dispatchRun.stdout),
@@ -295,19 +328,21 @@ export function runFixture(args) {
     // Test names, not raw logs, are public-safe and pin the no-spawn/cascade
     // assertion without copying arbitrary candidate output into the corpus.
     asserted: dispatchAssertions,
+    dependency: verified.dependency,
   });
 
-  const toolSurface = runDisposableToolSurface({ sourceDir, candidateSha: args.candidateSha, artifactDir, cap: args.cap });
   const toolSurfacePassed = toolSurface.passed && Object.values(toolSurface.asserted).every(Boolean);
   writeJson(path.join(artifactDir, 'typed-tool-surface.json'), {
     schema: 'openclaw.project81.r-cw-5.typed-tool-surface.v1',
     passed: toolSurfacePassed,
     cap: args.cap,
-    fixtureKind: 'disposable-exact-candidate-worktree-with-real-attempt-execution-and-typed-tool-capture',
+    fixtureKind: 'frozen-lockfile-verified-disposable-exact-candidate-worktree-with-real-attempt-execution-and-typed-tool-capture',
     productionConfigTouched: false,
     productionStateTouched: false,
     sourceDirMutated: false,
     disposableWorktreeCreated: true,
+    disposableWorktreeRemoved: true,
+    dependency: verified.dependency,
     ...toolSurface,
   });
 


### PR DESCRIPTION
Follow-up provenance hardening for the merged R-CW-5 fixture.

The fixture now creates a disposable exact-candidate worktree, verifies its committed pnpm lockfile, and runs a frozen-lockfile install there before any production-surface assertion. It no longer trusts source node_modules.

Validation: focused 9/9; complete proof suite 165/165; manifest and alignment validators; fresh exact 6ee7eca fixture PASS-candidate.