### PR TITLE
fix(proofs): follow split status formatter source

### DIFF
--- a/tools/k6-proofs/lib/source-function-extractor.js
+++ b/tools/k6-proofs/lib/source-function-extractor.js
@@ -1,0 +1,82 @@
+/**
+ * Extract the body of a named exported function from exact candidate source.
+ *
+ * The proof harness executes candidate-owned dependency-free functions without
+ * compiling the whole repository. A declaration-following text marker is too
+ * brittle for this: moving a function into its own module changes the next
+ * declaration without changing the function contract. Balance the function's
+ * braces instead, while ignoring brace-like characters in strings/comments.
+ */
+export function extractExportedFunctionBody(source, functionName, signatureEndMarker) {
+  const declarationMarker = `export function ${functionName}`;
+  const declarationStart = source.indexOf(declarationMarker);
+  if (declarationStart < 0) {
+    throw new Error(`${functionName} export was not found`);
+  }
+
+  const signatureEnd = source.indexOf(signatureEndMarker, declarationStart);
+  if (signatureEnd < 0) {
+    throw new Error(`${functionName} signature marker was not found`);
+  }
+  const bodyOpen = signatureEnd + signatureEndMarker.lastIndexOf('{');
+  if (source[bodyOpen] !== '{') {
+    throw new Error(`${functionName} body start was not found`);
+  }
+
+  let depth = 1;
+  let mode = 'code';
+  let escaped = false;
+
+  for (let index = bodyOpen + 1; index < source.length; index += 1) {
+    const char = source[index];
+    const next = source[index + 1];
+
+    if (mode === 'line-comment') {
+      if (char === '\n') mode = 'code';
+      continue;
+    }
+    if (mode === 'block-comment') {
+      if (char === '*' && next === '/') {
+        mode = 'code';
+        index += 1;
+      }
+      continue;
+    }
+    if (mode !== 'code') {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === mode) {
+        mode = 'code';
+      }
+      continue;
+    }
+
+    if (char === '/' && next === '/') {
+      mode = 'line-comment';
+      index += 1;
+      continue;
+    }
+    if (char === '/' && next === '*') {
+      mode = 'block-comment';
+      index += 1;
+      continue;
+    }
+    if (char === "'" || char === '"' || char === '`') {
+      mode = char;
+      escaped = false;
+      continue;
+    }
+    if (char === '{') {
+      depth += 1;
+      continue;
+    }
+    if (char === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(bodyOpen + 1, index);
+    }
+  }
+
+  throw new Error(`${functionName} closing brace was not found`);
+}

--- a/tools/k6-proofs/manifests/r-obs-status.json
+++ b/tools/k6-proofs/manifests/r-obs-status.json
@@ -17,7 +17,7 @@
   },
   "sourceContract": {
     "repository": "karmaterminal/openclaw",
-    "path": "src/status/status-text.ts",
+    "path": "src/status/status-continuation-line.ts",
     "issue": 1172,
     "publicEvidence": [
       "candidate_sha",

--- a/tools/k6-proofs/scenarios/r-obs-status.js
+++ b/tools/k6-proofs/scenarios/r-obs-status.js
@@ -17,6 +17,7 @@ import { check } from 'k6';
 import crypto from 'k6/crypto';
 import { Counter, Trend } from 'k6/metrics';
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+import { extractExportedFunctionBody } from '../lib/source-function-extractor.js';
 
 export const options = {
   scenarios: {
@@ -38,8 +39,6 @@ const duration = new Trend('r_obs_status_duration');
 const manifest = loadManifestFromEnv();
 const prefetchedSourcePath = __ENV.OPENCLAW_STATUS_SOURCE_PATH || '';
 const prefetchedSource = prefetchedSourcePath ? open(prefetchedSourcePath) : '';
-const FORMATTER_START = 'export function formatStatusTextContinuationLine(params: {';
-const FORMATTER_END = '\n}\n\nconst loadStatusMessageRuntime';
 const FORMATTER_SIGNATURE_END = '}): string | undefined {';
 
 function fail(message) {
@@ -48,15 +47,11 @@ function fail(message) {
 }
 
 function extractFormatter(source) {
-  const start = source.indexOf(FORMATTER_START);
-  if (start < 0) throw new Error('status formatter start marker was not found');
-  const end = source.indexOf(FORMATTER_END, start);
-  if (end < 0) throw new Error('status formatter end marker was not found');
-
-  const declaration = source.slice(start, end + 2);
-  const bodyStart = declaration.indexOf(FORMATTER_SIGNATURE_END);
-  if (bodyStart < 0) throw new Error('status formatter signature marker was not found');
-  const body = declaration.slice(bodyStart + FORMATTER_SIGNATURE_END.length, -2);
+  const body = extractExportedFunctionBody(
+    source,
+    'formatStatusTextContinuationLine',
+    FORMATTER_SIGNATURE_END,
+  );
 
   // The extracted formatter is dependency-free by design. Executing precisely
   // this candidate-owned body prevents the harness from re-implementing the
@@ -68,7 +63,7 @@ export default function () {
   const candidateSha = (manifest && manifest.candidateSha) || __ENV.OPENCLAW_CANDIDATE_SHA || '';
   const sourcePath =
     (manifest && manifest.sourceContract && manifest.sourceContract.path) ||
-    'src/status/status-text.ts';
+    'src/status/status-continuation-line.ts';
   const sourceRepo =
     (manifest && manifest.sourceContract && manifest.sourceContract.repository) ||
     'karmaterminal/openclaw';

--- a/tools/k6-proofs/scripts/__tests__/r-obs-status-source-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-obs-status-source-contract.test.mjs
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { extractExportedFunctionBody } from '../../lib/source-function-extractor.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const proofsRoot = path.resolve(here, '../..');
+const manifestPath = path.join(proofsRoot, 'manifests/r-obs-status.json');
+const scenarioPath = path.join(proofsRoot, 'scenarios/r-obs-status.js');
+const signatureEnd = '}): string | undefined {';
+
+const splitModuleSource = `
+export function formatStatusTextContinuationLine(params: {
+  maxChainLength: number;
+  chainCount: number;
+  pending: number;
+  staged: number;
+  volitional: number;
+}): string | undefined {
+  const { maxChainLength, chainCount, pending, staged, volitional } = params;
+  if (chainCount === 0 && pending === 0 && staged === 0 && volitional === 0) {
+    return undefined;
+  }
+  const parts = [\`chain \${chainCount}/\${maxChainLength}\`];
+  if (pending > 0) parts.push(\`\${pending} delegates pending\`);
+  if (staged > 0) parts.push(\`\${staged} post-compaction staged\`);
+  if (volitional > 0) parts.push(\`volitional: \${volitional}\`);
+  return \`🔄 Continuation: \${parts.join(' | ')}\`;
+}
+`;
+
+test('R-OBS-STATUS fetches the candidate-owned split formatter module', () => {
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const scenario = fs.readFileSync(scenarioPath, 'utf8');
+  assert.equal(manifest.sourceContract.path, 'src/status/status-continuation-line.ts');
+  assert.match(scenario, /src\/status\/status-continuation-line\.ts/);
+  assert.doesNotMatch(scenario, /src\/status\/status-text\.ts/);
+});
+
+test('R-OBS-STATUS candidate body proves clean omission and active rendering', () => {
+  const body = extractExportedFunctionBody(
+    splitModuleSource,
+    'formatStatusTextContinuationLine',
+    signatureEnd,
+  );
+  const format = new Function('params', `'use strict';\n${body}`);
+  const clean = format({ maxChainLength: 8, chainCount: 0, pending: 0, staged: 0, volitional: 0 });
+  const active = format({ maxChainLength: 8, chainCount: 1, pending: 0, staged: 0, volitional: 0 });
+  assert.equal(clean, undefined);
+  assert.equal(active, '🔄 Continuation: chain 1/8');
+});
+
+test('R-OBS-STATUS candidate body renders pending delegate state', () => {
+  const body = extractExportedFunctionBody(splitModuleSource, 'formatStatusTextContinuationLine', signatureEnd);
+  const format = new Function('params', `'use strict';\n${body}`);
+  assert.equal(
+    format({ maxChainLength: 8, chainCount: 0, pending: 2, staged: 0, volitional: 0 }),
+    '🔄 Continuation: chain 0/8 | 2 delegates pending',
+  );
+});
+
+test('R-OBS-STATUS candidate body renders staged post-compaction state', () => {
+  const body = extractExportedFunctionBody(splitModuleSource, 'formatStatusTextContinuationLine', signatureEnd);
+  const format = new Function('params', `'use strict';\n${body}`);
+  assert.equal(
+    format({ maxChainLength: 8, chainCount: 0, pending: 0, staged: 1, volitional: 0 }),
+    '🔄 Continuation: chain 0/8 | 1 post-compaction staged',
+  );
+});
+
+test('R-OBS-STATUS candidate body renders volitional state', () => {
+  const body = extractExportedFunctionBody(splitModuleSource, 'formatStatusTextContinuationLine', signatureEnd);
+  const format = new Function('params', `'use strict';\n${body}`);
+  assert.equal(
+    format({ maxChainLength: 8, chainCount: 0, pending: 0, staged: 0, volitional: 1 }),
+    '🔄 Continuation: chain 0/8 | volitional: 1',
+  );
+});
+
+test('balanced extraction ignores braces in strings and comments', () => {
+  const source = `
+export function target(params: { value: number }): string | undefined {
+  // } does not close the function
+  const left = "{";
+  const right = \`literal } \${params.value}\`;
+  /* { neither does this } */
+  return left + right;
+}
+export const after = true;
+`;
+  const body = extractExportedFunctionBody(source, 'target', '): string | undefined {');
+  const target = new Function('params', `'use strict';\n${body}`);
+  assert.equal(target({ value: 7 }), '{literal } 7');
+  assert.doesNotMatch(body, /export const after/);
+});
+
+test('balanced extraction rejects the stale re-export-only aggregator', () => {
+  const aggregator = `
+import { formatStatusTextContinuationLine } from './status-continuation-line.js';
+export { formatStatusTextContinuationLine };
+`;
+  assert.throws(
+    () => extractExportedFunctionBody(aggregator, 'formatStatusTextContinuationLine', signatureEnd),
+    /export was not found/,
+  );
+});
+
+test('balanced extraction fails closed on a signature mismatch', () => {
+  assert.throws(
+    () => extractExportedFunctionBody(splitModuleSource, 'formatStatusTextContinuationLine', '): boolean {'),
+    /signature marker was not found/,
+  );
+});
+
+test('balanced extraction fails closed on an unterminated body', () => {
+  const unterminated = `
+export function target(params: { value: number }): string | undefined {
+  if (params.value) {
+    return "value";
+  }
+`;
+  assert.throws(
+    () => extractExportedFunctionBody(unterminated, 'target', '): string | undefined {'),
+    /closing brace was not found/,
+  );
+});


### PR DESCRIPTION
Closes #438.

## What changed

- Fetch the exact-candidate formatter from its current owner, `src/status/status-continuation-line.ts`, instead of the stale `status-text.ts` re-export surface.
- Extract the candidate-owned dependency-free function with balanced brace parsing rather than a declaration-following marker tied to the old file layout.
- Preserve both product contracts: all-zero continuation state omits the line; active continuation state renders the exact line.
- Add regression coverage for pending, staged, and volitional rendering, the stale re-export-only shape, braces in strings/comments, signature drift, and unterminated bodies.

## Validation

- focused source-contract tests: 9/9
- full proof-harness Node suite: 213/213
- proof-row manifest coverage: 35/35, 0 missing
- `k6 inspect tools/k6-proofs/scenarios/r-obs-status.js`: pass
- `git diff --check`: pass

No behavioral proof row was refired and no canonical proof verdict is changed by this patch. Elliott and Silas should each re-execute `R-OBS-STATUS` once after merge under Ronan's coordinated fresh-attempt boundary, preserving the historical BAD_PROOF packets.
