### PR TITLE
proofs: bind R-CD-4 target return authority

### DIFF
--- a/tools/k6-proofs/lib/r-cd-4-authority.mjs
+++ b/tools/k6-proofs/lib/r-cd-4-authority.mjs
@@ -12,6 +12,12 @@ function directSessionKey(eventData) {
   return unique.length === 1 ? unique[0] : null;
 }
 
+function directMessageRole(eventData) {
+  const message = eventData?.message;
+  if (!message || typeof message !== 'object' || Array.isArray(message)) return null;
+  return typeof message.role === 'string' ? message.role : null;
+}
+
 function hasExactSentinel(eventData, marker, nonce) {
   const serialized = JSON.stringify(eventData);
   if (!serialized || serialized.includes(HARNESS_MARKER)) return false;
@@ -34,12 +40,14 @@ export function rCd4ReturnCandidate({ eventName, eventData, expectedSessionKey, 
   if (!expectedSessionKey || !nonce) return null;
   const sessionKey = directSessionKey(eventData);
   if (sessionKey !== expectedSessionKey) return null;
+  if (directMessageRole(eventData) !== 'system') return null;
   if (!hasExactSentinel(eventData, 'TARGET-RECEIVED', nonce)) return null;
   return {
     eventName,
     sessionKey,
     nonce,
     marker: `TARGET-RECEIVED ${nonce}`,
+    role: 'system',
   };
 }
 

--- a/tools/k6-proofs/lib/r-cd-4-authority.mjs
+++ b/tools/k6-proofs/lib/r-cd-4-authority.mjs
@@ -1,0 +1,52 @@
+const HARNESS_MARKER = '[k6-proof-harness]';
+
+function escapeRegex(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function directSessionKey(eventData) {
+  if (!eventData || typeof eventData !== 'object' || Array.isArray(eventData)) return null;
+  const candidates = [eventData.sessionKey, eventData.session]
+    .filter((value) => typeof value === 'string' && value.length > 0);
+  const unique = [...new Set(candidates)];
+  return unique.length === 1 ? unique[0] : null;
+}
+
+function hasExactSentinel(eventData, marker, nonce) {
+  const serialized = JSON.stringify(eventData);
+  if (!serialized || serialized.includes(HARNESS_MARKER)) return false;
+  const pattern = new RegExp(
+    `(?:^|[^A-Za-z0-9_-])${escapeRegex(marker)}\\s+${escapeRegex(nonce)}(?=$|[^A-Za-z0-9_-])`,
+  );
+  return pattern.test(serialized);
+}
+
+/**
+ * Identify the target/parent session event that carries the exact row marker.
+ *
+ * This deliberately accepts only the structured top-level event session. A
+ * session key or nonce appearing in nested prompt text must not route the
+ * receipt. Child identity is bound separately after a nonce-correlated spawn
+ * event is observed.
+ */
+export function rCd4ReturnCandidate({ eventName, eventData, expectedSessionKey, nonce }) {
+  if (eventName !== 'session.message') return null;
+  if (!expectedSessionKey || !nonce) return null;
+  const sessionKey = directSessionKey(eventData);
+  if (sessionKey !== expectedSessionKey) return null;
+  if (!hasExactSentinel(eventData, 'TARGET-RECEIVED', nonce)) return null;
+  return {
+    eventName,
+    sessionKey,
+    nonce,
+    marker: `TARGET-RECEIVED ${nonce}`,
+  };
+}
+
+/** Finalize only after the row has independently observed its spawned child. */
+export function rCd4ReturnReceipt(candidate, childSessionKey) {
+  if (!candidate || typeof childSessionKey !== 'string' || childSessionKey.length === 0) {
+    return null;
+  }
+  return { ...candidate, childSessionKey };
+}

--- a/tools/k6-proofs/lib/r-cd-4-authority.mjs
+++ b/tools/k6-proofs/lib/r-cd-4-authority.mjs
@@ -4,6 +4,7 @@ export const R_CD_4_OBSERVATION_WINDOW_MS = 90_000;
 export const R_CD_4_DURATION_THRESHOLD_MS = 110_000;
 
 const HARNESS_MARKER = '[k6-proof-harness]';
+const R_CD_4_TASK_TOKEN_SUFFIX_CHARS = 16;
 
 function escapeRegex(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -73,6 +74,31 @@ export function rCd4ReturnCandidate({ eventName, eventData, expectedSessionKey, 
   };
 }
 
+export function rCd4TaskIdentityToken(nonce) {
+  if (typeof nonce !== 'string' || nonce.length === 0) return null;
+  return `RCD4:${nonce.slice(-R_CD_4_TASK_TOKEN_SUFFIX_CHARS)}`;
+}
+
+export function rCd4TaskPrompt(template, nonce) {
+  if (typeof template !== 'string' || typeof nonce !== 'string' || nonce.length === 0) {
+    return null;
+  }
+  return template
+    .replaceAll('{{nonceSuffix16}}', nonce.slice(-R_CD_4_TASK_TOKEN_SUFFIX_CHARS))
+    .replaceAll('{{nonce}}', nonce);
+}
+
+export function rCd4ChildAuthority(candidates) {
+  const observedChildSessionKeys = [...new Set(
+    candidates.filter((value) => typeof value === 'string' && value.length > 0),
+  )];
+  return {
+    observedChildSessionKeys,
+    childSessionKey: observedChildSessionKeys.length === 1 ? observedChildSessionKeys[0] : null,
+    ambiguous: observedChildSessionKeys.length > 1,
+  };
+}
+
 /**
  * Inspect return authority for every post-dispatch session.message.
  *
@@ -115,7 +141,12 @@ export function rCd4SessionMessageObservation({
  * binds its real childSessionKey to this row nonce.
  */
 export function rCd4TaskObservation(task, nonce) {
-  const childSessionKey = directChildSessionKeyForRow(task, nonce);
+  const taskIdentityToken = rCd4TaskIdentityToken(nonce);
+  const childSessionKey = directChildSessionKeyForRow(
+    task,
+    nonce,
+    taskIdentityToken ? [taskIdentityToken] : [],
+  );
   if (!childSessionKey) {
     return {
       childSessionKey: null,

--- a/tools/k6-proofs/lib/r-cd-4-authority.mjs
+++ b/tools/k6-proofs/lib/r-cd-4-authority.mjs
@@ -68,6 +68,43 @@ export function rCd4ReturnCandidate({ eventName, eventData, expectedSessionKey, 
   };
 }
 
+/**
+ * Inspect return authority for every post-dispatch session.message.
+ *
+ * `wakeGateMs` is intentionally diagnostic-only: it tells the caller whether
+ * a generic message arrived after the expected wake delay, but it never gates
+ * nonce-bound target or parent authority. A legitimate continuation return can
+ * arrive before the generic wake timer, especially when delaySeconds is below
+ * the default observation gate.
+ */
+export function rCd4SessionMessageObservation({
+  eventName,
+  eventData,
+  targetSessionKey,
+  parentSessionKey,
+  nonce,
+  elapsedMs,
+  wakeGateMs,
+}) {
+  const elapsed = Number.isFinite(elapsedMs) ? elapsedMs : 0;
+  const gate = Number.isFinite(wakeGateMs) ? wakeGateMs : 0;
+  return {
+    targetCandidate: rCd4ReturnCandidate({
+      eventName,
+      eventData,
+      expectedSessionKey: targetSessionKey,
+      nonce,
+    }),
+    parentCandidate: rCd4ReturnCandidate({
+      eventName,
+      eventData,
+      expectedSessionKey: parentSessionKey,
+      nonce,
+    }),
+    genericWakeObserved: elapsed >= gate,
+  };
+}
+
 /** Finalize only after the row has independently observed its spawned child. */
 export function rCd4ReturnReceipt(candidate, childSessionKey) {
   if (!candidate || typeof childSessionKey !== 'string' || childSessionKey.length === 0) {

--- a/tools/k6-proofs/lib/r-cd-4-authority.mjs
+++ b/tools/k6-proofs/lib/r-cd-4-authority.mjs
@@ -1,3 +1,5 @@
+import { directChildSessionKeyForRow } from './row-child-correlation.mjs';
+
 const HARNESS_MARKER = '[k6-proof-harness]';
 
 function escapeRegex(value) {
@@ -102,6 +104,28 @@ export function rCd4SessionMessageObservation({
       nonce,
     }),
     genericWakeObserved: elapsed >= gate,
+  };
+}
+
+/**
+ * Treat tasks.list as child authority only when one structured task record
+ * binds its real childSessionKey to this row nonce.
+ */
+export function rCd4TaskObservation(task, nonce) {
+  const childSessionKey = directChildSessionKeyForRow(task, nonce);
+  if (!childSessionKey) {
+    return {
+      childSessionKey: null,
+      completed: false,
+      traceId: null,
+    };
+  }
+  return {
+    childSessionKey,
+    completed: task?.state === 'completed' || task?.status === 'completed',
+    traceId: typeof task?.traceId === 'string' && task.traceId.length > 0
+      ? task.traceId
+      : null,
   };
 }
 

--- a/tools/k6-proofs/lib/r-cd-4-authority.mjs
+++ b/tools/k6-proofs/lib/r-cd-4-authority.mjs
@@ -1,5 +1,8 @@
 import { directChildSessionKeyForRow } from './row-child-correlation.mjs';
 
+export const R_CD_4_OBSERVATION_WINDOW_MS = 90_000;
+export const R_CD_4_DURATION_THRESHOLD_MS = 110_000;
+
 const HARNESS_MARKER = '[k6-proof-harness]';
 
 function escapeRegex(value) {
@@ -127,6 +130,15 @@ export function rCd4TaskObservation(task, nonce) {
       ? task.traceId
       : null,
   };
+}
+
+/**
+ * A target receipt still needs the remaining observation window to prove that
+ * no matching parent receipt arrives later. A parent receipt is already a
+ * terminal target-only failure and may close early.
+ */
+export function rCd4ShouldScheduleEarlyClose({ parentReturnReceipt }) {
+  return parentReturnReceipt !== null && parentReturnReceipt !== undefined;
 }
 
 /** Finalize only after the row has independently observed its spawned child. */

--- a/tools/k6-proofs/lib/r-cd-4-authority.mjs
+++ b/tools/k6-proofs/lib/r-cd-4-authority.mjs
@@ -18,13 +18,30 @@ function directMessageRole(eventData) {
   return typeof message.role === 'string' ? message.role : null;
 }
 
+function directMessageText(eventData) {
+  const message = eventData?.message;
+  if (!message || typeof message !== 'object' || Array.isArray(message)) return null;
+  if (typeof message.content === 'string') return message.content;
+  if (!Array.isArray(message.content)) return null;
+  const textParts = message.content
+    .filter((part) => (
+      part
+      && typeof part === 'object'
+      && !Array.isArray(part)
+      && part.type === 'text'
+      && typeof part.text === 'string'
+    ))
+    .map((part) => part.text);
+  return textParts.length > 0 ? textParts.join('\n') : null;
+}
+
 function hasExactSentinel(eventData, marker, nonce) {
-  const serialized = JSON.stringify(eventData);
-  if (!serialized || serialized.includes(HARNESS_MARKER)) return false;
+  const messageText = directMessageText(eventData);
+  if (!messageText || messageText.includes(HARNESS_MARKER)) return false;
   const pattern = new RegExp(
     `(?:^|[^A-Za-z0-9_-])${escapeRegex(marker)}\\s+${escapeRegex(nonce)}(?=$|[^A-Za-z0-9_-])`,
   );
-  return pattern.test(serialized);
+  return pattern.test(messageText);
 }
 
 /**

--- a/tools/k6-proofs/lib/row-child-correlation.mjs
+++ b/tools/k6-proofs/lib/row-child-correlation.mjs
@@ -1,22 +1,37 @@
-function directStringValues(record) {
-  return Object.values(record).flatMap((value) => {
-    if (typeof value === 'string') return [value];
-    if (Array.isArray(value) && value.every((entry) => typeof entry === 'string')) return value;
-    return [];
+// Spawn events expose row text as task/text; tasks.list exposes it as title.
+// Routing keys identify sessions and must never supply row-nonce authority.
+const DIRECT_ROW_IDENTITY_FIELDS = ['task', 'text', 'title'];
+const TASK_RECORD_FIELDS = ['task'];
+const TASK_RECORD_COLLECTION_FIELDS = ['tasks', 'records'];
+
+function directTaskIdentityValues(record) {
+  return DIRECT_ROW_IDENTITY_FIELDS.flatMap((field) => {
+    const value = record[field];
+    return typeof value === 'string' ? [value] : [];
   });
 }
 
-function childKeyBoundToNonce(record, rowNonce) {
+function rowIdentityTokens(rowNonce, additionalTokens = []) {
+  return [rowNonce, ...additionalTokens]
+    .filter((value) => typeof value === 'string' && value.length > 0);
+}
+
+function childKeyBoundToNonce(record, rowNonce, additionalTokens = []) {
   if (!record || typeof record !== 'object' || Array.isArray(record)) return null;
   const childSessionKey = typeof record.childSessionKey === 'string' ? record.childSessionKey : null;
   if (!childSessionKey) return null;
-  return directStringValues(record).some((value) => value.includes(rowNonce)) ? childSessionKey : null;
+  const tokens = rowIdentityTokens(rowNonce, additionalTokens);
+  return directTaskIdentityValues(record).some((value) => (
+    tokens.some((token) => value.includes(token))
+  ))
+    ? childSessionKey
+    : null;
 }
 
 /** Return a child key only when this exact structured record binds it to the row. */
-export function directChildSessionKeyForRow(record, rowNonce) {
+export function directChildSessionKeyForRow(record, rowNonce, additionalTokens = []) {
   if (!rowNonce || typeof rowNonce !== 'string') return null;
-  return childKeyBoundToNonce(record, rowNonce);
+  return childKeyBoundToNonce(record, rowNonce, additionalTokens);
 }
 
 /**
@@ -24,11 +39,12 @@ export function directChildSessionKeyForRow(record, rowNonce) {
  * key to the proof-row nonce.
  *
  * Gateway subscriptions can contain aggregate events from earlier proof work.
- * A nonce anywhere in the outer event is not enough: a stale top-level child
- * key plus an unrelated nested task for the current row must fail closed.
+ * A nonce anywhere in the outer event is not enough: only direct records and
+ * recognized task-record containers are authoritative. Nested metadata must
+ * never supply or conflict with child authority.
  */
-export function childSessionKeyForRow(eventData, rowNonce) {
-  if (!rowNonce || typeof rowNonce !== 'string') return null;
+export function childSessionKeysForRow(eventData, rowNonce, additionalTokens = []) {
+  if (!rowNonce || typeof rowNonce !== 'string') return [];
   const matches = new Set();
   const seen = new Set();
 
@@ -36,12 +52,24 @@ export function childSessionKeyForRow(eventData, rowNonce) {
     if (!value || typeof value !== 'object' || seen.has(value)) return;
     seen.add(value);
     if (!Array.isArray(value)) {
-      const match = directChildSessionKeyForRow(value, rowNonce);
+      const match = directChildSessionKeyForRow(value, rowNonce, additionalTokens);
       if (match) matches.add(match);
     }
-    for (const child of Object.values(value)) visit(child);
+    if (Array.isArray(value)) {
+      for (const child of value) visit(child);
+      return;
+    }
+    for (const field of TASK_RECORD_FIELDS) visit(value[field]);
+    for (const field of TASK_RECORD_COLLECTION_FIELDS) {
+      if (Array.isArray(value[field])) visit(value[field]);
+    }
   }
 
   visit(eventData);
-  return matches.size === 1 ? [...matches][0] : null;
+  return [...matches];
+}
+
+export function childSessionKeyForRow(eventData, rowNonce, additionalTokens = []) {
+  const matches = childSessionKeysForRow(eventData, rowNonce, additionalTokens);
+  return matches?.length === 1 ? matches[0] : null;
 }

--- a/tools/k6-proofs/lib/row-child-correlation.mjs
+++ b/tools/k6-proofs/lib/row-child-correlation.mjs
@@ -13,6 +13,12 @@ function childKeyBoundToNonce(record, rowNonce) {
   return directStringValues(record).some((value) => value.includes(rowNonce)) ? childSessionKey : null;
 }
 
+/** Return a child key only when this exact structured record binds it to the row. */
+export function directChildSessionKeyForRow(record, rowNonce) {
+  if (!rowNonce || typeof rowNonce !== 'string') return null;
+  return childKeyBoundToNonce(record, rowNonce);
+}
+
 /**
  * Return a spawned child key only when the same structured record binds that
  * key to the proof-row nonce.
@@ -30,7 +36,7 @@ export function childSessionKeyForRow(eventData, rowNonce) {
     if (!value || typeof value !== 'object' || seen.has(value)) return;
     seen.add(value);
     if (!Array.isArray(value)) {
-      const match = childKeyBoundToNonce(value, rowNonce);
+      const match = directChildSessionKeyForRow(value, rowNonce);
       if (match) matches.add(match);
     }
     for (const child of Object.values(value)) visit(child);

--- a/tools/k6-proofs/manifests/r-cd-4.json
+++ b/tools/k6-proofs/manifests/r-cd-4.json
@@ -52,7 +52,12 @@
     {
       "name": "target-return-event",
       "required": true,
-      "description": "A delayed return/wake event arrives in the TARGET session"
+      "description": "The TARGET session receives the exact TARGET-RECEIVED {{nonce}} marker in a structured session.message event"
+    },
+    {
+      "name": "child-session-identity",
+      "required": true,
+      "description": "A structured spawn/task record binds the child session key to the same row nonce"
     },
     {
       "name": "no-parent-return",
@@ -80,7 +85,7 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Cross-session targeted return. PASS-candidate when: (1) dispatch accepted with targetSessionKey, (2) return lands in TARGET session, (3) dispatching session does NOT receive the return. A nonce-correlated tasks.list row is optional because continue_delegate uses pending-delegate/subagent surfaces, not the generic task registry."
+    "notes": "Cross-session targeted return. PASS-candidate requires dispatch acceptance, a nonce-bound child identity, the exact TARGET-RECEIVED {{nonce}} marker in the structured TARGET session, and no matching parent receipt. Unrelated delayed messages and nested session-key mentions fail closed."
   },
   "liveRunSafety": {
     "classification": "k6-runnable",
@@ -95,11 +100,12 @@
       "parent-session-created",
       "target-session-created",
       "dispatch-accepted",
+      "child-session-identity",
       "target-return-event",
       "no-parent-return",
       "trace-id"
     ],
     "foldRequiresReview": true,
-    "notes": "Live continuation row. Prefer OPENCLAW_CREATE_DISPOSABLE_SESSIONS=true for repeatability; explicit OPENCLAW_TARGET_SESSION_KEY still supported for reviewed manual runs."
+    "notes": "Live continuation row. Prefer OPENCLAW_CREATE_DISPOSABLE_SESSIONS=true for repeatability; explicit OPENCLAW_TARGET_SESSION_KEY still supported for reviewed manual runs. The detector requires exact row marker, structured target session, and separately nonce-bound child identity."
   }
 }

--- a/tools/k6-proofs/manifests/r-cd-4.json
+++ b/tools/k6-proofs/manifests/r-cd-4.json
@@ -52,7 +52,7 @@
     {
       "name": "target-return-event",
       "required": true,
-      "description": "The TARGET session receives the exact TARGET-RECEIVED {{nonce}} marker in a structured session.message event"
+      "description": "The TARGET session receives the exact TARGET-RECEIVED {{nonce}} marker in a structured role=system session.message event"
     },
     {
       "name": "child-session-identity",
@@ -85,7 +85,7 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Cross-session targeted return. PASS-candidate requires dispatch acceptance, a nonce-bound child identity, the exact TARGET-RECEIVED {{nonce}} marker in the structured TARGET session, and no matching parent receipt. Unrelated delayed messages and nested session-key mentions fail closed."
+    "notes": "Cross-session targeted return. PASS-candidate requires dispatch acceptance, a nonce-bound child identity, the exact TARGET-RECEIVED {{nonce}} marker in a role=system TARGET event, and no matching parent receipt. Unrelated/assistant messages and nested session-key mentions fail closed."
   },
   "liveRunSafety": {
     "classification": "k6-runnable",

--- a/tools/k6-proofs/manifests/r-cd-4.json
+++ b/tools/k6-proofs/manifests/r-cd-4.json
@@ -30,7 +30,7 @@
     "mode": "silent-wake",
     "delaySeconds": 1,
     "targetSessionKey": "${OPENCLAW_TARGET_SESSION_KEY}",
-    "promptTemplate": "Proof nonce {{nonce}}: reply with TARGET-RECEIVED and the nonce. Do not mutate files.",
+    "promptTemplate": "RCD4:{{nonceSuffix16}} Proof nonce {{nonce}}: reply with TARGET-RECEIVED and the nonce. Do not mutate files.",
     "idempotencyKeyPrefix": "R-CD-4"
   },
   "expectedReceipts": [

--- a/tools/k6-proofs/scenarios/r-cd-4-target-session-key.js
+++ b/tools/k6-proofs/scenarios/r-cd-4-target-session-key.js
@@ -14,7 +14,11 @@ import crypto from 'k6/crypto';
 import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
 import { childSessionKeyForRow } from '../lib/row-child-correlation.mjs';
-import { rCd4ReturnReceipt, rCd4SessionMessageObservation } from '../lib/r-cd-4-authority.mjs';
+import {
+  rCd4ReturnReceipt,
+  rCd4SessionMessageObservation,
+  rCd4TaskObservation,
+} from '../lib/r-cd-4-authority.mjs';
 import { closeSocketAfterDelay } from '../lib/socket-close.js';
 
 export const options = {
@@ -252,19 +256,20 @@ export default function () {
         if (classified.kind === 'response' && classified.method === 'tasks.list') {
           const tasks = classified.payload?.tasks || [];
           for (const task of tasks) {
-            const taskStr = JSON.stringify(task);
-            if (taskStr.includes(rowNonce)) {
-              const possibleChild = task.childSessionKey || task.sessionKey || null;
-              if (possibleChild && possibleChild !== sessionKey && possibleChild !== targetSessionKey) {
-                evidence.child_session = possibleChild;
-                finalizeReturnReceipts();
-              }
-              if (task.state === 'completed' || task.status === 'completed') {
-                evidence.child_completed = true;
-                console.log('✓ Child task completed');
-              }
-              if (task.traceId) evidence.trace_id = task.traceId;
+            const observation = rCd4TaskObservation(task, rowNonce);
+            const possibleChild = observation.childSessionKey;
+            if (!possibleChild ||
+                possibleChild === sessionKey ||
+                possibleChild === targetSessionKey) {
+              continue;
             }
+            evidence.child_session = possibleChild;
+            finalizeReturnReceipts();
+            if (observation.completed) {
+              evidence.child_completed = true;
+              console.log('✓ Child task completed');
+            }
+            if (observation.traceId) evidence.trace_id = observation.traceId;
           }
         }
 

--- a/tools/k6-proofs/scenarios/r-cd-4-target-session-key.js
+++ b/tools/k6-proofs/scenarios/r-cd-4-target-session-key.js
@@ -13,14 +13,17 @@ import { Counter, Trend } from 'k6/metrics';
 import crypto from 'k6/crypto';
 import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
-import { childSessionKeyForRow } from '../lib/row-child-correlation.mjs';
+import { childSessionKeysForRow } from '../lib/row-child-correlation.mjs';
 import {
   R_CD_4_DURATION_THRESHOLD_MS,
   R_CD_4_OBSERVATION_WINDOW_MS,
+  rCd4ChildAuthority,
   rCd4ReturnReceipt,
   rCd4SessionMessageObservation,
   rCd4ShouldScheduleEarlyClose,
+  rCd4TaskIdentityToken,
   rCd4TaskObservation,
+  rCd4TaskPrompt,
 } from '../lib/r-cd-4-authority.mjs';
 import { closeSocketAfterDelay } from '../lib/socket-close.js';
 
@@ -48,7 +51,7 @@ const DEFAULTS = {
   seat: 'ronan-dgx',
   mode: 'silent-wake',
   delaySeconds: 1,
-  promptTemplate: 'Proof nonce {{nonce}}: reply with TARGET-RECEIVED and the nonce. Do not mutate files. Do not post to any channel.',
+  promptTemplate: 'RCD4:{{nonceSuffix16}} Proof nonce {{nonce}}: reply with TARGET-RECEIVED and the nonce. Do not mutate files. Do not post to any channel.',
   idempotencyKeyPrefix: 'R-CD-4',
 };
 
@@ -76,6 +79,7 @@ export default function () {
   const createDisposableSessions = boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSIONS') || boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSION');
   const seat = manifest?.seat || __ENV.OPENCLAW_SEAT_NAME || DEFAULTS.seat;
   const rowNonce = nonce('R-CD-4');
+  const taskIdentityToken = rCd4TaskIdentityToken(rowNonce);
   const inv = invocationCfg();
   let targetSessionKey = inv.targetSessionKey;
 
@@ -102,6 +106,7 @@ export default function () {
     row: 'R-CD-4',
     manifest_loaded: !!manifest,
     nonce: rowNonce,
+    task_identity_token: taskIdentityToken,
     seat,
     requestedSessionKey,
     sessionKey,
@@ -116,6 +121,9 @@ export default function () {
     agent_turn_observed: false,
     child_completed: false,
     child_session: null,
+    child_session_candidates: [],
+    child_session_ambiguous: false,
+    child_session_invalid: false,
     return_in_target: false,
     return_in_parent: false,
     target_return_candidate: null,
@@ -154,6 +162,29 @@ export default function () {
       }
     }
 
+    function observeChildSessionKey(possibleChild) {
+      if (!possibleChild) return false;
+      const authority = rCd4ChildAuthority([
+        ...evidence.child_session_candidates,
+        possibleChild,
+      ]);
+      evidence.child_session_candidates = authority.observedChildSessionKeys;
+      evidence.child_session_invalid = evidence.child_session_candidates
+        .some((value) => value === sessionKey || value === targetSessionKey);
+      evidence.child_session = evidence.child_session_invalid
+        ? null
+        : authority.childSessionKey;
+      evidence.child_session_ambiguous = authority.ambiguous;
+      if (authority.ambiguous || evidence.child_session_invalid) {
+        evidence.child_completed = false;
+        console.warn('✗ conflicting or invalid nonce-bound child identity observed');
+      }
+      finalizeReturnReceipts();
+      return !authority.ambiguous &&
+        !evidence.child_session_invalid &&
+        authority.childSessionKey === possibleChild;
+    }
+
     function createParent(socket) {
       createPhase = 'parent';
       const parentKey = `r-cd-4-parent-${rowNonce}`.toLowerCase().replace(/[^a-z0-9-]/g, '-');
@@ -177,7 +208,7 @@ export default function () {
       tracker.send(socket, 'sessions.messages.subscribe', { key: targetSessionKey });
 
       socket.setTimeout(() => {
-        const prompt = inv.promptTemplate.replace(/\{\{nonce\}\}/g, rowNonce);
+        const prompt = rCd4TaskPrompt(inv.promptTemplate, rowNonce);
         evidence.reason_hash = crypto.sha256(prompt, 'hex').slice(0, 16);
         evidence.reason_length = prompt.length;
         evidence.delegate_mode = inv.mode;
@@ -261,13 +292,9 @@ export default function () {
           for (const task of tasks) {
             const observation = rCd4TaskObservation(task, rowNonce);
             const possibleChild = observation.childSessionKey;
-            if (!possibleChild ||
-                possibleChild === sessionKey ||
-                possibleChild === targetSessionKey) {
+            if (!observeChildSessionKey(possibleChild)) {
               continue;
             }
-            evidence.child_session = possibleChild;
-            finalizeReturnReceipts();
             if (observation.completed) {
               evidence.child_completed = true;
               console.log('✓ Child task completed');
@@ -279,10 +306,13 @@ export default function () {
         if (classified.kind === 'event') {
           const eventName = classified.event || '';
           const eventData = classified.data || {};
-          const observedChild = childSessionKeyForRow(eventData, rowNonce);
-          if (observedChild && observedChild !== sessionKey && observedChild !== targetSessionKey) {
-            evidence.child_session = observedChild;
-            finalizeReturnReceipts();
+          const observedChildren = childSessionKeysForRow(
+            eventData,
+            rowNonce,
+            taskIdentityToken ? [taskIdentityToken] : [],
+          );
+          for (const observedChild of observedChildren) {
+            observeChildSessionKey(observedChild);
           }
 
           if (eventName === 'agent' && evidence.tool_accepted) {
@@ -348,17 +378,22 @@ export default function () {
     'dispatch accepted': () => evidence.tool_accepted,
     'dispatching agent turn observed': () => evidence.agent_turn_observed,
     'nonce-bound child identity observed': () => evidence.child_session !== null,
+    'nonce-bound child identity is unambiguous': () => !evidence.child_session_ambiguous,
+    'nonce-bound child identity is not parent or target': () => !evidence.child_session_invalid,
     'nonce-bound target return receipt observed': () => evidence.target_return_receipt !== null,
     'no nonce-bound parent return receipt': () => evidence.parent_return_receipt === null,
   });
 
   if (!evidence.tool_accepted || !evidence.agent_turn_observed || !evidence.child_session ||
+      evidence.child_session_ambiguous || evidence.child_session_invalid ||
       !evidence.target_return_receipt || evidence.parent_return_receipt) {
     failures.add(1);
   }
 
   const passed = evidence.tool_accepted && evidence.agent_turn_observed &&
-    evidence.child_session !== null && evidence.target_return_receipt !== null &&
+    evidence.child_session !== null && !evidence.child_session_ambiguous &&
+    !evidence.child_session_invalid &&
+    evidence.target_return_receipt !== null &&
     evidence.parent_return_receipt === null;
 
   console.log(`R_CD_4_EVIDENCE ${JSON.stringify(evidence)}`);

--- a/tools/k6-proofs/scenarios/r-cd-4-target-session-key.js
+++ b/tools/k6-proofs/scenarios/r-cd-4-target-session-key.js
@@ -13,6 +13,8 @@ import { Counter, Trend } from 'k6/metrics';
 import crypto from 'k6/crypto';
 import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+import { childSessionKeyForRow } from '../lib/row-child-correlation.mjs';
+import { rCd4ReturnCandidate, rCd4ReturnReceipt } from '../lib/r-cd-4-authority.mjs';
 import { closeSocketAfterDelay } from '../lib/socket-close.js';
 
 export const options = {
@@ -106,8 +108,13 @@ export default function () {
     tool_accepted: false,
     agent_turn_observed: false,
     child_completed: false,
+    child_session: null,
     return_in_target: false,
     return_in_parent: false,
+    target_return_candidate: null,
+    parent_return_candidate: null,
+    target_return_receipt: null,
+    parent_return_receipt: null,
     dispatch_accepted_at_ms: null,
     wake_gate_ms: Number(__ENV.OPENCLAW_MIN_DELEGATE_DELAY_MS || 5000),
     reason_hash: null,
@@ -123,6 +130,22 @@ export default function () {
     const tracker = new RequestTracker();
     let createPhase = 'none';
     let returnCloseScheduled = false;
+
+    function finalizeReturnReceipts() {
+      evidence.target_return_receipt = rCd4ReturnReceipt(
+        evidence.target_return_candidate,
+        evidence.child_session,
+      );
+      evidence.parent_return_receipt = rCd4ReturnReceipt(
+        evidence.parent_return_candidate,
+        evidence.child_session,
+      );
+      evidence.return_in_target = evidence.target_return_receipt !== null;
+      evidence.return_in_parent = evidence.parent_return_receipt !== null;
+      if (evidence.return_in_target) {
+        evidence.child_completed = true;
+      }
+    }
 
     function createParent(socket) {
       createPhase = 'parent';
@@ -231,6 +254,11 @@ export default function () {
           for (const task of tasks) {
             const taskStr = JSON.stringify(task);
             if (taskStr.includes(rowNonce)) {
+              const possibleChild = task.childSessionKey || task.sessionKey || null;
+              if (possibleChild && possibleChild !== sessionKey && possibleChild !== targetSessionKey) {
+                evidence.child_session = possibleChild;
+                finalizeReturnReceipts();
+              }
               if (task.state === 'completed' || task.status === 'completed') {
                 evidence.child_completed = true;
                 console.log('✓ Child task completed');
@@ -243,8 +271,11 @@ export default function () {
         if (classified.kind === 'event') {
           const eventName = classified.event || '';
           const eventData = classified.data || {};
-          const eventStr = JSON.stringify(eventData);
-          const eventSession = eventData.sessionKey || eventData.session || null;
+          const observedChild = childSessionKeyForRow(eventData, rowNonce);
+          if (observedChild && observedChild !== sessionKey && observedChild !== targetSessionKey) {
+            evidence.child_session = observedChild;
+            finalizeReturnReceipts();
+          }
 
           if (eventName === 'agent' && evidence.tool_accepted) {
             evidence.agent_turn_observed = true;
@@ -253,15 +284,28 @@ export default function () {
           if (eventName === 'session.message' && evidence.tool_accepted) {
             const elapsed = evidence.dispatch_accepted_at_ms ? Date.now() - evidence.dispatch_accepted_at_ms : 0;
             if (elapsed >= evidence.wake_gate_ms) {
-              if (eventSession === targetSessionKey || eventStr.includes(targetSessionKey)) {
-                evidence.return_in_target = true;
+              const targetCandidate = rCd4ReturnCandidate({
+                eventName,
+                eventData,
+                expectedSessionKey: targetSessionKey,
+                nonce: rowNonce,
+              });
+              const parentCandidate = rCd4ReturnCandidate({
+                eventName,
+                eventData,
+                expectedSessionKey: sessionKey,
+                nonce: rowNonce,
+              });
+              if (targetCandidate) {
+                evidence.target_return_candidate = targetCandidate;
                 evidence.agent_turn_observed = true;
-                evidence.child_completed = true;
-                console.log('✓ Delayed return/wake landed in TARGET session');
-              } else if (eventSession === sessionKey || eventStr.includes(sessionKey)) {
-                evidence.return_in_parent = true;
-                console.warn('✗ Delayed return/wake landed in PARENT session (should be target only)');
+                console.log('✓ nonce-bound TARGET-RECEIVED candidate landed in target session');
               }
+              if (parentCandidate) {
+                evidence.parent_return_candidate = parentCandidate;
+                console.warn('✗ nonce-bound TARGET-RECEIVED candidate landed in parent session');
+              }
+              finalizeReturnReceipts();
             } else {
               evidence.agent_turn_observed = true;
               console.log('✓ initial session.message event observed (dispatching agent turn)');
@@ -294,16 +338,19 @@ export default function () {
   check(null, {
     'dispatch accepted': () => evidence.tool_accepted,
     'dispatching agent turn observed': () => evidence.agent_turn_observed,
-    'return landed in target session': () => evidence.return_in_target,
-    'no return in parent session (routing verified)': () => !evidence.return_in_parent,
+    'nonce-bound child identity observed': () => evidence.child_session !== null,
+    'nonce-bound target return receipt observed': () => evidence.target_return_receipt !== null,
+    'no nonce-bound parent return receipt': () => evidence.parent_return_receipt === null,
   });
 
-  if (!evidence.tool_accepted || !evidence.agent_turn_observed || !evidence.return_in_target || evidence.return_in_parent) {
+  if (!evidence.tool_accepted || !evidence.agent_turn_observed || !evidence.child_session ||
+      !evidence.target_return_receipt || evidence.parent_return_receipt) {
     failures.add(1);
   }
 
   const passed = evidence.tool_accepted && evidence.agent_turn_observed &&
-    evidence.return_in_target && !evidence.return_in_parent;
+    evidence.child_session !== null && evidence.target_return_receipt !== null &&
+    evidence.parent_return_receipt === null;
 
   console.log(`R_CD_4_EVIDENCE ${JSON.stringify(evidence)}`);
   console.log(`\n--- R-CD-4 EVIDENCE SUMMARY ---`);

--- a/tools/k6-proofs/scenarios/r-cd-4-target-session-key.js
+++ b/tools/k6-proofs/scenarios/r-cd-4-target-session-key.js
@@ -15,8 +15,11 @@ import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
 import { childSessionKeyForRow } from '../lib/row-child-correlation.mjs';
 import {
+  R_CD_4_DURATION_THRESHOLD_MS,
+  R_CD_4_OBSERVATION_WINDOW_MS,
   rCd4ReturnReceipt,
   rCd4SessionMessageObservation,
+  rCd4ShouldScheduleEarlyClose,
   rCd4TaskObservation,
 } from '../lib/r-cd-4-authority.mjs';
 import { closeSocketAfterDelay } from '../lib/socket-close.js';
@@ -32,7 +35,7 @@ export const options = {
   },
   thresholds: {
     proof_failures: ['count==0'],
-    r_cd_4_duration: ['p(95)<90000'],
+    r_cd_4_duration: [`p(95)<${R_CD_4_DURATION_THRESHOLD_MS}`],
   },
 };
 
@@ -189,7 +192,7 @@ export default function () {
       socket.setTimeout(() => tracker.send(socket, 'tasks.list', { limit: 10 }), 8000);
       socket.setTimeout(() => tracker.send(socket, 'tasks.list', { limit: 10 }), 25000);
       socket.setTimeout(() => tracker.send(socket, 'tasks.list', { limit: 10 }), 50000);
-      socket.setTimeout(() => socket.close(), 90000);
+      socket.setTimeout(() => socket.close(), R_CD_4_OBSERVATION_WINDOW_MS);
     }
 
     socket.on('open', () => {
@@ -318,7 +321,9 @@ export default function () {
         }
 
         if (evidence.tool_accepted &&
-            (evidence.return_in_target || evidence.return_in_parent) &&
+            rCd4ShouldScheduleEarlyClose({
+              parentReturnReceipt: evidence.parent_return_receipt,
+            }) &&
             !returnCloseScheduled) {
           returnCloseScheduled = true;
           closeSocketAfterDelay(socket, 2000);

--- a/tools/k6-proofs/scenarios/r-cd-4-target-session-key.js
+++ b/tools/k6-proofs/scenarios/r-cd-4-target-session-key.js
@@ -14,7 +14,7 @@ import crypto from 'k6/crypto';
 import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
 import { childSessionKeyForRow } from '../lib/row-child-correlation.mjs';
-import { rCd4ReturnCandidate, rCd4ReturnReceipt } from '../lib/r-cd-4-authority.mjs';
+import { rCd4ReturnReceipt, rCd4SessionMessageObservation } from '../lib/r-cd-4-authority.mjs';
 import { closeSocketAfterDelay } from '../lib/socket-close.js';
 
 export const options = {
@@ -283,32 +283,31 @@ export default function () {
 
           if (eventName === 'session.message' && evidence.tool_accepted) {
             const elapsed = evidence.dispatch_accepted_at_ms ? Date.now() - evidence.dispatch_accepted_at_ms : 0;
-            if (elapsed >= evidence.wake_gate_ms) {
-              const targetCandidate = rCd4ReturnCandidate({
-                eventName,
-                eventData,
-                expectedSessionKey: targetSessionKey,
-                nonce: rowNonce,
-              });
-              const parentCandidate = rCd4ReturnCandidate({
-                eventName,
-                eventData,
-                expectedSessionKey: sessionKey,
-                nonce: rowNonce,
-              });
-              if (targetCandidate) {
-                evidence.target_return_candidate = targetCandidate;
-                evidence.agent_turn_observed = true;
-                console.log('✓ nonce-bound TARGET-RECEIVED candidate landed in target session');
-              }
-              if (parentCandidate) {
-                evidence.parent_return_candidate = parentCandidate;
-                console.warn('✗ nonce-bound TARGET-RECEIVED candidate landed in parent session');
-              }
-              finalizeReturnReceipts();
-            } else {
+            const observation = rCd4SessionMessageObservation({
+              eventName,
+              eventData,
+              targetSessionKey,
+              parentSessionKey: sessionKey,
+              nonce: rowNonce,
+              elapsedMs: elapsed,
+              wakeGateMs: evidence.wake_gate_ms,
+            });
+            if (observation.targetCandidate) {
+              evidence.target_return_candidate = observation.targetCandidate;
               evidence.agent_turn_observed = true;
-              console.log('✓ initial session.message event observed (dispatching agent turn)');
+              console.log('✓ nonce-bound TARGET-RECEIVED candidate landed in target session');
+            }
+            if (observation.parentCandidate) {
+              evidence.parent_return_candidate = observation.parentCandidate;
+              console.warn('✗ nonce-bound TARGET-RECEIVED candidate landed in parent session');
+            }
+            finalizeReturnReceipts();
+
+            if (!observation.targetCandidate && !observation.parentCandidate) {
+              evidence.agent_turn_observed = true;
+              console.log(observation.genericWakeObserved
+                ? '✓ generic post-gate session.message event observed'
+                : '✓ initial pre-gate session.message event observed (dispatching agent turn)');
             }
           }
         }

--- a/tools/k6-proofs/scripts/__tests__/continuation-row-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/continuation-row-contract.test.mjs
@@ -148,7 +148,12 @@ test('every trace-required continue_delegate row persists the safe fingerprint c
       assert.match(scenario, /reason_hash:\s*null/);
       assert.match(scenario, /reason_length:\s*null/);
       assert.match(scenario, /delegate_mode:\s*null/);
-      assert.match(scenario, /promptTemplate\.replace\(\/\\\{\\\{nonce\\\}\\\}\/g,/);
+      if (manifest.rowId === 'R-CD-4') {
+        assert.match(manifest.invocation.promptTemplate, /^RCD4:\{\{nonceSuffix16\}\}/);
+        assert.match(scenario, /rCd4TaskPrompt\(inv\.promptTemplate,\s*rowNonce\)/);
+      } else {
+        assert.match(scenario, /promptTemplate\.replace\(\/\\\{\\\{nonce\\\}\\\}\/g,/);
+      }
     }
   }
 

--- a/tools/k6-proofs/scripts/collect-continuation-trace.mjs
+++ b/tools/k6-proofs/scripts/collect-continuation-trace.mjs
@@ -88,7 +88,11 @@ function traceContract(manifest, evidence) {
   if (tool === 'continue_delegate') {
     const template = manifest?.invocation?.promptTemplate;
     if (!template) throw new Error('continue_delegate manifest promptTemplate is required');
-    if (nonce) reason = String(template).replaceAll('{{nonce}}', String(nonce));
+    if (nonce) {
+      reason = String(template)
+        .replaceAll('{{nonceSuffix16}}', String(nonce).slice(-16))
+        .replaceAll('{{nonce}}', String(nonce));
+    }
     const manifestMode = manifest.invocation.mode;
     const evidenceMode = evidence.delegate_mode;
     if (manifestMode && evidenceMode && manifestMode !== evidenceMode) {

--- a/tools/k6-proofs/tests/r-cd-4-authority.test.mjs
+++ b/tools/k6-proofs/tests/r-cd-4-authority.test.mjs
@@ -1,0 +1,69 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { rCd4ReturnCandidate, rCd4ReturnReceipt } from '../lib/r-cd-4-authority.mjs';
+
+const nonce = 'R-CD-4-EXACT-NONCE';
+const target = 'agent:main:r-cd-4-target';
+const parent = 'agent:main:r-cd-4-parent';
+
+test('R-CD-4 accepts only the exact target marker and binds child identity', () => {
+  const candidate = rCd4ReturnCandidate({
+    eventName: 'session.message',
+    eventData: { sessionKey: target, role: 'system', text: `TARGET-RECEIVED ${nonce}` },
+    expectedSessionKey: target,
+    nonce,
+  });
+  assert.deepEqual(rCd4ReturnReceipt(candidate, 'agent:main:subagent:child'), {
+    eventName: 'session.message',
+    sessionKey: target,
+    nonce,
+    marker: `TARGET-RECEIVED ${nonce}`,
+    childSessionKey: 'agent:main:subagent:child',
+  });
+});
+
+test('R-CD-4 rejects an unrelated delayed target message', () => {
+  assert.equal(rCd4ReturnCandidate({
+    eventName: 'session.message',
+    eventData: { sessionKey: target, text: 'ordinary delayed target output' },
+    expectedSessionKey: target,
+    nonce,
+  }), null);
+});
+
+test('R-CD-4 rejects prompt echo and nonce-prefix lookalikes', () => {
+  assert.equal(rCd4ReturnCandidate({
+    eventName: 'session.message',
+    eventData: {
+      sessionKey: target,
+      text: `[k6-proof-harness] ask for TARGET-RECEIVED ${nonce}`,
+    },
+    expectedSessionKey: target,
+    nonce,
+  }), null);
+  assert.equal(rCd4ReturnCandidate({
+    eventName: 'session.message',
+    eventData: { sessionKey: target, text: `TARGET-RECEIVED ${nonce}-STALE` },
+    expectedSessionKey: target,
+    nonce,
+  }), null);
+});
+
+test('R-CD-4 never routes from a nested session-key mention', () => {
+  assert.equal(rCd4ReturnCandidate({
+    eventName: 'session.message',
+    eventData: { sessionKey: parent, text: `for ${target}: TARGET-RECEIVED ${nonce}` },
+    expectedSessionKey: target,
+    nonce,
+  }), null);
+});
+
+test('R-CD-4 withholds a marker candidate until child identity is available', () => {
+  const candidate = rCd4ReturnCandidate({
+    eventName: 'session.message',
+    eventData: { sessionKey: target, text: `TARGET-RECEIVED ${nonce}` },
+    expectedSessionKey: target,
+    nonce,
+  });
+  assert.equal(rCd4ReturnReceipt(candidate, null), null);
+});

--- a/tools/k6-proofs/tests/r-cd-4-authority.test.mjs
+++ b/tools/k6-proofs/tests/r-cd-4-authority.test.mjs
@@ -3,11 +3,14 @@ import assert from 'node:assert/strict';
 import {
   R_CD_4_DURATION_THRESHOLD_MS,
   R_CD_4_OBSERVATION_WINDOW_MS,
+  rCd4ChildAuthority,
   rCd4ReturnCandidate,
   rCd4ReturnReceipt,
   rCd4SessionMessageObservation,
   rCd4ShouldScheduleEarlyClose,
+  rCd4TaskIdentityToken,
   rCd4TaskObservation,
+  rCd4TaskPrompt,
 } from '../lib/r-cd-4-authority.mjs';
 
 const nonce = 'R-CD-4-EXACT-NONCE';
@@ -17,6 +20,35 @@ const parent = 'agent:main:r-cd-4-parent';
 test('R-CD-4 duration threshold leaves headroom after the full observation window', () => {
   assert.ok(R_CD_4_DURATION_THRESHOLD_MS > R_CD_4_OBSERVATION_WINDOW_MS);
   assert.ok(R_CD_4_DURATION_THRESHOLD_MS < 120_000);
+});
+
+test('R-CD-4 child authority fails closed across conflicting observations', () => {
+  assert.deepEqual(rCd4ChildAuthority(['agent:main:subagent:child-a']), {
+    observedChildSessionKeys: ['agent:main:subagent:child-a'],
+    childSessionKey: 'agent:main:subagent:child-a',
+    ambiguous: false,
+  });
+  assert.deepEqual(rCd4ChildAuthority([
+    'agent:main:subagent:child-a',
+    'agent:main:subagent:child-b',
+    'agent:main:subagent:child-a',
+  ]), {
+    observedChildSessionKeys: [
+      'agent:main:subagent:child-a',
+      'agent:main:subagent:child-b',
+    ],
+    childSessionKey: null,
+    ambiguous: true,
+  });
+});
+
+test('R-CD-4 task prompt keeps the compact token in the traced reason', () => {
+  const prompt = rCd4TaskPrompt(
+    'RCD4:{{nonceSuffix16}} Proof nonce {{nonce}}: return the marker.',
+    nonce,
+  );
+  assert.equal(prompt, `RCD4:${nonce.slice(-16)} Proof nonce ${nonce}: return the marker.`);
+  assert.ok(prompt.startsWith(rCd4TaskIdentityToken(nonce)));
 });
 
 test('R-CD-4 accepts only the exact target marker and binds child identity', () => {
@@ -169,10 +201,14 @@ test('R-CD-4 retains an early parent receipt so a later target cannot false-PASS
 });
 
 test('R-CD-4 accepts tasks.list child authority only from a nonce-bound childSessionKey', () => {
+  const taskIdentityToken = rCd4TaskIdentityToken(nonce);
+  const title = `[continuation:chain-hop:1] Delegated task (turn 1/3): ${taskIdentityToken} Proof nonce ${nonce}`
+    .slice(0, 80);
+  assert.ok(title.includes(taskIdentityToken));
   assert.deepEqual(rCd4TaskObservation({
     sessionKey: parent,
     childSessionKey: 'agent:main:subagent:child',
-    title: `R-CD-4 task ${nonce}`,
+    title,
     status: 'completed',
     traceId: 'a'.repeat(32),
   }, nonce), {
@@ -207,6 +243,30 @@ test('R-CD-4 rejects requester sessionKey and nested nonce as tasks.list child a
     nonce,
   });
   assert.equal(rCd4ReturnReceipt(targetCandidate, observation.childSessionKey), null);
+});
+
+test('R-CD-4 rejects nonce-bearing routing keys with an unrelated stale child', () => {
+  assert.deepEqual(rCd4TaskObservation({
+    sessionKey: `agent:main:r-cd-4-parent-${nonce}`,
+    childSessionKey: 'agent:main:subagent:stale-child',
+    title: 'unrelated completed task',
+    status: 'completed',
+  }, nonce), {
+    childSessionKey: null,
+    completed: false,
+    traceId: null,
+  });
+
+  assert.deepEqual(rCd4TaskObservation({
+    sessionKey: 'agent:main:requester',
+    childSessionKey: `agent:main:subagent:stale-${nonce}`,
+    title: 'unrelated completed task',
+    status: 'completed',
+  }, nonce), {
+    childSessionKey: null,
+    completed: false,
+    traceId: null,
+  });
 });
 
 test('R-CD-4 keeps observing after a target receipt but closes early on parent failure', () => {

--- a/tools/k6-proofs/tests/r-cd-4-authority.test.mjs
+++ b/tools/k6-proofs/tests/r-cd-4-authority.test.mjs
@@ -1,15 +1,23 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  R_CD_4_DURATION_THRESHOLD_MS,
+  R_CD_4_OBSERVATION_WINDOW_MS,
   rCd4ReturnCandidate,
   rCd4ReturnReceipt,
   rCd4SessionMessageObservation,
+  rCd4ShouldScheduleEarlyClose,
   rCd4TaskObservation,
 } from '../lib/r-cd-4-authority.mjs';
 
 const nonce = 'R-CD-4-EXACT-NONCE';
 const target = 'agent:main:r-cd-4-target';
 const parent = 'agent:main:r-cd-4-parent';
+
+test('R-CD-4 duration threshold leaves headroom after the full observation window', () => {
+  assert.ok(R_CD_4_DURATION_THRESHOLD_MS > R_CD_4_OBSERVATION_WINDOW_MS);
+  assert.ok(R_CD_4_DURATION_THRESHOLD_MS < 120_000);
+});
 
 test('R-CD-4 accepts only the exact target marker and binds child identity', () => {
   const candidate = rCd4ReturnCandidate({
@@ -199,4 +207,33 @@ test('R-CD-4 rejects requester sessionKey and nested nonce as tasks.list child a
     nonce,
   });
   assert.equal(rCd4ReturnReceipt(targetCandidate, observation.childSessionKey), null);
+});
+
+test('R-CD-4 keeps observing after a target receipt but closes early on parent failure', () => {
+  const child = 'agent:main:subagent:child';
+  const targetReceipt = rCd4ReturnReceipt(rCd4ReturnCandidate({
+    eventName: 'session.message',
+    eventData: {
+      sessionKey: target,
+      message: { role: 'system', content: `TARGET-RECEIVED ${nonce}` },
+    },
+    expectedSessionKey: target,
+    nonce,
+  }), child);
+  const parentReceipt = rCd4ReturnReceipt(rCd4ReturnCandidate({
+    eventName: 'session.message',
+    eventData: {
+      sessionKey: parent,
+      message: { role: 'system', content: `TARGET-RECEIVED ${nonce}` },
+    },
+    expectedSessionKey: parent,
+    nonce,
+  }), child);
+
+  assert.equal(rCd4ShouldScheduleEarlyClose({ parentReturnReceipt: null }), false);
+  assert.equal(rCd4ShouldScheduleEarlyClose({
+    targetReturnReceipt: targetReceipt,
+    parentReturnReceipt: null,
+  }), false);
+  assert.equal(rCd4ShouldScheduleEarlyClose({ parentReturnReceipt: parentReceipt }), true);
 });

--- a/tools/k6-proofs/tests/r-cd-4-authority.test.mjs
+++ b/tools/k6-proofs/tests/r-cd-4-authority.test.mjs
@@ -4,6 +4,7 @@ import {
   rCd4ReturnCandidate,
   rCd4ReturnReceipt,
   rCd4SessionMessageObservation,
+  rCd4TaskObservation,
 } from '../lib/r-cd-4-authority.mjs';
 
 const nonce = 'R-CD-4-EXACT-NONCE';
@@ -157,4 +158,45 @@ test('R-CD-4 retains an early parent receipt so a later target cannot false-PASS
   assert.equal(earlyParent.genericWakeObserved, false);
   assert.notEqual(rCd4ReturnReceipt(earlyParent.parentCandidate, child), null);
   assert.notEqual(rCd4ReturnReceipt(laterTarget.targetCandidate, child), null);
+});
+
+test('R-CD-4 accepts tasks.list child authority only from a nonce-bound childSessionKey', () => {
+  assert.deepEqual(rCd4TaskObservation({
+    sessionKey: parent,
+    childSessionKey: 'agent:main:subagent:child',
+    title: `R-CD-4 task ${nonce}`,
+    status: 'completed',
+    traceId: 'a'.repeat(32),
+  }, nonce), {
+    childSessionKey: 'agent:main:subagent:child',
+    completed: true,
+    traceId: 'a'.repeat(32),
+  });
+});
+
+test('R-CD-4 rejects requester sessionKey and nested nonce as tasks.list child authority', () => {
+  const observation = rCd4TaskObservation({
+    sessionKey: 'agent:main:requester',
+    childSessionKey: 'agent:main:subagent:stale-child',
+    status: 'completed',
+    metadata: {
+      childSessionKey: 'agent:main:subagent:nested-current-child',
+      task: `unrelated ${nonce}`,
+    },
+  }, nonce);
+  assert.deepEqual(observation, {
+    childSessionKey: null,
+    completed: false,
+    traceId: null,
+  });
+  const targetCandidate = rCd4ReturnCandidate({
+    eventName: 'session.message',
+    eventData: {
+      sessionKey: target,
+      message: { role: 'system', content: `TARGET-RECEIVED ${nonce}` },
+    },
+    expectedSessionKey: target,
+    nonce,
+  });
+  assert.equal(rCd4ReturnReceipt(targetCandidate, observation.childSessionKey), null);
 });

--- a/tools/k6-proofs/tests/r-cd-4-authority.test.mjs
+++ b/tools/k6-proofs/tests/r-cd-4-authority.test.mjs
@@ -1,6 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { rCd4ReturnCandidate, rCd4ReturnReceipt } from '../lib/r-cd-4-authority.mjs';
+import {
+  rCd4ReturnCandidate,
+  rCd4ReturnReceipt,
+  rCd4SessionMessageObservation,
+} from '../lib/r-cd-4-authority.mjs';
 
 const nonce = 'R-CD-4-EXACT-NONCE';
 const target = 'agent:main:r-cd-4-target';
@@ -100,4 +104,57 @@ test('R-CD-4 rejects a marker present only in sibling or nested metadata', () =>
     expectedSessionKey: target,
     nonce,
   }), null);
+});
+
+test('R-CD-4 retains an authoritative target receipt before the generic wake gate', () => {
+  const observation = rCd4SessionMessageObservation({
+    eventName: 'session.message',
+    eventData: {
+      sessionKey: target,
+      message: { role: 'system', content: `TARGET-RECEIVED ${nonce}` },
+    },
+    targetSessionKey: target,
+    parentSessionKey: parent,
+    nonce,
+    elapsedMs: 1_000,
+    wakeGateMs: 5_000,
+  });
+  assert.equal(observation.genericWakeObserved, false);
+  assert.equal(observation.parentCandidate, null);
+  assert.equal(observation.targetCandidate?.sessionKey, target);
+  assert.notEqual(rCd4ReturnReceipt(
+    observation.targetCandidate,
+    'agent:main:subagent:child',
+  ), null);
+});
+
+test('R-CD-4 retains an early parent receipt so a later target cannot false-PASS', () => {
+  const earlyParent = rCd4SessionMessageObservation({
+    eventName: 'session.message',
+    eventData: {
+      sessionKey: parent,
+      message: { role: 'system', content: `TARGET-RECEIVED ${nonce}` },
+    },
+    targetSessionKey: target,
+    parentSessionKey: parent,
+    nonce,
+    elapsedMs: 1_000,
+    wakeGateMs: 5_000,
+  });
+  const laterTarget = rCd4SessionMessageObservation({
+    eventName: 'session.message',
+    eventData: {
+      sessionKey: target,
+      message: { role: 'system', content: `TARGET-RECEIVED ${nonce}` },
+    },
+    targetSessionKey: target,
+    parentSessionKey: parent,
+    nonce,
+    elapsedMs: 6_000,
+    wakeGateMs: 5_000,
+  });
+  const child = 'agent:main:subagent:child';
+  assert.equal(earlyParent.genericWakeObserved, false);
+  assert.notEqual(rCd4ReturnReceipt(earlyParent.parentCandidate, child), null);
+  assert.notEqual(rCd4ReturnReceipt(laterTarget.targetCandidate, child), null);
 });

--- a/tools/k6-proofs/tests/r-cd-4-authority.test.mjs
+++ b/tools/k6-proofs/tests/r-cd-4-authority.test.mjs
@@ -9,7 +9,10 @@ const parent = 'agent:main:r-cd-4-parent';
 test('R-CD-4 accepts only the exact target marker and binds child identity', () => {
   const candidate = rCd4ReturnCandidate({
     eventName: 'session.message',
-    eventData: { sessionKey: target, role: 'system', text: `TARGET-RECEIVED ${nonce}` },
+    eventData: {
+      sessionKey: target,
+      message: { role: 'system', content: `TARGET-RECEIVED ${nonce}` },
+    },
     expectedSessionKey: target,
     nonce,
   });
@@ -18,6 +21,7 @@ test('R-CD-4 accepts only the exact target marker and binds child identity', () 
     sessionKey: target,
     nonce,
     marker: `TARGET-RECEIVED ${nonce}`,
+    role: 'system',
     childSessionKey: 'agent:main:subagent:child',
   });
 });
@@ -25,7 +29,7 @@ test('R-CD-4 accepts only the exact target marker and binds child identity', () 
 test('R-CD-4 rejects an unrelated delayed target message', () => {
   assert.equal(rCd4ReturnCandidate({
     eventName: 'session.message',
-    eventData: { sessionKey: target, text: 'ordinary delayed target output' },
+    eventData: { sessionKey: target, message: { role: 'system', content: 'ordinary delayed target output' } },
     expectedSessionKey: target,
     nonce,
   }), null);
@@ -36,14 +40,14 @@ test('R-CD-4 rejects prompt echo and nonce-prefix lookalikes', () => {
     eventName: 'session.message',
     eventData: {
       sessionKey: target,
-      text: `[k6-proof-harness] ask for TARGET-RECEIVED ${nonce}`,
+      message: { role: 'system', content: `[k6-proof-harness] ask for TARGET-RECEIVED ${nonce}` },
     },
     expectedSessionKey: target,
     nonce,
   }), null);
   assert.equal(rCd4ReturnCandidate({
     eventName: 'session.message',
-    eventData: { sessionKey: target, text: `TARGET-RECEIVED ${nonce}-STALE` },
+    eventData: { sessionKey: target, message: { role: 'system', content: `TARGET-RECEIVED ${nonce}-STALE` } },
     expectedSessionKey: target,
     nonce,
   }), null);
@@ -52,7 +56,7 @@ test('R-CD-4 rejects prompt echo and nonce-prefix lookalikes', () => {
 test('R-CD-4 never routes from a nested session-key mention', () => {
   assert.equal(rCd4ReturnCandidate({
     eventName: 'session.message',
-    eventData: { sessionKey: parent, text: `for ${target}: TARGET-RECEIVED ${nonce}` },
+    eventData: { sessionKey: parent, message: { role: 'system', content: `for ${target}: TARGET-RECEIVED ${nonce}` } },
     expectedSessionKey: target,
     nonce,
   }), null);
@@ -61,9 +65,21 @@ test('R-CD-4 never routes from a nested session-key mention', () => {
 test('R-CD-4 withholds a marker candidate until child identity is available', () => {
   const candidate = rCd4ReturnCandidate({
     eventName: 'session.message',
-    eventData: { sessionKey: target, text: `TARGET-RECEIVED ${nonce}` },
+    eventData: { sessionKey: target, message: { role: 'system', content: `TARGET-RECEIVED ${nonce}` } },
     expectedSessionKey: target,
     nonce,
   });
   assert.equal(rCd4ReturnReceipt(candidate, null), null);
+});
+
+test('R-CD-4 rejects an assistant-authored marker in the target session', () => {
+  assert.equal(rCd4ReturnCandidate({
+    eventName: 'session.message',
+    eventData: {
+      sessionKey: target,
+      message: { role: 'assistant', content: `TARGET-RECEIVED ${nonce}` },
+    },
+    expectedSessionKey: target,
+    nonce,
+  }), null);
 });

--- a/tools/k6-proofs/tests/r-cd-4-authority.test.mjs
+++ b/tools/k6-proofs/tests/r-cd-4-authority.test.mjs
@@ -83,3 +83,21 @@ test('R-CD-4 rejects an assistant-authored marker in the target session', () => 
     nonce,
   }), null);
 });
+
+test('R-CD-4 rejects a marker present only in sibling or nested metadata', () => {
+  const eventData = {
+    sessionKey: target,
+    message: {
+      role: 'system',
+      content: [{ type: 'text', text: 'unrelated target system message' }],
+      metadata: { echoedMarker: `TARGET-RECEIVED ${nonce}` },
+    },
+    metadata: { returnMarker: `TARGET-RECEIVED ${nonce}` },
+  };
+  assert.equal(rCd4ReturnCandidate({
+    eventName: 'session.message',
+    eventData,
+    expectedSessionKey: target,
+    nonce,
+  }), null);
+});

--- a/tools/k6-proofs/tests/row-child-correlation.test.mjs
+++ b/tools/k6-proofs/tests/row-child-correlation.test.mjs
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { childSessionKeyForRow } from '../lib/row-child-correlation.mjs';
+import {
+  childSessionKeyForRow,
+  childSessionKeysForRow,
+} from '../lib/row-child-correlation.mjs';
 
 test('rejects an earlier row child even when its event carries a child key', () => {
   const staleEvent = {
@@ -33,6 +36,33 @@ test('rejects a stale outer child key paired with an unrelated nested current-ro
   assert.equal(childSessionKeyForRow(mixedEvent, 'R-CD-MODEL-TOOL-new'), null);
 });
 
+test('rejects nonce-bearing routing keys as child authority', () => {
+  const rowNonce = 'R-CD-MODEL-TOOL-new';
+  assert.equal(childSessionKeyForRow({
+    sessionKey: `agent:main:parent-${rowNonce}`,
+    childSessionKey: 'luna-stale-child',
+  }, rowNonce), null);
+  assert.equal(childSessionKeyForRow({
+    sessionKey: 'agent:main:requester',
+    childSessionKey: `luna-stale-${rowNonce}`,
+  }, rowNonce), null);
+});
+
+test('accepts a bounded nested task summary through an explicit compact row token', () => {
+  const rowNonce = 'R-CD-4-EXACT-NONCE-WITH-LONG-RANDOM-SUFFIX';
+  const taskIdentityToken = `RCD4:${rowNonce.slice(-16)}`;
+  const title = `[continuation:chain-hop:1] Delegated task (turn 1/3): ${taskIdentityToken} ${rowNonce}`
+    .slice(0, 80);
+  assert.equal(childSessionKeyForRow({
+    action: 'upserted',
+    task: {
+      sessionKey: `agent:main:r-cd-4-parent-${rowNonce}`,
+      childSessionKey: 'luna-child-for-current-row',
+      title,
+    },
+  }, rowNonce, [taskIdentityToken]), 'luna-child-for-current-row');
+});
+
 test('accepts a direct spawn record that binds its child key and task nonce', () => {
   const spawnEvent = {
     childSessionKey: 'luna-child-for-current-row',
@@ -59,6 +89,29 @@ test('selects the one nested record whose own payload carries the current nonce'
   assert.equal(childSessionKeyForRow(aggregateEvent, 'R-CD-MODEL-TOOL-new'), 'luna-child-for-current-row');
 });
 
+test('rejects nested metadata as child authority without shadowing a real task record', () => {
+  const rowNonce = 'R-CD-MODEL-TOOL-new';
+  const metadataOnly = {
+    metadata: {
+      childSessionKey: 'stale-child-from-metadata',
+      title: `Proof nonce ${rowNonce}`,
+    },
+  };
+  assert.equal(childSessionKeyForRow(metadataOnly, rowNonce), null);
+
+  const eventWithRealTask = {
+    ...metadataOnly,
+    task: {
+      childSessionKey: 'luna-child-for-current-row',
+      title: `Proof nonce ${rowNonce}`,
+    },
+  };
+  assert.equal(
+    childSessionKeyForRow(eventWithRealTask, rowNonce),
+    'luna-child-for-current-row',
+  );
+});
+
 test('fails closed when two different child keys are both bound to the row nonce', () => {
   const ambiguousEvent = {
     records: [
@@ -74,4 +127,8 @@ test('fails closed when two different child keys are both bound to the row nonce
   };
 
   assert.equal(childSessionKeyForRow(ambiguousEvent, 'R-CD-MODEL-TOOL-new'), null);
+  assert.deepEqual(
+    childSessionKeysForRow(ambiguousEvent, 'R-CD-MODEL-TOOL-new'),
+    ['luna-child-a', 'luna-child-b'],
+  );
 });


### PR DESCRIPTION
## Summary

- require the exact `TARGET-RECEIVED <row nonce>` marker in a structured role=system target-session event
- bind PASS to a separately nonce-correlated child session identity
- reject unrelated delayed messages, prompt echoes, nonce-prefix lookalikes, and nested target-key mentions
- preserve explicit target and parent return receipts in row evidence

Closes the harness-authority defect tracked in #421. This patch does not fire the row or change canonical proof metadata.

## Validation

- `node --test tools/k6-proofs/tests/r-cd-4-authority.test.mjs tools/k6-proofs/tests/row-child-correlation.test.mjs` — 12/12
- full proof harness — 227/227
- manifest scenario registry — 38 manifests / 35 scenarios, green
- proof-row manifest coverage — 35/35, green
- `k6 inspect tools/k6-proofs/scenarios/r-cd-4-target-session-key.js` — green
- `git diff --check` — green

## Review probes

- ordinary delayed target message cannot set `return_in_target`
- assistant-authored marker cannot impersonate the system return
- prompt echo and nonce-prefix marker cannot satisfy the receipt
- a target session key mentioned inside a parent event cannot route the receipt
- exact target marker remains non-authoritative until the child identity is observed

After independent review and merge, `R-CD-4` still requires explicit one-fire authorization for a fresh behavioral packet.
