### PR TITLE
fix(proofs): bind source extraction to target declaration

### DIFF
--- a/tools/k6-proofs/lib/source-function-extractor.js
+++ b/tools/k6-proofs/lib/source-function-extractor.js
@@ -8,17 +8,35 @@
  * braces instead, while ignoring brace-like characters in strings/comments.
  */
 export function extractExportedFunctionBody(source, functionName, signatureEndMarker) {
-  const declarationMarker = `export function ${functionName}`;
-  const declarationStart = source.indexOf(declarationMarker);
-  if (declarationStart < 0) {
+  const escapedFunctionName = functionName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const declarationPattern = new RegExp(
+    `^export\\s+function\\s+${escapedFunctionName}(?=\\s*\\()`,
+    'gm',
+  );
+  const declarationMatch = declarationPattern.exec(source);
+  if (!declarationMatch) {
     throw new Error(`${functionName} export was not found`);
   }
+  const declarationStart = declarationMatch.index;
+
+  // Keep signature matching inside the selected top-level declaration. If the
+  // target signature drifts, a compatible marker on a later export must not
+  // cause the harness to execute that later function's body.
+  const nextDeclarationPattern =
+    /^(?:export\s+)?(?:declare\s+)?(?:async\s+)?(?:function|class|const|let|var|interface|type|enum|namespace)\b/gm;
+  nextDeclarationPattern.lastIndex = declarationStart + declarationMatch[0].length;
+  const nextDeclarationMatch = nextDeclarationPattern.exec(source);
+  const declarationEnd = nextDeclarationMatch ? nextDeclarationMatch.index : source.length;
 
   const signatureEnd = source.indexOf(signatureEndMarker, declarationStart);
-  if (signatureEnd < 0) {
+  if (signatureEnd < 0 || signatureEnd >= declarationEnd) {
     throw new Error(`${functionName} signature marker was not found`);
   }
-  const bodyOpen = signatureEnd + signatureEndMarker.lastIndexOf('{');
+  const bodyMarkerOffset = signatureEndMarker.lastIndexOf('{');
+  if (bodyMarkerOffset < 0) {
+    throw new Error(`${functionName} body start marker was not found`);
+  }
+  const bodyOpen = signatureEnd + bodyMarkerOffset;
   if (source[bodyOpen] !== '{') {
     throw new Error(`${functionName} body start was not found`);
   }

--- a/tools/k6-proofs/lib/source-function-extractor.js
+++ b/tools/k6-proofs/lib/source-function-extractor.js
@@ -18,27 +18,31 @@ export function extractExportedFunctionBody(source, functionName, signatureEndMa
     throw new Error(`${functionName} export was not found`);
   }
   const declarationStart = declarationMatch.index;
-
-  // Keep signature matching inside the selected top-level declaration. If the
-  // target signature drifts, a compatible marker on a later export must not
-  // cause the harness to execute that later function's body.
-  const nextDeclarationPattern =
-    /^(?:export\s+)?(?:declare\s+)?(?:async\s+)?(?:function|class|const|let|var|interface|type|enum|namespace)\b/gm;
-  nextDeclarationPattern.lastIndex = declarationStart + declarationMatch[0].length;
-  const nextDeclarationMatch = nextDeclarationPattern.exec(source);
-  const declarationEnd = nextDeclarationMatch ? nextDeclarationMatch.index : source.length;
-
-  const signatureEnd = source.indexOf(signatureEndMarker, declarationStart);
-  if (signatureEnd < 0 || signatureEnd >= declarationEnd) {
-    throw new Error(`${functionName} signature marker was not found`);
-  }
   const bodyMarkerOffset = signatureEndMarker.lastIndexOf('{');
   if (bodyMarkerOffset < 0) {
     throw new Error(`${functionName} body start marker was not found`);
   }
-  const bodyOpen = signatureEnd + bodyMarkerOffset;
-  if (source[bodyOpen] !== '{') {
+
+  // Parse only the selected declaration header. Searching arbitrary source
+  // text for the expected signature can accidentally accept a marker from a
+  // later export, string, or comment in the function body. First find the
+  // declaration's parameter list and its real body-opening brace lexically,
+  // then require the complete expected marker to end at that exact brace.
+  const parametersOpen = source.indexOf('(', declarationStart + declarationMatch[0].length - 1);
+  const parametersClose = findMatchingDelimiter(source, parametersOpen, '(', ')');
+  if (parametersClose < 0) {
+    throw new Error(`${functionName} parameter list was not closed`);
+  }
+  const bodyOpen = findNextCodeCharacter(source, parametersClose + 1, '{');
+  if (bodyOpen < 0) {
     throw new Error(`${functionName} body start was not found`);
+  }
+  const signatureStart = bodyOpen - bodyMarkerOffset;
+  if (
+    signatureStart < declarationStart ||
+    source.slice(signatureStart, bodyOpen + 1) !== signatureEndMarker
+  ) {
+    throw new Error(`${functionName} signature marker was not found`);
   }
 
   let depth = 1;
@@ -97,4 +101,97 @@ export function extractExportedFunctionBody(source, functionName, signatureEndMa
   }
 
   throw new Error(`${functionName} closing brace was not found`);
+}
+
+function findMatchingDelimiter(source, openIndex, openCharacter, closeCharacter) {
+  if (openIndex < 0 || source[openIndex] !== openCharacter) return -1;
+  let depth = 1;
+  let mode = 'code';
+  let escaped = false;
+
+  for (let index = openIndex + 1; index < source.length; index += 1) {
+    const char = source[index];
+    const next = source[index + 1];
+    if (mode === 'line-comment') {
+      if (char === '\n') mode = 'code';
+      continue;
+    }
+    if (mode === 'block-comment') {
+      if (char === '*' && next === '/') {
+        mode = 'code';
+        index += 1;
+      }
+      continue;
+    }
+    if (mode !== 'code') {
+      if (escaped) escaped = false;
+      else if (char === '\\') escaped = true;
+      else if (char === mode) mode = 'code';
+      continue;
+    }
+    if (char === '/' && next === '/') {
+      mode = 'line-comment';
+      index += 1;
+      continue;
+    }
+    if (char === '/' && next === '*') {
+      mode = 'block-comment';
+      index += 1;
+      continue;
+    }
+    if (char === "'" || char === '"' || char === '`') {
+      mode = char;
+      escaped = false;
+      continue;
+    }
+    if (char === openCharacter) depth += 1;
+    else if (char === closeCharacter) {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  }
+  return -1;
+}
+
+function findNextCodeCharacter(source, startIndex, expectedCharacter) {
+  let mode = 'code';
+  let escaped = false;
+  for (let index = startIndex; index < source.length; index += 1) {
+    const char = source[index];
+    const next = source[index + 1];
+    if (mode === 'line-comment') {
+      if (char === '\n') mode = 'code';
+      continue;
+    }
+    if (mode === 'block-comment') {
+      if (char === '*' && next === '/') {
+        mode = 'code';
+        index += 1;
+      }
+      continue;
+    }
+    if (mode !== 'code') {
+      if (escaped) escaped = false;
+      else if (char === '\\') escaped = true;
+      else if (char === mode) mode = 'code';
+      continue;
+    }
+    if (char === '/' && next === '/') {
+      mode = 'line-comment';
+      index += 1;
+      continue;
+    }
+    if (char === '/' && next === '*') {
+      mode = 'block-comment';
+      index += 1;
+      continue;
+    }
+    if (char === "'" || char === '"' || char === '`') {
+      mode = char;
+      escaped = false;
+      continue;
+    }
+    if (char === expectedCharacter) return index;
+  }
+  return -1;
 }

--- a/tools/k6-proofs/scripts/__tests__/r-obs-status-source-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-obs-status-source-contract.test.mjs
@@ -135,6 +135,19 @@ export function later(params: { value: number }): string | undefined {
   );
 });
 
+test('balanced extraction cannot borrow a matching signature from a body comment', () => {
+  const source = `
+export function target(value): boolean {
+  // ): string | undefined {
+  return "WRONG-SIGNATURE-ACCEPTED";
+}
+`;
+  assert.throws(
+    () => extractExportedFunctionBody(source, 'target', '): string | undefined {'),
+    /signature marker was not found/,
+  );
+});
+
 test('balanced extraction fails closed on an unterminated body', () => {
   const unterminated = `
 export function target(params: { value: number }): string | undefined {

--- a/tools/k6-proofs/scripts/__tests__/r-obs-status-source-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-obs-status-source-contract.test.mjs
@@ -115,6 +115,26 @@ test('balanced extraction fails closed on a signature mismatch', () => {
   );
 });
 
+test('balanced extraction cannot borrow a matching signature from a later export', () => {
+  const source = `
+export function targetExtra(params: { value: number }): string | undefined {
+  return "WRONG-PREFIX-BODY";
+}
+
+export function target(params: { value: number }): boolean {
+  return params.value > 0;
+}
+
+export function later(params: { value: number }): string | undefined {
+  return "WRONG-BODY";
+}
+`;
+  assert.throws(
+    () => extractExportedFunctionBody(source, 'target', '): string | undefined {'),
+    /signature marker was not found/,
+  );
+});
+
 test('balanced extraction fails closed on an unterminated body', () => {
   const unterminated = `
 export function target(params: { value: number }): string | undefined {


### PR DESCRIPTION
## Summary

Follow-up to #440 after independent review found that the source-function extractor could borrow a compatible signature marker from a later exported function when the requested target signature drifted.

This patch:

- matches the exact exported function name;
- bounds signature-marker lookup to the selected top-level declaration;
- fails closed when the marker appears only on a later declaration; and
- adds a regression fixture covering both a prefix-collision export and a later compatible signature/body.

## Verification

- focused source-contract tests: `10/10`
- full proof-harness script tests: `214/214`
- proof-row manifest coverage: `35/35`
- manifest registry: green
- scenario alignment: green
- `k6 inspect`: green
- `git diff --check`: green

Base is exact merged #440 head on docs `main@10fe10da42535175aa79f48018bdb9266b22bfa7`.

Closes the post-merge fail-closed review finding on #438; no proof row or canonical metadata is changed.
