### PR TITLE
proofs: repair Tempo status and continuation authority

### DIFF
--- a/tools/k6-proofs/lib/public-tempo-trace.mjs
+++ b/tools/k6-proofs/lib/public-tempo-trace.mjs
@@ -61,10 +61,11 @@ function publicTraceAttribute(attribute) {
 }
 
 export function publicTempoStatusCode(value) {
-  if (value === 0 || value === 'UNSET') return 'UNSET';
-  if (value === 1 || value === 'OK') return 'OK';
-  if (value === 2 || value === 'ERROR') return 'ERROR';
-  return 'UNSET';
+  if (value === undefined || value === null ||
+      value === 0 || value === 'UNSET' || value === 'STATUS_CODE_UNSET') return 'UNSET';
+  if (value === 1 || value === 'OK' || value === 'STATUS_CODE_OK') return 'OK';
+  if (value === 2 || value === 'ERROR' || value === 'STATUS_CODE_ERROR') return 'ERROR';
+  return null;
 }
 
 export function publicTempoSpanName(value) {
@@ -85,12 +86,16 @@ export function projectPublicTempoTrace(trace, traceId) {
     const spanId = safeSpanId(span.spanId, 8);
     if (!spanId) return [];
     const parentSpanId = safeSpanId(span.parentSpanId, 8);
+    const statusCode = publicTempoStatusCode(span.status?.code);
+    if (statusCode === null) {
+      throw new Error(`unsupported Tempo status code on ${name}`);
+    }
     return [{
       name,
       traceId,
       spanId,
       parentSpanId,
-      status: { code: publicTempoStatusCode(span.status?.code) },
+      status: { code: statusCode },
       attributes: (Array.isArray(span.attributes) ? span.attributes : [])
         .map(publicTraceAttribute)
         .filter(Boolean),

--- a/tools/k6-proofs/scripts/__tests__/collect-continuation-trace.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/collect-continuation-trace.test.mjs
@@ -193,33 +193,163 @@ test('correlates a unique trace and validates tool/fire/dispatch topology', asyn
   }
 });
 
-test('rejects duplicate dispatch/fire spans and unrelated causal parents', async () => {
+test('rejects duplicate dispatch spans while accepting distinct causal parents', async () => {
   const fixture = await fixtureDir();
   const traceId = '1234567890abcdef1234567890abcdef';
   const base = traceFixture({ traceId, reasonHash: fixture.reasonHash, reasonLength: fixture.reasonLength });
   const spans = base.batches[0].scopeSpans[0].spans;
   const dispatch = spans.find((entry) => entry.name === 'continuation.delegate.dispatch');
   const fire = spans.find((entry) => entry.name === 'continuation.delegate.fire');
-  const badCases = [
-    ['duplicate-dispatch', { ...dispatch, spanId: b64('9999999999999999') }],
-    ['duplicate-fire', { ...fire, spanId: b64('8888888888888888') }],
-    ['different-parent', { ...fire, parentSpanId: b64('7777777777777777') }],
+  const duplicateServer = await listen((request, response) => {
+    response.setHeader('content-type', 'application/json');
+    response.end(JSON.stringify(new URL(request.url, 'http://localhost').pathname === '/api/search'
+      ? { traces: [{ traceID: traceId }] }
+      : { batches: [{ scopeSpans: [{ spans: [
+        ...spans,
+        { ...dispatch, spanId: b64('9999999999999999') },
+      ] }] }] }));
+  });
+  try {
+    await assert.rejects(execFileAsync(process.execPath, [
+      script, '--run-dir', fixture.dir, '--manifest', fixture.manifestPath,
+      '--seat', 'silas-prince', '--tempo-url', duplicateServer.url, '--timeout-ms', '40', '--poll-ms', '10',
+    ]), /contains 2 continuation\.delegate\.dispatch spans/);
+  } finally {
+    await duplicateServer.close();
+  }
+
+  const differentParentServer = await listen((request, response) => {
+    response.setHeader('content-type', 'application/json');
+    response.end(JSON.stringify(new URL(request.url, 'http://localhost').pathname === '/api/search'
+      ? { traces: [{ traceID: traceId }] }
+      : {
+          batches: [{
+            scopeSpans: [{
+              spans: spans.map((entry) => entry === fire
+                ? { ...entry, parentSpanId: b64('7777777777777777') }
+                : entry),
+            }],
+          }],
+        }));
+  });
+  try {
+    const { stdout } = await execFileAsync(process.execPath, [
+      script, '--run-dir', fixture.dir, '--manifest', fixture.manifestPath,
+      '--seat', 'silas-prince', '--tempo-url', differentParentServer.url,
+      '--timeout-ms', '100', '--poll-ms', '10',
+    ]);
+    const result = JSON.parse(stdout);
+    const receipt = JSON.parse(await readFile(path.join(fixture.dir, result.receiptFile), 'utf8'));
+    assert.equal(receipt.dispatchParentSpanId, 'dddddddddddddddd');
+    assert.deepEqual(receipt.fireParentSpanIds, ['7777777777777777']);
+    assert.deepEqual(receipt.toolParentSpanIds, ['dddddddddddddddd']);
+  } finally {
+    await differentParentServer.close();
+  }
+  await rm(fixture.dir, { recursive: true, force: true });
+});
+
+test('accepts successful typed-tool UNSET or OK and rejects ERROR or blocked outcomes', async () => {
+  const fixture = await fixtureDir();
+  const traceId = 'abababababababababababababababab';
+  const cases = [
+    ['UNSET', undefined, true],
+    ['STATUS_CODE_OK', undefined, true],
+    ['STATUS_CODE_ERROR', undefined, false],
+    ['UNSET', attr('openclaw.outcome', 'blocked'), false],
   ];
-  for (const [label, extra] of badCases) {
+  for (const [statusCode, outcomeAttr, accepted] of cases) {
+    const trace = traceFixture({
+      traceId,
+      reasonHash: fixture.reasonHash,
+      reasonLength: fixture.reasonLength,
+    });
+    const tool = trace.batches[0].scopeSpans[0].spans
+      .find((entry) => entry.name === 'openclaw.tool.execution');
+    tool.status = { code: statusCode };
+    if (outcomeAttr) tool.attributes.push(outcomeAttr);
     const server = await listen((request, response) => {
       response.setHeader('content-type', 'application/json');
       response.end(JSON.stringify(new URL(request.url, 'http://localhost').pathname === '/api/search'
         ? { traces: [{ traceID: traceId }] }
-        : { batches: [{ scopeSpans: [{ spans: label === 'different-parent'
-          ? spans.map((entry) => entry === fire ? extra : entry)
-          : [...spans, extra] }] }] }));
+        : trace));
+    });
+    try {
+      const invocation = execFileAsync(process.execPath, [
+        script, '--run-dir', fixture.dir, '--manifest', fixture.manifestPath,
+        '--seat', 'silas-prince', '--tempo-url', server.url, '--timeout-ms', '0', '--poll-ms', '10',
+      ]);
+      if (accepted) {
+        await invocation;
+      } else {
+        await assert.rejects(invocation, /not a successful typed-tool execution/);
+      }
+    } finally {
+      await server.close();
+    }
+  }
+  await rm(fixture.dir, { recursive: true, force: true });
+});
+
+test('accepts repeated distinct continue_work fire spans and rejects zero or duplicate IDs', async () => {
+  const fixture = await fixtureDir({ tool: 'continue_work' });
+  const traceId = 'cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd';
+  const base = traceFixture({
+    traceId,
+    reasonHash: fixture.reasonHash,
+    reasonLength: fixture.reasonLength,
+    tool: 'continue_work',
+  });
+  const spans = base.batches[0].scopeSpans[0].spans;
+  const accept = spans.find((entry) => entry.name === 'continuation.work');
+  const fire = spans.find((entry) => entry.name === 'continuation.work.fire');
+  delete accept.parentSpanId;
+  const secondFire = {
+    ...fire,
+    spanId: b64('9999999999999999'),
+    parentSpanId: b64('7777777777777777'),
+  };
+
+  const acceptedServer = await listen((request, response) => {
+    response.setHeader('content-type', 'application/json');
+    response.end(JSON.stringify(new URL(request.url, 'http://localhost').pathname === '/api/search'
+      ? { traces: [{ traceID: traceId }] }
+      : { batches: [{ scopeSpans: [{ spans: [...spans, secondFire] }] }] }));
+  });
+  try {
+    const { stdout } = await execFileAsync(process.execPath, [
+      script, '--run-dir', fixture.dir, '--manifest', fixture.manifestPath,
+      '--seat', 'silas-prince', '--tempo-url', acceptedServer.url,
+      '--timeout-ms', '100', '--poll-ms', '10',
+    ]);
+    const result = JSON.parse(stdout);
+    const receipt = JSON.parse(await readFile(path.join(fixture.dir, result.receiptFile), 'utf8'));
+    assert.deepEqual(receipt.fireSpanIds, ['bbbbbbbbbbbbbbbb', '9999999999999999']);
+    assert.deepEqual(receipt.fireParentSpanIds, ['dddddddddddddddd', '7777777777777777']);
+    assert.equal(receipt.fireSpanId, 'bbbbbbbbbbbbbbbb');
+    assert.equal(receipt.workParentSpanId, null);
+  } finally {
+    await acceptedServer.close();
+  }
+
+  for (const [label, mutatedSpans, pattern] of [
+    ['zero', spans.filter((entry) => entry !== fire), /lacks the expected continuation\.work\.fire span/],
+    ['duplicate', [...spans, { ...fire }], /span IDs are not distinct/],
+  ]) {
+    const server = await listen((request, response) => {
+      response.setHeader('content-type', 'application/json');
+      response.end(JSON.stringify(new URL(request.url, 'http://localhost').pathname === '/api/search'
+        ? { traces: [{ traceID: traceId }] }
+        : { batches: [{ scopeSpans: [{ spans: mutatedSpans }] }] }));
     });
     try {
       await assert.rejects(execFileAsync(process.execPath, [
         script, '--run-dir', fixture.dir, '--manifest', fixture.manifestPath,
-        '--seat', 'silas-prince', '--tempo-url', server.url, '--timeout-ms', '40', '--poll-ms', '10',
-      ]), new RegExp(label === 'different-parent' ? 'causal parent' : `contains 2 .*${label.slice('duplicate-'.length)}`));
-    } finally { await server.close(); }
+        '--seat', 'silas-prince', '--tempo-url', server.url, '--timeout-ms', '0', '--poll-ms', '10',
+      ]), pattern, label);
+    } finally {
+      await server.close();
+    }
   }
   await rm(fixture.dir, { recursive: true, force: true });
 });
@@ -650,6 +780,7 @@ test('correlates continue_work tool/accept/fire topology by safe reason fingerpr
     assert.equal(receipt.continuation.tool, 'continue_work');
     assert.equal(receipt.workSpanId, 'cccccccccccccccc');
     assert.equal(receipt.fireSpanId, 'bbbbbbbbbbbbbbbb');
+    assert.deepEqual(receipt.fireSpanIds, ['bbbbbbbbbbbbbbbb']);
     assert.equal(receipt.sameTrace, true);
     assert.equal(receipt.distinctSpans, true);
     assert.match(observedQuery, /name="continuation\.work"/);

--- a/tools/k6-proofs/scripts/__tests__/tempo-fetch.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/tempo-fetch.test.mjs
@@ -6,6 +6,10 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import {
+  projectPublicTempoTrace,
+  publicTempoStatusCode,
+} from '../../lib/public-tempo-trace.mjs';
 
 const script = path.resolve('tools/k6-proofs/scripts/fetch-tempo-trace.mjs');
 const runNode = promisify(execFile);
@@ -21,6 +25,36 @@ async function withServer(handler, fn) {
   }
 }
 
+test('projects numeric, short, and protobuf Tempo status forms without ambiguous fallback', () => {
+  const cases = [
+    [0, 'UNSET'],
+    ['UNSET', 'UNSET'],
+    ['STATUS_CODE_UNSET', 'UNSET'],
+    [1, 'OK'],
+    ['OK', 'OK'],
+    ['STATUS_CODE_OK', 'OK'],
+    [2, 'ERROR'],
+    ['ERROR', 'ERROR'],
+    ['STATUS_CODE_ERROR', 'ERROR'],
+  ];
+  for (const [input, expected] of cases) {
+    assert.equal(publicTempoStatusCode(input), expected);
+  }
+  assert.equal(publicTempoStatusCode('STATUS_CODE_FUTURE'), null);
+  assert.throws(
+    () => projectPublicTempoTrace({
+      trace: {
+        spans: [{
+          spanId: '0123456789abcdef',
+          name: 'openclaw.tool',
+          status: { code: 'STATUS_CODE_FUTURE' },
+        }],
+      },
+    }, '0123456789abcdef'),
+    /unsupported Tempo status code/,
+  );
+});
+
 test('fetches and projects Tempo trace JSON by trace id without persisting private fields', async () => {
   const root = await mkdtemp(path.join(tmpdir(), 'tempo-fetch-'));
   try {
@@ -31,7 +65,7 @@ test('fetches and projects Tempo trace JSON by trace id without persisting priva
         traceId: '0123456789abcdef',
         spanId: '0123456789abcdef',
         name: 'openclaw.tool',
-        status: { code: 2, message: 'private status text' },
+        status: { code: 'STATUS_CODE_ERROR', message: 'private status text' },
         attributes: [
           { key: 'openclaw.toolName', value: { stringValue: 'continue_work' } },
           { key: 'session.key', value: { stringValue: 'agent:private:session' } },

--- a/tools/k6-proofs/scripts/collect-continuation-trace.mjs
+++ b/tools/k6-proofs/scripts/collect-continuation-trace.mjs
@@ -65,6 +65,10 @@ function idHex(value, bytes, label) {
   return safeHex(decoded.toString('hex'), bytes * 2, label);
 }
 
+function optionalIdHex(value, bytes, label) {
+  return value ? idHex(value, bytes, label) : null;
+}
+
 function attributes(span) {
   return new Map((span?.attributes || []).map((attribute) => [attribute.key, attributeValue(attribute)]));
 }
@@ -224,13 +228,13 @@ function validateTrace(trace, expected) {
       attrs.get('chain.id') === chainId &&
       (expected.mode === undefined || attrs.get('delegate.mode') === expected.mode);
   });
-  if (fires.length !== 1) {
-    throw new Error(fires.length === 0
-      ? `matched trace lacks the expected ${expected.fireSpanName} span`
-      : `matched trace contains ${fires.length} ${expected.fireSpanName} spans`);
+  if (fires.length === 0) {
+    throw new Error(`matched trace lacks the expected ${expected.fireSpanName} span`);
   }
-  const fire = fires[0];
-  if (publicStatusCode(fire.status?.code) !== 'OK') {
+  if (expected.tool !== 'continue_work' && fires.length !== 1) {
+    throw new Error(`matched trace contains ${fires.length} ${expected.fireSpanName} spans`);
+  }
+  if (fires.some((fire) => publicStatusCode(fire.status?.code) !== 'OK')) {
     throw new Error(`${expected.fireSpanName} span is not status OK`);
   }
 
@@ -250,29 +254,31 @@ function validateTrace(trace, expected) {
         : `matched trace contains ${tools.length} ${expected.tool} tool spans`,
     );
   }
-  if (tools.some((span) => publicStatusCode(span.status?.code) !== 'OK')) {
-    throw new Error(`originating ${expected.tool} tool span is not status OK`);
+  if (tools.some((span) => {
+    const status = publicStatusCode(span.status?.code);
+    return !['UNSET', 'OK'].includes(status) || attributes(span).get('openclaw.outcome') === 'blocked';
+  })) {
+    throw new Error(`originating ${expected.tool} tool span is not a successful typed-tool execution`);
   }
 
   const traceId = idHex(accept.traceId, 16, 'trace id');
-  const fireTraceId = idHex(fire.traceId, 16, 'fire trace id');
+  const fireTraceIds = fires.map((fire) => idHex(fire.traceId, 16, 'fire trace id'));
   const toolTraceIds = tools.map((span) => idHex(span.traceId, 16, 'tool trace id'));
-  if (fireTraceId !== traceId || toolTraceIds.some((value) => value !== traceId)) {
+  if (fireTraceIds.some((value) => value !== traceId) ||
+      toolTraceIds.some((value) => value !== traceId)) {
     throw new Error('tool/fire/accept do not share one trace');
   }
 
   const acceptSpanId = idHex(accept.spanId, 8, 'accept span id');
-  const fireSpanId = idHex(fire.spanId, 8, 'fire span id');
-  const acceptParentSpanId = idHex(accept.parentSpanId, 8, 'dispatch parent span id');
-  const fireParentSpanId = idHex(fire.parentSpanId, 8, 'fire parent span id');
-  const toolParentSpanIds = tools.map((span) => idHex(span.parentSpanId, 8, 'tool parent span id'));
-  if (fireParentSpanId !== acceptParentSpanId || toolParentSpanIds.some((value) => value !== acceptParentSpanId)) {
-    throw new Error('tool/fire/dispatch do not share one causal parent');
-  }
+  const fireSpanIds = fires.map((fire) => idHex(fire.spanId, 8, 'fire span id'));
+  const acceptParentSpanId = optionalIdHex(accept.parentSpanId, 8, 'accept parent span id');
+  const fireParentSpanIds = fires.map((fire) =>
+    optionalIdHex(fire.parentSpanId, 8, 'fire parent span id'));
+  const toolParentSpanIds = tools.map((span) =>
+    optionalIdHex(span.parentSpanId, 8, 'tool parent span id'));
   const toolSpanIds = tools.map((span) => idHex(span.spanId, 8, 'tool span id'));
-  if (acceptSpanId === fireSpanId ||
-      toolSpanIds.includes(acceptSpanId) ||
-      toolSpanIds.includes(fireSpanId)) {
+  const topologySpanIds = [acceptSpanId, ...fireSpanIds, ...toolSpanIds];
+  if (new Set(topologySpanIds).size !== topologySpanIds.length) {
     throw new Error('tool/fire/accept span IDs are not distinct');
   }
 
@@ -286,8 +292,11 @@ function validateTrace(trace, expected) {
     traceId,
     chainId,
     toolSpanIds,
-    fireSpanId,
-    fireParentSpanId,
+    toolParentSpanIds,
+    fireSpanId: fireSpanIds[0],
+    fireSpanIds,
+    fireParentSpanId: fireParentSpanIds[0],
+    fireParentSpanIds,
     childSpans,
   };
   if (expected.tool === 'continue_delegate') {
@@ -300,7 +309,7 @@ function validateTrace(trace, expected) {
   return {
     ...topology,
     workSpanId: acceptSpanId,
-    workParentSpanId: idHex(accept.parentSpanId, 8, 'work parent span id'),
+    workParentSpanId: acceptParentSpanId,
   };
 }
 


### PR DESCRIPTION
## Summary

Addresses #398 as a docs/harness repair only.

- maps numeric, short, and protobuf JSON `STATUS_CODE_*` Tempo status forms;
- fails projection on unknown explicit status values instead of collapsing them to `UNSET`;
- keeps continuation accept/fire status fail-closed at `OK`;
- accepts successful typed-tool `UNSET` or `OK`, while rejecting `ERROR`, unknown status, and `openclaw.outcome=blocked`;
- treats parent IDs as optional diagnostic receipts rather than equality authority;
- accepts one-or-more distinct `continuation.work.fire` spans, preserves every fire ID/parent, and still rejects zero-fire or duplicate IDs;
- retains same-trace, reason hash/length, mode, chain, and distinct-span requirements.

Delegate rows still require exactly one matching fire span.

## Immutable exact-4c replay

No behavioral proof row was fired. The repaired collector replayed the existing exact trace identities directly from Tempo:

- `R-CD-1` trace `6a904ad5ab0224352d0b92d5df09d5c6`: typed tool `UNSET`; delegate dispatch/fire `OK`; one fire; same trace and distinct IDs.
- `R-CW-1` trace `6e7ce77d61548079a36a0493d0a6a55f`: typed tool `UNSET`; work accept and both work-fire spans `OK`; two distinct fires preserved.

The checksummed replay envelope has `SHA256SUMS` digest `e748c7becc816e0c6fd47e84aa64309628b84c4be7207f3876f489cd847cdaf5`. The historical projected files remain immutable.

## Validation

- `node --test tools/k6-proofs/scripts/__tests__/*.test.mjs` — 218/218
- focused Tempo/collector suite — 26/26
- independent final diff review — no significant issue
- `git diff --check`

## Boundaries

This PR does not reopen runtime #1176, fire proof rows, relabel historical packets, or mutate `PROOFS/INDEX.json`, canonical manifests, assembly, deployment, or presentation.