### PR TITLE
fix: normalize Tempo status projection and topology review

### DIFF
--- a/tools/k6-proofs/lib/public-tempo-trace.mjs
+++ b/tools/k6-proofs/lib/public-tempo-trace.mjs
@@ -2,6 +2,7 @@ const PUBLIC_TRACE_ATTRIBUTE_KEYS = new Set([
   'chain.id',
   'delegate.mode',
   'gen_ai.tool.name',
+  'openclaw.outcome',
   'openclaw.toolName',
   'reason.hash',
   'reason.length',
@@ -19,6 +20,9 @@ export function allTempoSpans(trace) {
       (batch.scopeSpans || batch.instrumentationLibrarySpans || []).flatMap((scope) => scope.spans || []));
   }
   if (Array.isArray(trace?.trace?.spans)) return trace.trace.spans;
+  if (trace?.schema === 'openclaw.k6.public-tempo-trace.v1' && Array.isArray(trace.spans)) {
+    return trace.spans;
+  }
   return [];
 }
 
@@ -50,6 +54,7 @@ function publicTraceAttribute(attribute) {
   if (attribute.key === 'delegate.mode' && !['normal', 'silent', 'silent-wake', 'post-compaction'].includes(String(value))) return null;
   if (['gen_ai.tool.name', 'openclaw.toolName'].includes(attribute.key) &&
       !['continue_delegate', 'continue_work', 'request_compaction'].includes(String(value))) return null;
+  if (attribute.key === 'openclaw.outcome' && String(value) !== 'blocked') return null;
   if (attribute.key === 'chain.id' &&
       !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu.test(String(value))) return null;
 
@@ -61,10 +66,10 @@ function publicTraceAttribute(attribute) {
 }
 
 export function publicTempoStatusCode(value) {
-  if (value === 0 || value === 'UNSET') return 'UNSET';
-  if (value === 1 || value === 'OK') return 'OK';
-  if (value === 2 || value === 'ERROR') return 'ERROR';
-  return 'UNSET';
+  if (value === 0 || value === 'UNSET' || value === 'STATUS_CODE_UNSET') return 'UNSET';
+  if (value === 1 || value === 'OK' || value === 'STATUS_CODE_OK') return 'OK';
+  if (value === 2 || value === 'ERROR' || value === 'STATUS_CODE_ERROR') return 'ERROR';
+  return 'UNKNOWN';
 }
 
 export function publicTempoSpanName(value) {

--- a/tools/k6-proofs/scripts/__tests__/collect-continuation-trace.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/collect-continuation-trace.test.mjs
@@ -9,12 +9,24 @@ import path from 'node:path';
 import { promisify } from 'node:util';
 import { fileURLToPath } from 'node:url';
 import { resolveRcd2AuthoritativeReceipt } from '../../lib/r-cd-2-authoritative-receipt.mjs';
+import { publicTempoStatusCode } from '../../lib/public-tempo-trace.mjs';
 
 const execFileAsync = promisify(execFile);
 const script = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   '../collect-continuation-trace.mjs',
 );
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+const preservedTracePaths = {
+  delegate: path.join(
+    repoRoot,
+    'PROOFS/4c235d8c1997e8964160117f8d6bf650ad1e8203/artifacts/silas-lothric/comparator-20260719/prior-two-row/raw/4c235d8c1997e8964160117f8d6bf650ad1e8203/R-CD-1/silas/20260719T191117Z-r-cd-1/tempo-trace-postrun.json',
+  ),
+  work: path.join(
+    repoRoot,
+    'PROOFS/4c235d8c1997e8964160117f8d6bf650ad1e8203/artifacts/silas-lothric/comparator-20260719/prior-two-row/raw/4c235d8c1997e8964160117f8d6bf650ad1e8203/R-CW-1/silas/20260719T191326Z-r-cw-1/tempo-trace-postrun.json',
+  ),
+};
 
 function b64(hex) {
   return Buffer.from(hex, 'hex').toString('base64');
@@ -27,14 +39,31 @@ function attr(key, value) {
   };
 }
 
-function span(name, traceId, spanId, parentSpanId, attrs = []) {
+function span(name, traceId, spanId, parentSpanId, attrs = [], status = 'OK') {
   return {
     name,
     traceId: b64(traceId),
     spanId: b64(spanId),
     parentSpanId: b64(parentSpanId),
     attributes: attrs,
-    status: { code: 'OK' },
+    status: { code: status },
+  };
+}
+
+function publicAttrValue(spanEntry, key) {
+  const value = spanEntry.attributes?.find((entry) => entry.key === key)?.value;
+  return value?.stringValue ?? value?.intValue ?? value?.boolValue;
+}
+
+function withRawContinuationStatuses(trace) {
+  return {
+    ...trace,
+    spans: trace.spans.map((entry) => ({
+      ...entry,
+      status: entry.name.startsWith('continuation.')
+        ? { code: 'STATUS_CODE_OK' }
+        : entry.status,
+    })),
   };
 }
 
@@ -193,7 +222,7 @@ test('correlates a unique trace and validates tool/fire/dispatch topology', asyn
   }
 });
 
-test('rejects duplicate dispatch/fire spans and unrelated causal parents', async () => {
+test('rejects duplicate delegate dispatch/fire spans but retains different parents diagnostically', async () => {
   const fixture = await fixtureDir();
   const traceId = '1234567890abcdef1234567890abcdef';
   const base = traceFixture({ traceId, reasonHash: fixture.reasonHash, reasonLength: fixture.reasonLength });
@@ -203,25 +232,263 @@ test('rejects duplicate dispatch/fire spans and unrelated causal parents', async
   const badCases = [
     ['duplicate-dispatch', { ...dispatch, spanId: b64('9999999999999999') }],
     ['duplicate-fire', { ...fire, spanId: b64('8888888888888888') }],
-    ['different-parent', { ...fire, parentSpanId: b64('7777777777777777') }],
   ];
   for (const [label, extra] of badCases) {
     const server = await listen((request, response) => {
       response.setHeader('content-type', 'application/json');
       response.end(JSON.stringify(new URL(request.url, 'http://localhost').pathname === '/api/search'
         ? { traces: [{ traceID: traceId }] }
-        : { batches: [{ scopeSpans: [{ spans: label === 'different-parent'
-          ? spans.map((entry) => entry === fire ? extra : entry)
-          : [...spans, extra] }] }] }));
+        : { batches: [{ scopeSpans: [{ spans: [...spans, extra] }] }] }));
     });
     try {
       await assert.rejects(execFileAsync(process.execPath, [
         script, '--run-dir', fixture.dir, '--manifest', fixture.manifestPath,
         '--seat', 'silas-prince', '--tempo-url', server.url, '--timeout-ms', '40', '--poll-ms', '10',
-      ]), new RegExp(label === 'different-parent' ? 'causal parent' : `contains 2 .*${label.slice('duplicate-'.length)}`));
+      ]), new RegExp(`contains 2 .*${label.slice('duplicate-'.length)}`));
     } finally { await server.close(); }
   }
+  const differentParent = { ...fire, parentSpanId: b64('7777777777777777') };
+  const server = await listen((request, response) => {
+    response.setHeader('content-type', 'application/json');
+    response.end(JSON.stringify(new URL(request.url, 'http://localhost').pathname === '/api/search'
+      ? { traces: [{ traceID: traceId }] }
+      : { batches: [{ scopeSpans: [{ spans: spans.map((entry) => entry === fire ? differentParent : entry) }] }] }));
+  });
+  try {
+    const { stdout } = await execFileAsync(process.execPath, [
+      script, '--run-dir', fixture.dir, '--manifest', fixture.manifestPath,
+      '--seat', 'silas-prince', '--tempo-url', server.url, '--timeout-ms', '40', '--poll-ms', '10',
+    ]);
+    const result = JSON.parse(stdout);
+    const receipt = JSON.parse(await readFile(path.join(fixture.dir, result.receiptFile), 'utf8'));
+    assert.equal(receipt.dispatchParentSpanId, 'dddddddddddddddd');
+    assert.deepEqual(receipt.fireParentSpanIds, ['7777777777777777']);
+    assert.deepEqual(receipt.toolParentSpanIds, ['dddddddddddddddd']);
+  } finally { await server.close(); }
   await rm(fixture.dir, { recursive: true, force: true });
+});
+
+test('maps numeric, short, and protobuf Tempo status enums and fails unknown values closed', () => {
+  assert.deepEqual(
+    [0, 'UNSET', 'STATUS_CODE_UNSET', 1, 'OK', 'STATUS_CODE_OK', 2, 'ERROR', 'STATUS_CODE_ERROR']
+      .map(publicTempoStatusCode),
+    ['UNSET', 'UNSET', 'UNSET', 'OK', 'OK', 'OK', 'ERROR', 'ERROR', 'ERROR'],
+  );
+  assert.equal(publicTempoStatusCode('STATUS_CODE_FUTURE'), 'UNKNOWN');
+  assert.equal(publicTempoStatusCode(undefined), 'UNKNOWN');
+});
+
+test('replays immutable R-CD-1 and R-CW-1 topology against raw protobuf status forms', async (t) => {
+  for (const packet of [
+    { label: 'R-CD-1', path: preservedTracePaths.delegate, tool: 'continue_delegate', expectedFires: 1 },
+    { label: 'R-CW-1', path: preservedTracePaths.work, tool: 'continue_work', expectedFires: 2 },
+  ]) {
+    await t.test(packet.label, async () => {
+      const preserved = JSON.parse(await readFile(packet.path, 'utf8'));
+      const trace = withRawContinuationStatuses(preserved);
+      const acceptName = packet.tool === 'continue_work'
+        ? 'continuation.work'
+        : 'continuation.delegate.dispatch';
+      const accept = trace.spans.find((entry) => entry.name === acceptName);
+      assert.ok(accept, `${packet.label} preserved packet lacks ${acceptName}`);
+      const reasonHash = publicAttrValue(accept, 'reason.hash');
+      const reasonLength = Number(publicAttrValue(accept, 'reason.length'));
+      const fixture = await fixtureDir({
+        tool: packet.tool,
+        includeNonce: false,
+        extraEvidence: {
+          reason_hash: reasonHash,
+          reason_length: reasonLength,
+        },
+      });
+      const server = await listen((request, response) => {
+        response.setHeader('content-type', 'application/json');
+        response.end(JSON.stringify(new URL(request.url, 'http://localhost').pathname === '/api/search'
+          ? { traces: [{ traceID: preserved.traceId }] }
+          : trace));
+      });
+
+      try {
+        const { stdout } = await execFileAsync(process.execPath, [
+          script,
+          '--run-dir', fixture.dir,
+          '--manifest', fixture.manifestPath,
+          '--seat', 'silas-prince',
+          '--tempo-url', server.url,
+          '--timeout-ms', '100',
+          '--poll-ms', '10',
+        ]);
+        const result = JSON.parse(stdout);
+        const receipt = JSON.parse(await readFile(path.join(fixture.dir, result.receiptFile), 'utf8'));
+        const projected = JSON.parse(await readFile(path.join(fixture.dir, result.traceFile), 'utf8'));
+        assert.equal(receipt.traceId, preserved.traceId);
+        assert.equal(receipt.fireAttemptCount, packet.expectedFires);
+        assert.equal(receipt.fireSpanIds.length, packet.expectedFires);
+        assert.equal(receipt.reason.hash, reasonHash);
+        assert.equal(receipt.reason.length, reasonLength);
+        assert.equal(receipt.reason.source, 'public-evidence');
+        assert.equal(
+          projected.spans.find((entry) => entry.name === acceptName)?.status?.code,
+          'OK',
+        );
+        assert.equal(
+          projected.spans.find((entry) =>
+            entry.name === 'openclaw.tool.execution' &&
+            publicAttrValue(entry, 'gen_ai.tool.name') === packet.tool)?.status?.code,
+          'UNSET',
+        );
+      } finally {
+        await server.close();
+        await rm(fixture.dir, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+test('accepts protobuf OK continuation spans and successful UNSET typed-tool spans', async () => {
+  const fixture = await fixtureDir();
+  const traceId = '12121212121212121212121212121212';
+  const trace = traceFixture({ traceId, reasonHash: fixture.reasonHash, reasonLength: fixture.reasonLength });
+  const spans = trace.batches[0].scopeSpans[0].spans;
+  for (const entry of spans) {
+    if (entry.name.startsWith('continuation.')) entry.status = { code: 'STATUS_CODE_OK' };
+    if (entry.name === 'openclaw.tool.execution') entry.status = { code: 'STATUS_CODE_UNSET' };
+  }
+  const server = await listen((request, response) => {
+    response.setHeader('content-type', 'application/json');
+    response.end(JSON.stringify(new URL(request.url, 'http://localhost').pathname === '/api/search'
+      ? { traces: [{ traceID: traceId }] }
+      : trace));
+  });
+  try {
+    const { stdout } = await execFileAsync(process.execPath, [
+      script, '--run-dir', fixture.dir, '--manifest', fixture.manifestPath,
+      '--seat', 'silas-prince', '--tempo-url', server.url, '--timeout-ms', '40', '--poll-ms', '10',
+    ]);
+    const result = JSON.parse(stdout);
+    const publicTrace = JSON.parse(await readFile(path.join(fixture.dir, result.traceFile), 'utf8'));
+    assert.deepEqual(
+      publicTrace.spans
+        .filter((entry) => entry.name.startsWith('continuation.'))
+        .map((entry) => entry.status.code),
+      ['OK', 'OK'],
+    );
+    assert.equal(
+      publicTrace.spans.find((entry) => entry.name === 'openclaw.tool.execution').status.code,
+      'UNSET',
+    );
+  } finally {
+    await server.close();
+    await rm(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test('rejects typed-tool ERROR, blocked, and unknown status while accepting explicit OK', async (t) => {
+  for (const variant of ['OK', 'ERROR', 'blocked', 'unknown']) {
+    await t.test(variant, async () => {
+      const fixture = await fixtureDir();
+      const traceId = variant === 'OK'
+        ? '13131313131313131313131313131313'
+        : variant === 'ERROR'
+          ? '14141414141414141414141414141414'
+          : variant === 'blocked'
+            ? '15151515151515151515151515151515'
+            : '16161616161616161616161616161616';
+      const trace = traceFixture({ traceId, reasonHash: fixture.reasonHash, reasonLength: fixture.reasonLength });
+      const tool = trace.batches[0].scopeSpans[0].spans
+        .find((entry) => entry.name === 'openclaw.tool.execution');
+      tool.status = { code: variant === 'unknown' ? 'STATUS_CODE_FUTURE' : variant === 'blocked' ? 'UNSET' : variant };
+      if (variant === 'blocked') tool.attributes.push(attr('openclaw.outcome', 'blocked'));
+      const server = await listen((request, response) => {
+        response.setHeader('content-type', 'application/json');
+        response.end(JSON.stringify(new URL(request.url, 'http://localhost').pathname === '/api/search'
+          ? { traces: [{ traceID: traceId }] }
+          : trace));
+      });
+      try {
+        const run = () => execFileAsync(process.execPath, [
+          script, '--run-dir', fixture.dir, '--manifest', fixture.manifestPath,
+          '--seat', 'silas-prince', '--tempo-url', server.url, '--timeout-ms', '0', '--poll-ms', '10',
+        ]);
+        if (variant === 'OK') {
+          await run();
+        } else {
+          await assert.rejects(run(), /error, blocked, or has unknown status/);
+        }
+      } finally {
+        await server.close();
+        await rm(fixture.dir, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+test('accepts distinct repeated continue_work fire attempts and preserves every receipt', async () => {
+  const fixture = await fixtureDir({ tool: 'continue_work' });
+  const traceId = '17171717171717171717171717171717';
+  const trace = traceFixture({
+    traceId,
+    reasonHash: fixture.reasonHash,
+    reasonLength: fixture.reasonLength,
+    tool: 'continue_work',
+  });
+  const spans = trace.batches[0].scopeSpans[0].spans;
+  const fire = spans.find((entry) => entry.name === 'continuation.work.fire');
+  spans.push({
+    ...fire,
+    spanId: b64('9999999999999999'),
+    parentSpanId: b64('7777777777777777'),
+  });
+  const server = await listen((request, response) => {
+    response.setHeader('content-type', 'application/json');
+    response.end(JSON.stringify(new URL(request.url, 'http://localhost').pathname === '/api/search'
+      ? { traces: [{ traceID: traceId }] }
+      : trace));
+  });
+  try {
+    const { stdout } = await execFileAsync(process.execPath, [
+      script, '--run-dir', fixture.dir, '--manifest', fixture.manifestPath,
+      '--seat', 'silas-prince', '--tempo-url', server.url, '--timeout-ms', '40', '--poll-ms', '10',
+    ]);
+    const result = JSON.parse(stdout);
+    const receipt = JSON.parse(await readFile(path.join(fixture.dir, result.receiptFile), 'utf8'));
+    assert.equal(receipt.fireAttemptCount, 2);
+    assert.deepEqual(receipt.fireSpanIds, ['bbbbbbbbbbbbbbbb', '9999999999999999']);
+    assert.deepEqual(receipt.fireParentSpanIds, ['dddddddddddddddd', '7777777777777777']);
+    assert.equal(receipt.fireSpanId, 'bbbbbbbbbbbbbbbb');
+  } finally {
+    await server.close();
+    await rm(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test('rejects repeated continue_work fire attempts with duplicate span IDs', async () => {
+  const fixture = await fixtureDir({ tool: 'continue_work' });
+  const traceId = '18181818181818181818181818181818';
+  const trace = traceFixture({
+    traceId,
+    reasonHash: fixture.reasonHash,
+    reasonLength: fixture.reasonLength,
+    tool: 'continue_work',
+  });
+  const spans = trace.batches[0].scopeSpans[0].spans;
+  const fire = spans.find((entry) => entry.name === 'continuation.work.fire');
+  spans.push({ ...fire });
+  const server = await listen((request, response) => {
+    response.setHeader('content-type', 'application/json');
+    response.end(JSON.stringify(new URL(request.url, 'http://localhost').pathname === '/api/search'
+      ? { traces: [{ traceID: traceId }] }
+      : trace));
+  });
+  try {
+    await assert.rejects(execFileAsync(process.execPath, [
+      script, '--run-dir', fixture.dir, '--manifest', fixture.manifestPath,
+      '--seat', 'silas-prince', '--tempo-url', server.url, '--timeout-ms', '0', '--poll-ms', '10',
+    ]), /span IDs are not distinct/);
+  } finally {
+    await server.close();
+    await rm(fixture.dir, { recursive: true, force: true });
+  }
 });
 
 test('R-CD-2 correlation carries only matching opaque send run and nonce bindings', async () => {

--- a/tools/k6-proofs/scripts/collect-continuation-trace.mjs
+++ b/tools/k6-proofs/scripts/collect-continuation-trace.mjs
@@ -224,13 +224,13 @@ function validateTrace(trace, expected) {
       attrs.get('chain.id') === chainId &&
       (expected.mode === undefined || attrs.get('delegate.mode') === expected.mode);
   });
-  if (fires.length !== 1) {
+  const permitsRepeatedFireAttempts = expected.tool === 'continue_work';
+  if (fires.length === 0 || (!permitsRepeatedFireAttempts && fires.length !== 1)) {
     throw new Error(fires.length === 0
       ? `matched trace lacks the expected ${expected.fireSpanName} span`
       : `matched trace contains ${fires.length} ${expected.fireSpanName} spans`);
   }
-  const fire = fires[0];
-  if (publicStatusCode(fire.status?.code) !== 'OK') {
+  if (fires.some((span) => publicStatusCode(span.status?.code) !== 'OK')) {
     throw new Error(`${expected.fireSpanName} span is not status OK`);
   }
 
@@ -250,29 +250,29 @@ function validateTrace(trace, expected) {
         : `matched trace contains ${tools.length} ${expected.tool} tool spans`,
     );
   }
-  if (tools.some((span) => publicStatusCode(span.status?.code) !== 'OK')) {
-    throw new Error(`originating ${expected.tool} tool span is not status OK`);
+  if (tools.some((span) => {
+    const status = publicStatusCode(span.status?.code);
+    const attrs = attributes(span);
+    return !['UNSET', 'OK'].includes(status) || attrs.get('openclaw.outcome') === 'blocked';
+  })) {
+    throw new Error(`originating ${expected.tool} tool span is error, blocked, or has unknown status`);
   }
 
   const traceId = idHex(accept.traceId, 16, 'trace id');
-  const fireTraceId = idHex(fire.traceId, 16, 'fire trace id');
+  const fireTraceIds = fires.map((span) => idHex(span.traceId, 16, 'fire trace id'));
   const toolTraceIds = tools.map((span) => idHex(span.traceId, 16, 'tool trace id'));
-  if (fireTraceId !== traceId || toolTraceIds.some((value) => value !== traceId)) {
+  if (fireTraceIds.some((value) => value !== traceId) || toolTraceIds.some((value) => value !== traceId)) {
     throw new Error('tool/fire/accept do not share one trace');
   }
 
   const acceptSpanId = idHex(accept.spanId, 8, 'accept span id');
-  const fireSpanId = idHex(fire.spanId, 8, 'fire span id');
+  const fireSpanIds = fires.map((span) => idHex(span.spanId, 8, 'fire span id'));
   const acceptParentSpanId = idHex(accept.parentSpanId, 8, 'dispatch parent span id');
-  const fireParentSpanId = idHex(fire.parentSpanId, 8, 'fire parent span id');
+  const fireParentSpanIds = fires.map((span) => idHex(span.parentSpanId, 8, 'fire parent span id'));
   const toolParentSpanIds = tools.map((span) => idHex(span.parentSpanId, 8, 'tool parent span id'));
-  if (fireParentSpanId !== acceptParentSpanId || toolParentSpanIds.some((value) => value !== acceptParentSpanId)) {
-    throw new Error('tool/fire/dispatch do not share one causal parent');
-  }
   const toolSpanIds = tools.map((span) => idHex(span.spanId, 8, 'tool span id'));
-  if (acceptSpanId === fireSpanId ||
-      toolSpanIds.includes(acceptSpanId) ||
-      toolSpanIds.includes(fireSpanId)) {
+  const lifecycleSpanIds = [acceptSpanId, ...fireSpanIds, ...toolSpanIds];
+  if (new Set(lifecycleSpanIds).size !== lifecycleSpanIds.length) {
     throw new Error('tool/fire/accept span IDs are not distinct');
   }
 
@@ -286,8 +286,12 @@ function validateTrace(trace, expected) {
     traceId,
     chainId,
     toolSpanIds,
-    fireSpanId,
-    fireParentSpanId,
+    toolParentSpanIds,
+    fireSpanId: fireSpanIds[0],
+    fireParentSpanId: fireParentSpanIds[0],
+    fireSpanIds,
+    fireParentSpanIds,
+    fireAttemptCount: fireSpanIds.length,
     childSpans,
   };
   if (expected.tool === 'continue_delegate') {


### PR DESCRIPTION
Refs #398.

This repairs the Project 81 public Tempo projection and continuation topology validator without firing proof behavior or changing canonical proof surfaces.

- normalize numeric, short, and protobuf STATUS_CODE_* forms; unknown values fail closed
- accept successful typed-tool UNSET or OK; reject ERROR, blocked outcome, and unknown status
- retain parent IDs as diagnostics rather than requiring parent equality
- accept one or more distinct continue_work fire attempts while keeping continue_delegate exactly-once
- publish all fire IDs, parents, and attempt count
- replay the preserved R-CD-1 and R-CW-1 packet topology offline

Validation:
- focused collector suite: 31/31
- full k6 proof harness: 239/239
- scenario alignment: green
- proof-row manifest coverage: 35/35
- node syntax checks and git diff --check: green

No proof row fire, canonical manifest/index mutation, runtime change, or presentation movement.