### PR TITLE
proofs: close R-CD-4 tasks.list child-authority gap

### DIFF
--- a/tools/k6-proofs/lib/r-cd-4-authority.mjs
+++ b/tools/k6-proofs/lib/r-cd-4-authority.mjs
@@ -1,3 +1,5 @@
+import { directChildSessionKeyForRow } from './row-child-correlation.mjs';
+
 const HARNESS_MARKER = '[k6-proof-harness]';
 
 function escapeRegex(value) {
@@ -102,6 +104,28 @@ export function rCd4SessionMessageObservation({
       nonce,
     }),
     genericWakeObserved: elapsed >= gate,
+  };
+}
+
+/**
+ * Treat tasks.list as child authority only when one structured task record
+ * binds its real childSessionKey to this row nonce.
+ */
+export function rCd4TaskObservation(task, nonce) {
+  const childSessionKey = directChildSessionKeyForRow(task, nonce);
+  if (!childSessionKey) {
+    return {
+      childSessionKey: null,
+      completed: false,
+      traceId: null,
+    };
+  }
+  return {
+    childSessionKey,
+    completed: task?.state === 'completed' || task?.status === 'completed',
+    traceId: typeof task?.traceId === 'string' && task.traceId.length > 0
+      ? task.traceId
+      : null,
   };
 }
 

--- a/tools/k6-proofs/lib/row-child-correlation.mjs
+++ b/tools/k6-proofs/lib/row-child-correlation.mjs
@@ -13,6 +13,12 @@ function childKeyBoundToNonce(record, rowNonce) {
   return directStringValues(record).some((value) => value.includes(rowNonce)) ? childSessionKey : null;
 }
 
+/** Return a child key only when this exact structured record binds it to the row. */
+export function directChildSessionKeyForRow(record, rowNonce) {
+  if (!rowNonce || typeof rowNonce !== 'string') return null;
+  return childKeyBoundToNonce(record, rowNonce);
+}
+
 /**
  * Return a spawned child key only when the same structured record binds that
  * key to the proof-row nonce.
@@ -30,7 +36,7 @@ export function childSessionKeyForRow(eventData, rowNonce) {
     if (!value || typeof value !== 'object' || seen.has(value)) return;
     seen.add(value);
     if (!Array.isArray(value)) {
-      const match = childKeyBoundToNonce(value, rowNonce);
+      const match = directChildSessionKeyForRow(value, rowNonce);
       if (match) matches.add(match);
     }
     for (const child of Object.values(value)) visit(child);

--- a/tools/k6-proofs/scenarios/r-cd-4-target-session-key.js
+++ b/tools/k6-proofs/scenarios/r-cd-4-target-session-key.js
@@ -14,7 +14,11 @@ import crypto from 'k6/crypto';
 import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
 import { childSessionKeyForRow } from '../lib/row-child-correlation.mjs';
-import { rCd4ReturnReceipt, rCd4SessionMessageObservation } from '../lib/r-cd-4-authority.mjs';
+import {
+  rCd4ReturnReceipt,
+  rCd4SessionMessageObservation,
+  rCd4TaskObservation,
+} from '../lib/r-cd-4-authority.mjs';
 import { closeSocketAfterDelay } from '../lib/socket-close.js';
 
 export const options = {
@@ -252,19 +256,20 @@ export default function () {
         if (classified.kind === 'response' && classified.method === 'tasks.list') {
           const tasks = classified.payload?.tasks || [];
           for (const task of tasks) {
-            const taskStr = JSON.stringify(task);
-            if (taskStr.includes(rowNonce)) {
-              const possibleChild = task.childSessionKey || task.sessionKey || null;
-              if (possibleChild && possibleChild !== sessionKey && possibleChild !== targetSessionKey) {
-                evidence.child_session = possibleChild;
-                finalizeReturnReceipts();
-              }
-              if (task.state === 'completed' || task.status === 'completed') {
-                evidence.child_completed = true;
-                console.log('✓ Child task completed');
-              }
-              if (task.traceId) evidence.trace_id = task.traceId;
+            const observation = rCd4TaskObservation(task, rowNonce);
+            const possibleChild = observation.childSessionKey;
+            if (!possibleChild ||
+                possibleChild === sessionKey ||
+                possibleChild === targetSessionKey) {
+              continue;
             }
+            evidence.child_session = possibleChild;
+            finalizeReturnReceipts();
+            if (observation.completed) {
+              evidence.child_completed = true;
+              console.log('✓ Child task completed');
+            }
+            if (observation.traceId) evidence.trace_id = observation.traceId;
           }
         }
 

--- a/tools/k6-proofs/tests/r-cd-4-authority.test.mjs
+++ b/tools/k6-proofs/tests/r-cd-4-authority.test.mjs
@@ -4,6 +4,7 @@ import {
   rCd4ReturnCandidate,
   rCd4ReturnReceipt,
   rCd4SessionMessageObservation,
+  rCd4TaskObservation,
 } from '../lib/r-cd-4-authority.mjs';
 
 const nonce = 'R-CD-4-EXACT-NONCE';
@@ -157,4 +158,45 @@ test('R-CD-4 retains an early parent receipt so a later target cannot false-PASS
   assert.equal(earlyParent.genericWakeObserved, false);
   assert.notEqual(rCd4ReturnReceipt(earlyParent.parentCandidate, child), null);
   assert.notEqual(rCd4ReturnReceipt(laterTarget.targetCandidate, child), null);
+});
+
+test('R-CD-4 accepts tasks.list child authority only from a nonce-bound childSessionKey', () => {
+  assert.deepEqual(rCd4TaskObservation({
+    sessionKey: parent,
+    childSessionKey: 'agent:main:subagent:child',
+    title: `R-CD-4 task ${nonce}`,
+    status: 'completed',
+    traceId: 'a'.repeat(32),
+  }, nonce), {
+    childSessionKey: 'agent:main:subagent:child',
+    completed: true,
+    traceId: 'a'.repeat(32),
+  });
+});
+
+test('R-CD-4 rejects requester sessionKey and nested nonce as tasks.list child authority', () => {
+  const observation = rCd4TaskObservation({
+    sessionKey: 'agent:main:requester',
+    childSessionKey: 'agent:main:subagent:stale-child',
+    status: 'completed',
+    metadata: {
+      childSessionKey: 'agent:main:subagent:nested-current-child',
+      task: `unrelated ${nonce}`,
+    },
+  }, nonce);
+  assert.deepEqual(observation, {
+    childSessionKey: null,
+    completed: false,
+    traceId: null,
+  });
+  const targetCandidate = rCd4ReturnCandidate({
+    eventName: 'session.message',
+    eventData: {
+      sessionKey: target,
+      message: { role: 'system', content: `TARGET-RECEIVED ${nonce}` },
+    },
+    expectedSessionKey: target,
+    nonce,
+  });
+  assert.equal(rCd4ReturnReceipt(targetCandidate, observation.childSessionKey), null);
 });


### PR DESCRIPTION
## Summary
- remove `task.sessionKey` fallback from R-CD-4 child authority
- require the same flat task record to bind the row nonce to a real `childSessionKey`
- reject stale requester/child records whose current nonce exists only in nested payload text
- keep Rune’s pre-wake target/parent receipt handling unchanged

## Validation
- `node --test tools/k6-proofs/tests/*.test.mjs tools/k6-proofs/scripts/__tests__/*.test.mjs` — 232/232
- `k6 inspect tools/k6-proofs/scenarios/r-cd-4-target-session-key.js`
- `git diff --check`

No proof row was fired.