### PR TITLE
test(project-81): harden R-CD-TOKEN exactly-once proof

### DIFF
--- a/RUNBOOKS/project-81/rows/R-CD-TOKEN.md
+++ b/RUNBOOKS/project-81/rows/R-CD-TOKEN.md
@@ -24,7 +24,13 @@ Live candidate run:
 
 ```bash
 cd tools/k6-proofs
-OPENCLAW_GATEWAY_TOKEN=*** OPENCLAW_SESSION_KEY=<target-session-key> OPENCLAW_CREATE_DISPOSABLE_SESSION=true   ./scripts/run-proofs.sh --live R-CD-TOKEN <candidate-sha>
+OPENCLAW_GATEWAY_TOKEN=*** \
+OPENCLAW_SESSION_KEY=<target-session-key> \
+OPENCLAW_CREATE_DISPOSABLE_SESSION=true \
+OPENCLAW_SEAT_CLASS=raw-final-text \
+OPENCLAW_CANDIDATE_SHA=<exact-deployed-successor-sha> \
+OPENCLAW_RUNTIME_BUILD_SHA=<exact-deployed-successor-sha> \
+./scripts/run-proofs.sh --live --out-dir /tmp/r-cd-token-<exact-deployed-successor-sha> R-CD-TOKEN <exact-deployed-successor-sha>
 ```
 
 When using the GitHub Actions wrapper, include `R-CD-TOKEN` in the `rows` input and keep `create_disposable_sessions=true` for broad slices.
@@ -33,14 +39,21 @@ When using the GitHub Actions wrapper, include `R-CD-TOKEN` in the `rows` input 
 
 - Seat readiness and manifest/live-run-guard receipts are preserved beside the row artifacts.
 - The scenario drives the row-specific continuation/config path through the gateway/session API.
-- The runner records raw `k6.log`, `evidence.jsonl`, `evidence-lines.log`, `run-result.json`, summary JSON, row manifest, and public-safe metrics artifacts.
-- PASS-candidate requires `proof_failures=0` plus the row-specific sentinel/receipt checks implemented in the scenario.
+- The runner records public-safe `k6.log`, `evidence.jsonl`, `evidence-lines.log`, `run-result.json`, summary JSON, row manifest, and metrics artifacts; private acquisition files are transient.
+- Before creating an attempt, the runner requires exact 40-character candidate and runtime SHAs and requires them to be equal. Unknown, abbreviated, or mismatched build identity stops before dispatch as `HONEST-LIMIT-candidate`.
+- The runner persists a hashed attempt/nonce receipt before k6 starts and traps ordinary `INT`/`TERM`/early-exit interruption into a structured `PARTIAL-candidate` packet with automatic retry forbidden.
+- The task ledger is read through every `tasks.list` page. Because the deployed cursor is an offset over a live activity sort, PASS additionally requires at least three identical complete snapshot digests; a repeated task ID within one traversal permanently rejects the attempt. Origin/delegate matching uses short opaque markers that survive the public 80-character `TaskSummary.title` bound, plus requester/child-session lineage; it does not compare private raw task text.
+- The return receipt must be a structured `session.message` delivered to the ledger-matched origin child from the ledger-matched delegate child via `sourceTool=subagent_announce`; prompt echoes and unrelated nonce-bearing events do not count.
+- PASS-candidate requires a disposable `raw-final-text` origin, one accepted send run, exactly one origin task, exactly one token-scheduled delegate task, successful child settlement, the bound parent return, and one matching public Tempo dispatch/fire topology with no typed `continue_delegate` tool origin.
+- The k6 summary remains deliberately `PARTIAL-candidate`; only the HMAC-signed row-scoped resolver may promote the joined lifecycle/build/trace evidence to `PASS-candidate`.
+- Message-body or undeclared surface classes stop before dispatch as `HONEST-LIMIT-candidate`; they cannot enter the PASS lane.
 
 ## Manual collection still needed
 
 - Preserve the full candidate-run artifact directory, not only the summary JSON.
 - Review `run-result.json` for `review.status` and `pendingReceipts`; trace/receipt-marker gaps make the row review-pending, not failed.
-- Fetch and commit Tempo trace JSON when a trace id is emitted.
+- Preserve the signed `r-cd-token-authoritative-receipt.json`, `attempt-state.json`, `runner-metadata.json`, public Tempo JSON, and `continuation-trace-correlation.json` together. No individual file is authoritative alone.
+- If the run is interrupted, do **not** automatically replay it. Retain `interruption-receipt.json`; its `unknown-possibly-consumed` state is intentionally non-PASS and non-retriable until an operator reviews the prior attempt.
 - For model rows, record the requested model byte and observed child model byte in the fold note.
 - For token/bracket rows, record the surface class used (raw final text vs message-body) because scanner availability is the proof boundary.
 
@@ -48,7 +61,9 @@ When using the GitHub Actions wrapper, include `R-CD-TOKEN` in the `rows` input 
 
 A k6 `PASS-candidate` is review input, not a canonical proof fold. Fold only after checking:
 
-- artifact bundle is from the intended candidate SHA/runtime,
+- artifact bundle is from the intended candidate SHA/runtime and those exact 40-character SHAs are equal,
+- the signed receipt binds that exact equal build identity and its digest matches `run-result.json`,
+- `attempt-state.json` is terminal and bound to the same opaque attempt/nonce fingerprints as the authoritative receipt,
 - row manifest is the intended one,
 - nonce-correlated evidence is present,
 - any `review-pending` receipts are either supplied or explicitly accepted as honest limits,

--- a/RUNBOOKS/project-81/rows/R-CD-TOKEN.md
+++ b/RUNBOOKS/project-81/rows/R-CD-TOKEN.md
@@ -5,7 +5,7 @@
 - Manifest: `tools/k6-proofs/manifests/r-cd-token.json`
 - Scenario: `tools/k6-proofs/scenarios/r-cd-token-bracket-delegate.js`
 - Live safety: `k6-runnable`
-- Same-session concurrency: unsafe unless the manifest explicitly says otherwise; prefer `OPENCLAW_CREATE_DISPOSABLE_SESSION=true`.
+- Same-session concurrency: unsafe. A newly-created disposable origin is mandatory; the row runner forces `OPENCLAW_CREATE_DISPOSABLE_SESSION=true`, and the scenario stops before `sessions.send` unless creation succeeds with a distinct session key.
 
 ## Purpose
 
@@ -42,7 +42,7 @@ When using the GitHub Actions wrapper, include `R-CD-TOKEN` in the `rows` input 
 - The runner records public-safe `k6.log`, `evidence.jsonl`, `evidence-lines.log`, `run-result.json`, summary JSON, row manifest, and metrics artifacts; private acquisition files are transient.
 - Before creating an attempt, the runner requires exact 40-character candidate and runtime SHAs and requires them to be equal. Unknown, abbreviated, or mismatched build identity stops before dispatch as `HONEST-LIMIT-candidate`.
 - The runner persists a hashed attempt/nonce receipt before k6 starts and traps ordinary `INT`/`TERM`/early-exit interruption into a structured `PARTIAL-candidate` packet with automatic retry forbidden.
-- The task ledger is read through every `tasks.list` page. Because the deployed cursor is an offset over a live activity sort, PASS additionally requires at least three identical complete snapshot digests; a repeated task ID within one traversal permanently rejects the attempt. Origin/delegate matching uses short opaque markers that survive the public 80-character `TaskSummary.title` bound, plus requester/child-session lineage; it does not compare private raw task text.
+- The task ledger is read through every `tasks.list` page. Because the deployed cursor is an offset over a live activity sort, PASS additionally requires at least three identical complete snapshot digests; a repeated task ID within one traversal permanently rejects the attempt. Origin/delegate matching uses a 14-character opaque delegate marker placed first in `signal.task`; the exact production chain-hop/depth-1 wrapper is 63 characters, leaving the complete marker plus three characters of margin inside the public 80-character `TaskSummary.title` bound. Requester/child-session lineage remains mandatory; private raw task text is never compared.
 - The return receipt must be a structured `session.message` delivered to the ledger-matched origin child from the ledger-matched delegate child via `sourceTool=subagent_announce`; prompt echoes and unrelated nonce-bearing events do not count.
 - PASS-candidate requires a disposable `raw-final-text` origin, one accepted send run, exactly one origin task, exactly one token-scheduled delegate task, successful child settlement, the bound parent return, and one matching public Tempo dispatch/fire topology with no typed `continue_delegate` tool origin.
 - The k6 summary remains deliberately `PARTIAL-candidate`; only the HMAC-signed row-scoped resolver may promote the joined lifecycle/build/trace evidence to `PASS-candidate`.

--- a/tools/k6-proofs/lib/r-cd-token-authoritative-receipt.mjs
+++ b/tools/k6-proofs/lib/r-cd-token-authoritative-receipt.mjs
@@ -1,0 +1,209 @@
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
+import { classifyTokenEvidence } from './r-cd-token-contract.js';
+
+export const R_CD_TOKEN_RECEIPT_SCHEMA = 'openclaw.k6.r-cd-token-authoritative-receipt.v1';
+const SHA = /^[a-f0-9]{40}$/;
+const hex = (value, length) => typeof value === 'string' &&
+  new RegExp(`^[a-f0-9]{${length}}$`, 'i').test(value);
+const digest = (value) => createHash('sha256').update(JSON.stringify(value)).digest('hex');
+
+function canonical(receipt) {
+  return JSON.stringify({
+    schema: receipt.schema,
+    row: receipt.row,
+    authoritativeSource: receipt.authoritativeSource,
+    candidateOnly: receipt.candidateOnly,
+    foldRequiresReview: receipt.foldRequiresReview,
+    verdict: receipt.verdict,
+    failureCategory: receipt.failureCategory || null,
+    binding: receipt.binding,
+    lifecycle: receipt.lifecycle || null,
+  });
+}
+
+function seal(receipt, key) {
+  if (typeof key !== 'string' || !key) throw new Error('missing gateway signing key');
+  return {
+    ...receipt,
+    integrity: {
+      algorithm: 'hmac-sha256-gateway-token-v1',
+      signature: createHmac('sha256', key).update(canonical(receipt)).digest('hex'),
+    },
+  };
+}
+
+function topologyPasses(correlation) {
+  return correlation?.continuation?.tool === 'continue_delegate' &&
+    correlation?.continuation?.originSurface === 'raw-final-text' &&
+    Array.isArray(correlation?.toolSpanIds) && correlation.toolSpanIds.length === 0 &&
+    hex(correlation?.traceId, 32) &&
+    typeof correlation?.chainId === 'string' && correlation.chainId.length > 0 &&
+    hex(correlation?.dispatchSpanId, 16) &&
+    hex(correlation?.fireSpanId, 16) &&
+    correlation.dispatchSpanId !== correlation.fireSpanId &&
+    correlation?.sameTrace === true &&
+    correlation?.distinctSpans === true;
+}
+
+function sameReasonBinding(evidence, correlation) {
+  return evidence?.reason_hash === correlation?.reason?.hash &&
+    Number(evidence?.reason_length) === Number(correlation?.reason?.length);
+}
+
+function runnerIdentityMatches({ evidence, attemptState, metadata }) {
+  const candidateSha = metadata?.candidateSha;
+  const runtimeBuildSha = metadata?.runtimeBuildSha;
+  return metadata?.row === 'R-CD-TOKEN' &&
+    SHA.test(candidateSha || '') &&
+    SHA.test(runtimeBuildSha || '') &&
+    candidateSha === runtimeBuildSha &&
+    attemptState?.schema === 'openclaw.k6.r-cd-token.attempt-state.v1' &&
+    attemptState?.row === 'R-CD-TOKEN' &&
+    attemptState?.attemptIdHash === evidence?.attempt_id_hash &&
+    attemptState?.rowNonceHash === evidence?.row_nonce_hash &&
+    attemptState?.candidateSha === candidateSha &&
+    attemptState?.runtimeBuildSha === runtimeBuildSha &&
+    attemptState?.automaticRetryAllowed === false &&
+    evidence?.candidateSha === candidateSha &&
+    evidence?.runtimeBuildSha === runtimeBuildSha;
+}
+
+export function resolveRcdTokenAuthoritativeReceipt({
+  evidence,
+  correlation,
+  attemptState,
+  metadata,
+  signingKey,
+}) {
+  const identityMatches = runnerIdentityMatches({ evidence, attemptState, metadata });
+  const evidenceVerdict = identityMatches ? classifyTokenEvidence(evidence) : 'PARTIAL-candidate';
+  const base = {
+    schema: R_CD_TOKEN_RECEIPT_SCHEMA,
+    row: 'R-CD-TOKEN',
+    authoritativeSource: 'r-cd-token-row-scoped-resolver',
+    candidateOnly: true,
+    foldRequiresReview: true,
+    binding: {
+      candidateSha: metadata?.candidateSha || null,
+      runtimeBuildSha: metadata?.runtimeBuildSha || null,
+      localEvidenceFingerprint: digest({
+        attempt: evidence?.attempt_id_hash || null,
+        runnerAttempt: attemptState?.attemptIdHash || null,
+        nonce: evidence?.row_nonce_hash || null,
+        runnerNonce: attemptState?.rowNonceHash || null,
+        send: evidence?.send_run_id_hash || null,
+        origin: evidence?.origin_run_id_hash || null,
+        delegate: evidence?.delegate_run_id_hash || null,
+        returnTarget: evidence?.return_target_session_hash || null,
+        returnSource: evidence?.return_source_session_hash || null,
+        reason: evidence?.reason_hash || null,
+        length: evidence?.reason_length || null,
+      }),
+      topologyFingerprint: digest({
+        trace: correlation?.traceId || null,
+        chain: correlation?.chainId || null,
+        dispatch: correlation?.dispatchSpanId || null,
+        fire: correlation?.fireSpanId || null,
+        reason: correlation?.reason || null,
+        origin: correlation?.continuation?.originSurface || null,
+      }),
+    },
+  };
+
+  if (evidenceVerdict !== 'PASS-candidate' ||
+      !topologyPasses(correlation) ||
+      !sameReasonBinding(evidence, correlation)) {
+    const failureCategory = !identityMatches
+      ? 'runner-or-build-identity-mismatch'
+      : evidenceVerdict !== 'PASS-candidate'
+        ? 'incomplete-or-nonunique-lifecycle'
+        : !correlation
+          ? 'missing-continuation-topology'
+          : !sameReasonBinding(evidence, correlation)
+            ? 'reason-topology-mismatch'
+            : 'invalid-continuation-topology';
+    return seal({
+      ...base,
+      verdict: evidenceVerdict === 'HONEST-LIMIT-candidate'
+        ? evidenceVerdict
+        : 'PARTIAL-candidate',
+      failureCategory,
+    }, signingKey);
+  }
+
+  return seal({
+    ...base,
+    verdict: 'PASS-candidate',
+    lifecycle: {
+      surfaceClass: 'raw-final-text',
+      parserDetected: true,
+      exactlyOneOriginTask: true,
+      exactlyOneTokenDelegateTask: true,
+      taskLedgerFullyPaginated: true,
+      childCompleted: true,
+      parentReturnObserved: true,
+      returnBoundToDelegateChild: true,
+      delegateOwnedByOriginChild: true,
+      noTypedToolOrigin: true,
+      sameTrace: true,
+      sameChain: true,
+      attemptIdHash: evidence.attempt_id_hash,
+      rowNonceHash: evidence.row_nonce_hash,
+      sendRunIdHash: evidence.send_run_id_hash,
+      originRunIdHash: evidence.origin_run_id_hash,
+      delegateRunIdHash: evidence.delegate_run_id_hash,
+      returnTargetSessionHash: evidence.return_target_session_hash,
+      returnSourceSessionHash: evidence.return_source_session_hash,
+      traceFingerprint: createHash('sha256').update(correlation.traceId).digest('hex').slice(0, 16),
+      chainFingerprint: createHash('sha256').update(correlation.chainId).digest('hex').slice(0, 16),
+    },
+  }, signingKey);
+}
+
+export function validateRcdTokenAuthoritativeReceipt(receipt, key) {
+  if (!receipt ||
+      receipt.schema !== R_CD_TOKEN_RECEIPT_SCHEMA ||
+      receipt.row !== 'R-CD-TOKEN' ||
+      receipt.authoritativeSource !== 'r-cd-token-row-scoped-resolver' ||
+      receipt.candidateOnly !== true ||
+      receipt.foldRequiresReview !== true ||
+      !SHA.test(receipt.binding?.candidateSha || '') ||
+      receipt.binding?.runtimeBuildSha !== receipt.binding.candidateSha ||
+      !hex(receipt.binding?.localEvidenceFingerprint, 64) ||
+      !hex(receipt.binding?.topologyFingerprint, 64) ||
+      receipt.integrity?.algorithm !== 'hmac-sha256-gateway-token-v1' ||
+      !hex(receipt.integrity?.signature, 64) ||
+      typeof key !== 'string' || !key) {
+    return { valid: false, reason: 'invalid-shape' };
+  }
+  const expected = createHmac('sha256', key).update(canonical(receipt)).digest('hex');
+  if (!timingSafeEqual(Buffer.from(expected, 'hex'), Buffer.from(receipt.integrity.signature, 'hex'))) {
+    return { valid: false, reason: 'invalid-integrity' };
+  }
+  if (receipt.verdict !== 'PASS-candidate') {
+    return ['PARTIAL-candidate', 'HONEST-LIMIT-candidate'].includes(receipt.verdict) &&
+      typeof receipt.failureCategory === 'string'
+      ? { valid: true, verdict: receipt.verdict }
+      : { valid: false, reason: 'invalid-non-pass' };
+  }
+  const lifecycle = receipt.lifecycle;
+  const requiredTrue = [
+    'parserDetected', 'exactlyOneOriginTask', 'exactlyOneTokenDelegateTask',
+    'taskLedgerFullyPaginated', 'childCompleted', 'parentReturnObserved',
+    'returnBoundToDelegateChild', 'delegateOwnedByOriginChild', 'noTypedToolOrigin',
+    'sameTrace', 'sameChain',
+  ];
+  const hashes = [
+    'attemptIdHash', 'rowNonceHash', 'sendRunIdHash', 'originRunIdHash',
+    'delegateRunIdHash', 'returnTargetSessionHash', 'returnSourceSessionHash',
+    'traceFingerprint', 'chainFingerprint',
+  ];
+  const pass = lifecycle?.surfaceClass === 'raw-final-text' &&
+    requiredTrue.every((name) => lifecycle[name] === true) &&
+    hashes.every((name) => hex(lifecycle?.[name], 16)) &&
+    lifecycle.originRunIdHash !== lifecycle.delegateRunIdHash &&
+    lifecycle.returnTargetSessionHash !== lifecycle.returnSourceSessionHash;
+  return pass
+    ? { valid: true, verdict: receipt.verdict }
+    : { valid: false, reason: 'invalid-pass-lifecycle' };
+}

--- a/tools/k6-proofs/lib/r-cd-token-authoritative-receipt.mjs
+++ b/tools/k6-proofs/lib/r-cd-token-authoritative-receipt.mjs
@@ -91,6 +91,8 @@ export function resolveRcdTokenAuthoritativeReceipt({
         runnerAttempt: attemptState?.attemptIdHash || null,
         nonce: evidence?.row_nonce_hash || null,
         runnerNonce: attemptState?.rowNonceHash || null,
+        sessionCreated: evidence?.session_created === true,
+        disposableOriginReady: evidence?.disposable_origin_ready === true,
         send: evidence?.send_run_id_hash || null,
         origin: evidence?.origin_run_id_hash || null,
         delegate: evidence?.delegate_run_id_hash || null,
@@ -136,6 +138,7 @@ export function resolveRcdTokenAuthoritativeReceipt({
     verdict: 'PASS-candidate',
     lifecycle: {
       surfaceClass: 'raw-final-text',
+      disposableOriginReady: true,
       parserDetected: true,
       exactlyOneOriginTask: true,
       exactlyOneTokenDelegateTask: true,
@@ -188,7 +191,7 @@ export function validateRcdTokenAuthoritativeReceipt(receipt, key) {
   }
   const lifecycle = receipt.lifecycle;
   const requiredTrue = [
-    'parserDetected', 'exactlyOneOriginTask', 'exactlyOneTokenDelegateTask',
+    'disposableOriginReady', 'parserDetected', 'exactlyOneOriginTask', 'exactlyOneTokenDelegateTask',
     'taskLedgerFullyPaginated', 'childCompleted', 'parentReturnObserved',
     'returnBoundToDelegateChild', 'delegateOwnedByOriginChild', 'noTypedToolOrigin',
     'sameTrace', 'sameChain',

--- a/tools/k6-proofs/lib/r-cd-token-contract.js
+++ b/tools/k6-proofs/lib/r-cd-token-contract.js
@@ -1,0 +1,218 @@
+/** Fail-closed evidence accounting for R-CD-TOKEN. k6/Node compatible. */
+
+const RAW_FINAL_TEXT = 'raw-final-text';
+const MESSAGE_BODY = 'message-body';
+const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled', 'timed_out']);
+
+function normalizedSurface(value) {
+  const surface = String(value || '').trim().toLowerCase();
+  if (surface === RAW_FINAL_TEXT || surface === `${RAW_FINAL_TEXT}-seat`) return RAW_FINAL_TEXT;
+  if (surface === MESSAGE_BODY || surface === `${MESSAGE_BODY}-seat`) return MESSAGE_BODY;
+  return 'unknown';
+}
+
+function taskId(task) {
+  return String(task?.taskId || task?.id || '').trim();
+}
+
+function status(task) {
+  return String(task?.status || '').trim().toLowerCase();
+}
+
+function oneTask(seen) {
+  const tasks = Object.values(seen || {});
+  return tasks.length === 1 ? tasks[0] : null;
+}
+
+function rememberTask({ task, seen, hash }) {
+  const id = taskId(task);
+  if (!id) return;
+  const snapshot = {
+    taskId: id,
+    taskIdHash: hash(id),
+    runId: task?.runId ? String(task.runId) : null,
+    runIdHash: task?.runId ? hash(String(task.runId)) : null,
+    requesterSessionKey: task?.sessionKey ? String(task.sessionKey) : null,
+    requesterSessionHash: task?.sessionKey ? hash(String(task.sessionKey)) : null,
+    childSessionKey: task?.childSessionKey ? String(task.childSessionKey) : null,
+    childSessionHash: task?.childSessionKey ? hash(String(task.childSessionKey)) : null,
+    parentTaskId: task?.parentTaskId ? String(task.parentTaskId) : null,
+    parentTaskIdHash: task?.parentTaskId ? hash(String(task.parentTaskId)) : null,
+    status: status(task),
+  };
+  if (!seen[id]) seen[id] = snapshot;
+  else Object.assign(seen[id], snapshot);
+}
+
+export function createTokenLedger({ surfaceClass }) {
+  return {
+    surfaceClass: normalizedSurface(surfaceClass),
+    originTasks: {},
+    delegateTasks: {},
+    tasksListAccepted: 0,
+    tasksListRejected: 0,
+    taskPagesAccepted: 0,
+    paginationExhausted: false,
+    delegateParentMismatch: false,
+  };
+}
+
+/**
+ * Consume one complete tasks.list snapshot (all pages). TaskSummary.title is
+ * bounded to 80 characters, so the caller supplies short opaque markers that
+ * survive the public gateway projection. The delegate must be owned by the
+ * one origin child's session; title text alone is never enough to join it.
+ */
+export function observeTokenTaskLedger(
+  ledger,
+  { tasks, originTitle, delegateMarker, parentSessionKey, pages, hash },
+) {
+  if (!ledger || typeof hash !== 'function') return;
+  ledger.tasksListAccepted += 1;
+  ledger.taskPagesAccepted += Number(pages || 0);
+  ledger.paginationExhausted = true;
+
+  for (const task of Array.isArray(tasks) ? tasks : []) {
+    const title = String(task?.title || '').trim();
+    if (title === originTitle && String(task?.sessionKey || '') === String(parentSessionKey || '')) {
+      rememberTask({ task, seen: ledger.originTasks, hash });
+    }
+  }
+
+  const origin = oneTask(ledger.originTasks);
+  if (!origin?.childSessionKey) return;
+  for (const task of Array.isArray(tasks) ? tasks : []) {
+    const title = String(task?.title || '');
+    if (!title.includes(delegateMarker)) continue;
+    if (String(task?.sessionKey || '') !== origin.childSessionKey) continue;
+    if (task?.parentTaskId && String(task.parentTaskId) !== origin.taskId) {
+      ledger.delegateParentMismatch = true;
+      continue;
+    }
+    rememberTask({ task, seen: ledger.delegateTasks, hash });
+  }
+}
+
+export function rejectTokenTaskLedgerObservation(ledger) {
+  if (!ledger) return;
+  ledger.tasksListRejected += 1;
+  ledger.paginationExhausted = false;
+}
+
+export function tokenLedgerRuntimeIdentity(ledger) {
+  const origin = oneTask(ledger?.originTasks);
+  const delegate = oneTask(ledger?.delegateTasks);
+  return {
+    originTaskId: origin?.taskId || null,
+    originRunId: origin?.runId || null,
+    originChildSessionKey: origin?.childSessionKey || null,
+    delegateTaskId: delegate?.taskId || null,
+    delegateRunId: delegate?.runId || null,
+    delegateChildSessionKey: delegate?.childSessionKey || null,
+  };
+}
+
+export function summarizeTokenLedger(ledger) {
+  const origin = oneTask(ledger?.originTasks);
+  const delegate = oneTask(ledger?.delegateTasks);
+  return {
+    surface_class: ledger?.surfaceClass || 'unknown',
+    tasks_list_accepted: ledger?.tasksListAccepted || 0,
+    tasks_list_rejected: ledger?.tasksListRejected || 0,
+    task_pages_accepted: ledger?.taskPagesAccepted || 0,
+    task_pagination_exhausted: ledger?.paginationExhausted === true,
+    origin_task_unique_count: Object.keys(ledger?.originTasks || {}).length,
+    origin_task_id_hash: origin?.taskIdHash || null,
+    origin_run_id_hash: origin?.runIdHash || null,
+    origin_requester_session_hash: origin?.requesterSessionHash || null,
+    origin_child_session_hash: origin?.childSessionHash || null,
+    origin_task_status: origin?.status || null,
+    delegate_task_unique_count: Object.keys(ledger?.delegateTasks || {}).length,
+    delegate_task_id_hash: delegate?.taskIdHash || null,
+    delegate_run_id_hash: delegate?.runIdHash || null,
+    delegate_requester_session_hash: delegate?.requesterSessionHash || null,
+    delegate_child_session_hash: delegate?.childSessionHash || null,
+    delegate_parent_task_id_hash: delegate?.parentTaskIdHash || null,
+    delegate_task_status: delegate?.status || null,
+    delegate_requester_matches_origin_child:
+      Boolean(origin?.childSessionHash) && delegate?.requesterSessionHash === origin.childSessionHash,
+    delegate_parent_mismatch: ledger?.delegateParentMismatch === true,
+  };
+}
+
+function contentText(message) {
+  const content = message?.content;
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .filter((part) => part && part.type === 'text' && typeof part.text === 'string')
+    .map((part) => part.text)
+    .join('\n');
+}
+
+/** Parse only the structured session.message return surface, never arbitrary JSON. */
+export function parseTokenReturnEvent(
+  eventData,
+  { expectedTargetSessionKey, expectedSentinel, expectedDelegateChildSessionKey, hash },
+) {
+  if (!eventData || typeof hash !== 'function') return null;
+  if (String(eventData.sessionKey || '') !== String(expectedTargetSessionKey || '')) return null;
+  const message = eventData.message;
+  if (!message || !['user', 'system'].includes(String(message.role || '').toLowerCase())) return null;
+  const text = contentText(message);
+  if (!text || !text.includes(expectedSentinel) || text.includes('[k6-proof-harness]')) return null;
+  const header = text.match(/^\[Inter-session message\]([^\n]*)/);
+  if (!header || !/\bsourceTool=subagent_announce\b/.test(header[1])) return null;
+  const source = header[1].match(/\bsourceSession=([^\s]+)/)?.[1] || '';
+  if (!source || source !== String(expectedDelegateChildSessionKey || '')) return null;
+  return {
+    targetSessionHash: hash(String(eventData.sessionKey)),
+    sourceSessionHash: hash(source),
+  };
+}
+
+export function classifyTokenEvidence(evidence) {
+  if (evidence?.surface_class !== RAW_FINAL_TEXT) return 'HONEST-LIMIT-candidate';
+  const exactOnce = evidence.origin_task_unique_count === 1 && evidence.delegate_task_unique_count === 1;
+  const identities = [
+    evidence.origin_task_id_hash,
+    evidence.origin_run_id_hash,
+    evidence.origin_requester_session_hash,
+    evidence.origin_child_session_hash,
+    evidence.delegate_task_id_hash,
+    evidence.delegate_run_id_hash,
+    evidence.delegate_requester_session_hash,
+    evidence.delegate_child_session_hash,
+    evidence.send_run_id_hash,
+    evidence.row_nonce_hash,
+    evidence.attempt_id_hash,
+    evidence.return_target_session_hash,
+    evidence.return_source_session_hash,
+  ].every((value) => typeof value === 'string' && /^[0-9a-f]{16}$/.test(value));
+  const taskStates = evidence.origin_task_status === 'completed' && evidence.delegate_task_status === 'completed';
+  const complete = evidence.session_created === true &&
+    evidence.prompt_injected === true &&
+    evidence.send_accepted === true &&
+    evidence.origin_subscription_accepted === true &&
+    evidence.delegate_return_observed === true &&
+    evidence.task_pagination_exhausted === true &&
+    evidence.task_snapshot_consistent === true &&
+    Number(evidence.task_snapshot_stable_count || 0) >= 3 &&
+    evidence.tasks_list_rejected === 0 &&
+    exactOnce && identities &&
+    evidence.origin_run_id_hash !== evidence.delegate_run_id_hash &&
+    evidence.delegate_requester_matches_origin_child === true &&
+    evidence.delegate_parent_mismatch !== true &&
+    evidence.return_target_session_hash === evidence.origin_child_session_hash &&
+    evidence.return_source_session_hash === evidence.delegate_child_session_hash &&
+    taskStates && evidence.interrupted !== true;
+  return complete ? 'PASS-candidate' : 'PARTIAL-candidate';
+}
+
+export function tokenLedgerHasTerminalTasks(ledger) {
+  const origin = oneTask(ledger?.originTasks);
+  const delegate = oneTask(ledger?.delegateTasks);
+  return Boolean(
+    origin && delegate && TERMINAL_STATUSES.has(origin.status) && TERMINAL_STATUSES.has(delegate.status),
+  );
+}

--- a/tools/k6-proofs/lib/r-cd-token-contract.js
+++ b/tools/k6-proofs/lib/r-cd-token-contract.js
@@ -24,6 +24,24 @@ function oneTask(seen) {
   return tasks.length === 1 ? tasks[0] : null;
 }
 
+/**
+ * The token row may dispatch only from a newly-created disposable origin.
+ * Requiring the active key to differ from the configured/requested key keeps a
+ * malformed sessions.create response from silently falling back to a live
+ * operator session.
+ */
+export function tokenDisposableOriginReady({
+  creationRequested,
+  sessionCreated,
+  requestedSessionKey,
+  activeSessionKey,
+}) {
+  const requested = String(requestedSessionKey || '').trim();
+  const active = String(activeSessionKey || '').trim();
+  return creationRequested === true && sessionCreated === true &&
+    requested.length > 0 && active.length > 0 && active !== requested;
+}
+
 function rememberTask({ task, seen, hash }) {
   const id = taskId(task);
   if (!id) return;
@@ -191,6 +209,7 @@ export function classifyTokenEvidence(evidence) {
   ].every((value) => typeof value === 'string' && /^[0-9a-f]{16}$/.test(value));
   const taskStates = evidence.origin_task_status === 'completed' && evidence.delegate_task_status === 'completed';
   const complete = evidence.session_created === true &&
+    evidence.disposable_origin_ready === true &&
     evidence.prompt_injected === true &&
     evidence.send_accepted === true &&
     evidence.origin_subscription_accepted === true &&

--- a/tools/k6-proofs/manifests/r-cd-token.json
+++ b/tools/k6-proofs/manifests/r-cd-token.json
@@ -15,7 +15,7 @@
   },
   "scenario": {
     "name": "r-cd-token-bracket-delegate",
-    "description": "Bracket [[CONTINUE_DELEGATE:...]] path. Injects prompt requiring terminal bracket token, observes child spawn and return.",
+    "description": "Terminal [[CONTINUE_DELEGATE:...]] path from an isolated raw-final-text child; joins a runner-owned attempt to exactly one origin task, one token-scheduled delegate, completion, return, and Tempo topology.",
     "methods": [
       "sessions.send",
       "tasks.list",
@@ -23,34 +23,69 @@
     ],
     "status": "runnable",
     "expectedFile": "r-cd-token-bracket-delegate.js",
-    "registryNotes": "Local scratch conversion: runnable k6 scenario uses a lightContext subagent final bracket [[CONTINUE_DELEGATE:...]] and requires nonce-correlated delegate return.",
+    "registryNotes": "Issue #426 runnable repair: runner owns the attempt/nonce before launch; scenario requires a disposable raw-final-text origin and exactly one nonce-bound origin/delegate task identity through a settle window.",
     "file": "r-cd-token-bracket-delegate.js"
   },
   "seatClassExpectation": {
     "raw-final-text-seat": "PASS-candidate",
     "message-body-seat": "HONEST-LIMIT-candidate",
-    "reason": "Bracket scanner fires only on scanned-final-text. Seats that route final-text through message(send) body kill the scanner (bracketIdx=-1). ronan-dgx IS a message-body seat in its default Discord delivery — expected HONEST-LIMIT unless raw-final-text mode is forced (no message-tool call that turn). See TOOLS.md bracket-position-sensitive notes."
+    "reason": "Bracket scanner fires only on scanned-final-text. Seats that route final-text through message(send) body kill the scanner (bracketIdx=-1). ronan-dgx IS a message-body seat in its default Discord delivery \u2014 expected HONEST-LIMIT unless raw-final-text mode is forced (no message-tool call that turn). See TOOLS.md bracket-position-sensitive notes."
   },
   "expectedReceipts": [
     {
-      "name": "prompt-injected",
+      "name": "exact-candidate-runtime-identity",
       "required": true,
-      "description": "sessions.send accepted the bracket-instructing prompt"
+      "description": "Exact 40-character candidate and deployed runtime SHAs are equal before dispatch and bound into the signed authority receipt"
     },
     {
-      "name": "bracket-token-observed",
-      "required": false,
-      "description": "Bracket delegate token observed in session event stream (may be absent on message-body seats)"
+      "name": "attempt-state",
+      "required": true,
+      "description": "Runner-owned attempt/nonce fingerprint and automatic-retry disposition persisted before k6 launch"
+    },
+    {
+      "name": "raw-final-text-origin",
+      "required": true,
+      "description": "Declared scanner-supported raw-final-text surface; message-body and unknown surfaces cannot PASS"
+    },
+    {
+      "name": "prompt-injected",
+      "required": true,
+      "description": "sessions.send accepted the bracket-instructing prompt with a concrete run identity"
+    },
+    {
+      "name": "parser-detected",
+      "required": true,
+      "description": "Terminal bracket text observed from the isolated origin child and joined to the token delegate reason fingerprint"
+    },
+    {
+      "name": "queue-identity",
+      "required": true,
+      "description": "Exactly one token delegate task identity appears in the authoritative task ledger"
     },
     {
       "name": "child-spawned",
-      "required": false,
-      "description": "Child task/session created with nonce correlation"
+      "required": true,
+      "description": "Exactly one nonce-bound token delegate child/run identity is present"
+    },
+    {
+      "name": "child-completed",
+      "required": true,
+      "description": "The one token delegate task reaches succeeded state"
     },
     {
       "name": "parent-return-event",
-      "required": false,
-      "description": "Delegate return/silent-wake observed on parent session"
+      "required": true,
+      "description": "The exact nonce-bound delegate return sentinel is observed on the parent"
+    },
+    {
+      "name": "tempo-trace-json",
+      "required": true,
+      "description": "Public-safe Tempo trace for the token delegate dispatch/fire topology"
+    },
+    {
+      "name": "continuation-trace-correlation",
+      "required": true,
+      "description": "Reason fingerprint, one dispatch, one fire, chain identity, and absence of a typed continue_delegate tool origin are validated"
     }
   ],
   "artifactDestination": {
@@ -70,10 +105,13 @@
     "forms": [
       "bracket-token-delegate-from-lightcontext-subagent"
     ],
-    "delaySeconds": 1,
+    "delaySeconds": 10,
     "lightContext": true,
     "taskNamePrefix": "r-cd-token",
-    "idempotencyKeyPrefix": "R-CD-TOKEN"
+    "idempotencyKeyPrefix": "R-CD-TOKEN",
+    "originSurface": "raw-final-text",
+    "promptTemplate": "RCDT-D-{{tag}} reply exactly RCDT-RETURN-{{tag}}",
+    "parserSignalKind": "bracket-delegate"
   },
   "liveRunSafety": {
     "classification": "k6-runnable",
@@ -84,13 +122,20 @@
     "sameSessionConcurrencySafe": false,
     "expectedArtifactClass": "PASS-candidate",
     "requiredReceipts": [
-      "seat-readiness",
+      "exact-candidate-runtime-identity",
+      "attempt-state",
+      "raw-final-text-origin",
       "prompt-injected",
-      "bracket-token-observed",
+      "parser-detected",
+      "queue-identity",
       "child-spawned",
-      "parent-return-event"
+      "child-completed",
+      "parent-return-event",
+      "tempo-trace-json",
+      "continuation-trace-correlation"
     ],
     "foldRequiresReview": true,
-    "notes": "Bracket CONTINUE_DELEGATE path. Prefer disposable parent + lightContext child so scanner walks auto-delivered final text; message-body main-session path may honestly limit."
+    "notes": "PASS requires a runner-owned attempt, disposable raw-final-text origin, exactly one origin task and one token-scheduled delegate task through a settle window, exact completion/return binding, and public Tempo topology. Message-body/unknown surfaces are HONEST-LIMIT; interruption is structured PARTIAL and never auto-retried.",
+    "requiresDisposableSession": true
   }
 }

--- a/tools/k6-proofs/manifests/r-cd-token.json
+++ b/tools/k6-proofs/manifests/r-cd-token.json
@@ -17,6 +17,7 @@
     "name": "r-cd-token-bracket-delegate",
     "description": "Terminal [[CONTINUE_DELEGATE:...]] path from an isolated raw-final-text child; joins a runner-owned attempt to exactly one origin task, one token-scheduled delegate, completion, return, and Tempo topology.",
     "methods": [
+      "sessions.create",
       "sessions.send",
       "tasks.list",
       "sessions.messages.subscribe"
@@ -110,7 +111,7 @@
     "taskNamePrefix": "r-cd-token",
     "idempotencyKeyPrefix": "R-CD-TOKEN",
     "originSurface": "raw-final-text",
-    "promptTemplate": "RCDT-D-{{tag}} reply exactly RCDT-RETURN-{{tag}}",
+    "promptTemplate": "{{marker}} reply exactly RCDT-RETURN-{{tag}}",
     "parserSignalKind": "bracket-delegate"
   },
   "liveRunSafety": {

--- a/tools/k6-proofs/scenarios/r-cd-token-bracket-delegate.js
+++ b/tools/k6-proofs/scenarios/r-cd-token-bracket-delegate.js
@@ -12,6 +12,7 @@ import {
   parseTokenReturnEvent,
   rejectTokenTaskLedgerObservation,
   summarizeTokenLedger,
+  tokenDisposableOriginReady,
   tokenLedgerHasTerminalTasks,
   tokenLedgerRuntimeIdentity,
 } from '../lib/r-cd-token-contract.js';
@@ -45,7 +46,7 @@ function invocationCfg() {
     delaySeconds: Number(inv.delaySeconds ?? __ENV.OPENCLAW_DELEGATE_DELAY_SECONDS ?? DEFAULTS.delaySeconds),
     idempotencyKeyPrefix: inv.idempotencyKeyPrefix || DEFAULTS.idempotencyKeyPrefix,
     taskNamePrefix: inv.taskNamePrefix || DEFAULTS.taskNamePrefix,
-    promptTemplate: inv.promptTemplate || 'RCDT-D-{{tag}} reply exactly RCDT-RETURN-{{tag}}',
+    promptTemplate: inv.promptTemplate || '{{marker}} reply exactly RCDT-RETURN-{{tag}}',
     lightContext: inv.lightContext !== false,
   };
 }
@@ -65,9 +66,14 @@ export default function () {
   const inv = invocationCfg();
   const taskName = `${inv.taskNamePrefix}-${tag}`.toLowerCase().replace(/[^a-z0-9-]/g, '-').slice(0, 80);
   const originTitle = `RCDT-O-${tag}`;
-  const delegateMarker = `RCDT-D-${tag}`;
+  // Production prepends 63 characters before signal.task and then exposes only
+  // the first 80 title characters. Keep this marker to 14 characters so it is
+  // preserved with three characters of margin at chain-hop/depth 1.
+  const delegateMarker = `D-${tag.slice(0, 12)}`;
   const returnSentinel = `RCDT-RETURN-${tag}`;
-  const delegateTask = inv.promptTemplate.replace(/\{\{tag\}\}/g, tag);
+  const delegateTask = inv.promptTemplate
+    .replace(/\{\{marker\}\}/g, delegateMarker)
+    .replace(/\{\{tag\}\}/g, tag);
   const bracket = `[[CONTINUE_DELEGATE: ${delegateTask} +${inv.delaySeconds}s]]`;
   const childTask = `Reply exactly RCDT-HOP1-${tag}, then put this exact terminal bracket on its own final line: ${bracket} Do not call continue_delegate. Put no text after the closing brackets. Do not mutate files.`;
   const ledger = createTokenLedger({ surfaceClass });
@@ -79,6 +85,8 @@ export default function () {
   const evidence = {
     row: 'R-CD-TOKEN', manifest_loaded: !!manifest, seat,
     requested_session_hash: hash(requestedSessionKey), session_hash: hash(sessionKey),
+    disposable_creation_requested: createDisposableSession,
+    disposable_origin_ready: false,
     session_created: false,
     candidateSha: manifest?.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
     runtimeBuildSha: __ENV.OPENCLAW_RUNTIME_BUILD_SHA || 'unset',
@@ -258,6 +266,20 @@ export default function () {
     }
 
     function startProofFlow() {
+      if (!tokenDisposableOriginReady({
+        creationRequested: createDisposableSession,
+        sessionCreated: evidence.session_created,
+        requestedSessionKey,
+        activeSessionKey: sessionKey,
+      })) {
+        evidence.interrupted = false;
+        evidence.terminal_reason = 'pre-dispatch-disposable-origin-required';
+        failures.add(1);
+        closed = true;
+        socket.close();
+        return;
+      }
+      evidence.disposable_origin_ready = true;
       tracker.send(socket, 'sessions.messages.subscribe', { key: sessionKey });
       socket.setTimeout(() => {
         const instruction = `${HARNESS_MARKER} Call sessions_spawn exactly once with runtime="subagent", mode="run", taskName="${taskName}", label="${originTitle}", lightContext=${inv.lightContext ? 'true' : 'false'}, context="isolated", cleanup="delete", and task=${JSON.stringify(childTask)}. After sessions_spawn is accepted, reply exactly RCDT-PARENT-SPAWNED-${tag}. This is a proof run.`;
@@ -279,14 +301,20 @@ export default function () {
 
     socket.on('open', () => {
       socket.send(connectFrame(token));
-      if (createDisposableSession) {
-        socket.setTimeout(() => {
-          tracker.send(socket, 'sessions.create', {
-            key: `r-cd-token-${tag}`,
-            label: `k6 R-CD-TOKEN ${tag}`,
-          });
-        }, 250);
-      } else socket.setTimeout(() => startProofFlow(), 500);
+      if (!createDisposableSession) {
+        evidence.interrupted = false;
+        evidence.terminal_reason = 'pre-dispatch-disposable-creation-not-enabled';
+        failures.add(1);
+        closed = true;
+        socket.close();
+        return;
+      }
+      socket.setTimeout(() => {
+        tracker.send(socket, 'sessions.create', {
+          key: `r-cd-token-${tag}`,
+          label: `k6 R-CD-TOKEN ${tag}`,
+        });
+      }, 250);
     });
 
     socket.on('message', (raw) => {
@@ -309,8 +337,9 @@ export default function () {
           }
         }
         if (classified.kind === 'response' && classified.method === 'sessions.create') {
-          if (classified.ok && classified.payload) {
-            sessionKey = classified.payload.key || sessionKey;
+          const createdSessionKey = String(classified.payload?.key || '').trim();
+          if (classified.ok && createdSessionKey && createdSessionKey !== requestedSessionKey) {
+            sessionKey = createdSessionKey;
             evidence.session_hash = hash(sessionKey);
             evidence.session_created = true;
             startProofFlow();
@@ -358,7 +387,8 @@ export default function () {
   check(res, { 'websocket connected': (value) => value && value.status === 101 });
   check(null, {
     'raw final text surface declared': () => evidence.surface_class === 'raw-final-text',
-    'disposable session created': () => evidence.session_created,
+    'disposable session created and distinct': () => evidence.session_created &&
+      evidence.disposable_origin_ready,
     'send accepted with run identity': () => evidence.send_accepted && !!evidence.send_run_id_hash,
     'task ledger fully paginated': () => evidence.task_pagination_exhausted,
     'task ledger snapshot stable across full traversals': () => evidence.task_snapshot_consistent &&

--- a/tools/k6-proofs/scenarios/r-cd-token-bracket-delegate.js
+++ b/tools/k6-proofs/scenarios/r-cd-token-bracket-delegate.js
@@ -1,28 +1,51 @@
-/** Scenario: R-CD-TOKEN — bracket [[CONTINUE_DELEGATE:...]] path from lightContext subagent. */
+/** Scenario: R-CD-TOKEN — terminal bracket token from an isolated child. */
 import ws from 'k6/ws';
 import { check } from 'k6';
+import crypto from 'k6/crypto';
 import { Counter, Trend } from 'k6/metrics';
-import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
+import { connectFrame, nonce, RequestTracker } from '../lib/gateway-ws.js';
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+import {
+  classifyTokenEvidence,
+  createTokenLedger,
+  observeTokenTaskLedger,
+  parseTokenReturnEvent,
+  rejectTokenTaskLedgerObservation,
+  summarizeTokenLedger,
+  tokenLedgerHasTerminalTasks,
+  tokenLedgerRuntimeIdentity,
+} from '../lib/r-cd-token-contract.js';
 
 export const options = {
-  scenarios: { r_cd_token_bracket_delegate: { executor: 'shared-iterations', vus: 1, iterations: 1, maxDuration: '210s' } },
+  scenarios: {
+    r_cd_token_bracket_delegate: {
+      executor: 'shared-iterations', vus: 1, iterations: 1, maxDuration: '210s',
+    },
+  },
   thresholds: { proof_failures: ['count==0'], r_cd_token_duration: ['p(95)<180000'] },
 };
 
 const failures = new Counter('proof_failures');
 const duration = new Trend('r_cd_token_duration');
 const manifest = loadManifestFromEnv();
-const DEFAULTS = { sessionKey: 'main', seat: 'cael-dgx', delaySeconds: 1, idempotencyKeyPrefix: 'R-CD-TOKEN', taskNamePrefix: 'r-cd-token' };
+const DEFAULTS = {
+  sessionKey: 'main', seat: 'cael-dgx', delaySeconds: 10,
+  idempotencyKeyPrefix: 'R-CD-TOKEN', taskNamePrefix: 'r-cd-token',
+};
 const HARNESS_MARKER = '[k6-proof-harness]';
-const POST_DISPATCH_EVIDENCE_GATE_MS = Number(__ENV.OPENCLAW_MIN_TOKEN_EVIDENCE_DELAY_MS || 1500);
+const TASK_POLL_MS = Number(__ENV.OPENCLAW_TOKEN_TASK_POLL_MS || 750);
+const SETTLE_MS = Number(__ENV.OPENCLAW_TOKEN_SETTLE_MS || 5000);
+const TASK_PAGE_LIMIT = 500;
+const REQUIRED_STABLE_TASK_SNAPSHOTS = 3;
 function boolEnv(name) { return (__ENV[name] || '').toLowerCase() === 'true'; }
+function hash(value) { return crypto.sha256(String(value), 'hex').slice(0, 16); }
 function invocationCfg() {
   const inv = manifest?.invocation || {};
   return {
     delaySeconds: Number(inv.delaySeconds ?? __ENV.OPENCLAW_DELEGATE_DELAY_SECONDS ?? DEFAULTS.delaySeconds),
     idempotencyKeyPrefix: inv.idempotencyKeyPrefix || DEFAULTS.idempotencyKeyPrefix,
     taskNamePrefix: inv.taskNamePrefix || DEFAULTS.taskNamePrefix,
+    promptTemplate: inv.promptTemplate || 'RCDT-D-{{tag}} reply exactly RCDT-RETURN-{{tag}}',
     lightContext: inv.lightContext !== false,
   };
 }
@@ -32,84 +55,343 @@ export default function () {
   const token = __ENV.OPENCLW_GATEWAY_TOKEN || __ENV.OPENCLAW_GATEWAY_TOKEN;
   const requestedSessionKey = manifest?.sessionKey || __ENV.OPENCLAW_SESSION_KEY || DEFAULTS.sessionKey;
   let sessionKey = requestedSessionKey;
-  const createDisposableSession = boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSION') || boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSIONS');
+  const createDisposableSession = boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSION') ||
+    boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSIONS');
+  const surfaceClass = __ENV.OPENCLAW_SEAT_CLASS || 'unknown';
   const seat = manifest?.seat || __ENV.OPENCLAW_SEAT_NAME || DEFAULTS.seat;
-  const rowNonce = nonce('R-CD-TOKEN');
+  const rowNonce = __ENV.OPENCLAW_ROW_NONCE || nonce('R-CD-TOKEN');
+  const attemptId = __ENV.OPENCLAW_PROOF_ATTEMPT_ID || rowNonce;
+  const tag = hash(rowNonce);
+  const inv = invocationCfg();
+  const taskName = `${inv.taskNamePrefix}-${tag}`.toLowerCase().replace(/[^a-z0-9-]/g, '-').slice(0, 80);
+  const originTitle = `RCDT-O-${tag}`;
+  const delegateMarker = `RCDT-D-${tag}`;
+  const returnSentinel = `RCDT-RETURN-${tag}`;
+  const delegateTask = inv.promptTemplate.replace(/\{\{tag\}\}/g, tag);
+  const bracket = `[[CONTINUE_DELEGATE: ${delegateTask} +${inv.delaySeconds}s]]`;
+  const childTask = `Reply exactly RCDT-HOP1-${tag}, then put this exact terminal bracket on its own final line: ${bracket} Do not call continue_delegate. Put no text after the closing brackets. Do not mutate files.`;
+  const ledger = createTokenLedger({ surfaceClass });
   if (!token) { console.error('OPENCLAW_GATEWAY_TOKEN is required'); failures.add(1); return; }
-  if (manifest) { const errors = validateManifest(manifest); if (errors.length > 0) console.warn('Manifest validation warnings: ' + errors.join('; ')); }
+  if (manifest) {
+    const errors = validateManifest(manifest);
+    if (errors.length > 0) console.warn(`Manifest validation warnings: ${errors.join('; ')}`);
+  }
   const evidence = {
-    row: 'R-CD-TOKEN', manifest_loaded: !!manifest, nonce: rowNonce, seat, requestedSessionKey, sessionKey,
-    session_created: false, created_session_key: null, candidateSha: manifest?.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
-    started: new Date().toISOString(), prompt_injected: false, subagent_spawn_requested: false, subagent_spawn_accepted: false,
-    bracket_token_observed: false, delegate_spawn_or_return_observed: false, child_spawned: false, parent_return_event: false,
-    dispatch_accepted_at_ms: null, child_session_key: null, trace_id: null, redacted_events: [],
+    row: 'R-CD-TOKEN', manifest_loaded: !!manifest, seat,
+    requested_session_hash: hash(requestedSessionKey), session_hash: hash(sessionKey),
+    session_created: false,
+    candidateSha: manifest?.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
+    runtimeBuildSha: __ENV.OPENCLAW_RUNTIME_BUILD_SHA || 'unset',
+    started: new Date().toISOString(), prompt_injected: false, send_accepted: false,
+    send_run_id_hash: null, row_nonce_hash: hash(rowNonce), attempt_id_hash: hash(attemptId),
+    reason_hash: hash(delegateTask), reason_length: delegateTask.length, delegate_mode: 'normal',
+    origin_subscription_accepted: false, delegate_return_observed: false,
+    return_target_session_hash: null, return_source_session_hash: null,
+    interrupted: true, terminal_reason: 'observation-window-open',
+    dispatch_accepted_at_ms: null, trace_id: null, event_receipt_kinds: [],
+    task_snapshot_consistent: false, task_snapshot_stable_count: 0,
+    task_snapshot_digest: null,
   };
   const started = Date.now();
   const res = ws.connect(url, {}, (socket) => {
     const tracker = new RequestTracker();
-    function startProofFlow(socket) {
+    let taskPollPending = false;
+    let taskSnapshot = [];
+    let taskSnapshotPages = 0;
+    let taskCursorSeen = {};
+    let previousTaskSnapshotDigest = null;
+    let closed = false;
+    let settleStartedAt = null;
+    let originSubscriptionRequestId = null;
+    let originSubscriptionTarget = null;
+    const pendingReturnEvents = [];
+
+    function tryReturnEvent(eventData) {
+      const identity = tokenLedgerRuntimeIdentity(ledger);
+      if (!identity.originChildSessionKey || !identity.delegateChildSessionKey) return false;
+      const receipt = parseTokenReturnEvent(eventData, {
+        expectedTargetSessionKey: identity.originChildSessionKey,
+        expectedDelegateChildSessionKey: identity.delegateChildSessionKey,
+        expectedSentinel: returnSentinel,
+        hash,
+      });
+      if (!receipt) return false;
+      evidence.delegate_return_observed = true;
+      evidence.return_target_session_hash = receipt.targetSessionHash;
+      evidence.return_source_session_hash = receipt.sourceSessionHash;
+      evidence.event_receipt_kinds.push('bound-session-message-return');
+      return true;
+    }
+
+    function reconcilePendingReturns() {
+      for (const eventData of pendingReturnEvents) {
+        if (tryReturnEvent(eventData)) break;
+      }
+      if (evidence.delegate_return_observed) pendingReturnEvents.length = 0;
+    }
+
+    function maybeSubscribeOrigin() {
+      if (originSubscriptionRequestId || evidence.origin_subscription_accepted) return;
+      const identity = tokenLedgerRuntimeIdentity(ledger);
+      if (!identity.originChildSessionKey) return;
+      originSubscriptionTarget = identity.originChildSessionKey;
+      originSubscriptionRequestId = tracker.send(socket, 'sessions.messages.subscribe', {
+        key: originSubscriptionTarget,
+      });
+    }
+
+    function proofComplete() {
+      const summary = summarizeTokenLedger(ledger);
+      return tokenLedgerHasTerminalTasks(ledger) &&
+        summary.origin_task_unique_count === 1 &&
+        summary.delegate_task_unique_count === 1 &&
+        summary.delegate_requester_matches_origin_child === true &&
+        summary.delegate_parent_mismatch !== true &&
+        evidence.task_snapshot_consistent === true &&
+        evidence.task_snapshot_stable_count >= REQUIRED_STABLE_TASK_SNAPSHOTS &&
+        evidence.origin_subscription_accepted && evidence.delegate_return_observed;
+    }
+
+    function closeComplete() {
+      if (closed) return;
+      const summary = summarizeTokenLedger(ledger);
+      if (summary.origin_task_unique_count > 1 || summary.delegate_task_unique_count > 1 ||
+          summary.delegate_parent_mismatch) {
+        evidence.interrupted = false;
+        evidence.terminal_reason = 'duplicate-or-mislinked-task-identity-observed';
+        closed = true;
+        socket.close();
+        return;
+      }
+      if (!proofComplete()) { settleStartedAt = null; return; }
+      if (settleStartedAt === null) settleStartedAt = Date.now();
+      if (Date.now() - settleStartedAt < SETTLE_MS) return;
+      evidence.interrupted = false;
+      evidence.terminal_reason = 'exactly-once-token-chain-settled';
+      closed = true;
+      console.log('All required R-CD-TOKEN identities remained unique through the settle window');
+      socket.close();
+    }
+
+    function requestTaskPage(cursor) {
+      const params = { limit: TASK_PAGE_LIMIT };
+      if (cursor) params.cursor = cursor;
+      tracker.send(socket, 'tasks.list', params);
+    }
+
+    function scheduleTaskPoll(delay = TASK_POLL_MS) {
+      if (closed || taskPollPending || !evidence.send_accepted) return;
+      socket.setTimeout(() => {
+        if (closed || taskPollPending) return;
+        taskPollPending = true;
+        taskSnapshot = [];
+        taskSnapshotPages = 0;
+        taskCursorSeen = {};
+        requestTaskPage(null);
+      }, delay);
+    }
+
+    function consumeTaskPage(classified) {
+      if (!classified.ok || !Array.isArray(classified.payload?.tasks)) {
+        taskPollPending = false;
+        rejectTokenTaskLedgerObservation(ledger);
+        scheduleTaskPoll();
+        return;
+      }
+      taskSnapshot.push(...classified.payload.tasks);
+      taskSnapshotPages += 1;
+      const nextCursor = String(classified.payload.nextCursor || '').trim();
+      if (nextCursor) {
+        if (taskCursorSeen[nextCursor]) {
+          taskPollPending = false;
+          rejectTokenTaskLedgerObservation(ledger);
+          scheduleTaskPoll();
+          return;
+        }
+        taskCursorSeen[nextCursor] = true;
+        requestTaskPage(nextCursor);
+        return;
+      }
+      taskPollPending = false;
+      const uniqueTaskIds = {};
+      let duplicateTaskId = false;
+      for (const task of taskSnapshot) {
+        const id = String(task?.taskId || task?.id || '').trim();
+        if (!id) continue;
+        if (uniqueTaskIds[id]) duplicateTaskId = true;
+        uniqueTaskIds[id] = true;
+      }
+      if (duplicateTaskId) {
+        evidence.task_snapshot_consistent = false;
+        evidence.task_snapshot_stable_count = 0;
+        previousTaskSnapshotDigest = null;
+        rejectTokenTaskLedgerObservation(ledger);
+        scheduleTaskPoll();
+        return;
+      }
+      const taskSnapshotDigest = hash(JSON.stringify(taskSnapshot
+        .map((task) => ({
+          taskId: String(task?.taskId || task?.id || ''),
+          status: String(task?.status || ''),
+          updatedAt: task?.updatedAt ?? null,
+          title: String(task?.title || ''),
+          sessionKey: String(task?.sessionKey || ''),
+          childSessionKey: String(task?.childSessionKey || ''),
+          parentTaskId: String(task?.parentTaskId || ''),
+        }))
+        .sort((left, right) => left.taskId < right.taskId ? -1 : left.taskId > right.taskId ? 1 : 0)));
+      evidence.task_snapshot_stable_count = taskSnapshotDigest === previousTaskSnapshotDigest
+        ? evidence.task_snapshot_stable_count + 1
+        : 1;
+      previousTaskSnapshotDigest = taskSnapshotDigest;
+      evidence.task_snapshot_digest = taskSnapshotDigest;
+      evidence.task_snapshot_consistent =
+        evidence.task_snapshot_stable_count >= REQUIRED_STABLE_TASK_SNAPSHOTS;
+      observeTokenTaskLedger(ledger, {
+        tasks: taskSnapshot, originTitle, delegateMarker,
+        parentSessionKey: sessionKey, pages: taskSnapshotPages, hash,
+      });
+      maybeSubscribeOrigin();
+      reconcilePendingReturns();
+      closeComplete();
+      scheduleTaskPoll();
+    }
+
+    function startProofFlow() {
       tracker.send(socket, 'sessions.messages.subscribe', { key: sessionKey });
       socket.setTimeout(() => {
-        const inv = invocationCfg();
-        const taskName = (inv.taskNamePrefix + '-' + rowNonce).toLowerCase().replace(/[^a-z0-9-]/g, '-').slice(0, 80);
-        const delegateTask = 'Proof R-CD-TOKEN delegate return nonce ' + rowNonce + ': reply exactly CD-TOKEN-DELEGATE-DONE ' + rowNonce + '. Do not mutate files. Do not post externally.';
-        const bracket = '[[CONTINUE_DELEGATE: ' + delegateTask + ' +' + inv.delaySeconds + 's]]';
-        const childTask = 'k6 proof R-CD-TOKEN nonce ' + rowNonce + '. Reply exactly CD-TOKEN-HOP1 ' + rowNonce + ', then end your entire response with this exact terminal bracket on its own final line: ' + bracket + ' Do not call continue_delegate tool. Do not put any text after the closing brackets. Do not mutate files.';
-        const agentInstruction = HARNESS_MARKER + ' Call sessions_spawn exactly once with runtime="subagent", mode="run", taskName="' + taskName + '", label="k6 R-CD-TOKEN ' + rowNonce + '", lightContext=' + (inv.lightContext ? 'true' : 'false') + ', context="isolated", cleanup="delete", and task=' + JSON.stringify(childTask) + '. After the sessions_spawn tool result is accepted, reply exactly CD-TOKEN-PARENT-SPAWNED ' + rowNonce + '. This is a proof run.';
-        evidence.subagent_spawn_requested = true;
-        tracker.send(socket, 'sessions.send', { key: sessionKey, message: agentInstruction, idempotencyKey: inv.idempotencyKeyPrefix + '-DISPATCH-' + rowNonce });
+        const instruction = `${HARNESS_MARKER} Call sessions_spawn exactly once with runtime="subagent", mode="run", taskName="${taskName}", label="${originTitle}", lightContext=${inv.lightContext ? 'true' : 'false'}, context="isolated", cleanup="delete", and task=${JSON.stringify(childTask)}. After sessions_spawn is accepted, reply exactly RCDT-PARENT-SPAWNED-${tag}. This is a proof run.`;
+        tracker.send(socket, 'sessions.send', {
+          key: sessionKey,
+          message: instruction,
+          idempotencyKey: `${inv.idempotencyKeyPrefix}-DISPATCH-${tag}`,
+        });
       }, 500);
-      socket.setTimeout(() => socket.close(), 180000);
+      socket.setTimeout(() => {
+        if (!closed) {
+          evidence.interrupted = true;
+          evidence.terminal_reason = 'observation-window-expired';
+          closed = true;
+          socket.close();
+        }
+      }, 180000);
     }
+
     socket.on('open', () => {
       socket.send(connectFrame(token));
       if (createDisposableSession) {
         socket.setTimeout(() => {
-          const disposableKey = ('r-cd-token-' + rowNonce).toLowerCase().replace(/[^a-z0-9-]/g, '-');
-          tracker.send(socket, 'sessions.create', { key: disposableKey, label: 'k6 R-CD-TOKEN ' + rowNonce });
+          tracker.send(socket, 'sessions.create', {
+            key: `r-cd-token-${tag}`,
+            label: `k6 R-CD-TOKEN ${tag}`,
+          });
         }, 250);
-      } else socket.setTimeout(() => startProofFlow(socket), 500);
+      } else socket.setTimeout(() => startProofFlow(), 500);
     });
+
     socket.on('message', (raw) => {
       try {
-        const msg = JSON.parse(raw); const classified = tracker.classify(msg);
-        evidence.redacted_events.push({ ts: Date.now(), kind: classified.kind, method: classified.method || null, event: classified.event || null, ok: classified.ok !== undefined ? classified.ok : null, data: classified.payload ? redactEvent(classified.payload) : null });
-        if (classified.kind === 'response' && classified.method === 'sessions.create') {
-          if (classified.ok && classified.payload) { sessionKey = classified.payload.key || sessionKey; evidence.sessionKey = sessionKey; evidence.session_created = true; evidence.created_session_key = sessionKey; console.log('✓ disposable session created: ' + sessionKey); startProofFlow(socket); }
-          else { console.error('✗ sessions.create rejected: ' + JSON.stringify(classified.error)); failures.add(1); socket.close(); }
-        }
-        if (classified.kind === 'response' && classified.method === 'sessions.send') {
-          if (classified.ok) { evidence.prompt_injected = true; evidence.dispatch_accepted_at_ms = Date.now(); if (classified.payload?.traceId) evidence.trace_id = classified.payload.traceId; console.log('✓ sessions.send accepted — parent agent turn triggered'); }
-          else { console.error('✗ sessions.send rejected: ' + JSON.stringify(classified.error)); failures.add(1); }
-        }
-        if (classified.kind === 'event') {
-          const eventData = classified.data || {}; const eventStr = JSON.stringify(eventData);
-          if (eventData.traceId) evidence.trace_id = eventData.traceId;
-          if (eventData.childSessionKey) { evidence.child_session_key = eventData.childSessionKey; evidence.child_spawned = true; }
-          if (eventStr.includes(rowNonce)) {
-            if (eventStr.includes(HARNESS_MARKER)) console.log('ℹ Ignoring harness prompt echo event');
-            else if (evidence.prompt_injected && evidence.dispatch_accepted_at_ms && (Date.now() - evidence.dispatch_accepted_at_ms) >= POST_DISPATCH_EVIDENCE_GATE_MS) {
-              if (eventStr.includes('CD-TOKEN-PARENT-SPAWNED') || eventStr.includes('sessions_spawn') || eventStr.includes('childSessionKey')) { evidence.subagent_spawn_accepted = true; evidence.child_spawned = true; console.log('✓ parent sessions_spawn acceptance signal observed'); }
-              if (eventStr.includes('CD-TOKEN-HOP1 ' + rowNonce) || eventStr.includes('[[CONTINUE_DELEGATE:') || eventStr.includes('bracket')) { evidence.bracket_token_observed = true; console.log('✓ bracket-token child turn observed'); }
-              if (eventStr.includes('CD-TOKEN-DELEGATE-DONE ' + rowNonce)) { evidence.delegate_spawn_or_return_observed = true; evidence.parent_return_event = true; console.log('✓ CD-TOKEN-DELEGATE-DONE return sentinel observed'); }
-            }
+        const msg = JSON.parse(raw);
+        const originSubscribeResponse = Boolean(
+          originSubscriptionRequestId && msg.type === 'res' && msg.id === originSubscriptionRequestId,
+        );
+        const classified = tracker.classify(msg);
+        evidence.event_receipt_kinds.push(
+          `${classified.kind}:${classified.method || classified.event || 'other'}`,
+        );
+        if (originSubscribeResponse) {
+          if (classified.ok && classified.payload?.subscribed === true &&
+              classified.payload?.key === originSubscriptionTarget) {
+            evidence.origin_subscription_accepted = true;
+          } else {
+            evidence.terminal_reason = 'origin-session-subscription-rejected';
+            failures.add(1);
           }
         }
-        if (evidence.prompt_injected && evidence.subagent_spawn_accepted && evidence.bracket_token_observed && evidence.delegate_spawn_or_return_observed && evidence.parent_return_event) { console.log('All required R-CD-TOKEN evidence gathered, closing early'); socket.close(); }
-      } catch (e) { console.warn('parse error: ' + e); }
+        if (classified.kind === 'response' && classified.method === 'sessions.create') {
+          if (classified.ok && classified.payload) {
+            sessionKey = classified.payload.key || sessionKey;
+            evidence.session_hash = hash(sessionKey);
+            evidence.session_created = true;
+            startProofFlow();
+          } else {
+            failures.add(1); evidence.terminal_reason = 'disposable-session-rejected';
+            closed = true; socket.close();
+          }
+        }
+        if (classified.kind === 'response' && classified.method === 'sessions.send') {
+          if (classified.ok && classified.payload?.runId) {
+            evidence.prompt_injected = true;
+            evidence.send_accepted = true;
+            evidence.send_run_id_hash = hash(classified.payload.runId);
+            evidence.dispatch_accepted_at_ms = Date.now();
+            if (classified.payload.traceId) evidence.trace_id = classified.payload.traceId;
+            scheduleTaskPoll(250);
+          } else {
+            failures.add(1); evidence.terminal_reason = 'sessions-send-rejected';
+          }
+        }
+        if (classified.kind === 'response' && classified.method === 'tasks.list') {
+          consumeTaskPage(classified);
+        }
+        if (classified.kind === 'event' && classified.event === 'session.message') {
+          const eventData = classified.data || {};
+          if (pendingReturnEvents.length < 20) pendingReturnEvents.push(eventData);
+          tryReturnEvent(eventData);
+          closeComplete();
+        }
+      } catch (error) {
+        console.warn(`parse error: ${error}`);
+      }
     });
-    socket.on('error', (e) => { console.error('ws error: ' + (e && e.error ? e.error() : e)); failures.add(1); });
+    socket.on('error', (error) => {
+      console.error(`ws error: ${error && error.error ? error.error() : error}`);
+      evidence.interrupted = true; evidence.terminal_reason = 'websocket-error'; failures.add(1);
+    });
   });
-  evidence.ended = new Date().toISOString(); evidence.duration_ms = Date.now() - started; duration.add(evidence.duration_ms);
-  check(res, { 'websocket connected': (r) => r && r.status === 101 });
-  check(null, { 'prompt injected': () => evidence.prompt_injected, 'subagent spawn requested': () => evidence.subagent_spawn_requested, 'subagent spawn accepted': () => evidence.subagent_spawn_accepted, 'bracket token observed': () => evidence.bracket_token_observed, 'delegate return observed': () => evidence.delegate_spawn_or_return_observed, 'parent return event': () => evidence.parent_return_event });
-  if (!evidence.prompt_injected || !evidence.subagent_spawn_requested || !evidence.subagent_spawn_accepted || !evidence.bracket_token_observed || !evidence.delegate_spawn_or_return_observed || !evidence.parent_return_event) failures.add(1);
-  const passed = (!createDisposableSession || evidence.session_created) && evidence.prompt_injected && evidence.subagent_spawn_requested && evidence.subagent_spawn_accepted && evidence.bracket_token_observed && evidence.delegate_spawn_or_return_observed && evidence.parent_return_event;
-  console.log('\n--- R-CD-TOKEN EVIDENCE SUMMARY ---'); console.log(JSON.stringify(evidence, null, 2)); console.log('--- END EVIDENCE ---'); console.log('\n[R-CD-TOKEN] VERDICT: ' + (passed ? 'PASS-candidate' : 'PARTIAL-candidate'));
+
+  Object.assign(evidence, summarizeTokenLedger(ledger));
+  evidence.ended = new Date().toISOString();
+  evidence.duration_ms = Date.now() - started;
+  duration.add(evidence.duration_ms);
+  const verdict = classifyTokenEvidence(evidence);
+  check(res, { 'websocket connected': (value) => value && value.status === 101 });
+  check(null, {
+    'raw final text surface declared': () => evidence.surface_class === 'raw-final-text',
+    'disposable session created': () => evidence.session_created,
+    'send accepted with run identity': () => evidence.send_accepted && !!evidence.send_run_id_hash,
+    'task ledger fully paginated': () => evidence.task_pagination_exhausted,
+    'task ledger snapshot stable across full traversals': () => evidence.task_snapshot_consistent &&
+      evidence.task_snapshot_stable_count >= REQUIRED_STABLE_TASK_SNAPSHOTS,
+    'origin task exactly once': () => evidence.origin_task_unique_count === 1,
+    'token delegate task exactly once': () => evidence.delegate_task_unique_count === 1,
+    'delegate owned by origin child': () => evidence.delegate_requester_matches_origin_child,
+    'origin child subscription accepted': () => evidence.origin_subscription_accepted,
+    'bound delegate return observed': () => evidence.delegate_return_observed,
+    'run not interrupted': () => evidence.interrupted === false,
+  });
+  if (verdict !== 'PASS-candidate') failures.add(1);
+  console.log('\n--- R-CD-TOKEN EVIDENCE SUMMARY ---');
+  console.log(JSON.stringify(evidence, null, 2));
+  console.log('--- END EVIDENCE ---');
+  console.log(`\n[R-CD-TOKEN] VERDICT: ${verdict}`);
 }
 
 export function handleSummary(data) {
-  const timestamp = new Date().toISOString(); const passRate = data.metrics.proof_failures?.values?.count === 0;
-  const summary = { row: 'R-CD-TOKEN', sha: __ENV.OPENCLAW_CANDIDATE_SHA || 'unset', seat: __ENV.OPENCLAW_SEAT_NAME || 'cael-dgx', timestamp, verdict: passRate ? 'PASS-candidate' : 'PARTIAL-candidate', metrics: { duration_ms: data.metrics.r_cd_token_duration?.values || null, failures: data.metrics.proof_failures?.values?.count || 0 } };
-  return { stdout: '\n[R-CD-TOKEN] Summary: ' + summary.verdict + ' | SHA: ' + summary.sha + ' | Seat: ' + summary.seat + '\n', 'r-cd-token-bracket-delegate-summary.json': JSON.stringify(summary, null, 2) };
+  const summary = {
+    row: 'R-CD-TOKEN',
+    sha: __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
+    seat: __ENV.OPENCLAW_SEAT_NAME || 'cael-dgx',
+    timestamp: new Date().toISOString(),
+    // Never authoritative. The row-scoped signed resolver may promote this.
+    verdict: 'PARTIAL-candidate',
+    metrics: {
+      duration_ms: data.metrics.r_cd_token_duration?.values || null,
+      failures: data.metrics.proof_failures?.values?.count || 0,
+    },
+  };
+  return {
+    stdout: `\n[R-CD-TOKEN] Summary: ${summary.verdict} | SHA: ${summary.sha} | Seat: ${summary.seat}\n`,
+    'r-cd-token-bracket-delegate-summary.json': JSON.stringify(summary, null, 2),
+  };
 }

--- a/tools/k6-proofs/scripts/__tests__/candidate-run-result.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/candidate-run-result.test.mjs
@@ -5,12 +5,15 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { resolveRcdTokenAuthoritativeReceipt } from '../../lib/r-cd-token-authoritative-receipt.mjs';
 
 const runNode = promisify(execFile);
 const script = path.resolve('tools/k6-proofs/scripts/validate-candidate-run-result.mjs');
 const corpusValidator = path.resolve('tools/k6-proofs/scripts/validate-corpus.mjs');
 const sha = 'a'.repeat(40);
 const docsRef = 'b'.repeat(40);
+const gatewayKey = 'candidate-test-gateway-key';
 
 function manifest() {
   return {
@@ -53,7 +56,7 @@ async function fixture({ result = runResult(), metadata = null } = {}) {
 async function invoke({ manifestPath, candidateDir, out = null }) {
   const args = [script, '--manifest', manifestPath, '--candidate-dir', candidateDir, '--docs-ref', docsRef];
   if (out) args.push('--out', out);
-  return runNode(process.execPath, args, { encoding: 'utf8' });
+  return runNode(process.execPath, args, { encoding: 'utf8', env: { ...process.env, OPENCLAW_GATEWAY_TOKEN: gatewayKey } });
 }
 
 test('emits a public-safe, candidate-only routing envelope for a complete candidate run', async () => {
@@ -132,5 +135,90 @@ test('refuses output outside the candidate directory', async () => {
     );
   } finally {
     await rm(setup.root, { recursive: true, force: true });
+  }
+});
+
+test('R-CD-TOKEN requires the signed authoritative receipt and rejects tampering', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'candidate-token-'));
+  const candidateDir = path.join(root, 'candidate');
+  await mkdir(candidateDir);
+  const manifestPath = path.join(root, 'manifest.json');
+  const h = (character) => character.repeat(16);
+  const metadata = {
+    row: 'R-CD-TOKEN', candidateSha: sha, runtimeBuildSha: sha,
+    seat: 'elliott', scenario: 'r-cd-token-bracket-delegate.js',
+  };
+  const evidence = {
+    surface_class: 'raw-final-text', session_created: true, prompt_injected: true,
+    send_accepted: true, send_run_id_hash: h('1'), row_nonce_hash: h('2'),
+    attempt_id_hash: h('3'), candidateSha: sha, runtimeBuildSha: sha,
+    origin_subscription_accepted: true, delegate_return_observed: true,
+    return_target_session_hash: h('4'), return_source_session_hash: h('5'),
+    task_pagination_exhausted: true, tasks_list_rejected: 0,
+    task_snapshot_consistent: true, task_snapshot_stable_count: 3,
+    task_snapshot_digest: h('f'),
+    origin_task_unique_count: 1, delegate_task_unique_count: 1,
+    origin_task_id_hash: h('6'), origin_run_id_hash: h('7'),
+    origin_requester_session_hash: h('8'), origin_child_session_hash: h('4'),
+    delegate_task_id_hash: h('9'), delegate_run_id_hash: h('a'),
+    delegate_requester_session_hash: h('4'), delegate_child_session_hash: h('5'),
+    delegate_requester_matches_origin_child: true, delegate_parent_mismatch: false,
+    origin_task_status: 'completed', delegate_task_status: 'completed', interrupted: false,
+    reason_hash: h('b'), reason_length: 42,
+  };
+  const attemptState = {
+    schema: 'openclaw.k6.r-cd-token.attempt-state.v1', row: 'R-CD-TOKEN',
+    attemptIdHash: h('3'), rowNonceHash: h('2'), candidateSha: sha,
+    runtimeBuildSha: sha, automaticRetryAllowed: false,
+  };
+  const correlation = {
+    traceId: 'c'.repeat(32), chainId: '11111111-1111-4111-8111-111111111111',
+    dispatchSpanId: h('d'), fireSpanId: h('e'), toolSpanIds: [],
+    sameTrace: true, distinctSpans: true, reason: { hash: h('b'), length: 42 },
+    continuation: { tool: 'continue_delegate', originSurface: 'raw-final-text' },
+  };
+  const receipt = resolveRcdTokenAuthoritativeReceipt({
+    evidence, correlation, attemptState, metadata, signingKey: gatewayKey,
+  });
+  const raw = `${JSON.stringify(receipt, null, 2)}\n`;
+  const digest = createHash('sha256').update(raw).digest('hex');
+  await writeFile(manifestPath, `${JSON.stringify({
+    schema: 'openclaw.k6.proof-row-manifest.v1', rowId: 'R-CD-TOKEN', candidateSha: sha,
+    scenario: { name: 'r-cd-token-bracket-delegate' },
+    review: { candidateOnly: true, foldRequiresReview: true },
+    liveRunSafety: { expectedArtifactClass: 'PASS-candidate' },
+  }, null, 2)}\n`);
+  await writeFile(path.join(candidateDir, 'runner-metadata.json'), `${JSON.stringify(metadata)}\n`);
+  await writeFile(path.join(candidateDir, 'r-cd-token-authoritative-receipt.json'), raw);
+  await writeFile(path.join(candidateDir, 'run-result.json'), `${JSON.stringify({
+    effectiveExitCode: 0, verdict: 'PASS-candidate',
+    verdictSource: 'r-cd-token-authoritative-receipt', candidateOnly: true,
+    foldRequiresReview: true,
+    authoritativeReceipt: {
+      file: 'r-cd-token-authoritative-receipt.json', sha256: digest,
+      validated: true, source: 'r-cd-token-row-scoped-resolver',
+    },
+    observability: {
+      traceStatus: 'present', traceId: 'c'.repeat(32),
+      correlationReceipt: 'continuation-trace-correlation.json',
+    },
+    review: { status: 'ready-for-human-review', pendingReceipts: [] },
+  }, null, 2)}\n`);
+  try {
+    const good = JSON.parse((await invoke({ manifestPath, candidateDir })).stdout);
+    assert.equal(good.authoritativeReceipt.sha256, digest);
+    await writeFile(
+      path.join(candidateDir, 'runner-metadata.json'),
+      `${JSON.stringify({ ...metadata, runtimeBuildSha: 'f'.repeat(40) })}\n`,
+    );
+    await assert.rejects(invoke({ manifestPath, candidateDir }), /build identity mismatch/);
+    await writeFile(path.join(candidateDir, 'runner-metadata.json'), `${JSON.stringify(metadata)}\n`);
+    await writeFile(
+      path.join(candidateDir, 'r-cd-token-authoritative-receipt.json'),
+      raw.replace('PASS-candidate', 'PARTIAL-candidate'),
+    );
+    await assert.rejects(invoke({ manifestPath, candidateDir }), /digest mismatch/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
   }
 });

--- a/tools/k6-proofs/scripts/__tests__/candidate-run-result.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/candidate-run-result.test.mjs
@@ -149,7 +149,8 @@ test('R-CD-TOKEN requires the signed authoritative receipt and rejects tampering
     seat: 'elliott', scenario: 'r-cd-token-bracket-delegate.js',
   };
   const evidence = {
-    surface_class: 'raw-final-text', session_created: true, prompt_injected: true,
+    surface_class: 'raw-final-text', session_created: true, disposable_origin_ready: true,
+    prompt_injected: true,
     send_accepted: true, send_run_id_hash: h('1'), row_nonce_hash: h('2'),
     attempt_id_hash: h('3'), candidateSha: sha, runtimeBuildSha: sha,
     origin_subscription_accepted: true, delegate_return_observed: true,

--- a/tools/k6-proofs/scripts/__tests__/collect-continuation-trace.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/collect-continuation-trace.test.mjs
@@ -34,6 +34,7 @@ function span(name, traceId, spanId, parentSpanId, attrs = []) {
     spanId: b64(spanId),
     parentSpanId: b64(parentSpanId),
     attributes: attrs,
+    status: { code: 'OK' },
   };
 }
 
@@ -471,7 +472,7 @@ test('recovers a unique non-continuation tool trace by seat, tool, and evidence 
     assert.equal(receipt.attribution, 'seat-tool-dispatch-window');
     assert.equal(receipt.tool.name, 'request_compaction');
     assert.equal(receipt.tool.spanId, 'aaaaaaaaaaaaaaaa');
-    assert.equal(receipt.tool.status.code, 'UNSET');
+    assert.equal(receipt.tool.status.code, 'OK');
     assert.equal(receipt.uniqueTrace, true);
     assert.equal('generatedAt' in receipt, false);
     assert.deepEqual(receipt.searchWindow, {
@@ -813,5 +814,84 @@ test('rejects a matched trace that leaks raw task or traceparent material', asyn
   } finally {
     await server.close();
     await rm(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test('correlates terminal bracket-token topology without a typed continue_delegate tool span', async () => {
+  const fixture = await fixtureDir();
+  const manifest = JSON.parse(await readFile(fixture.manifestPath, 'utf8'));
+  manifest.rowId = 'R-CD-TOKEN';
+  manifest.invocation.originSurface = 'raw-final-text';
+  await writeFile(fixture.manifestPath, JSON.stringify(manifest));
+  const traceId = '99999999999999999999999999999999';
+  const trace = traceFixture({ traceId, reasonHash: fixture.reasonHash, reasonLength: fixture.reasonLength });
+  trace.batches[0].scopeSpans[0].spans = trace.batches[0].scopeSpans[0].spans
+    .filter((entry) => entry.name !== 'openclaw.tool.execution');
+  const server = await listen((request, response) => {
+    const url = new URL(request.url, 'http://localhost');
+    response.setHeader('content-type', 'application/json');
+    response.end(url.pathname === '/api/search'
+      ? JSON.stringify({ traces: [{ traceID: traceId }] })
+      : JSON.stringify(trace));
+  });
+  try {
+    const { stdout } = await execFileAsync(process.execPath, [script,
+      '--run-dir', fixture.dir, '--manifest', fixture.manifestPath, '--seat', 'elliott-prince',
+      '--tempo-url', server.url, '--timeout-ms', '100', '--poll-ms', '10',
+    ]);
+    const result = JSON.parse(stdout);
+    const receipt = JSON.parse(await readFile(path.join(fixture.dir, result.receiptFile), 'utf8'));
+    assert.equal(receipt.attribution, 'bracket-token-reason-hash-length-mode');
+    assert.equal(receipt.continuation.originSurface, 'raw-final-text');
+    assert.deepEqual(receipt.toolSpanIds, []);
+  } finally {
+    await server.close();
+    await rm(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test('bracket-token topology rejects a typed tool origin and duplicate dispatch spans', async (t) => {
+  for (const variant of ['typed-tool', 'duplicate-dispatch']) {
+    await t.test(variant, async () => {
+      const fixture = await fixtureDir();
+      const manifest = JSON.parse(await readFile(fixture.manifestPath, 'utf8'));
+      manifest.rowId = 'R-CD-TOKEN';
+      manifest.invocation.originSurface = 'raw-final-text';
+      await writeFile(fixture.manifestPath, JSON.stringify(manifest));
+      const traceId = variant === 'typed-tool'
+        ? '88888888888888888888888888888888'
+        : '77777777777777777777777777777777';
+      const trace = traceFixture({ traceId, reasonHash: fixture.reasonHash, reasonLength: fixture.reasonLength });
+      if (variant === 'duplicate-dispatch') {
+        const spans = trace.batches[0].scopeSpans[0].spans;
+        trace.batches[0].scopeSpans[0].spans = [
+          ...spans.filter((entry) => entry.name !== 'openclaw.tool.execution'),
+          span('continuation.delegate.dispatch', traceId, 'ffffffffffffffff', 'dddddddddddddddd', [
+            attr('chain.id', '11111111-1111-4111-8111-111111111111'),
+            attr('reason.hash', fixture.reasonHash), attr('reason.length', fixture.reasonLength),
+            attr('delegate.mode', 'normal'),
+          ]),
+        ];
+      }
+      const server = await listen((request, response) => {
+        const url = new URL(request.url, 'http://localhost');
+        response.setHeader('content-type', 'application/json');
+        response.end(url.pathname === '/api/search'
+          ? JSON.stringify({ traces: [{ traceID: traceId }] })
+          : JSON.stringify(trace));
+      });
+      try {
+        await assert.rejects(execFileAsync(process.execPath, [script,
+          '--run-dir', fixture.dir, '--manifest', fixture.manifestPath, '--seat', 'elliott-prince',
+          '--tempo-url', server.url, '--timeout-ms', '30', '--poll-ms', '10',
+        ]), (error) => {
+          assert.match(error.stderr, variant === 'typed-tool' ? /must not contain a typed/ : /contains 2 continuation\.delegate\.dispatch/);
+          return true;
+        });
+      } finally {
+        await server.close();
+        await rm(fixture.dir, { recursive: true, force: true });
+      }
+    });
   }
 });

--- a/tools/k6-proofs/scripts/__tests__/continuation-row-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/continuation-row-contract.test.mjs
@@ -137,11 +137,18 @@ test('every trace-required continue_delegate row persists the safe fingerprint c
     }
     rows.push(manifest.rowId);
     const scenario = await readFile(path.join(scenariosDir, manifest.scenario.file), 'utf8');
-    assert.match(scenario, /reason_hash:\s*null/);
-    assert.match(scenario, /reason_length:\s*null/);
-    assert.match(scenario, /delegate_mode:\s*null/);
     assert.match(scenario, /crypto\.sha256\([^,]+,\s*'hex'\)\.slice\(0,\s*16\)/);
-    assert.match(scenario, /promptTemplate\.replace\(\/\\\{\\\{nonce\\\}\\\}\/g,/);
+    if (manifest.rowId === 'R-CD-TOKEN') {
+      assert.match(scenario, /reason_hash:\s*hash\(delegateTask\)/);
+      assert.match(scenario, /reason_length:\s*delegateTask\.length/);
+      assert.match(scenario, /delegate_mode:\s*'normal'/);
+      assert.match(scenario, /promptTemplate\.replace\(\/\\\{\\\{tag\\\}\\\}\/g,/);
+    } else {
+      assert.match(scenario, /reason_hash:\s*null/);
+      assert.match(scenario, /reason_length:\s*null/);
+      assert.match(scenario, /delegate_mode:\s*null/);
+      assert.match(scenario, /promptTemplate\.replace\(\/\\\{\\\{nonce\\\}\\\}\/g,/);
+    }
   }
 
   assert.deepEqual(rows.sort(), [
@@ -149,6 +156,7 @@ test('every trace-required continue_delegate row persists the safe fingerprint c
     'R-CD-2',
     'R-CD-4',
     'R-CD-CHAINED-DEPTH-2',
+    'R-CD-TOKEN',
     'R-RC-2',
   ]);
 });
@@ -209,7 +217,9 @@ test('R-CD-2 row-list runner declares the signed receipt that candidate routing 
   const runner = await readFile(path.join(repoRoot, 'tools/k6-proofs/scripts/run-proofs.sh'), 'utf8');
   assert.match(runner, /R_CD_2_RECEIPT_SHA256/);
   assert.match(runner, /createHash\("sha256"\)/);
-  assert.match(runner, /authoritativeReceipt:\(if \$authoritativeReceiptSha256 == "" then null else \{file:"r-cd-2-authoritative-receipt\.json", sha256:\$authoritativeReceiptSha256, validated:true/);
+  assert.match(runner, /AUTHORITATIVE_RECEIPT="\$R_CD_2_RECEIPT"/);
+  assert.match(runner, /AUTHORITATIVE_RECEIPT_SOURCE="r-cd-2-row-scoped-resolver"/);
+  assert.match(runner, /authoritativeReceipt:\(if \$authoritativeReceiptSha256 == "" then null else \{file:\$authoritativeReceipt, sha256:\$authoritativeReceiptSha256, validated:true, source:\$authoritativeReceiptSource\}/);
 });
 
 test('R-CD-2 live runner emits an envelope only for an untampered authoritative receipt', async (t) => {

--- a/tools/k6-proofs/scripts/__tests__/continuation-row-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/continuation-row-contract.test.mjs
@@ -142,7 +142,8 @@ test('every trace-required continue_delegate row persists the safe fingerprint c
       assert.match(scenario, /reason_hash:\s*hash\(delegateTask\)/);
       assert.match(scenario, /reason_length:\s*delegateTask\.length/);
       assert.match(scenario, /delegate_mode:\s*'normal'/);
-      assert.match(scenario, /promptTemplate\.replace\(\/\\\{\\\{tag\\\}\\\}\/g,/);
+      assert.match(scenario, /replace\(\/\\\{\\\{marker\\\}\\\}\/g,/);
+      assert.match(scenario, /replace\(\/\\\{\\\{tag\\\}\\\}\/g,/);
     } else {
       assert.match(scenario, /reason_hash:\s*null/);
       assert.match(scenario, /reason_length:\s*null/);

--- a/tools/k6-proofs/scripts/__tests__/r-cd-token-authoritative-receipt.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cd-token-authoritative-receipt.test.mjs
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  resolveRcdTokenAuthoritativeReceipt,
+  validateRcdTokenAuthoritativeReceipt,
+} from '../../lib/r-cd-token-authoritative-receipt.mjs';
+
+const h = (character) => character.repeat(16);
+const key = 'test-gateway-key';
+const sha = 'a'.repeat(40);
+const metadata = { row: 'R-CD-TOKEN', candidateSha: sha, runtimeBuildSha: sha };
+const evidence = {
+  surface_class: 'raw-final-text',
+  session_created: true,
+  prompt_injected: true,
+  send_accepted: true,
+  send_run_id_hash: h('1'),
+  row_nonce_hash: h('2'),
+  attempt_id_hash: h('3'),
+  candidateSha: sha,
+  runtimeBuildSha: sha,
+  origin_subscription_accepted: true,
+  delegate_return_observed: true,
+  return_target_session_hash: h('4'),
+  return_source_session_hash: h('5'),
+  task_pagination_exhausted: true,
+  task_snapshot_consistent: true,
+  task_snapshot_stable_count: 3,
+  task_snapshot_digest: '0'.repeat(16),
+  tasks_list_rejected: 0,
+  origin_task_unique_count: 1,
+  delegate_task_unique_count: 1,
+  origin_task_id_hash: h('6'),
+  origin_run_id_hash: h('7'),
+  origin_requester_session_hash: h('8'),
+  origin_child_session_hash: h('4'),
+  delegate_task_id_hash: h('9'),
+  delegate_run_id_hash: h('a'),
+  delegate_requester_session_hash: h('4'),
+  delegate_child_session_hash: h('5'),
+  delegate_requester_matches_origin_child: true,
+  delegate_parent_mismatch: false,
+  origin_task_status: 'completed',
+  delegate_task_status: 'completed',
+  interrupted: false,
+  reason_hash: h('b'),
+  reason_length: 42,
+};
+const attemptState = {
+  schema: 'openclaw.k6.r-cd-token.attempt-state.v1',
+  row: 'R-CD-TOKEN',
+  attemptIdHash: h('3'),
+  rowNonceHash: h('2'),
+  candidateSha: sha,
+  runtimeBuildSha: sha,
+  automaticRetryAllowed: false,
+};
+const correlation = {
+  traceId: 'c'.repeat(32),
+  chainId: '11111111-1111-4111-8111-111111111111',
+  dispatchSpanId: h('d'),
+  fireSpanId: h('e'),
+  toolSpanIds: [],
+  sameTrace: true,
+  distinctSpans: true,
+  reason: { hash: h('b'), length: 42 },
+  continuation: { tool: 'continue_delegate', originSurface: 'raw-final-text' },
+};
+
+function resolve(overrides = {}) {
+  return resolveRcdTokenAuthoritativeReceipt({
+    evidence: overrides.evidence || evidence,
+    correlation: overrides.correlation || correlation,
+    attemptState: overrides.attemptState || attemptState,
+    metadata: overrides.metadata || metadata,
+    signingKey: key,
+  });
+}
+
+test('only the complete exactly-once bracket lifecycle plus matching topology can PASS', () => {
+  const receipt = resolve();
+  assert.equal(receipt.verdict, 'PASS-candidate');
+  assert.equal(receipt.binding.candidateSha, sha);
+  assert.equal(receipt.binding.runtimeBuildSha, sha);
+  assert.deepEqual(validateRcdTokenAuthoritativeReceipt(receipt, key), {
+    valid: true, verdict: 'PASS-candidate',
+  });
+});
+
+test('duplicate scheduling, interruption, typed-tool origin, and mismatched reason are non-PASS', () => {
+  for (const overrides of [
+    { evidence: { ...evidence, delegate_task_unique_count: 2 } },
+    { evidence: { ...evidence, interrupted: true } },
+    { correlation: { ...correlation, toolSpanIds: [h('f')] } },
+    { correlation: { ...correlation, reason: { hash: h('f'), length: 42 } } },
+  ]) {
+    const receipt = resolve(overrides);
+    assert.notEqual(receipt.verdict, 'PASS-candidate');
+    assert.equal(validateRcdTokenAuthoritativeReceipt(receipt, key).valid, true);
+  }
+});
+
+test('candidate/runtime mismatch is signed non-PASS and cannot become authority', () => {
+  const receipt = resolve({
+    metadata: { ...metadata, runtimeBuildSha: 'f'.repeat(40) },
+  });
+  assert.equal(receipt.verdict, 'PARTIAL-candidate');
+  assert.equal(validateRcdTokenAuthoritativeReceipt(receipt, key).valid, false);
+});
+
+test('tampering invalidates the signed receipt', () => {
+  const receipt = resolve();
+  receipt.lifecycle.delegateRunIdHash = h('f');
+  assert.equal(validateRcdTokenAuthoritativeReceipt(receipt, key).valid, false);
+});

--- a/tools/k6-proofs/scripts/__tests__/r-cd-token-authoritative-receipt.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cd-token-authoritative-receipt.test.mjs
@@ -12,6 +12,7 @@ const metadata = { row: 'R-CD-TOKEN', candidateSha: sha, runtimeBuildSha: sha };
 const evidence = {
   surface_class: 'raw-final-text',
   session_created: true,
+  disposable_origin_ready: true,
   prompt_injected: true,
   send_accepted: true,
   send_run_id_hash: h('1'),
@@ -91,6 +92,7 @@ test('duplicate scheduling, interruption, typed-tool origin, and mismatched reas
   for (const overrides of [
     { evidence: { ...evidence, delegate_task_unique_count: 2 } },
     { evidence: { ...evidence, interrupted: true } },
+    { evidence: { ...evidence, disposable_origin_ready: false } },
     { correlation: { ...correlation, toolSpanIds: [h('f')] } },
     { correlation: { ...correlation, reason: { hash: h('f'), length: 42 } } },
   ]) {

--- a/tools/k6-proofs/scripts/__tests__/r-cd-token-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cd-token-contract.test.mjs
@@ -1,0 +1,205 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import test from 'node:test';
+import {
+  classifyTokenEvidence,
+  createTokenLedger,
+  observeTokenTaskLedger,
+  parseTokenReturnEvent,
+  rejectTokenTaskLedgerObservation,
+  summarizeTokenLedger,
+  tokenLedgerHasTerminalTasks,
+} from '../../lib/r-cd-token-contract.js';
+
+const hash = (value) => createHash('sha256').update(String(value)).digest('hex').slice(0, 16);
+const parentSessionKey = 'agent:main:proof-parent';
+const originTitle = 'RCDT-O-0123456789abcdef';
+const delegateMarker = 'RCDT-D-0123456789abcdef';
+const returnSentinel = 'RCDT-RETURN-0123456789abcdef';
+const originChild = 'agent:main:subagent:origin-child';
+const delegateChild = 'agent:main:subagent:delegate-child';
+
+function taskSummary({
+  id, runId, childSessionKey, title, sessionKey, status = 'completed', parentTaskId,
+}) {
+  return {
+    id,
+    taskId: id,
+    kind: 'subagent',
+    runtime: 'subagent',
+    runId,
+    childSessionKey,
+    title,
+    sessionKey,
+    status,
+    ...(parentTaskId ? { parentTaskId } : {}),
+  };
+}
+
+function wireTasks(status = 'completed') {
+  return [
+    taskSummary({
+      id: 'origin-id', runId: 'origin-run', childSessionKey: originChild,
+      title: originTitle, sessionKey: parentSessionKey, status,
+    }),
+    taskSummary({
+      id: 'delegate-id', runId: 'delegate-run', childSessionKey: delegateChild,
+      title: `[continuation:chain-hop:1] Delegated task (turn 1/50): ${delegateMarker}`,
+      sessionKey: originChild, parentTaskId: 'origin-id', status,
+    }),
+  ];
+}
+
+function completeEvidence(overrides = {}) {
+  const ledger = createTokenLedger({ surfaceClass: 'raw-final-text' });
+  observeTokenTaskLedger(ledger, {
+    hash,
+    originTitle,
+    delegateMarker,
+    parentSessionKey,
+    pages: 2,
+    tasks: wireTasks(),
+  });
+  return {
+    ...summarizeTokenLedger(ledger),
+    session_created: true,
+    prompt_injected: true,
+    send_accepted: true,
+    send_run_id_hash: hash('send-run'),
+    row_nonce_hash: hash('nonce'),
+    attempt_id_hash: hash('attempt'),
+    origin_subscription_accepted: true,
+    delegate_return_observed: true,
+    task_snapshot_consistent: true,
+    task_snapshot_stable_count: 3,
+    task_snapshot_digest: hash('stable-task-snapshot'),
+    return_target_session_hash: hash(originChild),
+    return_source_session_hash: hash(delegateChild),
+    interrupted: false,
+    ...overrides,
+  };
+}
+
+test('accepts the real public TaskSummary shape and normalizes completed status', () => {
+  const ledger = createTokenLedger({ surfaceClass: 'raw-final-text-seat' });
+  observeTokenTaskLedger(ledger, {
+    tasks: wireTasks('running'), originTitle, delegateMarker, parentSessionKey, pages: 2, hash,
+  });
+  observeTokenTaskLedger(ledger, {
+    tasks: wireTasks('completed'), originTitle, delegateMarker, parentSessionKey, pages: 2, hash,
+  });
+  const summary = summarizeTokenLedger(ledger);
+  assert.equal(summary.origin_task_unique_count, 1);
+  assert.equal(summary.delegate_task_unique_count, 1);
+  assert.equal(summary.origin_task_status, 'completed');
+  assert.equal(summary.delegate_task_status, 'completed');
+  assert.equal(summary.delegate_requester_matches_origin_child, true);
+  assert.equal(summary.task_pagination_exhausted, true);
+  assert.equal(summary.task_pages_accepted, 4);
+  assert.equal(tokenLedgerHasTerminalTasks(ledger), true);
+});
+
+test('bounded public titles are joined by short markers plus requester lineage, not raw task text', () => {
+  const ledger = createTokenLedger({ surfaceClass: 'raw-final-text' });
+  const tasks = wireTasks();
+  tasks[1].title = tasks[1].title.slice(0, 80);
+  observeTokenTaskLedger(ledger, {
+    tasks, originTitle, delegateMarker, parentSessionKey, pages: 1, hash,
+  });
+  assert.equal(summarizeTokenLedger(ledger).delegate_task_unique_count, 1);
+  const wrongOwner = createTokenLedger({ surfaceClass: 'raw-final-text' });
+  tasks[1].sessionKey = 'agent:main:subagent:unrelated';
+  observeTokenTaskLedger(wrongOwner, {
+    tasks, originTitle, delegateMarker, parentSessionKey, pages: 1, hash,
+  });
+  assert.equal(summarizeTokenLedger(wrongOwner).delegate_task_unique_count, 0);
+});
+
+test('duplicate scheduling and parent-task mismatch are deterministic PARTIAL', () => {
+  assert.equal(classifyTokenEvidence(completeEvidence({ delegate_task_unique_count: 2 })), 'PARTIAL-candidate');
+  assert.equal(classifyTokenEvidence(completeEvidence({ delegate_parent_mismatch: true })), 'PARTIAL-candidate');
+});
+
+test('interruption, unstable pagination, missing return, and incomplete identities are PARTIAL', () => {
+  for (const overrides of [
+    { interrupted: true },
+    { tasks_list_rejected: 1 },
+    { task_pagination_exhausted: false },
+    { task_snapshot_consistent: false },
+    { task_snapshot_stable_count: 2 },
+    { origin_subscription_accepted: false },
+    { delegate_return_observed: false },
+    { delegate_run_id_hash: null },
+    { delegate_task_status: 'running' },
+    { delegate_run_id_hash: completeEvidence().origin_run_id_hash },
+    { return_source_session_hash: hash('other-child') },
+  ]) {
+    assert.equal(classifyTokenEvidence(completeEvidence(overrides)), 'PARTIAL-candidate');
+  }
+});
+
+test('message-body and undeclared surfaces can never PASS', () => {
+  assert.equal(classifyTokenEvidence(completeEvidence({ surface_class: 'message-body' })), 'HONEST-LIMIT-candidate');
+  assert.equal(classifyTokenEvidence(completeEvidence({ surface_class: 'unknown' })), 'HONEST-LIMIT-candidate');
+});
+
+test('complete raw-final-text task ledger and bound return are PASS-candidate', () => {
+  assert.equal(classifyTokenEvidence(completeEvidence()), 'PASS-candidate');
+});
+
+test('structured return parser binds target and source sessions', () => {
+  const event = {
+    sessionKey: originChild,
+    message: {
+      role: 'user',
+      content: [{
+        type: 'text',
+        text: `[Inter-session message] sourceSession=${delegateChild} sourceChannel=internal sourceTool=subagent_announce isUser=false\n${returnSentinel}`,
+      }],
+    },
+  };
+  assert.deepEqual(parseTokenReturnEvent(event, {
+    expectedTargetSessionKey: originChild,
+    expectedDelegateChildSessionKey: delegateChild,
+    expectedSentinel: returnSentinel,
+    hash,
+  }), {
+    targetSessionHash: hash(originChild),
+    sourceSessionHash: hash(delegateChild),
+  });
+});
+
+test('prompt echo, arbitrary event text, wrong session, and wrong delegate are rejected', () => {
+  const base = {
+    sessionKey: originChild,
+    message: {
+      role: 'user',
+      content: [{
+        type: 'text',
+        text: `[Inter-session message] sourceSession=${delegateChild} sourceTool=subagent_announce\n${returnSentinel}`,
+      }],
+    },
+  };
+  const variants = [
+    { ...base, sessionKey: 'agent:main:unrelated' },
+    { ...base, message: { ...base.message, content: [{ type: 'text', text: `[k6-proof-harness] ${returnSentinel}` }] } },
+    { ...base, message: { ...base.message, content: [{ type: 'text', text: `random ${returnSentinel}` }] } },
+    { ...base, message: { ...base.message, content: [{ type: 'text', text: `[Inter-session message] sourceSession=agent:main:other sourceTool=subagent_announce\n${returnSentinel}` }] } },
+  ];
+  for (const event of variants) {
+    assert.equal(parseTokenReturnEvent(event, {
+      expectedTargetSessionKey: originChild,
+      expectedDelegateChildSessionKey: delegateChild,
+      expectedSentinel: returnSentinel,
+      hash,
+    }), null);
+  }
+});
+
+test('task-list rejection is recorded fail-closed', () => {
+  const ledger = createTokenLedger({ surfaceClass: 'raw-final-text' });
+  rejectTokenTaskLedgerObservation(ledger);
+  const summary = summarizeTokenLedger(ledger);
+  assert.equal(summary.tasks_list_rejected, 1);
+  assert.equal(summary.task_pagination_exhausted, false);
+});

--- a/tools/k6-proofs/scripts/__tests__/r-cd-token-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cd-token-contract.test.mjs
@@ -8,13 +8,14 @@ import {
   parseTokenReturnEvent,
   rejectTokenTaskLedgerObservation,
   summarizeTokenLedger,
+  tokenDisposableOriginReady,
   tokenLedgerHasTerminalTasks,
 } from '../../lib/r-cd-token-contract.js';
 
 const hash = (value) => createHash('sha256').update(String(value)).digest('hex').slice(0, 16);
 const parentSessionKey = 'agent:main:proof-parent';
 const originTitle = 'RCDT-O-0123456789abcdef';
-const delegateMarker = 'RCDT-D-0123456789abcdef';
+const delegateMarker = 'D-0123456789ab';
 const returnSentinel = 'RCDT-RETURN-0123456789abcdef';
 const originChild = 'agent:main:subagent:origin-child';
 const delegateChild = 'agent:main:subagent:delegate-child';
@@ -44,7 +45,8 @@ function wireTasks(status = 'completed') {
     }),
     taskSummary({
       id: 'delegate-id', runId: 'delegate-run', childSessionKey: delegateChild,
-      title: `[continuation:chain-hop:1] Delegated task (turn 1/50): ${delegateMarker}`,
+      title: `[continuation:chain-hop:1] Delegated from sub-agent (depth 1): ${delegateMarker}`
+        .replace(/\s+/g, ' ').trim().slice(0, 80),
       sessionKey: originChild, parentTaskId: 'origin-id', status,
     }),
   ];
@@ -63,6 +65,7 @@ function completeEvidence(overrides = {}) {
   return {
     ...summarizeTokenLedger(ledger),
     session_created: true,
+    disposable_origin_ready: true,
     prompt_injected: true,
     send_accepted: true,
     send_run_id_hash: hash('send-run'),
@@ -102,7 +105,11 @@ test('accepts the real public TaskSummary shape and normalizes completed status'
 test('bounded public titles are joined by short markers plus requester lineage, not raw task text', () => {
   const ledger = createTokenLedger({ surfaceClass: 'raw-final-text' });
   const tasks = wireTasks();
-  tasks[1].title = tasks[1].title.slice(0, 80);
+  const productionTask = `[continuation:chain-hop:1] Delegated from sub-agent (depth 1): ${delegateMarker} reply exactly ${returnSentinel}`;
+  tasks[1].title = productionTask.replace(/\s+/g, ' ').trim().slice(0, 80);
+  assert.equal('[continuation:chain-hop:1] Delegated from sub-agent (depth 1): '.length, 63);
+  assert.equal(tasks[1].title.length, 80);
+  assert.equal(tasks[1].title.includes(delegateMarker), true);
   observeTokenTaskLedger(ledger, {
     tasks, originTitle, delegateMarker, parentSessionKey, pages: 1, hash,
   });
@@ -115,6 +122,26 @@ test('bounded public titles are joined by short markers plus requester lineage, 
   assert.equal(summarizeTokenLedger(wrongOwner).delegate_task_unique_count, 0);
 });
 
+test('disposable origin gate rejects disabled, failed, missing, and fallback creation', () => {
+  const ready = {
+    creationRequested: true,
+    sessionCreated: true,
+    requestedSessionKey: parentSessionKey,
+    activeSessionKey: 'agent:main:proof-disposable',
+  };
+  assert.equal(tokenDisposableOriginReady(ready), true);
+  for (const overrides of [
+    { creationRequested: false },
+    { sessionCreated: false },
+    { activeSessionKey: '' },
+    { activeSessionKey: parentSessionKey },
+  ]) {
+    let dispatches = 0;
+    if (tokenDisposableOriginReady({ ...ready, ...overrides })) dispatches += 1;
+    assert.equal(dispatches, 0);
+  }
+});
+
 test('duplicate scheduling and parent-task mismatch are deterministic PARTIAL', () => {
   assert.equal(classifyTokenEvidence(completeEvidence({ delegate_task_unique_count: 2 })), 'PARTIAL-candidate');
   assert.equal(classifyTokenEvidence(completeEvidence({ delegate_parent_mismatch: true })), 'PARTIAL-candidate');
@@ -123,6 +150,7 @@ test('duplicate scheduling and parent-task mismatch are deterministic PARTIAL', 
 test('interruption, unstable pagination, missing return, and incomplete identities are PARTIAL', () => {
   for (const overrides of [
     { interrupted: true },
+    { disposable_origin_ready: false },
     { tasks_list_rejected: 1 },
     { task_pagination_exhausted: false },
     { task_snapshot_consistent: false },

--- a/tools/k6-proofs/scripts/__tests__/r-cd-token-interruption.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cd-token-interruption.test.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const script = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../write-interrupted-run-result.mjs');
+const sha = 'a'.repeat(40);
+
+function run(dir) {
+  return spawnSync(process.execPath, [script,
+    '--run-dir', dir, '--row', 'R-CD-TOKEN', '--candidate-sha', sha, '--runtime-sha', sha,
+    '--attempt-hash', '1'.repeat(16), '--nonce-hash', '2'.repeat(16),
+    '--phase', 'k6-running', '--cause', 'signal-term',
+  ], { encoding: 'utf8' });
+}
+
+test('writes a structured non-PASS, non-retriable interruption packet', async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'r-cd-token-interrupt-'));
+  await writeFile(path.join(dir, 'attempt-state.json'), `${JSON.stringify({
+    schema: 'openclaw.k6.r-cd-token.attempt-state.v1',
+    row: 'R-CD-TOKEN',
+    terminal: false,
+    automaticRetryAllowed: false,
+  })}\n`);
+  const result = run(dir);
+  assert.equal(result.status, 0, result.stderr);
+  const receipt = JSON.parse(await readFile(path.join(dir, 'interruption-receipt.json'), 'utf8'));
+  const runResult = JSON.parse(await readFile(path.join(dir, 'run-result.json'), 'utf8'));
+  const attemptState = JSON.parse(await readFile(path.join(dir, 'attempt-state.json'), 'utf8'));
+  assert.equal(attemptState.phase, 'interrupted');
+  assert.equal(attemptState.proofTerminal, false);
+  assert.equal(attemptState.terminal, false);
+  assert.equal(attemptState.consumptionState, 'unknown-possibly-consumed');
+  assert.equal(attemptState.automaticRetryAllowed, false);
+  assert.equal(receipt.consumptionState, 'unknown-possibly-consumed');
+  assert.equal(receipt.automaticRetryAllowed, false);
+  assert.equal(receipt.proofTerminal, false);
+  assert.equal(runResult.verdict, 'PARTIAL-candidate');
+  assert.equal(runResult.effectiveExitCode, 130);
+  assert.equal(runResult.review.status, 'review-pending');
+  assert.equal(runResult.terminal, false);
+});
+
+test('supersedes a premature pass-shaped run-result while the attempt is still active', async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'r-cd-token-existing-'));
+  await writeFile(path.join(dir, 'run-result.json'), '{"verdict":"PASS-candidate"}\n');
+  const result = run(dir);
+  assert.equal(result.status, 0, result.stderr);
+  const runResult = JSON.parse(await readFile(path.join(dir, 'run-result.json'), 'utf8'));
+  const receipt = JSON.parse(await readFile(path.join(dir, 'interruption-receipt.json'), 'utf8'));
+  assert.equal(runResult.verdict, 'PARTIAL-candidate');
+  assert.equal(runResult.terminal, false);
+  assert.equal(receipt.candidateOutcome, 'PARTIAL-candidate');
+});
+
+test('rejects malformed identity fingerprints', async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'r-cd-token-invalid-'));
+  const result = spawnSync(process.execPath, [script,
+    '--run-dir', dir, '--row', 'R-CD-TOKEN', '--candidate-sha', sha, '--runtime-sha', sha,
+    '--attempt-hash', 'raw-attempt', '--nonce-hash', '2'.repeat(16), '--phase', 'prepared', '--cause', 'exit',
+  ], { encoding: 'utf8' });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /fingerprints/);
+});

--- a/tools/k6-proofs/scripts/__tests__/r-cd-token-runner-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cd-token-runner-contract.test.mjs
@@ -12,18 +12,25 @@ test('runner gates exact build and surface identity before token dispatch', asyn
   const buildGate = source.indexOf('openclaw.k6.r-cd-token.build-identity-gate.v1');
   const prepared = source.indexOf('openclaw.k6.r-cd-token.attempt-state.v1');
   const surfaceGate = source.indexOf('pre-dispatch-surface-gate');
+  const disposableGate = source.indexOf('export OPENCLAW_CREATE_DISPOSABLE_SESSION=true');
   const k6 = source.indexOf('k6 run "scenarios/$SCENARIO_FILE"');
-  assert.ok(buildGate > 0 && prepared > buildGate && surfaceGate > prepared && k6 > surfaceGate);
+  assert.ok(buildGate > 0 && prepared > buildGate && surfaceGate > prepared &&
+    disposableGate > surfaceGate && k6 > disposableGate);
   assert.match(source, /OPENCLAW_CANDIDATE_SHA" != "\$OPENCLAW_RUNTIME_BUILD_SHA/);
   assert.match(source, /trap finalize_interrupted_token_run EXIT/);
   assert.match(source, /signal-int/);
   assert.match(source, /signal-term/);
   assert.match(source, /automaticRetryAllowed:false/);
+  assert.match(source, /export OPENCLAW_CREATE_DISPOSABLE_SESSION=true/);
   assert.doesNotMatch(source, /INTERRUPTED_RESULT_WRITER[\s\S]{0,700}>\/dev\/null 2>&1 \|\| true/);
 });
 
 test('scenario paginates the public task ledger and binds a structured return', async () => {
   const source = await read('scenarios/r-cd-token-bracket-delegate.js');
+  const proofFlow = source.indexOf('function startProofFlow()');
+  const disposableCheck = source.indexOf('if (!tokenDisposableOriginReady({', proofFlow);
+  const proofSend = source.indexOf("tracker.send(socket, 'sessions.send'", proofFlow);
+  assert.ok(proofFlow > 0 && disposableCheck > proofFlow && proofSend > disposableCheck);
   assert.match(source, /tasks\.list/);
   assert.match(source, /nextCursor/);
   assert.match(source, /TASK_PAGE_LIMIT = 500/);
@@ -38,6 +45,10 @@ test('scenario paginates the public task ledger and binds a structured return', 
   assert.match(source, /SETTLE_MS/);
   assert.match(source, /OPENCLAW_ROW_NONCE/);
   assert.match(source, /OPENCLAW_PROOF_ATTEMPT_ID/);
+  assert.match(source, /tokenDisposableOriginReady/);
+  assert.match(source, /pre-dispatch-disposable-creation-not-enabled/);
+  assert.match(source, /createdSessionKey && createdSessionKey !== requestedSessionKey/);
+  assert.doesNotMatch(source, /else socket\.setTimeout\(\(\) => startProofFlow\(\)/);
   assert.match(source, /verdict: 'PARTIAL-candidate'/);
   assert.doesNotMatch(source, /JSON\.stringify\(eventData\).*includes/);
 });
@@ -51,6 +62,7 @@ test('manifest required and expected receipt surfaces are identical and fail clo
   assert.equal(manifest.invocation.originSurface, 'raw-final-text');
   assert.equal(manifest.invocation.delaySeconds, 10);
   assert.equal(manifest.liveRunSafety.requiresDisposableSession, true);
+  assert.ok(manifest.scenario.methods.includes('sessions.create'));
 });
 
 test('candidate/report surfaces depend on the signed row-scoped receipt', async () => {

--- a/tools/k6-proofs/scripts/__tests__/r-cd-token-runner-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cd-token-runner-contract.test.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const read = (file) => readFile(path.join(root, file), 'utf8');
+
+test('runner gates exact build and surface identity before token dispatch', async () => {
+  const source = await read('scripts/run-proofs.sh');
+  const buildGate = source.indexOf('openclaw.k6.r-cd-token.build-identity-gate.v1');
+  const prepared = source.indexOf('openclaw.k6.r-cd-token.attempt-state.v1');
+  const surfaceGate = source.indexOf('pre-dispatch-surface-gate');
+  const k6 = source.indexOf('k6 run "scenarios/$SCENARIO_FILE"');
+  assert.ok(buildGate > 0 && prepared > buildGate && surfaceGate > prepared && k6 > surfaceGate);
+  assert.match(source, /OPENCLAW_CANDIDATE_SHA" != "\$OPENCLAW_RUNTIME_BUILD_SHA/);
+  assert.match(source, /trap finalize_interrupted_token_run EXIT/);
+  assert.match(source, /signal-int/);
+  assert.match(source, /signal-term/);
+  assert.match(source, /automaticRetryAllowed:false/);
+  assert.doesNotMatch(source, /INTERRUPTED_RESULT_WRITER[\s\S]{0,700}>\/dev\/null 2>&1 \|\| true/);
+});
+
+test('scenario paginates the public task ledger and binds a structured return', async () => {
+  const source = await read('scenarios/r-cd-token-bracket-delegate.js');
+  assert.match(source, /tasks\.list/);
+  assert.match(source, /nextCursor/);
+  assert.match(source, /TASK_PAGE_LIMIT = 500/);
+  assert.match(source, /REQUIRED_STABLE_TASK_SNAPSHOTS = 3/);
+  assert.match(source, /duplicateTaskId/);
+  assert.match(source, /task_snapshot_consistent/);
+  assert.match(source, /origin_task_unique_count === 1/);
+  assert.match(source, /delegate_task_unique_count === 1/);
+  assert.match(source, /delegate_requester_matches_origin_child/);
+  assert.match(source, /classified\.event === 'session\.message'/);
+  assert.match(source, /parseTokenReturnEvent/);
+  assert.match(source, /SETTLE_MS/);
+  assert.match(source, /OPENCLAW_ROW_NONCE/);
+  assert.match(source, /OPENCLAW_PROOF_ATTEMPT_ID/);
+  assert.match(source, /verdict: 'PARTIAL-candidate'/);
+  assert.doesNotMatch(source, /JSON\.stringify\(eventData\).*includes/);
+});
+
+test('manifest required and expected receipt surfaces are identical and fail closed', async () => {
+  const manifest = JSON.parse(await read('manifests/r-cd-token.json'));
+  const expected = manifest.expectedReceipts.map((receipt) => receipt.name).sort();
+  const required = [...manifest.liveRunSafety.requiredReceipts].sort();
+  assert.deepEqual(required, expected);
+  assert.ok(manifest.expectedReceipts.every((receipt) => receipt.required === true));
+  assert.equal(manifest.invocation.originSurface, 'raw-final-text');
+  assert.equal(manifest.invocation.delaySeconds, 10);
+  assert.equal(manifest.liveRunSafety.requiresDisposableSession, true);
+});
+
+test('candidate/report surfaces depend on the signed row-scoped receipt', async () => {
+  for (const file of [
+    'scripts/run-proofs.sh',
+    'scripts/validate-candidate-run-result.mjs',
+    'scripts/candidate-run-result-contract.mjs',
+    'scripts/render-run-report.mjs',
+  ]) {
+    assert.match(await read(file), /r-cd-token-authoritative-receipt/);
+  }
+});

--- a/tools/k6-proofs/scripts/candidate-run-result-contract.mjs
+++ b/tools/k6-proofs/scripts/candidate-run-result-contract.mjs
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { existsSync, readFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { validateRcd2AuthoritativeReceipt } from '../lib/r-cd-2-authoritative-receipt.mjs';
+import { validateRcdTokenAuthoritativeReceipt } from '../lib/r-cd-token-authoritative-receipt.mjs';
 
 export const CANDIDATE_RUN_RESULT_SCHEMA = 'openclaw.k6.candidate-run-result.v1';
 export const PROOF_ROW_MANIFEST_SCHEMA = 'openclaw.k6.proof-row-manifest.v1';
@@ -15,6 +16,26 @@ function nonEmptyString(value) {
 
 function scenarioName(manifest) {
   return manifest?.scenario?.name || manifest?.scenario?.file?.replace(/\.js$/, '') || null;
+}
+
+function authoritativeReceiptContract(rowId) {
+  if (rowId === 'R-CD-2') {
+    return {
+      file: 'r-cd-2-authoritative-receipt.json',
+      source: 'r-cd-2-row-scoped-resolver',
+      verdictSource: 'r-cd-2-authoritative-receipt',
+      validate: validateRcd2AuthoritativeReceipt,
+    };
+  }
+  if (rowId === 'R-CD-TOKEN') {
+    return {
+      file: 'r-cd-token-authoritative-receipt.json',
+      source: 'r-cd-token-row-scoped-resolver',
+      verdictSource: 'r-cd-token-authoritative-receipt',
+      validate: validateRcdTokenAuthoritativeReceipt,
+    };
+  }
+  return null;
 }
 
 // Consumers must use this before a sidecar can replace its sibling raw result.
@@ -36,29 +57,36 @@ export function candidateEnvelopeMatchesSiblings({ envelope, manifest, metadata,
   const seat = nonEmptyString(metadata.seat);
   const scenario = nonEmptyString(metadata.scenario)?.replace(/\.js$/, '');
   if (!rowId || !candidateSha || !seat || !scenario || !SHA.test(candidateSha)) return false;
-  if (rowId === 'R-CD-2' && (
-    runResult.verdictSource !== 'r-cd-2-authoritative-receipt' ||
+  const authoritative = authoritativeReceiptContract(rowId);
+  if (authoritative && (
+    runResult.verdictSource !== authoritative.verdictSource ||
     runResult.authoritativeReceipt?.validated !== true ||
-    runResult.authoritativeReceipt?.source !== 'r-cd-2-row-scoped-resolver' ||
-    !existsSync(path.join(runDir, 'r-cd-2-authoritative-receipt.json'))
+    runResult.authoritativeReceipt?.source !== authoritative.source ||
+    runResult.authoritativeReceipt?.file !== authoritative.file ||
+    !existsSync(path.join(runDir, authoritative.file))
   )) return false;
   if (manifest.rowId !== rowId || scenarioName(manifest) !== scenario) return false;
   if (manifest.candidateSha && manifest.candidateSha !== candidateSha) return false;
   if (envelope.candidate?.sha !== candidateSha || !SHA.test(envelope.candidate?.docsRef || '')) return false;
   if (envelope.run?.id !== path.basename(runDir) || envelope.run?.rowId !== rowId || envelope.run?.seat !== seat || envelope.run?.scenario !== scenario) return false;
   if (envelope.result?.outcome !== runResult.verdict || envelope.result?.outcomeSource !== runResult.verdictSource) return false;
-  if (rowId === 'R-CD-2') {
+  if (authoritative) {
     const declared = runResult.authoritativeReceipt;
-    if (declared?.validated !== true || declared?.source !== 'r-cd-2-row-scoped-resolver' ||
-        envelope.authoritativeReceipt?.file !== 'r-cd-2-authoritative-receipt.json' ||
+    if (declared?.validated !== true || declared?.source !== authoritative.source ||
+        envelope.authoritativeReceipt?.file !== authoritative.file ||
         envelope.authoritativeReceipt?.sha256 !== declared?.sha256 ||
         !/^[a-f0-9]{64}$/iu.test(declared?.sha256 || '')) return false;
     try {
       const raw = readFileSync(path.join(runDir, declared.file));
       if (createHash('sha256').update(raw).digest('hex') !== declared.sha256) return false;
       const receipt = JSON.parse(raw.toString('utf8'));
-      const integrity = validateRcd2AuthoritativeReceipt(receipt, process.env.OPENCLAW_GATEWAY_TOKEN);
+      const integrity = authoritative.validate(receipt, process.env.OPENCLAW_GATEWAY_TOKEN);
       if (!integrity.valid || integrity.verdict !== runResult.verdict) return false;
+      if (rowId === 'R-CD-TOKEN' && (
+        receipt.binding?.candidateSha !== candidateSha ||
+        receipt.binding?.runtimeBuildSha !== candidateSha ||
+        metadata.runtimeBuildSha !== candidateSha
+      )) return false;
     } catch { return false; }
   }
   if (manifest.liveRunSafety?.expectedArtifactClass === 'construct-only' && envelope.result.outcome !== 'construct-only') return false;

--- a/tools/k6-proofs/scripts/collect-continuation-trace.mjs
+++ b/tools/k6-proofs/scripts/collect-continuation-trace.mjs
@@ -99,7 +99,9 @@ function traceContract(manifest, evidence) {
     mode = escapeTraceqlString(evidenceMode || manifestMode);
     acceptSpanName = 'continuation.delegate.dispatch';
     fireSpanName = 'continuation.delegate.fire';
-    attribution = 'reason-hash-length-mode';
+    attribution = manifest?.invocation?.originSurface === 'raw-final-text'
+      ? 'bracket-token-reason-hash-length-mode'
+      : 'reason-hash-length-mode';
   } else if (tool === 'continue_work') {
     const template = manifest?.invocation?.reason;
     if (!template) throw new Error('continue_work manifest reason is required');
@@ -150,6 +152,7 @@ function traceContract(manifest, evidence) {
     acceptSpanName,
     fireSpanName,
     attribution,
+    originSurface: manifest?.invocation?.originSurface,
   };
 }
 
@@ -206,6 +209,9 @@ function validateTrace(trace, expected) {
       : `matched trace contains ${accepts.length} ${expected.acceptSpanName} spans`);
   }
   const accept = accepts[0];
+  if (publicStatusCode(accept.status?.code) !== 'OK') {
+    throw new Error(`${expected.acceptSpanName} span is not status OK`);
+  }
   const acceptAttrs = attributes(accept);
   const chainId = String(acceptAttrs.get('chain.id') || '');
   if (!/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu.test(chainId)) {
@@ -224,18 +230,28 @@ function validateTrace(trace, expected) {
       : `matched trace contains ${fires.length} ${expected.fireSpanName} spans`);
   }
   const fire = fires[0];
+  if (publicStatusCode(fire.status?.code) !== 'OK') {
+    throw new Error(`${expected.fireSpanName} span is not status OK`);
+  }
 
   const tools = spans.filter((span) => {
     const attrs = attributes(span);
     return span.name === 'openclaw.tool.execution' &&
       attrs.get('gen_ai.tool.name') === expected.tool;
   });
-  if (tools.length !== 1) {
+  if (expected.originSurface === 'raw-final-text') {
+    if (tools.length !== 0) {
+      throw new Error(`bracket-token trace must not contain a typed ${expected.tool} tool span`);
+    }
+  } else if (tools.length !== 1) {
     throw new Error(
       tools.length === 0
         ? `matched trace lacks the originating ${expected.tool} tool span`
         : `matched trace contains ${tools.length} ${expected.tool} tool spans`,
     );
+  }
+  if (tools.some((span) => publicStatusCode(span.status?.code) !== 'OK')) {
+    throw new Error(`originating ${expected.tool} tool span is not status OK`);
   }
 
   const traceId = idHex(accept.traceId, 16, 'trace id');
@@ -382,6 +398,7 @@ async function main() {
               mode: contract.mode,
               acceptSpanName: contract.acceptSpanName,
               fireSpanName: contract.fireSpanName,
+              originSurface: contract.originSurface,
             })
           : validateToolTrace(trace, { tool: contract.tool });
         if (topology.traceId !== traceId) throw new Error('Tempo search and trace payload IDs disagree');
@@ -440,6 +457,7 @@ async function main() {
           },
           continuation: {
             tool: contract.tool,
+            originSurface: contract.originSurface || 'typed-tool',
             acceptSpan: contract.acceptSpanName,
             fireSpan: contract.fireSpanName,
           },

--- a/tools/k6-proofs/scripts/render-run-report.mjs
+++ b/tools/k6-proofs/scripts/render-run-report.mjs
@@ -14,6 +14,7 @@ import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { candidateEnvelopeMatchesSiblings } from './candidate-run-result-contract.mjs';
 import { validateRcd2AuthoritativeReceipt } from '../lib/r-cd-2-authoritative-receipt.mjs';
+import { validateRcdTokenAuthoritativeReceipt } from '../lib/r-cd-token-authoritative-receipt.mjs';
 
 function usage() {
   console.error('Usage: node render-run-report.mjs --root <run-out-root> [--out report.html]');
@@ -80,6 +81,24 @@ function numberFromDuration(raw) {
   return Number(raw);
 }
 
+function authoritativeReceiptContract(rowId) {
+  if (rowId === 'R-CD-2') {
+    return {
+      file: 'r-cd-2-authoritative-receipt.json',
+      verdictSource: 'r-cd-2-authoritative-receipt',
+      validate: validateRcd2AuthoritativeReceipt,
+    };
+  }
+  if (rowId === 'R-CD-TOKEN') {
+    return {
+      file: 'r-cd-token-authoritative-receipt.json',
+      verdictSource: 'r-cd-token-authoritative-receipt',
+      validate: validateRcdTokenAuthoritativeReceipt,
+    };
+  }
+  return null;
+}
+
 function receiptSummary({ manifest, runResult, evidenceRows }) {
   const receipts = [];
   for (const name of manifest?.liveRunSafety?.requiredReceipts || []) {
@@ -126,16 +145,22 @@ async function rowFromRunResult(root, runResultPath) {
   const evidenceRows = files.includes('evidence.jsonl') ? await readEvidenceJsonl(path.join(runDir, 'evidence.jsonl')) : [];
   const rel = path.relative(root, runDir).split(path.sep).join('/');
   const proofFailures = Number(summary?.metrics?.failures ?? runResult.proofFailures ?? (runResult.k6ExitCode === 0 ? 0 : 1));
-  let outcome = safeText(summary?.verdict || (runResult.k6ExitCode === 0 ? 'PASS-candidate' : 'FAIL-candidate'));
-  if ((metadata?.row || manifest?.rowId) === 'R-CD-2') {
+  let outcome = safeText(runResult.verdict || summary?.verdict || (runResult.k6ExitCode === 0 ? 'PASS-candidate' : 'FAIL-candidate'));
+  const authoritative = authoritativeReceiptContract(metadata?.row || manifest?.rowId);
+  if (authoritative) {
     const declared = runResult.authoritativeReceipt;
     try {
-      if (runResult.verdictSource !== 'r-cd-2-authoritative-receipt' || declared?.file !== 'r-cd-2-authoritative-receipt.json' || !/^[a-f0-9]{64}$/iu.test(declared?.sha256 || '')) throw new Error('missing authoritative receipt declaration');
+      if (runResult.verdictSource !== authoritative.verdictSource || declared?.file !== authoritative.file || !/^[a-f0-9]{64}$/iu.test(declared?.sha256 || '')) throw new Error('missing authoritative receipt declaration');
       const raw = await readFile(path.join(runDir, declared.file));
       if (createHash('sha256').update(raw).digest('hex') !== declared.sha256) throw new Error('authoritative receipt digest mismatch');
       const receipt = JSON.parse(raw.toString('utf8'));
-      const integrity = validateRcd2AuthoritativeReceipt(receipt, process.env.OPENCLAW_GATEWAY_TOKEN);
+      const integrity = authoritative.validate(receipt, process.env.OPENCLAW_GATEWAY_TOKEN);
       if (!integrity.valid || integrity.verdict !== runResult.verdict) throw new Error('authoritative receipt invalid');
+      if ((metadata?.row || manifest?.rowId) === 'R-CD-TOKEN' && (
+        receipt.binding?.candidateSha !== metadata?.candidateSha ||
+        receipt.binding?.runtimeBuildSha !== metadata?.runtimeBuildSha ||
+        metadata?.candidateSha !== metadata?.runtimeBuildSha
+      )) throw new Error('authoritative receipt build identity mismatch');
       outcome = safeText(receipt.verdict);
     } catch {
       outcome = 'PARTIAL-candidate';

--- a/tools/k6-proofs/scripts/resolve-r-cd-token-authoritative-receipt.mjs
+++ b/tools/k6-proofs/scripts/resolve-r-cd-token-authoritative-receipt.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { resolveRcdTokenAuthoritativeReceipt } from '../lib/r-cd-token-authoritative-receipt.mjs';
+
+function argsOf(argv) {
+  const out = {};
+  for (let i = 2; i < argv.length; i += 2) {
+    if (!argv[i]?.startsWith('--') || !argv[i + 1]) {
+      throw new Error('usage: --run-dir <dir> --evidence <json> [--correlation <json>]');
+    }
+    out[argv[i].slice(2)] = argv[i + 1];
+  }
+  return out;
+}
+
+async function readJson(file) {
+  try { return JSON.parse(await readFile(file, 'utf8')); }
+  catch { return null; }
+}
+
+const args = argsOf(process.argv);
+if (!args['run-dir'] || !args.evidence) throw new Error('run-dir and evidence are required');
+const runDir = path.resolve(args['run-dir']);
+const [evidence, attemptState, metadata, correlation] = await Promise.all([
+  readJson(args.evidence),
+  readJson(path.join(runDir, 'attempt-state.json')),
+  readJson(path.join(runDir, 'runner-metadata.json')),
+  readJson(args.correlation || path.join(runDir, 'continuation-trace-correlation.json')),
+]);
+const receipt = resolveRcdTokenAuthoritativeReceipt({
+  evidence,
+  correlation,
+  attemptState,
+  metadata,
+  signingKey: process.env.OPENCLAW_GATEWAY_TOKEN,
+});
+const target = path.join(runDir, 'r-cd-token-authoritative-receipt.json');
+await writeFile(target, `${JSON.stringify(receipt, null, 2)}\n`);
+process.stdout.write(`${JSON.stringify({ verdict: receipt.verdict, receipt: path.basename(target) })}\n`);

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -307,6 +307,10 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
         echo "[$ROW_ID] HONEST-LIMIT-candidate: seat readiness class '$OPENCLAW_SEAT_CLASS' is not scanner-supported raw-final-text; no dispatch occurred."
         continue
       fi
+      # R-CD-TOKEN is never allowed to fall back to the configured/live
+      # session. The scenario independently checks creation success and key
+      # distinctness before it can send the proof prompt.
+      export OPENCLAW_CREATE_DISPOSABLE_SESSION=true
     fi
     PRIVATE_K6_LOG="$(mktemp "${TMPDIR:-/tmp}/openclaw-k6-log.XXXXXX")"
     PRIVATE_EVIDENCE_FILE="$(mktemp "${TMPDIR:-/tmp}/openclaw-k6-evidence.XXXXXX")"

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -15,10 +15,17 @@ CONTINUATION_TRACE_COLLECTOR="$SCRIPT_DIR/collect-continuation-trace.mjs"
 R_CD_2_RECEIPT_RESOLVER="$SCRIPT_DIR/resolve-r-cd-2-authoritative-receipt.mjs"
 ARTIFACT_SANITIZER="$SCRIPT_DIR/sanitize-k6-artifacts.mjs"
 CANDIDATE_RESULT_VALIDATOR="$SCRIPT_DIR/validate-candidate-run-result.mjs"
+INTERRUPTED_RESULT_WRITER="$SCRIPT_DIR/write-interrupted-run-result.mjs"
+R_CD_TOKEN_RECEIPT_RESOLVER="$SCRIPT_DIR/resolve-r-cd-token-authoritative-receipt.mjs"
 PRIVATE_K6_LOG=""
 PRIVATE_EVIDENCE_FILE=""
 PRIVATE_GATEWAY_LOG=""
 SOURCE_CONTRACT_FILE=""
+ACTIVE_TOKEN_RUN_DIR=""
+ACTIVE_TOKEN_PHASE=""
+ACTIVE_TOKEN_ATTEMPT_HASH=""
+ACTIVE_TOKEN_NONCE_HASH=""
+ACTIVE_TOKEN_CAUSE="runner-exit-before-terminal-result"
 
 cleanup_private_artifacts() {
   rm -f \
@@ -27,7 +34,31 @@ cleanup_private_artifacts() {
     "${PRIVATE_GATEWAY_LOG:-}" \
     "${SOURCE_CONTRACT_FILE:-}"
 }
-trap cleanup_private_artifacts EXIT
+
+finalize_interrupted_token_run() {
+  local exit_code=$?
+  # ACTIVE_TOKEN_RUN_DIR is cleared only after the row's entire terminal packet
+  # is complete.  If it is still set, even an already-created run-result may be
+  # truncated or pre-terminal and must be superseded fail-closed.
+  if [[ -n "${ACTIVE_TOKEN_RUN_DIR:-}" ]]; then
+    if ! node "$INTERRUPTED_RESULT_WRITER" \
+      --run-dir "$ACTIVE_TOKEN_RUN_DIR" \
+      --row R-CD-TOKEN \
+      --candidate-sha "$OPENCLAW_CANDIDATE_SHA" \
+      --runtime-sha "$OPENCLAW_RUNTIME_BUILD_SHA" \
+      --attempt-hash "$ACTIVE_TOKEN_ATTEMPT_HASH" \
+      --nonce-hash "$ACTIVE_TOKEN_NONCE_HASH" \
+      --phase "${ACTIVE_TOKEN_PHASE:-unknown}" \
+      --cause "${ACTIVE_TOKEN_CAUSE:-runner-exit-before-terminal-result}"; then
+      echo "[R-CD-TOKEN] ERROR: failed to persist interruption receipt at $ACTIVE_TOKEN_RUN_DIR" >&2
+    fi
+  fi
+  cleanup_private_artifacts
+  return "$exit_code"
+}
+trap finalize_interrupted_token_run EXIT
+trap 'ACTIVE_TOKEN_CAUSE=signal-int; exit 130' INT
+trap 'ACTIVE_TOKEN_CAUSE=signal-term; exit 143' TERM
 
 DRY_RUN=true
 ROWS=""
@@ -208,9 +239,6 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
     touch "$RUN_DIR/.started"
     cp "$MANIFEST_FILE" "$RUN_DIR/row-manifest.json"
     RUN_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-    if [[ -f "$SEAT_READINESS_JSON" ]]; then
-      cp "$SEAT_READINESS_JSON" "$RUN_DIR/seat-readiness.json"
-    fi
     jq -n \
       --arg row "$ROW_ID" \
       --arg scenario "$SCENARIO_FILE" \
@@ -220,7 +248,66 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
       --arg started "$RUN_STARTED_AT" \
       '{row:$row, scenario:$scenario, candidateSha:$candidate, runtimeBuildSha:$runtime, seat:$seat, sessionConfigured:true, startedAt:$started}' \
       > "$RUN_DIR/runner-metadata.json"
-
+    if [[ "$ROW_ID" == "R-CD-TOKEN" ]]; then
+      if [[ ! "$OPENCLAW_CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ||
+            ! "$OPENCLAW_RUNTIME_BUILD_SHA" =~ ^[0-9a-f]{40}$ ||
+            "$OPENCLAW_CANDIDATE_SHA" != "$OPENCLAW_RUNTIME_BUILD_SHA" ]]; then
+        RUN_ENDED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        jq -n \
+          --arg candidateSha "$OPENCLAW_CANDIDATE_SHA" \
+          --arg runtimeBuildSha "$OPENCLAW_RUNTIME_BUILD_SHA" \
+          --arg endedAt "$RUN_ENDED_AT" \
+          '{schema:"openclaw.k6.r-cd-token.build-identity-gate.v1",row:"R-CD-TOKEN",candidateSha:$candidateSha,runtimeBuildSha:$runtimeBuildSha,equalExactSha:false,dispatched:false,verdict:"HONEST-LIMIT-candidate",endedAt:$endedAt}' \
+          > "$RUN_DIR/build-identity-gate.json"
+        jq -n \
+          --arg endedAt "$RUN_ENDED_AT" \
+          '{k6ExitCode:0,postprocessExitCode:0,effectiveExitCode:0,endedAt:$endedAt,verdict:"HONEST-LIMIT-candidate",verdictSource:"pre-dispatch-build-identity-gate",summaryFileVerdict:null,vuLogVerdict:null,summaryFiles:[],evidence:{row:"R-CD-TOKEN",dispatched:false},candidateOnly:true,foldRequiresReview:true,terminal:true,observability:{traceStatus:"not-applicable",traceId:null,tempoTraceJson:null,correlationReceipt:null,serviceLogStatus:"not-started",serviceLog:null,serviceLogCapture:null,serviceLogRedaction:null},review:{status:"review-pending",pendingReceipts:["exact-candidate-runtime-identity","attempt-state","raw-final-text-origin","parser-detected","queue-identity","child-spawned","child-completed","parent-return-event","tempo-trace-json","continuation-trace-correlation"]}}' \
+          > "$RUN_DIR/run-result.json"
+        rm -f "$RUN_DIR/.started"
+        echo "[$ROW_ID] HONEST-LIMIT-candidate: exact equal candidate/runtime SHAs are required; no dispatch occurred."
+        continue
+      fi
+      ATTEMPT_UUID="$(cat /proc/sys/kernel/random/uuid)"
+      export OPENCLAW_PROOF_ATTEMPT_ID="${RUN_ID}-${ATTEMPT_UUID}"
+      export OPENCLAW_ROW_NONCE="R-CD-TOKEN-${ATTEMPT_UUID}"
+      ACTIVE_TOKEN_RUN_DIR="$RUN_DIR"
+      ACTIVE_TOKEN_PHASE="prepared"
+      ACTIVE_TOKEN_ATTEMPT_HASH="$(printf '%s' "$OPENCLAW_PROOF_ATTEMPT_ID" | sha256sum | cut -c1-16)"
+      ACTIVE_TOKEN_NONCE_HASH="$(printf '%s' "$OPENCLAW_ROW_NONCE" | sha256sum | cut -c1-16)"
+      jq -n \
+        --arg attemptIdHash "$ACTIVE_TOKEN_ATTEMPT_HASH" \
+        --arg rowNonceHash "$ACTIVE_TOKEN_NONCE_HASH" \
+        --arg candidateSha "$OPENCLAW_CANDIDATE_SHA" \
+        --arg runtimeBuildSha "$OPENCLAW_RUNTIME_BUILD_SHA" \
+        --arg startedAt "$RUN_STARTED_AT" \
+        '{schema:"openclaw.k6.r-cd-token.attempt-state.v1",row:"R-CD-TOKEN",attemptIdHash:$attemptIdHash,rowNonceHash:$rowNonceHash,candidateSha:$candidateSha,runtimeBuildSha:$runtimeBuildSha,startedAt:$startedAt,phase:"prepared",proofTerminal:false,consumptionState:"not-yet-dispatched",automaticRetryAllowed:false}' \
+        > "$RUN_DIR/attempt-state.json"
+    fi
+    if [[ -f "$SEAT_READINESS_JSON" ]]; then
+      cp "$SEAT_READINESS_JSON" "$RUN_DIR/seat-readiness.json"
+    fi
+    if [[ "$ROW_ID" == "R-CD-TOKEN" ]]; then
+      export OPENCLAW_SEAT_CLASS="$(jq -r '.seat.class // "unknown"' "$RUN_DIR/seat-readiness.json" 2>/dev/null || echo unknown)"
+      if [[ "$OPENCLAW_SEAT_CLASS" != "raw-final-text" ]]; then
+        RUN_ENDED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        jq \
+          --arg endedAt "$RUN_ENDED_AT" \
+          --arg surfaceClass "$OPENCLAW_SEAT_CLASS" \
+          '. + {endedAt:$endedAt,phase:"pre-dispatch-surface-gate",proofTerminal:true,consumptionState:"not-dispatched",automaticRetryAllowed:false,verdict:"HONEST-LIMIT-candidate",surfaceClass:$surfaceClass,effectiveExitCode:0}' \
+          "$RUN_DIR/attempt-state.json" > "$RUN_DIR/attempt-state.json.tmp"
+        mv "$RUN_DIR/attempt-state.json.tmp" "$RUN_DIR/attempt-state.json"
+        jq -n \
+          --arg endedAt "$RUN_ENDED_AT" \
+          --arg surfaceClass "$OPENCLAW_SEAT_CLASS" \
+          '{k6ExitCode:0,postprocessExitCode:0,effectiveExitCode:0,endedAt:$endedAt,verdict:"HONEST-LIMIT-candidate",verdictSource:"pre-dispatch-surface-gate",summaryFileVerdict:null,vuLogVerdict:null,summaryFiles:[],evidence:{row:"R-CD-TOKEN",surface_class:$surfaceClass,dispatched:false},candidateOnly:true,foldRequiresReview:true,terminal:true,observability:{traceStatus:"not-applicable",traceId:null,tempoTraceJson:null,correlationReceipt:null,serviceLogStatus:"not-started",serviceLog:null,serviceLogCapture:null,serviceLogRedaction:null},review:{status:"review-pending",pendingReceipts:["raw-final-text-origin","parser-detected","queue-identity","child-spawned","child-completed","parent-return-event","tempo-trace-json","continuation-trace-correlation"]}}' \
+          > "$RUN_DIR/run-result.json"
+        rm -f "$RUN_DIR/.started"
+        ACTIVE_TOKEN_PHASE="pre-dispatch-surface-gate"
+        ACTIVE_TOKEN_RUN_DIR=""
+        echo "[$ROW_ID] HONEST-LIMIT-candidate: seat readiness class '$OPENCLAW_SEAT_CLASS' is not scanner-supported raw-final-text; no dispatch occurred."
+        continue
+      fi
+    fi
     PRIVATE_K6_LOG="$(mktemp "${TMPDIR:-/tmp}/openclaw-k6-log.XXXXXX")"
     PRIVATE_EVIDENCE_FILE="$(mktemp "${TMPDIR:-/tmp}/openclaw-k6-evidence.XXXXXX")"
     PRIVATE_GATEWAY_LOG="$(mktemp "${TMPDIR:-/tmp}/openclaw-gateway-journal.XXXXXX")"
@@ -259,10 +346,12 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
       unset OPENCLAW_STATUS_SOURCE_PATH
     fi
     POSTPROCESS_RC=0
+    if [[ "$ROW_ID" == "R-CD-TOKEN" ]]; then ACTIVE_TOKEN_PHASE="k6-running"; fi
     set +e
     k6 run "scenarios/$SCENARIO_FILE" > "$PRIVATE_K6_LOG" 2>&1
     k6_rc=$?
     set -e
+    if [[ "$ROW_ID" == "R-CD-TOKEN" ]]; then ACTIVE_TOKEN_PHASE="postprocess"; fi
     RUN_ENDED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
     set +e
@@ -475,6 +564,27 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
       fi
     fi
 
+    R_CD_TOKEN_RECEIPT=""
+    R_CD_TOKEN_RECEIPT_SHA256=""
+    if [[ "$ROW_ID" == "R-CD-TOKEN" ]]; then
+      R_CD_TOKEN_RECEIPT="r-cd-token-authoritative-receipt.json"
+      TOKEN_RESOLVER_ARGS=(--run-dir "$RUN_DIR" --evidence "$PRIVATE_EVIDENCE_FILE")
+      if [[ -n "$CORRELATION_RECEIPT_PATH" && -f "$CORRELATION_RECEIPT_PATH" ]]; then
+        TOKEN_RESOLVER_ARGS+=(--correlation "$CORRELATION_RECEIPT_PATH")
+      fi
+      if node "$R_CD_TOKEN_RECEIPT_RESOLVER" "${TOKEN_RESOLVER_ARGS[@]}" > "$RUN_DIR/r-cd-token-authoritative-resolution.json"; then
+        SUMMARY_VERDICT="$(jq -r '.verdict // "PARTIAL-candidate"' "$RUN_DIR/$R_CD_TOKEN_RECEIPT")"
+        SUMMARY_VERDICT_SOURCE="r-cd-token-authoritative-receipt"
+        SUMMARY_FILE_VERDICT="$SUMMARY_VERDICT"
+        VU_LOG_VERDICT=""
+        R_CD_TOKEN_RECEIPT_SHA256="$(sha256sum "$RUN_DIR/$R_CD_TOKEN_RECEIPT" | cut -d' ' -f1)"
+      else
+        SUMMARY_VERDICT="PARTIAL-candidate"
+        SUMMARY_VERDICT_SOURCE="r-cd-token-authoritative-receipt-missing"
+        POSTPROCESS_RC=1
+      fi
+    fi
+
     if ! node "$ARTIFACT_SANITIZER" \
       --input "$PRIVATE_EVIDENCE_FILE" \
       --out "$RUN_DIR/evidence.jsonl" \
@@ -535,6 +645,18 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
     if [[ "$EFFECTIVE_RC" -eq 0 && "$POSTPROCESS_RC" -ne 0 ]]; then
       EFFECTIVE_RC="$POSTPROCESS_RC"
     fi
+    AUTHORITATIVE_RECEIPT=""
+    AUTHORITATIVE_RECEIPT_SHA256=""
+    AUTHORITATIVE_RECEIPT_SOURCE=""
+    if [[ "$ROW_ID" == "R-CD-2" ]]; then
+      AUTHORITATIVE_RECEIPT="$R_CD_2_RECEIPT"
+      AUTHORITATIVE_RECEIPT_SHA256="$R_CD_2_RECEIPT_SHA256"
+      AUTHORITATIVE_RECEIPT_SOURCE="r-cd-2-row-scoped-resolver"
+    elif [[ "$ROW_ID" == "R-CD-TOKEN" ]]; then
+      AUTHORITATIVE_RECEIPT="$R_CD_TOKEN_RECEIPT"
+      AUTHORITATIVE_RECEIPT_SHA256="$R_CD_TOKEN_RECEIPT_SHA256"
+      AUTHORITATIVE_RECEIPT_SOURCE="r-cd-token-row-scoped-resolver"
+    fi
     jq -n \
       --argjson rc "$k6_rc" \
       --argjson postprocessRc "$POSTPROCESS_RC" \
@@ -545,7 +667,9 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
       --arg tempoTraceJson "$TEMPO_TRACE_JSON" \
       --arg correlationReceipt "$CORRELATION_RECEIPT" \
       --arg lifecycleReceipt "$R_CD_2_RECEIPT" \
-      --arg authoritativeReceiptSha256 "$R_CD_2_RECEIPT_SHA256" \
+      --arg authoritativeReceipt "$AUTHORITATIVE_RECEIPT" \
+      --arg authoritativeReceiptSource "$AUTHORITATIVE_RECEIPT_SOURCE" \
+      --arg authoritativeReceiptSha256 "$AUTHORITATIVE_RECEIPT_SHA256" \
       --arg serviceLogStatus "$GATEWAY_JOURNAL_STATUS" \
       --arg verdict "$SUMMARY_VERDICT" \
       --arg verdictSource "$SUMMARY_VERDICT_SOURCE" \
@@ -554,8 +678,19 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
       --argjson summaryFiles "$SUMMARY_FILES_JSON" \
       --argjson evidence "$EVIDENCE_JSON" \
       --argjson reviewPendingReceipts "$REVIEW_PENDING_RECEIPTS" \
-      '{k6ExitCode:$rc, postprocessExitCode:$postprocessRc, effectiveExitCode:$effectiveRc, endedAt:$ended, verdict:(if $verdict == "unknown" then null else $verdict end), verdictSource:$verdictSource, summaryFileVerdict:(if $summaryFileVerdict == "unknown" then null else $summaryFileVerdict end), vuLogVerdict:(if $vuLogVerdict == "" then null else $vuLogVerdict end), summaryFiles:$summaryFiles, evidence:$evidence, candidateOnly:true, foldRequiresReview:true, authoritativeReceipt:(if $authoritativeReceiptSha256 == "" then null else {file:"r-cd-2-authoritative-receipt.json", sha256:$authoritativeReceiptSha256, validated:true, source:"r-cd-2-row-scoped-resolver"} end), observability:{traceStatus:$traceStatus, traceId:(if $traceId == "" then null else $traceId end), tempoTraceJson:(if $tempoTraceJson == "" then null else $tempoTraceJson end), correlationReceipt:(if $correlationReceipt == "" then null else $correlationReceipt end), lifecycleReceipt:(if $lifecycleReceipt == "" then null else $lifecycleReceipt end), serviceLogStatus:$serviceLogStatus, serviceLog:"gateway-journal.log", serviceLogCapture:"gateway-journal-capture.json", serviceLogRedaction:"gateway-journal-redaction.json"}, review:{status:(if ($reviewPendingReceipts|length)>0 then "review-pending" else "ready-for-human-review" end), pendingReceipts:$reviewPendingReceipts}}' \
+      '{k6ExitCode:$rc, postprocessExitCode:$postprocessRc, effectiveExitCode:$effectiveRc, endedAt:$ended, verdict:(if $verdict == "unknown" then null else $verdict end), verdictSource:$verdictSource, summaryFileVerdict:(if $summaryFileVerdict == "unknown" then null else $summaryFileVerdict end), vuLogVerdict:(if $vuLogVerdict == "" then null else $vuLogVerdict end), summaryFiles:$summaryFiles, evidence:$evidence, candidateOnly:true, foldRequiresReview:true, authoritativeReceipt:(if $authoritativeReceiptSha256 == "" then null else {file:$authoritativeReceipt, sha256:$authoritativeReceiptSha256, validated:true, source:$authoritativeReceiptSource} end), observability:{traceStatus:$traceStatus, traceId:(if $traceId == "" then null else $traceId end), tempoTraceJson:(if $tempoTraceJson == "" then null else $tempoTraceJson end), correlationReceipt:(if $correlationReceipt == "" then null else $correlationReceipt end), lifecycleReceipt:(if $lifecycleReceipt == "" then null else $lifecycleReceipt end), serviceLogStatus:$serviceLogStatus, serviceLog:"gateway-journal.log", serviceLogCapture:"gateway-journal-capture.json", serviceLogRedaction:"gateway-journal-redaction.json"}, review:{status:(if ($reviewPendingReceipts|length)>0 then "review-pending" else "ready-for-human-review" end), pendingReceipts:$reviewPendingReceipts}}' \
       > "$RUN_DIR/run-result.json"
+    if [[ "$ROW_ID" == "R-CD-TOKEN" ]]; then
+      jq \
+        --arg endedAt "$RUN_ENDED_AT" \
+        --arg verdict "$SUMMARY_VERDICT" \
+        --argjson effectiveExitCode "$EFFECTIVE_RC" \
+        '. + {endedAt:$endedAt,phase:"terminal-result-written",proofTerminal:true,consumptionState:(if $verdict == "PASS-candidate" then "complete" else "non-pass-terminal" end),automaticRetryAllowed:false,verdict:(if $verdict == "unknown" then "PARTIAL-candidate" else $verdict end),effectiveExitCode:$effectiveExitCode}' \
+        "$RUN_DIR/attempt-state.json" > "$RUN_DIR/attempt-state.json.tmp"
+      mv "$RUN_DIR/attempt-state.json.tmp" "$RUN_DIR/attempt-state.json"
+      ACTIVE_TOKEN_PHASE="terminal-result-written"
+      ACTIVE_TOKEN_RUN_DIR=""
+    fi
     # A review-complete candidate can now receive a public-safe routing
     # envelope. Review-pending runs intentionally remain represented only by
     # run-result.json so review-debt can route their missing receipts; neither

--- a/tools/k6-proofs/scripts/validate-candidate-run-result.mjs
+++ b/tools/k6-proofs/scripts/validate-candidate-run-result.mjs
@@ -9,6 +9,7 @@ import { readFile, writeFile, readdir, realpath } from 'node:fs/promises';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { validateRcd2AuthoritativeReceipt } from '../lib/r-cd-2-authoritative-receipt.mjs';
+import { validateRcdTokenAuthoritativeReceipt } from '../lib/r-cd-token-authoritative-receipt.mjs';
 
 const SHA = /^[0-9a-f]{40}$/;
 const OUTCOME = new Set(['PASS-candidate', 'HONEST-LIMIT-candidate', 'PARTIAL-candidate', 'FAIL-candidate', 'construct-only']);
@@ -71,12 +72,32 @@ function manifestCandidateSha(manifest) {
   return SHA.test(value || '') ? value : null;
 }
 
+function authoritativeReceiptContract(rowId) {
+  if (rowId === 'R-CD-2') {
+    return {
+      file: 'r-cd-2-authoritative-receipt.json',
+      verdictSource: 'r-cd-2-authoritative-receipt',
+      validate: validateRcd2AuthoritativeReceipt,
+    };
+  }
+  if (rowId === 'R-CD-TOKEN') {
+    return {
+      file: 'r-cd-token-authoritative-receipt.json',
+      verdictSource: 'r-cd-token-authoritative-receipt',
+      validate: validateRcdTokenAuthoritativeReceipt,
+    };
+  }
+  return null;
+}
+
 async function listSafeArtifacts(dir) {
   const entries = await readdir(dir, { withFileTypes: true });
   const allowed = new Set([
     'row-manifest.json', 'runner-metadata.json', 'run-result.json',
     'candidate-run-result.json', 'seat-readiness.json', 'evidence.jsonl',
     'r-cd-2-authoritative-receipt.json',
+    'attempt-state.json', 'build-identity-gate.json', 'interruption-receipt.json',
+    'r-cd-token-authoritative-receipt.json',
     'evidence-lines.log', 'evidence-redaction.json', 'gateway-journal.log',
     'gateway-journal-capture.json', 'gateway-journal-redaction.json',
   ]);
@@ -121,16 +142,22 @@ async function main() {
 
   const observability = runResult.observability || {};
   let authoritativeReceipt = null;
-  if (rowId === 'R-CD-2') {
+  const authoritative = authoritativeReceiptContract(rowId);
+  if (authoritative) {
     const declared = runResult.authoritativeReceipt;
-    if (runResult.verdictSource !== 'r-cd-2-authoritative-receipt' || declared?.file !== 'r-cd-2-authoritative-receipt.json' || !/^[a-f0-9]{64}$/iu.test(declared?.sha256 || '')) {
-      throw new Error('R-CD-2 candidate requires a declared authoritative receipt digest');
+    if (runResult.verdictSource !== authoritative.verdictSource || declared?.file !== authoritative.file || !/^[a-f0-9]{64}$/iu.test(declared?.sha256 || '')) {
+      throw new Error(`${rowId} candidate requires a declared authoritative receipt digest`);
     }
     const raw = await readFile(path.join(candidateDir, declared.file));
-    if (createHash('sha256').update(raw).digest('hex') !== declared.sha256) throw new Error('R-CD-2 authoritative receipt digest mismatch');
+    if (createHash('sha256').update(raw).digest('hex') !== declared.sha256) throw new Error(`${rowId} authoritative receipt digest mismatch`);
     authoritativeReceipt = JSON.parse(raw);
-    const integrity = validateRcd2AuthoritativeReceipt(authoritativeReceipt, process.env.OPENCLAW_GATEWAY_TOKEN);
-    if (!integrity.valid || integrity.verdict !== runResult.verdict) throw new Error(`R-CD-2 authoritative receipt invalid: ${integrity.reason || 'verdict mismatch'}`);
+    const integrity = authoritative.validate(authoritativeReceipt, process.env.OPENCLAW_GATEWAY_TOKEN);
+    if (!integrity.valid || integrity.verdict !== runResult.verdict) throw new Error(`${rowId} authoritative receipt invalid: ${integrity.reason || 'verdict mismatch'}`);
+    if (rowId === 'R-CD-TOKEN' && (
+      authoritativeReceipt.binding?.candidateSha !== candidateSha ||
+      authoritativeReceipt.binding?.runtimeBuildSha !== requireSha(metadata.runtimeBuildSha, 'runner metadata runtimeBuildSha') ||
+      authoritativeReceipt.binding.runtimeBuildSha !== candidateSha
+    )) throw new Error('R-CD-TOKEN authoritative receipt build identity mismatch');
   }
   const artifacts = {
     manifest: 'row-manifest.json',
@@ -164,7 +191,7 @@ async function main() {
       traceCaptured: Boolean(observability.traceId),
       correlationReceiptPresent: Boolean(observability.correlationReceipt),
     },
-    ...(authoritativeReceipt ? { authoritativeReceipt: { file: 'r-cd-2-authoritative-receipt.json', sha256: runResult.authoritativeReceipt.sha256 } } : {}),
+    ...(authoritativeReceipt ? { authoritativeReceipt: { file: authoritative.file, sha256: runResult.authoritativeReceipt.sha256 } } : {}),
     review: { status: review.status, pendingReceipts: [], complete: true },
     artifacts,
   };

--- a/tools/k6-proofs/scripts/write-interrupted-run-result.mjs
+++ b/tools/k6-proofs/scripts/write-interrupted-run-result.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const SHA = /^[0-9a-f]{40}$/;
+const HASH = /^[0-9a-f]{16}$/;
+
+function argsOf(argv) {
+  const out = {};
+  for (let i = 2; i < argv.length; i += 2) {
+    const key = argv[i]; const value = argv[i + 1];
+    if (!key?.startsWith('--') || value == null) throw new Error(`invalid argument near ${key || '(end)'}`);
+    out[key.slice(2).replaceAll('-', '')] = value;
+  }
+  return out;
+}
+
+async function main() {
+  const a = argsOf(process.argv);
+  if (!a.rundir || a.row !== 'R-CD-TOKEN') throw new Error('R-CD-TOKEN run-dir and row are required');
+  if (!SHA.test(a.candidatesha || '') || !SHA.test(a.runtimesha || '')) throw new Error('candidate/runtime SHA must be exact 40-character lowercase hex');
+  if (!HASH.test(a.attempthash || '') || !HASH.test(a.noncehash || '')) throw new Error('attempt/nonce fingerprints must be 16-character lowercase hex');
+  const dir = path.resolve(a.rundir);
+  await mkdir(dir, { recursive: true });
+  const runResult = path.join(dir, 'run-result.json');
+  const now = new Date().toISOString();
+  const receipt = {
+    schema: 'openclaw.k6.r-cd-token.interruption-receipt.v1',
+    row: a.row,
+    candidateSha: a.candidatesha,
+    runtimeBuildSha: a.runtimesha,
+    attemptIdHash: a.attempthash,
+    rowNonceHash: a.noncehash,
+    phase: a.phase || 'unknown',
+    cause: a.cause || 'runner-exit-before-terminal-result',
+    proofTerminal: false,
+    consumptionState: 'unknown-possibly-consumed',
+    automaticRetryAllowed: false,
+    candidateOutcome: 'PARTIAL-candidate',
+    generatedAt: now,
+  };
+  const attemptStatePath = path.join(dir, 'attempt-state.json');
+  try {
+    const attemptState = JSON.parse(await readFile(attemptStatePath, 'utf8'));
+    if (attemptState?.schema === 'openclaw.k6.r-cd-token.attempt-state.v1') {
+      attemptState.phase = 'interrupted';
+      attemptState.proofTerminal = false;
+      attemptState.terminal = false;
+      attemptState.consumptionState = 'unknown-possibly-consumed';
+      attemptState.endedAt = now;
+      attemptState.automaticRetryAllowed = false;
+      await writeFile(attemptStatePath, `${JSON.stringify(attemptState, null, 2)}\n`);
+    }
+  } catch {
+    // The interruption receipt remains authoritative if attempt-state is absent or malformed.
+  }
+  await writeFile(path.join(dir, 'interruption-receipt.json'), `${JSON.stringify(receipt, null, 2)}\n`, { flag: 'wx' });
+  await writeFile(runResult, `${JSON.stringify({
+    k6ExitCode: 130,
+    postprocessExitCode: 1,
+    effectiveExitCode: 130,
+    endedAt: now,
+    verdict: 'PARTIAL-candidate',
+    verdictSource: 'runner-interruption-receipt',
+    summaryFileVerdict: null,
+    vuLogVerdict: null,
+    summaryFiles: [],
+    evidence: null,
+    candidateOnly: true,
+    foldRequiresReview: true,
+    terminal: false,
+    interruption: receipt,
+    observability: {
+      traceStatus: 'unknown', traceId: null, tempoTraceJson: null, correlationReceipt: null,
+      serviceLogStatus: 'unknown', serviceLog: null, serviceLogCapture: null, serviceLogRedaction: null,
+    },
+    review: {
+      status: 'review-pending',
+      pendingReceipts: ['parser-detected', 'queue-identity', 'child-spawned', 'child-completed', 'parent-return-event', 'tempo-trace-json', 'continuation-trace-correlation'],
+    },
+  }, null, 2)}\n`);
+}
+
+main().catch((error) => { console.error(error.message || error); process.exitCode = 1; });


### PR DESCRIPTION
## Summary

Refs #426.

Hardens the `R-CD-TOKEN` proof harness so the bracket-token path cannot become `PASS-candidate` from a partial, duplicated, cross-attempt, undeclared-surface, identity-mismatched, tampered, interrupted, title-truncated, or non-disposable-origin run.

## What Problem This Solves

The prior row could classify incomplete evidence fail-closed, but it did not yet make the intended live proof genuinely runnable and safe:

- production exposes `TaskSummary.title` through an 80-character cap, while the bracket delegate task has a 63-character production wrapper; a longer marker was truncated and could never be ledger-matched;
- disposable-session creation was optional in the scenario, so a direct invocation could still send the proof prompt to a configured/live session even though that run could not later PASS;
- partial lifecycle, duplicate scheduling, mismatched task/session lineage, arbitrary return text, trace ambiguity, and unsigned report surfaces needed one row-scoped authority boundary.

This head uses a 14-character opaque marker as the first bytes of `signal.task`, leaving three characters of margin under the exact production depth-1 wrapper, and tests the exact production construction/truncation. The runner forces disposable creation; the scenario independently refuses `sessions.send` unless creation succeeded with a non-empty session key distinct from the requested session. The signed receipt and PASS classifier both require that disposable-origin gate.

## Evidence / Implementation

- gates dispatch on exact equal lowercase 40-character candidate/runtime build SHAs and declared `raw-final-text`;
- forces a newly-created disposable origin and rejects disabled, failed, missing-key, or fallback-to-requested-session creation before `sessions.send`;
- paginates the public task ledger and requires exactly one origin plus exactly one completed delegate bound by requester/task/session lineage;
- matches the 14-character delegate marker through the exact 63-character production wrapper and 80-character public title projection;
- accepts only the structured `session.message` parent return for the bound child;
- requires exactly one token accept/fire/dispatch topology with no typed `continue_delegate` origin;
- resolves a row-scoped HMAC-signed authoritative receipt; candidate and report surfaces validate the persisted receipt plus SHA-256 digest;
- records active-at-exit attempts as immutable, non-terminal, non-retriable interruption evidence, overriding premature/pass-shaped run results;
- keeps scenario output non-authoritative (`PARTIAL-candidate`) until the signed resolver promotes it;
- preserves the existing `R-CD-2` authoritative-receipt path.

## Static Validation

Exact head: `3e26ac769295099ccde164823c688617830bb257`

- `node --test tools/k6-proofs/scripts/__tests__/*.test.mjs` — **190/190 PASS**
- focused R-CD-TOKEN/candidate/continuation suite after final edits — **34/34 PASS**
- `node tools/k6-proofs/scripts/check-proof-row-manifests.mjs` — PASS
- `node tools/k6-proofs/scripts/check-manifest-scenarios.mjs` — PASS
- `bash -n tools/k6-proofs/scripts/run-proofs.sh` — PASS
- changed `.mjs` files checked with `node --check` — PASS
- `git diff --check` — PASS

A fresh independent static review is required on this exact head before fold.

## Safety Boundary

No live proof was fired. No GitHub Actions workflow was manually dispatched. No fleet/core config or runtime state was mutated. The row remains readiness-only until this harness is merged, the intended successor is deployed, and the target seat independently proves its running build SHA equals the supplied candidate SHA.
