### PR TITLE
proofs: bind depth-2 return to root authority

### DIFF
--- a/tools/k6-proofs/lib/r-cd-chained-depth-2-authority.mjs
+++ b/tools/k6-proofs/lib/r-cd-chained-depth-2-authority.mjs
@@ -1,0 +1,58 @@
+const HARNESS_MARKER = '[k6-proof-harness]';
+
+function escapeRegex(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function directSessionKey(eventData) {
+  if (!eventData || typeof eventData !== 'object' || Array.isArray(eventData)) return null;
+  const candidates = [eventData.sessionKey, eventData.session]
+    .filter((value) => typeof value === 'string' && value.length > 0);
+  const unique = [...new Set(candidates)];
+  return unique.length === 1 ? unique[0] : null;
+}
+
+function directMessageRole(eventData) {
+  const message = eventData?.message;
+  if (!message || typeof message !== 'object' || Array.isArray(message)) return null;
+  return typeof message.role === 'string' ? message.role : null;
+}
+
+function hasExactGrandchildMarker(eventData, nonce) {
+  const serialized = JSON.stringify(eventData);
+  if (!serialized || serialized.includes(HARNESS_MARKER)) return false;
+  const pattern = new RegExp(
+    `(?:^|[^A-Za-z0-9_-])GRANDCHILD-DONE\\s+${escapeRegex(nonce)}(?=$|[^A-Za-z0-9_-])`,
+  );
+  return pattern.test(serialized);
+}
+
+/**
+ * Identify the root system-event candidate independently of the grandchild's
+ * ordinary assistant output. The event must be a structured session.message
+ * for the exact root and must carry the exact row marker as role=system.
+ */
+export function rCdChainRootReturnCandidate({ eventName, eventData, rootSessionKey, nonce }) {
+  if (eventName !== 'session.message') return null;
+  if (!rootSessionKey || !nonce) return null;
+  if (directSessionKey(eventData) !== rootSessionKey) return null;
+  if (directMessageRole(eventData) !== 'system') return null;
+  if (!hasExactGrandchildMarker(eventData, nonce)) return null;
+  return {
+    eventName,
+    rootSessionKey,
+    nonce,
+    marker: `GRANDCHILD-DONE ${nonce}`,
+    role: 'system',
+  };
+}
+
+/** Finalize only when both distinct nonce-bound hop identities are known. */
+export function rCdChainRootReturnReceipt(
+  candidate,
+  { childSessionKey, grandchildSessionKey } = {},
+) {
+  if (!candidate || !childSessionKey || !grandchildSessionKey) return null;
+  if (childSessionKey === grandchildSessionKey) return null;
+  return { ...candidate, childSessionKey, grandchildSessionKey };
+}

--- a/tools/k6-proofs/lib/r-cd-chained-depth-2-authority.mjs
+++ b/tools/k6-proofs/lib/r-cd-chained-depth-2-authority.mjs
@@ -18,13 +18,30 @@ function directMessageRole(eventData) {
   return typeof message.role === 'string' ? message.role : null;
 }
 
+function directMessageText(eventData) {
+  const message = eventData?.message;
+  if (!message || typeof message !== 'object' || Array.isArray(message)) return null;
+  if (typeof message.content === 'string') return message.content;
+  if (!Array.isArray(message.content)) return null;
+  const textParts = message.content
+    .filter((part) => (
+      part
+      && typeof part === 'object'
+      && !Array.isArray(part)
+      && part.type === 'text'
+      && typeof part.text === 'string'
+    ))
+    .map((part) => part.text);
+  return textParts.length > 0 ? textParts.join('\n') : null;
+}
+
 function hasExactGrandchildMarker(eventData, nonce) {
-  const serialized = JSON.stringify(eventData);
-  if (!serialized || serialized.includes(HARNESS_MARKER)) return false;
+  const messageText = directMessageText(eventData);
+  if (!messageText || messageText.includes(HARNESS_MARKER)) return false;
   const pattern = new RegExp(
     `(?:^|[^A-Za-z0-9_-])GRANDCHILD-DONE\\s+${escapeRegex(nonce)}(?=$|[^A-Za-z0-9_-])`,
   );
-  return pattern.test(serialized);
+  return pattern.test(messageText);
 }
 
 /**

--- a/tools/k6-proofs/manifests/r-cd-chained-depth-2.json
+++ b/tools/k6-proofs/manifests/r-cd-chained-depth-2.json
@@ -61,12 +61,12 @@
     {
       "name": "grandchild-returns",
       "required": true,
-      "description": "GRANDCHILD-DONE sentinel observed after dispatch acceptance gate"
+      "description": "A nonce-bound grandchild identity and exact GRANDCHILD-DONE sentinel are observed after dispatch acceptance"
     },
     {
       "name": "parent-receives-chain-return",
       "required": true,
-      "description": "Parent session receives nonce-correlated, non-harness chained return evidence"
+      "description": "The exact root session receives GRANDCHILD-DONE {{nonce}} as a structured role=system return event, bound to distinct child and grandchild identities"
     },
     {
       "name": "trace-id",
@@ -84,7 +84,7 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Depth-2 chain proof. PASS-candidate requires post-dispatch, non-harness CHILD-DONE and GRANDCHILD-DONE sentinels (strict evidence gate). Ignore prompt-echo events from the original [k6-proof-harness] instruction. Chain depth limit enforcement tested implicitly (depth-2 should succeed; gateway caps apply). tasks.list remains optional context because continue_delegate uses pending-delegate/subagent surfaces, not the generic task registry."
+    "notes": "Depth-2 chain proof. PASS-candidate requires strict child/grandchild sentinels, two distinct nonce-bound hop identities, and an explicit role=system GRANDCHILD-DONE {{nonce}} receipt in the exact root session. Grandchild assistant output alone is not return authority."
   },
   "liveRunSafety": {
     "classification": "k6-runnable",
@@ -105,6 +105,6 @@
       "trace-id"
     ],
     "foldRequiresReview": true,
-    "notes": "Live depth-2 chain row. Prefer OPENCLAW_CREATE_DISPOSABLE_SESSION=true for repeatability so the proof does not touch the live #sprites/main Discord lane. Serialize per target session (sameSessionConcurrencySafe=false). Detector must ignore [k6-proof-harness] prompt echo; only post-dispatch sentinel evidence counts."
+    "notes": "Live depth-2 chain row. Prefer OPENCLAW_CREATE_DISPOSABLE_SESSION=true. Detector ignores prompt echoes and ordinary GRANDCHILD-DONE assistant output; PASS requires distinct hop identities plus the exact root role=system return receipt."
   }
 }

--- a/tools/k6-proofs/scenarios/r-cd-chained-depth-2.js
+++ b/tools/k6-proofs/scenarios/r-cd-chained-depth-2.js
@@ -23,6 +23,11 @@ import { Counter, Trend } from 'k6/metrics';
 import crypto from 'k6/crypto';
 import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+import { childSessionKeyForRow } from '../lib/row-child-correlation.mjs';
+import {
+  rCdChainRootReturnCandidate,
+  rCdChainRootReturnReceipt,
+} from '../lib/r-cd-chained-depth-2-authority.mjs';
 
 export const options = {
   scenarios: {
@@ -108,6 +113,8 @@ export default function () {
     child_done_sentinel: false,
     grandchild_done_sentinel: false,
     chain_return_received: false,
+    root_return_candidate: null,
+    root_return_receipt: null,
     dispatch_accepted_at_ms: null,
     // Depth tracking
     max_depth_observed: 0,
@@ -124,6 +131,31 @@ export default function () {
 
   const res = ws.connect(url, {}, (socket) => {
     const tracker = new RequestTracker();
+
+    function finalizeRootReturnReceipt() {
+      evidence.root_return_receipt = rCdChainRootReturnReceipt(
+        evidence.root_return_candidate,
+        {
+          childSessionKey: evidence.child_session,
+          grandchildSessionKey: evidence.grandchild_session,
+        },
+      );
+      evidence.chain_return_received = evidence.root_return_receipt !== null;
+    }
+
+    function observeChainSession(observedSessionKey) {
+      if (!observedSessionKey || observedSessionKey === sessionKey) return;
+      if (!evidence.child_session) {
+        evidence.child_session = observedSessionKey;
+        evidence.child_spawned = true;
+        if (evidence.max_depth_observed < 1) evidence.max_depth_observed = 1;
+      } else if (observedSessionKey !== evidence.child_session && !evidence.grandchild_session) {
+        evidence.grandchild_session = observedSessionKey;
+        evidence.grandchild_spawned = true;
+        if (evidence.max_depth_observed < 2) evidence.max_depth_observed = 2;
+      }
+      finalizeRootReturnReceipt();
+    }
 
     function startProofFlow(socket) {
       // Subscribe to parent session events — primary proof surface for chain progression.
@@ -229,12 +261,8 @@ export default function () {
           for (const task of tasks) {
             const taskStr = JSON.stringify(task);
             if (!taskStr.includes(chainNonce)) continue;
-            if (!evidence.child_session && task.sessionKey && task.sessionKey !== sessionKey) {
-              evidence.child_session = task.sessionKey;
-            }
-            if (!evidence.grandchild_session && task.childSessionKey && task.childSessionKey !== sessionKey) {
-              evidence.grandchild_session = task.childSessionKey;
-            }
+            observeChainSession(task.sessionKey);
+            observeChainSession(task.childSessionKey);
             if (task.traceId) evidence.trace_id = task.traceId;
           }
         }
@@ -243,8 +271,10 @@ export default function () {
         // public proof surface for continue_delegate chains; task registry rows
         // are only optional context.
         if (classified.kind === 'event') {
+          const eventName = classified.event || '';
           const eventData = classified.data || {};
           const eventStr = JSON.stringify(eventData);
+          observeChainSession(childSessionKeyForRow(eventData, chainNonce));
           if (eventStr.includes(chainNonce)) {
             if (eventStr.includes(HARNESS_MARKER)) {
               console.log('ℹ Ignoring harness prompt echo event');
@@ -253,19 +283,22 @@ export default function () {
               if (elapsed >= POST_DISPATCH_EVIDENCE_GATE_MS) {
                 if (eventStr.includes(`CHILD-DONE ${chainNonce} CHILD-DELEGATE-SCHEDULED`)) {
                   evidence.child_done_sentinel = true;
-                  evidence.child_spawned = true;
-                  if (evidence.max_depth_observed < 1) evidence.max_depth_observed = 1;
                   console.log('✓ CHILD-DONE/CHILD-DELEGATE-SCHEDULED sentinel observed post-dispatch');
                 }
                 if (eventStr.includes(`GRANDCHILD-DONE ${chainNonce}`)) {
                   evidence.grandchild_done_sentinel = true;
-                  evidence.grandchild_spawned = true;
-                  evidence.chain_return_received = true;
-                  if (evidence.max_depth_observed < 2) evidence.max_depth_observed = 2;
                   console.log('✓ GRANDCHILD-DONE sentinel observed post-dispatch');
                 }
-                if (evidence.child_done_sentinel && evidence.grandchild_done_sentinel) {
-                  evidence.chain_return_received = true;
+                const rootReturnCandidate = rCdChainRootReturnCandidate({
+                  eventName,
+                  eventData,
+                  rootSessionKey: sessionKey,
+                  nonce: chainNonce,
+                });
+                if (rootReturnCandidate) {
+                  evidence.root_return_candidate = rootReturnCandidate;
+                  finalizeRootReturnReceipt();
+                  console.log('✓ explicit nonce-bound root system return candidate observed');
                 }
               }
             }
@@ -276,7 +309,9 @@ export default function () {
         if (evidence.parent_dispatch_accepted &&
             evidence.child_done_sentinel &&
             evidence.grandchild_done_sentinel &&
-            evidence.chain_return_received) {
+            evidence.child_session &&
+            evidence.grandchild_session &&
+            evidence.root_return_receipt) {
           console.log('Full chain evidence gathered, closing early');
           socket.close();
         }
@@ -300,11 +335,15 @@ export default function () {
     'parent dispatch accepted': () => evidence.parent_dispatch_accepted,
     'child sentinel observed post-dispatch': () => evidence.child_done_sentinel,
     'grandchild sentinel observed post-dispatch': () => evidence.grandchild_done_sentinel,
-    'chain return received at parent': () => evidence.chain_return_received,
+    'nonce-bound child identity observed': () => evidence.child_session !== null,
+    'nonce-bound grandchild identity observed': () => evidence.grandchild_session !== null,
+    'explicit root return receipt observed': () => evidence.root_return_receipt !== null,
     'max depth >= 2': () => evidence.max_depth_observed >= 2,
   });
 
-  if (!evidence.parent_dispatch_accepted || !evidence.child_done_sentinel || !evidence.grandchild_done_sentinel) {
+  if (!evidence.parent_dispatch_accepted || !evidence.child_done_sentinel ||
+      !evidence.grandchild_done_sentinel || !evidence.child_session ||
+      !evidence.grandchild_session || !evidence.root_return_receipt) {
     failures.add(1);
   }
 
@@ -312,7 +351,9 @@ export default function () {
     evidence.parent_dispatch_accepted &&
     evidence.child_done_sentinel &&
     evidence.grandchild_done_sentinel &&
-    evidence.chain_return_received;
+    evidence.child_session !== null &&
+    evidence.grandchild_session !== null &&
+    evidence.root_return_receipt !== null;
 
   console.log(`\n--- R-CD-CHAINED-DEPTH-2 EVIDENCE SUMMARY ---`);
   console.log(JSON.stringify(evidence, null, 2));

--- a/tools/k6-proofs/tests/r-cd-chained-depth-2-authority.test.mjs
+++ b/tools/k6-proofs/tests/r-cd-chained-depth-2-authority.test.mjs
@@ -69,6 +69,18 @@ test('depth-2 chain rejects prompt echoes and nonce-prefix lookalikes', () => {
   }), null);
 });
 
+test('depth-2 chain rejects a marker present only in sibling or nested metadata', () => {
+  const eventData = systemEvent('unrelated root system message');
+  eventData.metadata = { returnMarker: `GRANDCHILD-DONE ${nonce}` };
+  eventData.message.metadata = { echoedMarker: `GRANDCHILD-DONE ${nonce}` };
+  assert.equal(rCdChainRootReturnCandidate({
+    eventName: 'session.message',
+    eventData,
+    rootSessionKey: root,
+    nonce,
+  }), null);
+});
+
 test('depth-2 chain withholds return authority without two distinct hop identities', () => {
   const candidate = rCdChainRootReturnCandidate({
     eventName: 'session.message',

--- a/tools/k6-proofs/tests/r-cd-chained-depth-2-authority.test.mjs
+++ b/tools/k6-proofs/tests/r-cd-chained-depth-2-authority.test.mjs
@@ -1,0 +1,87 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  rCdChainRootReturnCandidate,
+  rCdChainRootReturnReceipt,
+} from '../lib/r-cd-chained-depth-2-authority.mjs';
+
+const nonce = 'R-CD-CHAIN-EXACT-NONCE';
+const root = 'agent:main:r-cd-chain-root';
+
+function systemEvent(text, sessionKey = root) {
+  return { sessionKey, message: { role: 'system', content: [{ type: 'text', text }] } };
+}
+
+test('depth-2 chain binds an explicit root system receipt to both hop identities', () => {
+  const candidate = rCdChainRootReturnCandidate({
+    eventName: 'session.message',
+    eventData: systemEvent(`GRANDCHILD-DONE ${nonce}`),
+    rootSessionKey: root,
+    nonce,
+  });
+  assert.deepEqual(rCdChainRootReturnReceipt(candidate, {
+    childSessionKey: 'agent:main:subagent:child',
+    grandchildSessionKey: 'agent:main:subagent:grandchild',
+  }), {
+    eventName: 'session.message',
+    rootSessionKey: root,
+    nonce,
+    marker: `GRANDCHILD-DONE ${nonce}`,
+    role: 'system',
+    childSessionKey: 'agent:main:subagent:child',
+    grandchildSessionKey: 'agent:main:subagent:grandchild',
+  });
+});
+
+test('depth-2 chain rejects ordinary GRANDCHILD-DONE assistant output', () => {
+  assert.equal(rCdChainRootReturnCandidate({
+    eventName: 'session.message',
+    eventData: {
+      sessionKey: root,
+      message: { role: 'assistant', content: `GRANDCHILD-DONE ${nonce}` },
+    },
+    rootSessionKey: root,
+    nonce,
+  }), null);
+});
+
+test('depth-2 chain rejects a correct marker delivered outside the root', () => {
+  assert.equal(rCdChainRootReturnCandidate({
+    eventName: 'session.message',
+    eventData: systemEvent(`GRANDCHILD-DONE ${nonce}`, 'agent:main:subagent:child'),
+    rootSessionKey: root,
+    nonce,
+  }), null);
+});
+
+test('depth-2 chain rejects prompt echoes and nonce-prefix lookalikes', () => {
+  assert.equal(rCdChainRootReturnCandidate({
+    eventName: 'session.message',
+    eventData: systemEvent(`[k6-proof-harness] expect GRANDCHILD-DONE ${nonce}`),
+    rootSessionKey: root,
+    nonce,
+  }), null);
+  assert.equal(rCdChainRootReturnCandidate({
+    eventName: 'session.message',
+    eventData: systemEvent(`GRANDCHILD-DONE ${nonce}-STALE`),
+    rootSessionKey: root,
+    nonce,
+  }), null);
+});
+
+test('depth-2 chain withholds return authority without two distinct hop identities', () => {
+  const candidate = rCdChainRootReturnCandidate({
+    eventName: 'session.message',
+    eventData: systemEvent(`GRANDCHILD-DONE ${nonce}`),
+    rootSessionKey: root,
+    nonce,
+  });
+  assert.equal(rCdChainRootReturnReceipt(candidate, {
+    childSessionKey: 'agent:main:subagent:child',
+    grandchildSessionKey: null,
+  }), null);
+  assert.equal(rCdChainRootReturnReceipt(candidate, {
+    childSessionKey: 'agent:main:subagent:same',
+    grandchildSessionKey: 'agent:main:subagent:same',
+  }), null);
+});


### PR DESCRIPTION
## Summary

- stop treating `GRANDCHILD-DONE <nonce>` alone as final ancestor delivery
- require distinct nonce-bound child and grandchild session identities
- require the exact marker as a structured role=system event in the exact root session
- preserve the root return receipt with both hop identities
- reject ordinary assistant output, non-root delivery, prompt echoes, nonce-prefix lookalikes, and incomplete/ambiguous hop identity

Closes the harness-authority defect tracked in #424. This patch does not fire the row, alter trace adjudication, update runtime #1183, or change canonical proof metadata.

## Validation

- focused authority + child-correlation tests — 11/11
- full proof harness — 226/226
- manifest scenario registry — 38 manifests / 35 scenarios, green
- proof-row manifest coverage — 35/35, green
- `k6 inspect tools/k6-proofs/scenarios/r-cd-chained-depth-2.js` — green
- `git diff --check` — green

## Review probes

- ordinary `GRANDCHILD-DONE` assistant output cannot satisfy root return
- a matching marker in a child/non-root session cannot satisfy root return
- prompt echo and nonce-prefix marker fail closed
- missing or identical hop identities cannot finalize the receipt
- only exact root role=system marker plus two distinct hop identities becomes return authority

After independent review and merge, `R-CD-CHAINED-DEPTH-2` still requires explicit one-fire authorization for a fresh behavioral packet. Trace/status topology remains the separate #398/#416 lane.
