### PR TITLE
fix(proofs): bind R-CD-4 child task authority

### DIFF
--- a/tools/k6-proofs/lib/r-cd-4-authority.mjs
+++ b/tools/k6-proofs/lib/r-cd-4-authority.mjs
@@ -4,6 +4,7 @@ export const R_CD_4_OBSERVATION_WINDOW_MS = 90_000;
 export const R_CD_4_DURATION_THRESHOLD_MS = 110_000;
 
 const HARNESS_MARKER = '[k6-proof-harness]';
+const R_CD_4_TASK_TOKEN_SUFFIX_CHARS = 16;
 
 function escapeRegex(value) {
   return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -73,6 +74,31 @@ export function rCd4ReturnCandidate({ eventName, eventData, expectedSessionKey, 
   };
 }
 
+export function rCd4TaskIdentityToken(nonce) {
+  if (typeof nonce !== 'string' || nonce.length === 0) return null;
+  return `RCD4:${nonce.slice(-R_CD_4_TASK_TOKEN_SUFFIX_CHARS)}`;
+}
+
+export function rCd4TaskPrompt(template, nonce) {
+  if (typeof template !== 'string' || typeof nonce !== 'string' || nonce.length === 0) {
+    return null;
+  }
+  return template
+    .replaceAll('{{nonceSuffix16}}', nonce.slice(-R_CD_4_TASK_TOKEN_SUFFIX_CHARS))
+    .replaceAll('{{nonce}}', nonce);
+}
+
+export function rCd4ChildAuthority(candidates) {
+  const observedChildSessionKeys = [...new Set(
+    candidates.filter((value) => typeof value === 'string' && value.length > 0),
+  )];
+  return {
+    observedChildSessionKeys,
+    childSessionKey: observedChildSessionKeys.length === 1 ? observedChildSessionKeys[0] : null,
+    ambiguous: observedChildSessionKeys.length > 1,
+  };
+}
+
 /**
  * Inspect return authority for every post-dispatch session.message.
  *
@@ -115,7 +141,12 @@ export function rCd4SessionMessageObservation({
  * binds its real childSessionKey to this row nonce.
  */
 export function rCd4TaskObservation(task, nonce) {
-  const childSessionKey = directChildSessionKeyForRow(task, nonce);
+  const taskIdentityToken = rCd4TaskIdentityToken(nonce);
+  const childSessionKey = directChildSessionKeyForRow(
+    task,
+    nonce,
+    taskIdentityToken ? [taskIdentityToken] : [],
+  );
   if (!childSessionKey) {
     return {
       childSessionKey: null,

--- a/tools/k6-proofs/lib/row-child-correlation.mjs
+++ b/tools/k6-proofs/lib/row-child-correlation.mjs
@@ -1,22 +1,37 @@
-function directStringValues(record) {
-  return Object.values(record).flatMap((value) => {
-    if (typeof value === 'string') return [value];
-    if (Array.isArray(value) && value.every((entry) => typeof entry === 'string')) return value;
-    return [];
+// Spawn events expose row text as task/text; tasks.list exposes it as title.
+// Routing keys identify sessions and must never supply row-nonce authority.
+const DIRECT_ROW_IDENTITY_FIELDS = ['task', 'text', 'title'];
+const TASK_RECORD_FIELDS = ['task'];
+const TASK_RECORD_COLLECTION_FIELDS = ['tasks', 'records'];
+
+function directTaskIdentityValues(record) {
+  return DIRECT_ROW_IDENTITY_FIELDS.flatMap((field) => {
+    const value = record[field];
+    return typeof value === 'string' ? [value] : [];
   });
 }
 
-function childKeyBoundToNonce(record, rowNonce) {
+function rowIdentityTokens(rowNonce, additionalTokens = []) {
+  return [rowNonce, ...additionalTokens]
+    .filter((value) => typeof value === 'string' && value.length > 0);
+}
+
+function childKeyBoundToNonce(record, rowNonce, additionalTokens = []) {
   if (!record || typeof record !== 'object' || Array.isArray(record)) return null;
   const childSessionKey = typeof record.childSessionKey === 'string' ? record.childSessionKey : null;
   if (!childSessionKey) return null;
-  return directStringValues(record).some((value) => value.includes(rowNonce)) ? childSessionKey : null;
+  const tokens = rowIdentityTokens(rowNonce, additionalTokens);
+  return directTaskIdentityValues(record).some((value) => (
+    tokens.some((token) => value.includes(token))
+  ))
+    ? childSessionKey
+    : null;
 }
 
 /** Return a child key only when this exact structured record binds it to the row. */
-export function directChildSessionKeyForRow(record, rowNonce) {
+export function directChildSessionKeyForRow(record, rowNonce, additionalTokens = []) {
   if (!rowNonce || typeof rowNonce !== 'string') return null;
-  return childKeyBoundToNonce(record, rowNonce);
+  return childKeyBoundToNonce(record, rowNonce, additionalTokens);
 }
 
 /**
@@ -24,11 +39,12 @@ export function directChildSessionKeyForRow(record, rowNonce) {
  * key to the proof-row nonce.
  *
  * Gateway subscriptions can contain aggregate events from earlier proof work.
- * A nonce anywhere in the outer event is not enough: a stale top-level child
- * key plus an unrelated nested task for the current row must fail closed.
+ * A nonce anywhere in the outer event is not enough: only direct records and
+ * recognized task-record containers are authoritative. Nested metadata must
+ * never supply or conflict with child authority.
  */
-export function childSessionKeyForRow(eventData, rowNonce) {
-  if (!rowNonce || typeof rowNonce !== 'string') return null;
+export function childSessionKeysForRow(eventData, rowNonce, additionalTokens = []) {
+  if (!rowNonce || typeof rowNonce !== 'string') return [];
   const matches = new Set();
   const seen = new Set();
 
@@ -36,12 +52,24 @@ export function childSessionKeyForRow(eventData, rowNonce) {
     if (!value || typeof value !== 'object' || seen.has(value)) return;
     seen.add(value);
     if (!Array.isArray(value)) {
-      const match = directChildSessionKeyForRow(value, rowNonce);
+      const match = directChildSessionKeyForRow(value, rowNonce, additionalTokens);
       if (match) matches.add(match);
     }
-    for (const child of Object.values(value)) visit(child);
+    if (Array.isArray(value)) {
+      for (const child of value) visit(child);
+      return;
+    }
+    for (const field of TASK_RECORD_FIELDS) visit(value[field]);
+    for (const field of TASK_RECORD_COLLECTION_FIELDS) {
+      if (Array.isArray(value[field])) visit(value[field]);
+    }
   }
 
   visit(eventData);
-  return matches.size === 1 ? [...matches][0] : null;
+  return [...matches];
+}
+
+export function childSessionKeyForRow(eventData, rowNonce, additionalTokens = []) {
+  const matches = childSessionKeysForRow(eventData, rowNonce, additionalTokens);
+  return matches?.length === 1 ? matches[0] : null;
 }

--- a/tools/k6-proofs/manifests/r-cd-4.json
+++ b/tools/k6-proofs/manifests/r-cd-4.json
@@ -30,7 +30,7 @@
     "mode": "silent-wake",
     "delaySeconds": 1,
     "targetSessionKey": "${OPENCLAW_TARGET_SESSION_KEY}",
-    "promptTemplate": "Proof nonce {{nonce}}: reply with TARGET-RECEIVED and the nonce. Do not mutate files.",
+    "promptTemplate": "RCD4:{{nonceSuffix16}} Proof nonce {{nonce}}: reply with TARGET-RECEIVED and the nonce. Do not mutate files.",
     "idempotencyKeyPrefix": "R-CD-4"
   },
   "expectedReceipts": [

--- a/tools/k6-proofs/scenarios/r-cd-4-target-session-key.js
+++ b/tools/k6-proofs/scenarios/r-cd-4-target-session-key.js
@@ -13,14 +13,17 @@ import { Counter, Trend } from 'k6/metrics';
 import crypto from 'k6/crypto';
 import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
-import { childSessionKeyForRow } from '../lib/row-child-correlation.mjs';
+import { childSessionKeysForRow } from '../lib/row-child-correlation.mjs';
 import {
   R_CD_4_DURATION_THRESHOLD_MS,
   R_CD_4_OBSERVATION_WINDOW_MS,
+  rCd4ChildAuthority,
   rCd4ReturnReceipt,
   rCd4SessionMessageObservation,
   rCd4ShouldScheduleEarlyClose,
+  rCd4TaskIdentityToken,
   rCd4TaskObservation,
+  rCd4TaskPrompt,
 } from '../lib/r-cd-4-authority.mjs';
 import { closeSocketAfterDelay } from '../lib/socket-close.js';
 
@@ -48,7 +51,7 @@ const DEFAULTS = {
   seat: 'ronan-dgx',
   mode: 'silent-wake',
   delaySeconds: 1,
-  promptTemplate: 'Proof nonce {{nonce}}: reply with TARGET-RECEIVED and the nonce. Do not mutate files. Do not post to any channel.',
+  promptTemplate: 'RCD4:{{nonceSuffix16}} Proof nonce {{nonce}}: reply with TARGET-RECEIVED and the nonce. Do not mutate files. Do not post to any channel.',
   idempotencyKeyPrefix: 'R-CD-4',
 };
 
@@ -76,6 +79,7 @@ export default function () {
   const createDisposableSessions = boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSIONS') || boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSION');
   const seat = manifest?.seat || __ENV.OPENCLAW_SEAT_NAME || DEFAULTS.seat;
   const rowNonce = nonce('R-CD-4');
+  const taskIdentityToken = rCd4TaskIdentityToken(rowNonce);
   const inv = invocationCfg();
   let targetSessionKey = inv.targetSessionKey;
 
@@ -102,6 +106,7 @@ export default function () {
     row: 'R-CD-4',
     manifest_loaded: !!manifest,
     nonce: rowNonce,
+    task_identity_token: taskIdentityToken,
     seat,
     requestedSessionKey,
     sessionKey,
@@ -116,6 +121,9 @@ export default function () {
     agent_turn_observed: false,
     child_completed: false,
     child_session: null,
+    child_session_candidates: [],
+    child_session_ambiguous: false,
+    child_session_invalid: false,
     return_in_target: false,
     return_in_parent: false,
     target_return_candidate: null,
@@ -154,6 +162,29 @@ export default function () {
       }
     }
 
+    function observeChildSessionKey(possibleChild) {
+      if (!possibleChild) return false;
+      const authority = rCd4ChildAuthority([
+        ...evidence.child_session_candidates,
+        possibleChild,
+      ]);
+      evidence.child_session_candidates = authority.observedChildSessionKeys;
+      evidence.child_session_invalid = evidence.child_session_candidates
+        .some((value) => value === sessionKey || value === targetSessionKey);
+      evidence.child_session = evidence.child_session_invalid
+        ? null
+        : authority.childSessionKey;
+      evidence.child_session_ambiguous = authority.ambiguous;
+      if (authority.ambiguous || evidence.child_session_invalid) {
+        evidence.child_completed = false;
+        console.warn('✗ conflicting or invalid nonce-bound child identity observed');
+      }
+      finalizeReturnReceipts();
+      return !authority.ambiguous &&
+        !evidence.child_session_invalid &&
+        authority.childSessionKey === possibleChild;
+    }
+
     function createParent(socket) {
       createPhase = 'parent';
       const parentKey = `r-cd-4-parent-${rowNonce}`.toLowerCase().replace(/[^a-z0-9-]/g, '-');
@@ -177,7 +208,7 @@ export default function () {
       tracker.send(socket, 'sessions.messages.subscribe', { key: targetSessionKey });
 
       socket.setTimeout(() => {
-        const prompt = inv.promptTemplate.replace(/\{\{nonce\}\}/g, rowNonce);
+        const prompt = rCd4TaskPrompt(inv.promptTemplate, rowNonce);
         evidence.reason_hash = crypto.sha256(prompt, 'hex').slice(0, 16);
         evidence.reason_length = prompt.length;
         evidence.delegate_mode = inv.mode;
@@ -261,13 +292,9 @@ export default function () {
           for (const task of tasks) {
             const observation = rCd4TaskObservation(task, rowNonce);
             const possibleChild = observation.childSessionKey;
-            if (!possibleChild ||
-                possibleChild === sessionKey ||
-                possibleChild === targetSessionKey) {
+            if (!observeChildSessionKey(possibleChild)) {
               continue;
             }
-            evidence.child_session = possibleChild;
-            finalizeReturnReceipts();
             if (observation.completed) {
               evidence.child_completed = true;
               console.log('✓ Child task completed');
@@ -279,10 +306,13 @@ export default function () {
         if (classified.kind === 'event') {
           const eventName = classified.event || '';
           const eventData = classified.data || {};
-          const observedChild = childSessionKeyForRow(eventData, rowNonce);
-          if (observedChild && observedChild !== sessionKey && observedChild !== targetSessionKey) {
-            evidence.child_session = observedChild;
-            finalizeReturnReceipts();
+          const observedChildren = childSessionKeysForRow(
+            eventData,
+            rowNonce,
+            taskIdentityToken ? [taskIdentityToken] : [],
+          );
+          for (const observedChild of observedChildren) {
+            observeChildSessionKey(observedChild);
           }
 
           if (eventName === 'agent' && evidence.tool_accepted) {
@@ -348,17 +378,22 @@ export default function () {
     'dispatch accepted': () => evidence.tool_accepted,
     'dispatching agent turn observed': () => evidence.agent_turn_observed,
     'nonce-bound child identity observed': () => evidence.child_session !== null,
+    'nonce-bound child identity is unambiguous': () => !evidence.child_session_ambiguous,
+    'nonce-bound child identity is not parent or target': () => !evidence.child_session_invalid,
     'nonce-bound target return receipt observed': () => evidence.target_return_receipt !== null,
     'no nonce-bound parent return receipt': () => evidence.parent_return_receipt === null,
   });
 
   if (!evidence.tool_accepted || !evidence.agent_turn_observed || !evidence.child_session ||
+      evidence.child_session_ambiguous || evidence.child_session_invalid ||
       !evidence.target_return_receipt || evidence.parent_return_receipt) {
     failures.add(1);
   }
 
   const passed = evidence.tool_accepted && evidence.agent_turn_observed &&
-    evidence.child_session !== null && evidence.target_return_receipt !== null &&
+    evidence.child_session !== null && !evidence.child_session_ambiguous &&
+    !evidence.child_session_invalid &&
+    evidence.target_return_receipt !== null &&
     evidence.parent_return_receipt === null;
 
   console.log(`R_CD_4_EVIDENCE ${JSON.stringify(evidence)}`);

--- a/tools/k6-proofs/scripts/__tests__/continuation-row-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/continuation-row-contract.test.mjs
@@ -148,7 +148,12 @@ test('every trace-required continue_delegate row persists the safe fingerprint c
       assert.match(scenario, /reason_hash:\s*null/);
       assert.match(scenario, /reason_length:\s*null/);
       assert.match(scenario, /delegate_mode:\s*null/);
-      assert.match(scenario, /promptTemplate\.replace\(\/\\\{\\\{nonce\\\}\\\}\/g,/);
+      if (manifest.rowId === 'R-CD-4') {
+        assert.match(manifest.invocation.promptTemplate, /^RCD4:\{\{nonceSuffix16\}\}/);
+        assert.match(scenario, /rCd4TaskPrompt\(inv\.promptTemplate,\s*rowNonce\)/);
+      } else {
+        assert.match(scenario, /promptTemplate\.replace\(\/\\\{\\\{nonce\\\}\\\}\/g,/);
+      }
     }
   }
 

--- a/tools/k6-proofs/scripts/collect-continuation-trace.mjs
+++ b/tools/k6-proofs/scripts/collect-continuation-trace.mjs
@@ -88,7 +88,11 @@ function traceContract(manifest, evidence) {
   if (tool === 'continue_delegate') {
     const template = manifest?.invocation?.promptTemplate;
     if (!template) throw new Error('continue_delegate manifest promptTemplate is required');
-    if (nonce) reason = String(template).replaceAll('{{nonce}}', String(nonce));
+    if (nonce) {
+      reason = String(template)
+        .replaceAll('{{nonceSuffix16}}', String(nonce).slice(-16))
+        .replaceAll('{{nonce}}', String(nonce));
+    }
     const manifestMode = manifest.invocation.mode;
     const evidenceMode = evidence.delegate_mode;
     if (manifestMode && evidenceMode && manifestMode !== evidenceMode) {

--- a/tools/k6-proofs/tests/r-cd-4-authority.test.mjs
+++ b/tools/k6-proofs/tests/r-cd-4-authority.test.mjs
@@ -3,11 +3,14 @@ import assert from 'node:assert/strict';
 import {
   R_CD_4_DURATION_THRESHOLD_MS,
   R_CD_4_OBSERVATION_WINDOW_MS,
+  rCd4ChildAuthority,
   rCd4ReturnCandidate,
   rCd4ReturnReceipt,
   rCd4SessionMessageObservation,
   rCd4ShouldScheduleEarlyClose,
+  rCd4TaskIdentityToken,
   rCd4TaskObservation,
+  rCd4TaskPrompt,
 } from '../lib/r-cd-4-authority.mjs';
 
 const nonce = 'R-CD-4-EXACT-NONCE';
@@ -17,6 +20,35 @@ const parent = 'agent:main:r-cd-4-parent';
 test('R-CD-4 duration threshold leaves headroom after the full observation window', () => {
   assert.ok(R_CD_4_DURATION_THRESHOLD_MS > R_CD_4_OBSERVATION_WINDOW_MS);
   assert.ok(R_CD_4_DURATION_THRESHOLD_MS < 120_000);
+});
+
+test('R-CD-4 child authority fails closed across conflicting observations', () => {
+  assert.deepEqual(rCd4ChildAuthority(['agent:main:subagent:child-a']), {
+    observedChildSessionKeys: ['agent:main:subagent:child-a'],
+    childSessionKey: 'agent:main:subagent:child-a',
+    ambiguous: false,
+  });
+  assert.deepEqual(rCd4ChildAuthority([
+    'agent:main:subagent:child-a',
+    'agent:main:subagent:child-b',
+    'agent:main:subagent:child-a',
+  ]), {
+    observedChildSessionKeys: [
+      'agent:main:subagent:child-a',
+      'agent:main:subagent:child-b',
+    ],
+    childSessionKey: null,
+    ambiguous: true,
+  });
+});
+
+test('R-CD-4 task prompt keeps the compact token in the traced reason', () => {
+  const prompt = rCd4TaskPrompt(
+    'RCD4:{{nonceSuffix16}} Proof nonce {{nonce}}: return the marker.',
+    nonce,
+  );
+  assert.equal(prompt, `RCD4:${nonce.slice(-16)} Proof nonce ${nonce}: return the marker.`);
+  assert.ok(prompt.startsWith(rCd4TaskIdentityToken(nonce)));
 });
 
 test('R-CD-4 accepts only the exact target marker and binds child identity', () => {
@@ -169,10 +201,14 @@ test('R-CD-4 retains an early parent receipt so a later target cannot false-PASS
 });
 
 test('R-CD-4 accepts tasks.list child authority only from a nonce-bound childSessionKey', () => {
+  const taskIdentityToken = rCd4TaskIdentityToken(nonce);
+  const title = `[continuation:chain-hop:1] Delegated task (turn 1/3): ${taskIdentityToken} Proof nonce ${nonce}`
+    .slice(0, 80);
+  assert.ok(title.includes(taskIdentityToken));
   assert.deepEqual(rCd4TaskObservation({
     sessionKey: parent,
     childSessionKey: 'agent:main:subagent:child',
-    title: `R-CD-4 task ${nonce}`,
+    title,
     status: 'completed',
     traceId: 'a'.repeat(32),
   }, nonce), {
@@ -207,6 +243,30 @@ test('R-CD-4 rejects requester sessionKey and nested nonce as tasks.list child a
     nonce,
   });
   assert.equal(rCd4ReturnReceipt(targetCandidate, observation.childSessionKey), null);
+});
+
+test('R-CD-4 rejects nonce-bearing routing keys with an unrelated stale child', () => {
+  assert.deepEqual(rCd4TaskObservation({
+    sessionKey: `agent:main:r-cd-4-parent-${nonce}`,
+    childSessionKey: 'agent:main:subagent:stale-child',
+    title: 'unrelated completed task',
+    status: 'completed',
+  }, nonce), {
+    childSessionKey: null,
+    completed: false,
+    traceId: null,
+  });
+
+  assert.deepEqual(rCd4TaskObservation({
+    sessionKey: 'agent:main:requester',
+    childSessionKey: `agent:main:subagent:stale-${nonce}`,
+    title: 'unrelated completed task',
+    status: 'completed',
+  }, nonce), {
+    childSessionKey: null,
+    completed: false,
+    traceId: null,
+  });
 });
 
 test('R-CD-4 keeps observing after a target receipt but closes early on parent failure', () => {

--- a/tools/k6-proofs/tests/row-child-correlation.test.mjs
+++ b/tools/k6-proofs/tests/row-child-correlation.test.mjs
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { childSessionKeyForRow } from '../lib/row-child-correlation.mjs';
+import {
+  childSessionKeyForRow,
+  childSessionKeysForRow,
+} from '../lib/row-child-correlation.mjs';
 
 test('rejects an earlier row child even when its event carries a child key', () => {
   const staleEvent = {
@@ -33,6 +36,33 @@ test('rejects a stale outer child key paired with an unrelated nested current-ro
   assert.equal(childSessionKeyForRow(mixedEvent, 'R-CD-MODEL-TOOL-new'), null);
 });
 
+test('rejects nonce-bearing routing keys as child authority', () => {
+  const rowNonce = 'R-CD-MODEL-TOOL-new';
+  assert.equal(childSessionKeyForRow({
+    sessionKey: `agent:main:parent-${rowNonce}`,
+    childSessionKey: 'luna-stale-child',
+  }, rowNonce), null);
+  assert.equal(childSessionKeyForRow({
+    sessionKey: 'agent:main:requester',
+    childSessionKey: `luna-stale-${rowNonce}`,
+  }, rowNonce), null);
+});
+
+test('accepts a bounded nested task summary through an explicit compact row token', () => {
+  const rowNonce = 'R-CD-4-EXACT-NONCE-WITH-LONG-RANDOM-SUFFIX';
+  const taskIdentityToken = `RCD4:${rowNonce.slice(-16)}`;
+  const title = `[continuation:chain-hop:1] Delegated task (turn 1/3): ${taskIdentityToken} ${rowNonce}`
+    .slice(0, 80);
+  assert.equal(childSessionKeyForRow({
+    action: 'upserted',
+    task: {
+      sessionKey: `agent:main:r-cd-4-parent-${rowNonce}`,
+      childSessionKey: 'luna-child-for-current-row',
+      title,
+    },
+  }, rowNonce, [taskIdentityToken]), 'luna-child-for-current-row');
+});
+
 test('accepts a direct spawn record that binds its child key and task nonce', () => {
   const spawnEvent = {
     childSessionKey: 'luna-child-for-current-row',
@@ -59,6 +89,29 @@ test('selects the one nested record whose own payload carries the current nonce'
   assert.equal(childSessionKeyForRow(aggregateEvent, 'R-CD-MODEL-TOOL-new'), 'luna-child-for-current-row');
 });
 
+test('rejects nested metadata as child authority without shadowing a real task record', () => {
+  const rowNonce = 'R-CD-MODEL-TOOL-new';
+  const metadataOnly = {
+    metadata: {
+      childSessionKey: 'stale-child-from-metadata',
+      title: `Proof nonce ${rowNonce}`,
+    },
+  };
+  assert.equal(childSessionKeyForRow(metadataOnly, rowNonce), null);
+
+  const eventWithRealTask = {
+    ...metadataOnly,
+    task: {
+      childSessionKey: 'luna-child-for-current-row',
+      title: `Proof nonce ${rowNonce}`,
+    },
+  };
+  assert.equal(
+    childSessionKeyForRow(eventWithRealTask, rowNonce),
+    'luna-child-for-current-row',
+  );
+});
+
 test('fails closed when two different child keys are both bound to the row nonce', () => {
   const ambiguousEvent = {
     records: [
@@ -74,4 +127,8 @@ test('fails closed when two different child keys are both bound to the row nonce
   };
 
   assert.equal(childSessionKeyForRow(ambiguousEvent, 'R-CD-MODEL-TOOL-new'), null);
+  assert.deepEqual(
+    childSessionKeysForRow(ambiguousEvent, 'R-CD-MODEL-TOOL-new'),
+    ['luna-child-a', 'luna-child-b'],
+  );
 });


### PR DESCRIPTION
## What Problem This Solves

R-CD-4 could bind a stale child from requester routing fields, arbitrary nested metadata, or conflicting observations across tasks.list responses and subscription events. TaskSummary titles can also truncate the full nonce after continuation prefixes.

## Evidence

- Adds an explicit compact task token to the actual delegated reason and matching Tempo fingerprint contract.
- Accepts child authority only from direct task/text/title fields in recognized task records.
- Permanently fails closed on multiple child keys or parent/target-as-child observations.
- Preserves the full target-only parent-negative observation window.
- Full proof harness: 240/240 passed.
- k6 inspect, diff hygiene, and independent exact-diff review passed.