### PR TITLE
proofs: preserve R-CD-4 parent negative window

### DIFF
--- a/tools/k6-proofs/lib/r-cd-4-authority.mjs
+++ b/tools/k6-proofs/lib/r-cd-4-authority.mjs
@@ -1,5 +1,8 @@
 import { directChildSessionKeyForRow } from './row-child-correlation.mjs';
 
+export const R_CD_4_OBSERVATION_WINDOW_MS = 90_000;
+export const R_CD_4_DURATION_THRESHOLD_MS = 110_000;
+
 const HARNESS_MARKER = '[k6-proof-harness]';
 
 function escapeRegex(value) {
@@ -127,6 +130,15 @@ export function rCd4TaskObservation(task, nonce) {
       ? task.traceId
       : null,
   };
+}
+
+/**
+ * A target receipt still needs the remaining observation window to prove that
+ * no matching parent receipt arrives later. A parent receipt is already a
+ * terminal target-only failure and may close early.
+ */
+export function rCd4ShouldScheduleEarlyClose({ parentReturnReceipt }) {
+  return parentReturnReceipt !== null && parentReturnReceipt !== undefined;
 }
 
 /** Finalize only after the row has independently observed its spawned child. */

--- a/tools/k6-proofs/scenarios/r-cd-4-target-session-key.js
+++ b/tools/k6-proofs/scenarios/r-cd-4-target-session-key.js
@@ -15,8 +15,11 @@ import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
 import { childSessionKeyForRow } from '../lib/row-child-correlation.mjs';
 import {
+  R_CD_4_DURATION_THRESHOLD_MS,
+  R_CD_4_OBSERVATION_WINDOW_MS,
   rCd4ReturnReceipt,
   rCd4SessionMessageObservation,
+  rCd4ShouldScheduleEarlyClose,
   rCd4TaskObservation,
 } from '../lib/r-cd-4-authority.mjs';
 import { closeSocketAfterDelay } from '../lib/socket-close.js';
@@ -32,7 +35,7 @@ export const options = {
   },
   thresholds: {
     proof_failures: ['count==0'],
-    r_cd_4_duration: ['p(95)<90000'],
+    r_cd_4_duration: [`p(95)<${R_CD_4_DURATION_THRESHOLD_MS}`],
   },
 };
 
@@ -189,7 +192,7 @@ export default function () {
       socket.setTimeout(() => tracker.send(socket, 'tasks.list', { limit: 10 }), 8000);
       socket.setTimeout(() => tracker.send(socket, 'tasks.list', { limit: 10 }), 25000);
       socket.setTimeout(() => tracker.send(socket, 'tasks.list', { limit: 10 }), 50000);
-      socket.setTimeout(() => socket.close(), 90000);
+      socket.setTimeout(() => socket.close(), R_CD_4_OBSERVATION_WINDOW_MS);
     }
 
     socket.on('open', () => {
@@ -318,7 +321,9 @@ export default function () {
         }
 
         if (evidence.tool_accepted &&
-            (evidence.return_in_target || evidence.return_in_parent) &&
+            rCd4ShouldScheduleEarlyClose({
+              parentReturnReceipt: evidence.parent_return_receipt,
+            }) &&
             !returnCloseScheduled) {
           returnCloseScheduled = true;
           closeSocketAfterDelay(socket, 2000);

--- a/tools/k6-proofs/tests/r-cd-4-authority.test.mjs
+++ b/tools/k6-proofs/tests/r-cd-4-authority.test.mjs
@@ -1,15 +1,23 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  R_CD_4_DURATION_THRESHOLD_MS,
+  R_CD_4_OBSERVATION_WINDOW_MS,
   rCd4ReturnCandidate,
   rCd4ReturnReceipt,
   rCd4SessionMessageObservation,
+  rCd4ShouldScheduleEarlyClose,
   rCd4TaskObservation,
 } from '../lib/r-cd-4-authority.mjs';
 
 const nonce = 'R-CD-4-EXACT-NONCE';
 const target = 'agent:main:r-cd-4-target';
 const parent = 'agent:main:r-cd-4-parent';
+
+test('R-CD-4 duration threshold leaves headroom after the full observation window', () => {
+  assert.ok(R_CD_4_DURATION_THRESHOLD_MS > R_CD_4_OBSERVATION_WINDOW_MS);
+  assert.ok(R_CD_4_DURATION_THRESHOLD_MS < 120_000);
+});
 
 test('R-CD-4 accepts only the exact target marker and binds child identity', () => {
   const candidate = rCd4ReturnCandidate({
@@ -199,4 +207,33 @@ test('R-CD-4 rejects requester sessionKey and nested nonce as tasks.list child a
     nonce,
   });
   assert.equal(rCd4ReturnReceipt(targetCandidate, observation.childSessionKey), null);
+});
+
+test('R-CD-4 keeps observing after a target receipt but closes early on parent failure', () => {
+  const child = 'agent:main:subagent:child';
+  const targetReceipt = rCd4ReturnReceipt(rCd4ReturnCandidate({
+    eventName: 'session.message',
+    eventData: {
+      sessionKey: target,
+      message: { role: 'system', content: `TARGET-RECEIVED ${nonce}` },
+    },
+    expectedSessionKey: target,
+    nonce,
+  }), child);
+  const parentReceipt = rCd4ReturnReceipt(rCd4ReturnCandidate({
+    eventName: 'session.message',
+    eventData: {
+      sessionKey: parent,
+      message: { role: 'system', content: `TARGET-RECEIVED ${nonce}` },
+    },
+    expectedSessionKey: parent,
+    nonce,
+  }), child);
+
+  assert.equal(rCd4ShouldScheduleEarlyClose({ parentReturnReceipt: null }), false);
+  assert.equal(rCd4ShouldScheduleEarlyClose({
+    targetReturnReceipt: targetReceipt,
+    parentReturnReceipt: null,
+  }), false);
+  assert.equal(rCd4ShouldScheduleEarlyClose({ parentReturnReceipt: parentReceipt }), true);
 });


### PR DESCRIPTION
## Summary
- keep the R-CD-4 socket open for the full existing 90-second negative-evidence window after a target receipt
- close early only when an authoritative parent receipt already proves target-only failure
- raise the duration threshold to 110 seconds so valid full-window runs do not fail k6 timing policy
- add regressions for target-only observation, parent terminal failure, and threshold headroom

## Validation
- full proof harness: 234/234
- targeted authority/correlation: 19/19
- `k6 inspect tools/k6-proofs/scenarios/r-cd-4-target-session-key.js`
- independent exact-diff review: no findings

No proof row was fired.