### PR TITLE
tools/k6-proofs: P86 delegate attachment I/O proof rows (docs#491)

### DIFF
--- a/.github/workflows/k6-proof.yml
+++ b/.github/workflows/k6-proof.yml
@@ -237,13 +237,15 @@ jobs:
           mkdir -p /tmp/k6-out
           {
             echo "== dry run: no scenario execution, no live session contact =="
-            # Export the EXACT env a live run would export. `k6 archive`
-            # evaluates the init context, which is where loadManifestFromEnv()
-            # calls open(); an unresolvable manifest path therefore fails here
-            # (k6 exit 107) instead of at the head of a live row.
+            # `k6 archive` excludes system env by default. Pass this through
+            # k6's explicit environment flag, otherwise __ENV would not see
+            # it and the init-context manifest open() would silently take its
+            # defaults branch.
             if [ -n "$MANIFEST_PATH" ]; then
-              OPENCLAW_ROW_MANIFEST="$MANIFEST_PATH" \
-                k6 archive "tools/k6-proofs/scenarios/${SCENARIO}.js" -O /tmp/k6-out/archive.tar
+              k6 archive \
+                -e "OPENCLAW_ROW_MANIFEST=$MANIFEST_PATH" \
+                "tools/k6-proofs/scenarios/${SCENARIO}.js" \
+                -O /tmp/k6-out/archive.tar
               echo "scenario compiled and archived with OPENCLAW_ROW_MANIFEST=$MANIFEST_PATH"
             else
               k6 archive "tools/k6-proofs/scenarios/${SCENARIO}.js" -O /tmp/k6-out/archive.tar

--- a/.github/workflows/k6-proof.yml
+++ b/.github/workflows/k6-proof.yml
@@ -123,6 +123,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate inputs
+        id: inputs
         env:
           DRY_RUN: ${{ github.event.inputs.dry_run }}
           SCENARIO: ${{ github.event.inputs.scenario }}
@@ -140,10 +141,30 @@ jobs:
             echo "::error::scenario file not found: $scenario_file"
             exit 1
           fi
-          if [ -n "$MANIFEST_PATH" ] && [ ! -f "$MANIFEST_PATH" ]; then
-            echo "::error::manifest path not found: $MANIFEST_PATH"
-            exit 1
+          # NORMALIZE ONCE. Node consumers (live-run-guard, evidence-writer, the
+          # existence check below) take the repo-root form; k6's open() resolves
+          # OPENCLAW_ROW_MANIFEST relative to the scenario directory. Accept
+          # either input form here, emit exactly one canonical repo-root value,
+          # and let lib/manifest-loader.js re-derive the k6-relative form.
+          normalized=""
+          if [ -n "$MANIFEST_PATH" ]; then
+            normalized="${MANIFEST_PATH#./}"
+            case "$normalized" in
+              /*) : ;;
+              tools/k6-proofs/*) : ;;
+              manifests/*) normalized="tools/k6-proofs/$normalized" ;;
+              */*)
+                echo "::error::manifest_path must live under tools/k6-proofs/manifests/: $MANIFEST_PATH"
+                exit 1
+                ;;
+              *) normalized="tools/k6-proofs/manifests/$normalized" ;;
+            esac
+            if [ ! -f "$normalized" ]; then
+              echo "::error::manifest path not found: $normalized (from input '$MANIFEST_PATH')"
+              exit 1
+            fi
           fi
+          echo "manifest_path=$normalized" >> "$GITHUB_OUTPUT"
           if [ "$DRY_RUN" != "true" ]; then
             if [ -z "$ROW" ]; then
               echo "::error::row is required when dry_run=false"
@@ -156,12 +177,12 @@ jobs:
             # A live run without a manifest cannot compute its lock identity,
             # cannot check its own live-run safety contract, and cannot carry
             # classification/safety metadata into the artifact.
-            if [ -z "$MANIFEST_PATH" ]; then
+            if [ -z "$normalized" ]; then
               echo "::error::manifest_path is required when dry_run=false"
               exit 1
             fi
           fi
-          echo "inputs validated (dry_run=$DRY_RUN, scenario=$SCENARIO)"
+          echo "inputs validated (dry_run=$DRY_RUN, scenario=$SCENARIO, manifest=${normalized:-none})"
 
       - name: Install k6
         run: |
@@ -210,14 +231,24 @@ jobs:
         if: ${{ github.event.inputs.dry_run == 'true' }}
         env:
           SCENARIO: ${{ github.event.inputs.scenario }}
-          MANIFEST_PATH: ${{ github.event.inputs.manifest_path }}
+          MANIFEST_PATH: ${{ steps.inputs.outputs.manifest_path }}
         run: |
           set -euo pipefail
           mkdir -p /tmp/k6-out
           {
             echo "== dry run: no scenario execution, no live session contact =="
-            k6 archive "tools/k6-proofs/scenarios/${SCENARIO}.js" -O /tmp/k6-out/archive.tar
-            echo "scenario compiled and archived: ${SCENARIO}.js"
+            # Export the EXACT env a live run would export. `k6 archive`
+            # evaluates the init context, which is where loadManifestFromEnv()
+            # calls open(); an unresolvable manifest path therefore fails here
+            # (k6 exit 107) instead of at the head of a live row.
+            if [ -n "$MANIFEST_PATH" ]; then
+              OPENCLAW_ROW_MANIFEST="$MANIFEST_PATH" \
+                k6 archive "tools/k6-proofs/scenarios/${SCENARIO}.js" -O /tmp/k6-out/archive.tar
+              echo "scenario compiled and archived with OPENCLAW_ROW_MANIFEST=$MANIFEST_PATH"
+            else
+              k6 archive "tools/k6-proofs/scenarios/${SCENARIO}.js" -O /tmp/k6-out/archive.tar
+              echo "scenario compiled and archived: ${SCENARIO}.js (no manifest env)"
+            fi
             if [ -n "$MANIFEST_PATH" ]; then
               node tools/k6-proofs/scripts/live-run-guard.mjs --manifest "$MANIFEST_PATH" --json || \
                 echo "live-run-guard reported a safety contract failure for $MANIFEST_PATH"
@@ -237,7 +268,7 @@ jobs:
         env:
           OPENCLAW_SESSION_KEY: ${{ github.event.inputs.session_key }}
           OPENCLAW_CANDIDATE_SHA: ${{ github.event.inputs.candidate_sha }}
-          MANIFEST_PATH: ${{ github.event.inputs.manifest_path }}
+          MANIFEST_PATH: ${{ steps.inputs.outputs.manifest_path }}
         run: |
           export OPENCLAW_GATEWAY_TOKEN="$(python3 -c 'import json, os; print(json.load(open(os.path.expanduser("~/.openclaw/openclaw.json")))["gateway"]["auth"]["token"])')"
           set +x
@@ -268,12 +299,15 @@ jobs:
         # flock exit 75 means a conflicting run owns the session: that output is
         # a coordination failure, not row evidence.
         if: ${{ github.event.inputs.dry_run != 'true' }}
+        id: k6run
         env:
           OPENCLAW_GATEWAY_WS: ${{ github.event.inputs.gateway_ws }}
           OPENCLAW_SESSION_KEY: ${{ github.event.inputs.session_key }}
           OPENCLAW_CANDIDATE_SHA: ${{ github.event.inputs.candidate_sha }}
           OPENCLAW_SEAT_NAME: ${{ github.event.inputs.seat }}
-          OPENCLAW_ROW_MANIFEST: ${{ github.event.inputs.manifest_path }}
+          # Same canonical repo-root value the Node consumers use;
+          # lib/manifest-loader.js normalizes it for k6's open().
+          OPENCLAW_ROW_MANIFEST: ${{ steps.inputs.outputs.manifest_path }}
           SCENARIO: ${{ github.event.inputs.scenario }}
           SESSION_LOCK_PATH: ${{ steps.guard.outputs.session_lock_path }}
           ROW_LOCK_PATH: ${{ steps.guard.outputs.lock_path }}
@@ -294,7 +328,9 @@ jobs:
               k6 run "tools/k6-proofs/scenarios/${SCENARIO}.js" 2>&1 | tee /tmp/k6-out/run.txt
           status=${PIPESTATUS[0]}
           set -e
+          echo "k6_status=$status" >> "$GITHUB_OUTPUT"
           if [ "$status" = "75" ]; then
+            echo "conflict=true" >> "$GITHUB_OUTPUT"
             echo "::error::another proof row already holds this target session (flock 75); this output is a coordination failure, not row evidence"
             exit 75
           fi
@@ -302,12 +338,17 @@ jobs:
 
       - name: Write evidence artifacts
         # Skipped on dry_run: a preflight/dry run writes NO proof verdicts.
-        if: ${{ github.event.inputs.dry_run != 'true' }}
+        #
+        # `!cancelled()` rather than `success()`: a row that fails its checks
+        # still emitted its evidence block, and that PARTIAL/FAIL candidate is
+        # exactly what a reviewer needs. A flock-75 conflict is skipped — that
+        # output is a coordination failure, not row evidence.
+        if: ${{ !cancelled() && github.event.inputs.dry_run != 'true' && steps.k6run.outputs.conflict != 'true' && steps.k6run.outcome != 'skipped' }}
         env:
           ROW: ${{ github.event.inputs.row }}
           SEAT: ${{ github.event.inputs.seat }}
           CANDIDATE_SHA: ${{ github.event.inputs.candidate_sha }}
-          MANIFEST_PATH: ${{ github.event.inputs.manifest_path }}
+          MANIFEST_PATH: ${{ steps.inputs.outputs.manifest_path }}
           SCENARIO: ${{ github.event.inputs.scenario }}
           OPENCLAW_SESSION_KEY: ${{ github.event.inputs.session_key }}
         run: |
@@ -343,7 +384,7 @@ jobs:
           rm -f /tmp/k6-out/run.txt
 
       - name: Upload run log (dry_run)
-        if: ${{ github.event.inputs.dry_run == 'true' }}
+        if: ${{ !cancelled() && github.event.inputs.dry_run == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: k6-dry-run-log
@@ -356,7 +397,10 @@ jobs:
           retention-days: 14
 
       - name: Upload proof artifacts
-        if: ${{ github.event.inputs.dry_run != 'true' }}
+        # Must survive a failing row: without `!cancelled()` a non-zero k6 exit
+        # (or a writer/sanitizer failure) left the run with no artifact at all,
+        # so there was nothing to review and nothing to prove the failure with.
+        if: ${{ !cancelled() && github.event.inputs.dry_run != 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: k6-proof-${{ github.event.inputs.row }}-${{ github.event.inputs.seat }}
@@ -365,5 +409,8 @@ jobs:
             PROOFS/${{ github.event.inputs.candidate_sha }}/${{ github.event.inputs.row }}/${{ github.event.inputs.seat }}/
             /tmp/k6-out/run.public.txt
             /tmp/k6-out/run-log-redaction.json
-          if-no-files-found: error
+          # `warn`, not `error`: on the failure path some of these paths may not
+          # exist, and failing the upload would destroy the diagnostic it exists
+          # to carry. The job's own exit status still reports the failure.
+          if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/k6-proof.yml
+++ b/.github/workflows/k6-proof.yml
@@ -13,8 +13,18 @@ name: k6 PROOF row
 # The target gateway WS URL is a workflow input (the gateway runs on a prince
 # seat, not the runner). For a network-reachable target, point gateway_ws at it
 # and run on a runner with a route to that seat (self-hosted runner on/near the
-# seat is the typical shape). dry_run=true (default) runs preflight only and
-# writes no proof verdicts, so it is safe to exercise the plumbing first.
+# seat is the typical shape).
+#
+# dry_run=true (default) NEVER executes the scenario: it compiles/archives it,
+# evaluates the manifest live-run safety contract, and runs the static manifest
+# and alignment checks. No live session is contacted and no proof verdict is
+# written, so it is safe to exercise the plumbing first.
+#
+# Live runs (dry_run=false) require a manifest_path: it supplies the live-run
+# safety contract, the flock lock identity, and the classification metadata that
+# lands in the artifact. Rows classified `orchestration-required` are rejected by
+# live-run-guard.mjs by design — they need an explicit orchestration window, not
+# a plain workflow_dispatch.
 
 on:
   workflow_dispatch:
@@ -86,7 +96,7 @@ on:
         type: string
         default: "main"
       dry_run:
-        description: "Preflight/dry mode: run preflight only, write NO proof verdicts"
+        description: "Dry mode: validate scenario/manifest/safety WITHOUT executing the scenario against a live session. Writes NO proof verdicts."
         required: false
         type: boolean
         default: true
@@ -97,9 +107,11 @@ permissions:
   contents: read
 
 concurrency:
-  # Serialize proof runs on the same row+seat — k6 proof rows are single-VU and
-  # must not run in parallel against the same session.
-  group: k6-proof-${{ github.event.inputs.seat }}-${{ github.event.inputs.row }}
+  # Serialize on the TARGET SESSION, not on row+seat. Two different rows aimed
+  # at the same session are exactly the overlap live-run-guard.mjs exists to
+  # prevent; a row-scoped group would let them run side by side. The workflow
+  # group is the coarse fence; the flock pair below is the enforced one.
+  group: k6-proof-session-${{ github.event.inputs.gateway_ws }}-${{ github.event.inputs.session_key }}
   cancel-in-progress: false
 
 jobs:
@@ -141,6 +153,13 @@ jobs:
               echo "::error::candidate_sha must be a 40-char hex string when dry_run=false"
               exit 1
             fi
+            # A live run without a manifest cannot compute its lock identity,
+            # cannot check its own live-run safety contract, and cannot carry
+            # classification/safety metadata into the artifact.
+            if [ -z "$MANIFEST_PATH" ]; then
+              echo "::error::manifest_path is required when dry_run=false"
+              exit 1
+            fi
           fi
           echo "inputs validated (dry_run=$DRY_RUN, scenario=$SCENARIO)"
 
@@ -169,18 +188,86 @@ jobs:
           set +x
           set -euo pipefail
           if ! node tools/k6-proofs/scripts/seat-readiness-preflight.mjs --json | tee /tmp/seat-readiness.json; then
+            # Fail closed. A dry run may report the failure and keep going only
+            # because a dry run never touches a live session; the live path is
+            # gated on this step succeeding, so it cannot "return success and
+            # continue into execution".
             if [ "$DRY_RUN" = "true" ]; then
-              echo "::warning::seat readiness preflight did not pass; dry_run continues, but output is not proof-standard"
+              echo "::warning::seat readiness preflight did not pass; this dry run validates artifacts only and executes nothing"
               exit 0
             fi
             echo "::error::seat readiness preflight did not pass; inspect /tmp/seat-readiness.json before treating k6 output as proof-standard"
             exit 1
           fi
 
-      - name: Run k6 scenario
+      - name: Dry run — validate without executing
+        # A dry run must not mutate a live session. Executing the scenario would
+        # invoke its default function, which for every row in this harness
+        # dispatches a real agent turn. The dry path therefore compiles and
+        # inspects the scenario (`k6 archive`, which loads the module graph and
+        # evaluates only the init context) and validates the manifest/safety
+        # contract. No iteration is executed.
+        if: ${{ github.event.inputs.dry_run == 'true' }}
+        env:
+          SCENARIO: ${{ github.event.inputs.scenario }}
+          MANIFEST_PATH: ${{ github.event.inputs.manifest_path }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/k6-out
+          {
+            echo "== dry run: no scenario execution, no live session contact =="
+            k6 archive "tools/k6-proofs/scenarios/${SCENARIO}.js" -O /tmp/k6-out/archive.tar
+            echo "scenario compiled and archived: ${SCENARIO}.js"
+            if [ -n "$MANIFEST_PATH" ]; then
+              node tools/k6-proofs/scripts/live-run-guard.mjs --manifest "$MANIFEST_PATH" --json || \
+                echo "live-run-guard reported a safety contract failure for $MANIFEST_PATH"
+            else
+              echo "no manifest_path supplied: live-run safety contract not evaluated"
+            fi
+            node tools/k6-proofs/scripts/check-manifest-scenarios.mjs
+            node tools/k6-proofs/scripts/check-scenario-alignment.mjs
+          } 2>&1 | tee /tmp/k6-out/run.txt
+          echo "dry run complete — no k6 iteration was executed"
+
+      - name: Compute live-run lock identity
+        # The guard COMPUTES lock identity and fails closed on the manifest
+        # safety contract; the flock pair below is what actually serializes.
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        id: guard
+        env:
+          OPENCLAW_SESSION_KEY: ${{ github.event.inputs.session_key }}
+          OPENCLAW_CANDIDATE_SHA: ${{ github.event.inputs.candidate_sha }}
+          MANIFEST_PATH: ${{ github.event.inputs.manifest_path }}
+        run: |
+          export OPENCLAW_GATEWAY_TOKEN="$(python3 -c 'import json, os; print(json.load(open(os.path.expanduser("~/.openclaw/openclaw.json")))["gateway"]["auth"]["token"])')"
+          set +x
+          set -euo pipefail
+          command -v flock >/dev/null || { echo "::error::flock is required to serialize live proof rows"; exit 1; }
+          GUARD_VARS="$(node tools/k6-proofs/scripts/live-run-guard.mjs --manifest "$MANIFEST_PATH" --shell --require-lock)"
+          eval "$GUARD_VARS"
+          if [ "${K6_PROOF_LOCK_REQUIRED:-0}" != "1" ] || [ -z "${K6_PROOF_LOCK_PATH:-}" ] || [ -z "${K6_PROOF_SESSION_LOCK_PATH:-}" ]; then
+            echo "::error::live-run-guard did not produce both lock paths"
+            exit 1
+          fi
+          {
+            echo "lock_path=$K6_PROOF_LOCK_PATH"
+            echo "session_lock_path=$K6_PROOF_SESSION_LOCK_PATH"
+            echo "lock_reason=$K6_PROOF_LOCK_REASON"
+          } >> "$GITHUB_OUTPUT"
+          node tools/k6-proofs/scripts/live-run-guard.mjs --manifest "$MANIFEST_PATH" --json > /tmp/live-run-guard.json
+
+      - name: Run k6 scenario (live)
         # Token is injected ONLY here, ONLY as env. Never echoed; runner masks
         # registered secrets in logs, and we keep `set +x` so the env line is
         # not traced. k6 reads OPENCLAW_GATEWAY_TOKEN from the environment.
+        #
+        # Two nested locks, always session-outer then row-inner, so the ordering
+        # is global and cannot deadlock (both are --nonblock in any case):
+        #   session lock  no OTHER continuation row on this target session
+        #   row lock      no second run of THIS row on this target session
+        # flock exit 75 means a conflicting run owns the session: that output is
+        # a coordination failure, not row evidence.
+        if: ${{ github.event.inputs.dry_run != 'true' }}
         env:
           OPENCLAW_GATEWAY_WS: ${{ github.event.inputs.gateway_ws }}
           OPENCLAW_SESSION_KEY: ${{ github.event.inputs.session_key }}
@@ -188,8 +275,10 @@ jobs:
           OPENCLAW_SEAT_NAME: ${{ github.event.inputs.seat }}
           OPENCLAW_ROW_MANIFEST: ${{ github.event.inputs.manifest_path }}
           SCENARIO: ${{ github.event.inputs.scenario }}
+          SESSION_LOCK_PATH: ${{ steps.guard.outputs.session_lock_path }}
+          ROW_LOCK_PATH: ${{ steps.guard.outputs.lock_path }}
         run: |
-          export OPENCLAW_GATEWAY_TOKEN="$(python3 -c 'import json, os; print(json.load(open(os.path.expanduser(\"~/.openclaw/openclaw.json\")))[\"gateway\"][\"auth\"][\"token\"])')"
+          export OPENCLAW_GATEWAY_TOKEN="$(python3 -c 'import json, os; print(json.load(open(os.path.expanduser("~/.openclaw/openclaw.json")))["gateway"]["auth"]["token"])')"
           set +x
           set -euo pipefail
           if [ -z "${OPENCLAW_GATEWAY_TOKEN:-}" ]; then
@@ -199,8 +288,17 @@ jobs:
           mkdir -p /tmp/k6-out
           # tee to a file for the evidence post-processor; k6's own stdout is the
           # human log. The token is never printed by k6 or by us.
-          k6 run "tools/k6-proofs/scenarios/${SCENARIO}.js" 2>&1 | tee /tmp/k6-out/run.txt
-          echo "k6 run complete"
+          set +e
+          flock --nonblock --conflict-exit-code 75 "$SESSION_LOCK_PATH" \
+            flock --nonblock --conflict-exit-code 75 "$ROW_LOCK_PATH" \
+              k6 run "tools/k6-proofs/scenarios/${SCENARIO}.js" 2>&1 | tee /tmp/k6-out/run.txt
+          status=${PIPESTATUS[0]}
+          set -e
+          if [ "$status" = "75" ]; then
+            echo "::error::another proof row already holds this target session (flock 75); this output is a coordination failure, not row evidence"
+            exit 75
+          fi
+          exit "$status"
 
       - name: Write evidence artifacts
         # Skipped on dry_run: a preflight/dry run writes NO proof verdicts.
@@ -209,6 +307,9 @@ jobs:
           ROW: ${{ github.event.inputs.row }}
           SEAT: ${{ github.event.inputs.seat }}
           CANDIDATE_SHA: ${{ github.event.inputs.candidate_sha }}
+          MANIFEST_PATH: ${{ github.event.inputs.manifest_path }}
+          SCENARIO: ${{ github.event.inputs.scenario }}
+          OPENCLAW_SESSION_KEY: ${{ github.event.inputs.session_key }}
         run: |
           set -euo pipefail
           node tools/k6-proofs/scripts/evidence-writer.mjs \
@@ -216,16 +317,40 @@ jobs:
             --row "$ROW" \
             --seat "$SEAT" \
             --sha "$CANDIDATE_SHA" \
+            --manifest "$MANIFEST_PATH" \
+            --scenario "${SCENARIO}.js" \
             --seat-readiness /tmp/seat-readiness.json
+          run_dir="$(ls -d PROOFS/${CANDIDATE_SHA}/${ROW}/${SEAT}/k6-run-* | tail -1)"
+          cp /tmp/live-run-guard.json "$run_dir/live-run-guard.json"
           echo "evidence written under PROOFS/${CANDIDATE_SHA}/${ROW}/${SEAT}/"
+
+      - name: Sanitize run log for upload
+        # The raw k6 console log carries session keys, claim ids, child session
+        # keys and workspace paths. Nothing raw is ever uploaded.
+        if: ${{ always() }}
+        env:
+          OPENCLAW_SESSION_KEY: ${{ github.event.inputs.session_key }}
+        run: |
+          set -euo pipefail
+          if [ ! -f /tmp/k6-out/run.txt ]; then
+            echo "no run log to sanitize"
+            exit 0
+          fi
+          node tools/k6-proofs/scripts/sanitize-k6-artifacts.mjs \
+            --log-input /tmp/k6-out/run.txt \
+            --log-out /tmp/k6-out/run.public.txt \
+            --receipt-out /tmp/k6-out/run-log-redaction.json
+          rm -f /tmp/k6-out/run.txt
 
       - name: Upload run log (dry_run)
         if: ${{ github.event.inputs.dry_run == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: k6-dry-run-log
+          # Sanitized log only — the raw tee output is deleted above.
           path: |
-            /tmp/k6-out/run.txt
+            /tmp/k6-out/run.public.txt
+            /tmp/k6-out/run-log-redaction.json
             /tmp/seat-readiness.json
           if-no-files-found: warn
           retention-days: 14
@@ -238,5 +363,7 @@ jobs:
           # CANDIDATE artifacts only — human review folds into canonical PROOFS/.
           path: |
             PROOFS/${{ github.event.inputs.candidate_sha }}/${{ github.event.inputs.row }}/${{ github.event.inputs.seat }}/
+            /tmp/k6-out/run.public.txt
+            /tmp/k6-out/run-log-redaction.json
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/k6-proof.yml
+++ b/.github/workflows/k6-proof.yml
@@ -36,6 +36,14 @@ on:
           - r-cd-model-chained-alt
           - r-cd-model-token
           - r-cd-token-bracket-delegate
+          - r-cd-in-1-typed-input-snapshot
+          - r-cd-in-recovery-queued-restart
+          - r-cd-in-revoke-no-spawn-scrub
+          - r-cd-out-publish-claim
+          - r-cd-out-claim-lifecycle
+          - r-cd-out-unauthorized-reject
+          - r-cd-out-restart-replay
+          - r-cd-io-negative-boundary
           - r-config-defaults
           - r-cw-1
           - r-cw-1-tool-schedule-wake

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -404,6 +404,22 @@ Row-specific configuration lives in **manifests** (`tools/k6-proofs/manifests/*.
 
 Manifests use `${ENV_VAR:-default}` placeholders resolved at runtime — no secrets or seat-specific values baked into source.
 
+`OPENCLAW_ROW_MANIFEST` takes the **repo-root form** — the same value the Node
+consumers (`live-run-guard.mjs`, `evidence-writer.mjs`, the workflow's
+`manifest_path` input) take:
+
+```
+OPENCLAW_ROW_MANIFEST="tools/k6-proofs/manifests/r-cd-1.json"
+```
+
+k6 resolves a relative `open()` against the running scenario's directory, so
+`lib/manifest-loader.js` normalizes that value (`normalizeManifestOpenPath`)
+rather than making callers keep two spellings of the same path. An absolute
+path, `manifests/<row>.json`, and a bare `<row>.json` are all accepted and
+resolve to the same file; passing the repo-root form used to produce
+`tools/k6-proofs/tools/k6-proofs/manifests/...` and fail `k6 archive` with
+exit 107.
+
 Manifests follow the schema defined by #100 (foundation): `openclaw.k6.proof-row-manifest.v1`.
 
 ### Live-run safety contract

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -107,7 +107,7 @@ See [`docs/GOLDEN-PATH.md`](docs/GOLDEN-PATH.md). Output remains
 `PASS-candidate` / review-required and must not be folded automatically.
 
 - [`docs/PROOF-RUN-METHOD.md`](docs/PROOF-RUN-METHOD.md) is the short GATES/proof-round entrypoint: row enumeration, dry-run/live run shape, bootstrap workflow anchor, and the #331 receipt boundary.
-- [`docs/DELEGATE-ATTACHMENT-IO-ROWS.md`](docs/DELEGATE-ATTACHMENT-IO-ROWS.md) covers the P86 delegate attachment I/O family (docs#491): typed `continue_delegate` input snapshots and the managed `delegate_artifacts` claim lifecycle, including which rows are orchestration-gated to `PARTIAL-candidate` by construction.
+- [`docs/DELEGATE-ATTACHMENT-IO-ROWS.md`](docs/DELEGATE-ATTACHMENT-IO-ROWS.md) covers the P86 delegate attachment I/O family (docs#491): typed `continue_delegate` input snapshots and the managed `delegate_artifacts` claim lifecycle, including which rows are orchestration-gated to `PARTIAL-candidate` by construction. These eight rows are **supplemental**: the Project 86 accountable contract stays at 38 issues / 35 corpus rows, and they remain manifest-only until a coordinator folds them onto the proof board.
 
 ### 1. Seat readiness / version preflight
 

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -107,6 +107,7 @@ See [`docs/GOLDEN-PATH.md`](docs/GOLDEN-PATH.md). Output remains
 `PASS-candidate` / review-required and must not be folded automatically.
 
 - [`docs/PROOF-RUN-METHOD.md`](docs/PROOF-RUN-METHOD.md) is the short GATES/proof-round entrypoint: row enumeration, dry-run/live run shape, bootstrap workflow anchor, and the #331 receipt boundary.
+- [`docs/DELEGATE-ATTACHMENT-IO-ROWS.md`](docs/DELEGATE-ATTACHMENT-IO-ROWS.md) covers the P86 delegate attachment I/O family (docs#491): typed `continue_delegate` input snapshots and the managed `delegate_artifacts` claim lifecycle, including which rows are orchestration-gated to `PARTIAL-candidate` by construction.
 
 ### 1. Seat readiness / version preflight
 

--- a/tools/k6-proofs/docs/DELEGATE-ATTACHMENT-IO-ROWS.md
+++ b/tools/k6-proofs/docs/DELEGATE-ATTACHMENT-IO-ROWS.md
@@ -136,6 +136,25 @@ choices.
 - Only sanitized logs are uploaded. The raw `k6` console log carries session
   keys, claim ids, child session keys and paths, so it is passed through
   `sanitize-k6-artifacts.mjs` and the raw file is deleted before upload.
+- `manifest_path` is **normalized once** in the validate step and every
+  downstream consumer — `live-run-guard.mjs`, `evidence-writer.mjs`, and the
+  exported `OPENCLAW_ROW_MANIFEST` — reads that single canonical repo-root
+  value. The dry run runs `k6 archive` with that exact env, so an unresolvable
+  manifest fails in dry mode instead of at the head of a live row.
+- Artifacts are uploaded on the **failure path** too (`!cancelled()`). A row
+  that fails still emitted its evidence block, and that PARTIAL/FAIL candidate
+  plus the sanitized log is exactly what a reviewer needs. The one exception is
+  a `flock` 75 conflict, which is skipped because it is a coordination failure
+  rather than row evidence.
+
+**Log framing.** k6 does not print `console.log` verbatim: every call becomes a
+logrus record and the whole evidence JSON lands inside one escaped `msg="..."`
+value. `lib/k6-log-evidence.mjs` is the single decode-aware extractor shared by
+`extract-k6-evidence.mjs`, `sanitize-k6-artifacts.mjs` and
+`evidence-writer.mjs`, so no consumer can silently parse a real run as zero
+records. The sanitizer **fails closed** when evidence markers are present but no
+record parses, rather than attesting `evidenceBlocks: 0` over a log that still
+carries the sensitive values.
 
 ### Row-specific environment
 

--- a/tools/k6-proofs/docs/DELEGATE-ATTACHMENT-IO-ROWS.md
+++ b/tools/k6-proofs/docs/DELEGATE-ATTACHMENT-IO-ROWS.md
@@ -1,0 +1,177 @@
+# Delegate attachment I/O proof rows (P86 / docs#491)
+
+Eight rows covering the typed `continue_delegate` **INPUT** snapshot surface and
+the managed delegate **OUTPUT** claim lifecycle, as assembled in the Project 86
+candidate.
+
+Binding: [karmaterminal/karmaterminal-openclaw-docs#491](https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/491)
+— acceptance item 4 ("Exact-canary Project 86 receipts").
+
+---
+
+## Why these rows exist
+
+Issue #491 is a deployment/proof binding gap, not a feature gap. The delegate
+input surface and the managed return-claim control plane are assembled in the
+candidate; what was missing was *reviewable automation* that produces public-safe
+receipts for them. Before #491, the 38-row Project 86 plan had **no** row for
+delegate attachment I/O: every `R-CD-*` row proved scheduling, wake, return, and
+model propagation, and none of them touched attachments or artifact claims.
+
+These rows close that hole. They are one-command local-gateway WebSocket
+scenarios in the existing harness shape — same manifest schema, same evidence
+writer, same validator, same fold contract.
+
+---
+
+## Runtime controller binding
+
+Every row names the controller it exercises. If you are reviewing a receipt,
+this is the map from sentinel to source:
+
+| Row | Runtime surface at the candidate |
+|---|---|
+| R-CD-IN-1 | `src/agents/tools/continue-delegate-tool.ts` (`attachments`, `attachAs`), `src/agents/subagent-attachments.ts` |
+| R-CD-IN-RECOVERY | `src/auto-reply/continuation/delegate-flow-store.ts` (persisted attachment state, `hasStoredDelegateAttachmentState`) |
+| R-CD-IN-REVOKE | `continue-delegate-tool.ts` policy refusal + `delegate-flow-store.ts` `scrubStoredDelegateAttachmentState` |
+| R-CD-OUT-PUBLISH | `src/agents/tools/delegate-artifacts-tool.ts` (`delegate_artifacts_publish`), `src/agents/delegate-artifact-store.ts` |
+| R-CD-OUT-CLAIM | `delegate-artifacts-tool.ts` (`action: list \| inspect \| materialize \| discard`), `src/agents/delegate-artifacts.ts` |
+| R-CD-OUT-UNAUTHORIZED | `src/agents/delegate-artifact-recipient.ts`, `delegate-artifact-store.ts` claim/binding status |
+| R-CD-OUT-REPLAY | `src/agents/delegate-artifact-delivery.ts` (delivery phases `attempt` / `replay` / `acknowledged`), `src/state/delegate-artifacts-schema.ts` |
+| R-CD-IO-NEG | `src/agents/internal-events.ts` (explicit-action announcement footer) |
+
+---
+
+## Row table
+
+| Row | Manifest | Scenario | Class | Expected artifact class |
+|---|---|---|---|---|
+| R-CD-IN-1 | `r-cd-in-1.json` | `r-cd-in-1-typed-input-snapshot.js` | k6-runnable | PASS-candidate |
+| R-CD-IN-RECOVERY | `r-cd-in-recovery.json` | `r-cd-in-recovery-queued-restart.js` | orchestration-required | PARTIAL-candidate |
+| R-CD-IN-REVOKE | `r-cd-in-revoke.json` | `r-cd-in-revoke-no-spawn-scrub.js` | orchestration-required | PARTIAL-candidate |
+| R-CD-OUT-PUBLISH | `r-cd-out-publish.json` | `r-cd-out-publish-claim.js` | k6-runnable | PASS-candidate |
+| R-CD-OUT-CLAIM | `r-cd-out-claim.json` | `r-cd-out-claim-lifecycle.js` | k6-runnable | PASS-candidate |
+| R-CD-OUT-UNAUTHORIZED | `r-cd-out-unauthorized.json` | `r-cd-out-unauthorized-reject.js` | k6-runnable | PASS-candidate |
+| R-CD-OUT-REPLAY | `r-cd-out-replay.json` | `r-cd-out-restart-replay.js` | orchestration-required | PARTIAL-candidate |
+| R-CD-IO-NEG | `r-cd-io-neg.json` | `r-cd-io-negative-boundary.js` | k6-runnable | PASS-candidate |
+
+### Both-forms mandate: not applicable
+
+Only the typed `continue_delegate` tool can carry attachment blobs. The bracket
+form is explicitly documented at the candidate as unable to:
+
+> `Bracket [[CONTINUE_DELEGATE: ...]] syntax cannot carry attachment blobs; reference an existing workspace file instead.`
+> — `src/agents/system-prompt.ts`
+
+So these rows have no token-form sibling, and a single-surface row here is
+complete rather than incomplete. This is the same shape as the R-OBS-1
+not-applicable ruling.
+
+---
+
+## Running a row
+
+One command per row, in the standard harness shape:
+
+```bash
+OPENCLAW_GATEWAY_WS="ws://127.0.0.1:18789" \
+OPENCLAW_GATEWAY_TOKEN="***" \
+OPENCLAW_SESSION_KEY="<recipient-session>" \
+OPENCLAW_CANDIDATE_SHA="<40-char-sha>" \
+OPENCLAW_SEAT_NAME="<seat>" \
+OPENCLAW_CREATE_DISPOSABLE_SESSION=true \
+OPENCLAW_ROW_MANIFEST="tools/k6-proofs/manifests/r-cd-out-claim.json" \
+  k6 run tools/k6-proofs/scenarios/r-cd-out-claim-lifecycle.js \
+  | tee /tmp/r-cd-out-claim.txt
+```
+
+Then post-process exactly as any other row:
+
+```bash
+node tools/k6-proofs/scripts/evidence-writer.mjs \
+  --input /tmp/r-cd-out-claim.txt \
+  --row R-CD-OUT-CLAIM \
+  --seat <seat> \
+  --sha <40-char-sha> \
+  --manifest tools/k6-proofs/manifests/r-cd-out-claim.json
+```
+
+The GitHub `k6 PROOF row` workflow carries all eight scenarios as dispatch
+choices.
+
+### Row-specific environment
+
+| Variable | Rows | Meaning |
+|---|---|---|
+| `OPENCLAW_QUEUE_DELAY_SECONDS` | R-CD-IN-RECOVERY | Queue window the delegate stays pending (default 120) |
+| `OPENCLAW_RESTART_WINDOW_MS` | R-CD-OUT-REPLAY | Window during which the operator restarts the gateway (default 120000) |
+| `OPENCLAW_RESTART_ORCHESTRATED` | R-CD-IN-RECOVERY, R-CD-OUT-REPLAY | Set `true` **only** when a restart genuinely happened |
+| `OPENCLAW_NEGATIVE_WINDOW_MS` | R-CD-IO-NEG and the OUT rows | Bounded window held open to catch unsolicited delivery |
+
+---
+
+## The honesty contract
+
+These rows are built so that a PARTIAL cannot be quietly upgraded.
+
+**`computeVerdict` returns `PASS-candidate` only when** every required receipt
+fired **and** every negative check held **and** any declared orchestration
+precondition was observed. Anything else is `PARTIAL-candidate`. There is no
+third path and no override env var.
+
+**Orchestration gates.** Two preconditions cannot be produced by a k6 harness and
+must not be faked:
+
+1. *Policy revoke* (R-CD-IN-REVOKE). The gateway exposes `config.get` but no
+   `config.set`. The scenario reads the live value of
+   `tools.sessions_spawn.attachments.enabled`. If it is still `true`, or if the
+   config surface does not expose it at all, the row is PARTIAL with the reason
+   recorded verbatim in `evidence.orchestration.reason`. It never assumes a
+   default and never infers a revoke that was not applied.
+2. *Gateway restart* (R-CD-IN-RECOVERY, R-CD-OUT-REPLAY). Restarting a seat is an
+   operator action. The harness logs when its restart window opens and otherwise
+   does nothing. Without `OPENCLAW_RESTART_ORCHESTRATED=true` **and** an observed
+   post-window receipt, the row is PARTIAL.
+
+A PARTIAL from these rows is still informative: the pre-condition legs that did
+fire are recorded as receipts, so the artifact says exactly how far the run got
+and precisely which operator step was missing.
+
+**Positive controls.** Two rows would be vacuous without one, and both carry it:
+
+- R-CD-OUT-UNAUTHORIZED requires `recipient-positive-control` — the true
+  recipient must still be able to inspect. Without it, a rejection could just
+  mean the claim was dead.
+- R-CD-IO-NEG requires `claim-announced-positive-control` — a real claim must
+  have been announced. Without it, a clean negative window proves nothing.
+
+---
+
+## Redaction boundary
+
+The rows deliberately move a known payload through the system so the negative
+checks have something to detect. Handling rules:
+
+- The payload is a synthetic canary, `P86-CANARY-<rowNonce>`. It is never a
+  secret, never user content, and never a real transcript.
+- Evidence records only `{ bytes, sha256_prefix }` for it — `contentReceipt()`
+  in `lib/delegate-attachment-io.js`. The content itself is never written to an
+  artifact.
+- Every captured frame passes through `redactEvent` from `lib/gateway-ws.js`
+  before it enters `redacted_events`. The allowlist has no `text`/`content` key.
+- The harness must name the canary in the instruction it sends, so frames
+  carrying `[k6-proof-harness]` are excluded from the raw-byte scan. This is the
+  established R-CD-1 prompt-echo convention; echoes are counted in
+  `prompt_echoes_ignored` rather than silently dropped.
+- No tokens, no session secrets, no prompt bodies, and no raw attachment bytes
+  ever reach a receipt.
+
+---
+
+## See also
+
+- [`CONTRIBUTING-ROWS.md`](../CONTRIBUTING-ROWS.md) — row PR checklist and fold contract
+- [`../README.md`](../README.md) — harness usage and redaction boundary
+- [`../row-manifest.schema.json`](../row-manifest.schema.json) — manifest schema
+- `tools/k6-proofs/scripts/__tests__/delegate-attachment-io-rows.test.mjs` — the
+  contract test that keeps these invariants from drifting

--- a/tools/k6-proofs/docs/DELEGATE-ATTACHMENT-IO-ROWS.md
+++ b/tools/k6-proofs/docs/DELEGATE-ATTACHMENT-IO-ROWS.md
@@ -22,6 +22,24 @@ These rows close that hole. They are one-command local-gateway WebSocket
 scenarios in the existing harness shape — same manifest schema, same evidence
 writer, same validator, same fold contract.
 
+### Denominator: supplemental, not denominator-changing
+
+**These eight rows do not move the Project 86 denominator.** The merged Project
+86 contract is **38 accountable issues / 35 corpus rows**, and it stays at 38/35.
+Mechanically:
+
+- `check-proof-row-manifests.mjs` still reports `Proof rows: 35` and lists all
+  eight of these as *manifest-only (catalog but not yet on proof board)*.
+- `list-runnable-rows.mjs --live-suite` moves 34 → 39, because the five
+  `k6-runnable` rows join the live suite. The three `orchestration-required`
+  rows are correctly excluded from it. The live suite is an execution list, not
+  the accountable-row denominator.
+
+Any generated plan showing 44 row entries is counting the manifest catalog, not
+the accountable-issue contract. Folding these rows onto the proof board — and
+therefore changing the denominator — is a separate coordinator decision under
+`CONTRIBUTING-ROWS.md`, and this PR does not take it.
+
 ---
 
 ## Runtime controller binding
@@ -99,13 +117,34 @@ node tools/k6-proofs/scripts/evidence-writer.mjs \
 The GitHub `k6 PROOF row` workflow carries all eight scenarios as dispatch
 choices.
 
+**Workflow safety shape (what a reviewer should expect to see):**
+
+- `dry_run=true` (the default) **never executes** a scenario. It compiles it via
+  `k6 archive`, evaluates the manifest live-run safety contract, and runs the
+  static manifest/alignment checks. No live session is contacted.
+- A live run (`dry_run=false`) requires `manifest_path`. Without it there is no
+  lock identity, no safety contract, and no classification metadata for the
+  artifact.
+- Workflow `concurrency` is keyed on the **target session**
+  (`gateway_ws` + `session_key`), not on row+seat, and the run itself is wrapped
+  in the two `flock` locks `live-run-guard.mjs --shell --require-lock` computes:
+  session-outer then row-inner. `flock` exit 75 means a conflicting run owns the
+  session; that output is a coordination failure, not row evidence.
+- The three `orchestration-required` rows are **rejected by `live-run-guard.mjs`**
+  on the plain dispatch path by design. They need an explicit orchestration
+  window with an operator in the loop.
+- Only sanitized logs are uploaded. The raw `k6` console log carries session
+  keys, claim ids, child session keys and paths, so it is passed through
+  `sanitize-k6-artifacts.mjs` and the raw file is deleted before upload.
+
 ### Row-specific environment
 
 | Variable | Rows | Meaning |
 |---|---|---|
 | `OPENCLAW_QUEUE_DELAY_SECONDS` | R-CD-IN-RECOVERY | Queue window the delegate stays pending (default 120) |
-| `OPENCLAW_RESTART_WINDOW_MS` | R-CD-OUT-REPLAY | Window during which the operator restarts the gateway (default 120000) |
-| `OPENCLAW_RESTART_ORCHESTRATED` | R-CD-IN-RECOVERY, R-CD-OUT-REPLAY | Set `true` **only** when a restart genuinely happened |
+| `OPENCLAW_RESTART_WINDOW_MS` | R-CD-IN-RECOVERY, R-CD-OUT-REPLAY | Window during which the operator restarts the gateway (default 120000) |
+| `OPENCLAW_RESTART_POLL_MS` | R-CD-IN-RECOVERY, R-CD-OUT-REPLAY | Poll interval for the `/status` lifecycle probe (default 5000) |
+| `OPENCLAW_RESTART_ORCHESTRATED` | R-CD-IN-RECOVERY, R-CD-OUT-REPLAY | Operator **declaration** only. Recorded in evidence, never credited: the restart receipt comes from `/status` |
 | `OPENCLAW_NEGATIVE_WINDOW_MS` | R-CD-IO-NEG and the OUT rows | Bounded window held open to catch unsolicited delivery |
 
 ---
@@ -129,13 +168,48 @@ must not be faked:
    recorded verbatim in `evidence.orchestration.reason`. It never assumes a
    default and never infers a revoke that was not applied.
 2. *Gateway restart* (R-CD-IN-RECOVERY, R-CD-OUT-REPLAY). Restarting a seat is an
-   operator action. The harness logs when its restart window opens and otherwise
-   does nothing. Without `OPENCLAW_RESTART_ORCHESTRATED=true` **and** an observed
-   post-window receipt, the row is PARTIAL.
+   operator action, and `OPENCLAW_RESTART_ORCHESTRATED=true` is a **declaration,
+   not evidence**. The restart is credited only from the gateway's own public
+   `/status` surface — uptime going backwards, or the endpoint dropping and
+   coming back — observed by `observeGatewayRestart()` while the harness is
+   deliberately disconnected. Each of these rows opens **two** WebSocket
+   connections: one before the window, one after. That is why a real restart
+   cannot fail the row by tearing down a held socket, and why a restart that
+   never happened cannot be declared away. Without both
+   `gateway-restart-observed` and `reconnected-after-restart`, plus the
+   post-restart behavioral receipt, the row is PARTIAL.
 
 A PARTIAL from these rows is still informative: the pre-condition legs that did
 fire are recorded as receipts, so the artifact says exactly how far the run got
 and precisely which operator step was missing.
+
+**Receipts come from authoritative surfaces, not from model prose.** A sentinel
+line sequences a probe; it is never the receipt on its own:
+
+- R-CD-IN-1 credits `child-bytes-bound-to-canary` only when the byte length AND
+  the sha256 prefix the child reports for its mounted file equal the canary this
+  run staged. The canary is known only to the harness, so a matching digest
+  cannot be produced without reading the staged bytes at the path the child
+  named. It also requires a structured `continue_delegate` tool record and a
+  structured child-session binding (`childSessionKeysForRow`).
+- R-CD-IN-REVOKE credits the refusal from a structured `continue_delegate` error
+  record, credits no-spawn from a `sessions.list` inventory taken **before and
+  after** the probe (a diff, not a default-true absence), and credits the scrub
+  only when the follow-up tool record was observed and no observed record still
+  carries delegate attachment state.
+- R-CD-OUT-CLAIM requires `post-discard-inspect-rejected`: the post-discard probe
+  must name the **same** claim id, report a rejection, and be accompanied by a
+  structured `delegate_artifacts` error record.
+
+**Verdict transport.** `computeVerdict` publishes its result on the
+`proof_row_pass` / `proof_row_partial` metrics, and `handleSummary` reads those.
+A summary derived from `proof_failures` alone would print PASS for the
+orchestration-gated rows, which deliberately do not raise that counter.
+
+**Evidence writer.** `evidence-writer.mjs` recomputes the verdict from the
+receipt map and the manifest's `requiredReceipts`, and **refuses to write** a
+PASS the receipts do not support. It also binds identity: `manifest.rowId`, the
+evidence block's own `row`, `--row` and `--scenario` must all agree.
 
 **Positive controls.** Two rows would be vacuous without one, and both carry it:
 

--- a/tools/k6-proofs/lib/delegate-attachment-io.js
+++ b/tools/k6-proofs/lib/delegate-attachment-io.js
@@ -1,0 +1,209 @@
+/**
+ * Shared helpers for the P86 delegate attachment I/O row family (docs#491).
+ *
+ * These rows prove the typed `continue_delegate` INPUT snapshot surface and the
+ * managed delegate OUTPUT (`delegate_artifacts_publish` / `delegate_artifacts`)
+ * claim lifecycle against the assembly candidate.
+ *
+ * Public-safety contract enforced here:
+ *   - Attachment/artifact CONTENT never enters an artifact. Only a byte count
+ *     and a truncated sha256 digest are recorded.
+ *   - Every captured event is passed through `redactEvent` first.
+ *   - Harness prompt echoes (events carrying HARNESS_MARKER) are excluded from
+ *     the raw-byte leak scan, because the harness itself must name the canary in
+ *     the instruction it sends. This mirrors the existing R-CD-1 convention.
+ *
+ * Honesty contract enforced here:
+ *   - `computeVerdict` returns PASS-candidate only when every required receipt
+ *     fired AND every negative check held. Anything else is PARTIAL-candidate.
+ *   - `orchestrationGate` forces PARTIAL-candidate when a row depends on an
+ *     operator step (config revoke, gateway restart) that this run did not
+ *     observe. A row must never claim PASS on an unperformed precondition.
+ */
+import crypto from 'k6/crypto';
+import { redactEvent } from './gateway-ws.js';
+
+export const HARNESS_MARKER = '[k6-proof-harness]';
+
+/** Deterministic public-safe canary content for a row nonce. */
+export function canaryFor(rowNonce) {
+  return `P86-CANARY-${rowNonce}`;
+}
+
+/** Digest a payload for evidence without ever recording the payload itself. */
+export function contentReceipt(value) {
+  const text = String(value ?? '');
+  return {
+    bytes: text.length,
+    sha256_prefix: crypto.sha256(text, 'hex').slice(0, 16),
+  };
+}
+
+export function boolEnv(name) {
+  return String(__ENV[name] || '').toLowerCase() === 'true';
+}
+
+/**
+ * Base evidence record shared by every row in the family.
+ * `required` and `negative` are receipt-name arrays used by computeVerdict.
+ */
+export function baseEvidence(params) {
+  return {
+    row: params.row,
+    issue: 491,
+    manifest_loaded: !!params.manifest,
+    nonce: params.nonce,
+    seat: params.seat,
+    requestedSessionKey: params.requestedSessionKey,
+    sessionKey: params.sessionKey,
+    session_created: false,
+    created_session_key: null,
+    candidateSha: params.manifest?.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
+    started: new Date().toISOString(),
+    receipts: {},
+    negative_checks: {},
+    provenance: {
+      flow_id: null,
+      dispatch_id: null,
+      claim_id: null,
+      child_session_key: null,
+      trace_id: null,
+      mount_rel_path: null,
+      materialized_destination: null,
+    },
+    orchestration: {
+      required: params.orchestrationRequired || null,
+      observed: false,
+      reason: null,
+    },
+    content_receipt: null,
+    prompt_echoes_ignored: 0,
+    redacted_events: [],
+    verdict: 'PARTIAL-candidate',
+  };
+}
+
+/** Mark a named receipt as fired (idempotent, records first-fire timestamp). */
+export function fire(evidence, name) {
+  if (!evidence.receipts[name]) {
+    evidence.receipts[name] = { observed: true, at_ms: Date.now() };
+    console.log(`✓ receipt: ${name}`);
+  }
+  return evidence.receipts[name];
+}
+
+/** Declare a negative check. Starts held=true and is broken by `breakNegative`. */
+export function declareNegative(evidence, name, description) {
+  evidence.negative_checks[name] = { held: true, description, violated_at_ms: null };
+}
+
+export function breakNegative(evidence, name, why) {
+  const entry = evidence.negative_checks[name];
+  if (!entry || !entry.held) return;
+  entry.held = false;
+  entry.violated_at_ms = Date.now();
+  entry.violation = why;
+  console.error(`✗ negative check violated: ${name} — ${why}`);
+}
+
+/**
+ * Capture one classified frame into the evidence stream, redacted.
+ * Returns the stringified payload for sentinel matching, or null when the frame
+ * is a harness prompt echo that must be excluded from behavioral matching.
+ */
+export function capture(evidence, classified) {
+  evidence.redacted_events.push({
+    ts: Date.now(),
+    kind: classified.kind,
+    method: classified.method || null,
+    event: classified.event || null,
+    ok: classified.ok !== undefined ? classified.ok : null,
+    data: classified.payload || classified.data
+      ? redactEvent(classified.payload || classified.data)
+      : null,
+  });
+  const body = JSON.stringify(classified.payload || classified.data || {});
+  if (body.includes(HARNESS_MARKER)) {
+    evidence.prompt_echoes_ignored += 1;
+    return null;
+  }
+  return body;
+}
+
+/**
+ * Raw-byte boundary scan. `body` must already have passed the harness-echo
+ * filter in `capture`. Any appearance of the canary content outside the harness
+ * instruction means the runtime rendered or forwarded attachment bytes.
+ */
+export function scanRawBytes(evidence, body, rowNonce, negativeName) {
+  if (!body) return;
+  if (body.includes(canaryFor(rowNonce))) {
+    breakNegative(evidence, negativeName, 'attachment/artifact content observed on a non-harness frame');
+  }
+}
+
+/** Extract the first capture group of `pattern` from `body`, or null. */
+export function matchGroup(body, pattern) {
+  if (!body) return null;
+  const found = body.match(pattern);
+  return found ? found[1] : null;
+}
+
+/**
+ * Force PARTIAL when an operator-orchestrated precondition was not observed.
+ * `reason` is recorded verbatim so the artifact says why, never silently.
+ */
+export function orchestrationGate(evidence, observed, reason) {
+  evidence.orchestration.observed = !!observed;
+  if (!observed) evidence.orchestration.reason = reason;
+  return !!observed;
+}
+
+/**
+ * PASS-candidate only when every required receipt fired, every negative check
+ * held, and any declared orchestration precondition was observed.
+ */
+export function computeVerdict(evidence, requiredReceipts) {
+  const missing = requiredReceipts.filter((name) => !evidence.receipts[name]);
+  const violated = Object.keys(evidence.negative_checks).filter(
+    (name) => !evidence.negative_checks[name].held,
+  );
+  const orchestrationOk = !evidence.orchestration.required || evidence.orchestration.observed;
+  evidence.missing_receipts = missing;
+  evidence.violated_negative_checks = violated;
+  evidence.verdict =
+    missing.length === 0 && violated.length === 0 && orchestrationOk
+      ? 'PASS-candidate'
+      : 'PARTIAL-candidate';
+  return evidence.verdict;
+}
+
+export function logEvidence(evidence) {
+  evidence.ended = new Date().toISOString();
+  console.log(`\n--- ${evidence.row} EVIDENCE SUMMARY ---`);
+  console.log(JSON.stringify(evidence, null, 2));
+  console.log(`--- END EVIDENCE ---`);
+  console.log(`\n[${evidence.row}] VERDICT: ${evidence.verdict}`);
+}
+
+/** Standard handleSummary payload for this row family. */
+export function rowSummary(params) {
+  const { row, data, durationMetric, summaryFile } = params;
+  const failures = data.metrics.proof_failures?.values?.count || 0;
+  const summary = {
+    row,
+    issue: 491,
+    sha: __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
+    seat: __ENV.OPENCLAW_SEAT_NAME || 'rune-rog-ally',
+    timestamp: new Date().toISOString(),
+    verdict: failures === 0 ? 'PASS-candidate' : 'PARTIAL-candidate',
+    metrics: {
+      duration_ms: data.metrics[durationMetric]?.values || null,
+      failures,
+    },
+  };
+  return {
+    stdout: `\n[${row}] Summary: ${summary.verdict} | SHA: ${summary.sha} | Seat: ${summary.seat}\n`,
+    [summaryFile]: JSON.stringify(summary, null, 2),
+  };
+}

--- a/tools/k6-proofs/lib/delegate-attachment-io.js
+++ b/tools/k6-proofs/lib/delegate-attachment-io.js
@@ -19,11 +19,44 @@
  *   - `orchestrationGate` forces PARTIAL-candidate when a row depends on an
  *     operator step (config revoke, gateway restart) that this run did not
  *     observe. A row must never claim PASS on an unperformed precondition.
+ *   - The row verdict is published on a metric (`proof_row_pass`) so
+ *     `handleSummary` reports the SAME verdict `computeVerdict` produced.
+ *     Deriving a summary verdict from `proof_failures` alone is forbidden: the
+ *     orchestration-gated rows do not raise that counter.
  */
 import crypto from 'k6/crypto';
+import http from 'k6/http';
+import { Counter } from 'k6/metrics';
 import { redactEvent } from './gateway-ws.js';
 
 export const HARNESS_MARKER = '[k6-proof-harness]';
+
+/**
+ * Verdict transport between the iteration and `handleSummary`.
+ * k6 evaluates `handleSummary` in a fresh runtime, so module state does not
+ * survive; a metric does. Exactly one of these is incremented per iteration.
+ */
+export const rowPassCounter = new Counter('proof_row_pass');
+export const rowPartialCounter = new Counter('proof_row_partial');
+export const rowIterationCounter = new Counter('proof_row_iterations');
+
+/** Escape a value for literal use inside a RegExp source. */
+export function escapeRegex(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Build a sentinel matcher: `<SENTINEL> <nonce> <trailing>`. */
+export function sentinel(prefix, rowNonce, trailing = '') {
+  return new RegExp(`${escapeRegex(prefix)} ${escapeRegex(rowNonce)}${trailing}`);
+}
+
+/** Derive the gateway HTTP base from its WS URL. */
+export function httpBaseFromWs(wsUrl) {
+  return String(wsUrl || '')
+    .replace(/^wss:/i, 'https:')
+    .replace(/^ws:/i, 'http:')
+    .replace(/\/+$/, '');
+}
 
 /** Deterministic public-safe canary content for a row nonce. */
 export function canaryFor(rowNonce) {
@@ -160,8 +193,172 @@ export function orchestrationGate(evidence, observed, reason) {
 }
 
 /**
+ * Deep-walk a structured payload and return every plain object for which
+ * `predicate` holds. Used to bind receipts to structured tool/session records
+ * instead of to model prose anywhere in a frame.
+ */
+export function findRecords(value, predicate, seen) {
+  const visited = seen || [];
+  const out = [];
+  if (!value || typeof value !== 'object') return out;
+  for (const entry of visited) if (entry === value) return out;
+  visited.push(value);
+  if (Array.isArray(value)) {
+    for (const child of value) out.push(...findRecords(child, predicate, visited));
+    return out;
+  }
+  if (predicate(value)) out.push(value);
+  for (const key of Object.keys(value)) out.push(...findRecords(value[key], predicate, visited));
+  return out;
+}
+
+/**
+ * Structured tool-result records for `toolName`. A gateway tool frame carries
+ * the tool name plus a result/error container; model prose never does.
+ */
+export function toolResultRecords(eventData, toolName) {
+  return findRecords(eventData, (record) => {
+    const name = typeof record.name === 'string' ? record.name : record.toolName;
+    if (name !== toolName) return false;
+    return 'result' in record || 'error' in record || 'isError' in record || 'ok' in record;
+  });
+}
+
+/** True when a structured tool record reports a refusal/error rather than a success. */
+export function toolRecordRejected(record) {
+  if (!record || typeof record !== 'object') return false;
+  if (record.isError === true) return true;
+  if (record.ok === false) return true;
+  if (record.error) return true;
+  const status = String(record.status || record.result?.status || '').toLowerCase();
+  return ['error', 'rejected', 'denied', 'refused', 'failed'].includes(status);
+}
+
+const ATTACHMENT_STATE_KEYS = [
+  'attachments',
+  'attachmentSnapshot',
+  'attachmentState',
+  'pendingAttachments',
+  'storedAttachments',
+];
+
+/**
+ * True when a structured record still carries non-empty delegate attachment
+ * state. Used as the authority for "the durable snapshot was scrubbed": an
+ * absence claimed in model prose is not a receipt.
+ */
+export function recordCarriesAttachmentState(record) {
+  if (!record || typeof record !== 'object') return false;
+  return ATTACHMENT_STATE_KEYS.some((key) => {
+    const value = record[key];
+    if (value === undefined || value === null) return false;
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value === 'object') return Object.keys(value).length > 0;
+    if (typeof value === 'number') return value > 0;
+    return Boolean(value);
+  });
+}
+
+/** Session keys present in a sessions.list payload. */
+export function sessionKeysFromList(payload) {
+  const rows = payload?.sessions || payload?.items || payload?.records || [];
+  if (!Array.isArray(rows)) return [];
+  return rows
+    .map((row) => (typeof row === 'string' ? row : row?.key || row?.sessionKey))
+    .filter((key) => typeof key === 'string' && key.length > 0);
+}
+
+/** Read a public-safe gateway lifecycle sample from the HTTP status surface. */
+export function sampleGatewayStatus(httpBase, token) {
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  let res;
+  try {
+    res = http.get(`${httpBase}/status`, { headers, timeout: '5s' });
+  } catch (error) {
+    return { reachable: false, uptime: null, version: null, error: String(error) };
+  }
+  if (!res || res.status !== 200) {
+    return { reachable: false, uptime: null, version: null, status: res ? res.status : 0 };
+  }
+  let body = null;
+  try {
+    body = JSON.parse(res.body);
+  } catch (error) {
+    return { reachable: true, uptime: null, version: null, parseError: true };
+  }
+  const uptime = typeof body.uptime === 'number' ? body.uptime : Number(body.uptime);
+  return {
+    reachable: true,
+    uptime: Number.isFinite(uptime) ? uptime : null,
+    version: typeof body.version === 'string' ? body.version : null,
+  };
+}
+
+/**
+ * Externally observable gateway restart receipt.
+ *
+ * `OPENCLAW_RESTART_ORCHESTRATED` is an operator DECLARATION and can never be
+ * the evidence. A restart is credited only when the public `/status` surface
+ * shows the process identity change from outside the harness: either the
+ * endpoint went unreachable and came back, or reported uptime went backwards.
+ * Both are properties of the gateway, not of this script's beliefs.
+ *
+ * Returns `{ observed, downtimeObserved, uptimeReset, samples, reason }`.
+ */
+export function observeGatewayRestart(params) {
+  const { httpBase, token, baseline, windowMs, pollMs, sleep } = params;
+  const deadline = Date.now() + Math.max(0, windowMs);
+  const interval = Math.max(1000, pollMs || 5000);
+  const result = {
+    observed: false,
+    downtimeObserved: false,
+    uptimeReset: false,
+    baselineUptime: baseline && baseline.reachable ? baseline.uptime : null,
+    finalUptime: null,
+    samples: 0,
+    reason: null,
+  };
+  if (!baseline || !baseline.reachable) {
+    result.reason = 'gateway /status was not reachable before the restart window, so no lifecycle baseline exists';
+    return result;
+  }
+  if (baseline.uptime === null) {
+    result.reason = 'gateway /status did not expose a numeric uptime, so a restart cannot be observed externally';
+    return result;
+  }
+  while (Date.now() < deadline) {
+    sleep(interval / 1000);
+    const sample = sampleGatewayStatus(httpBase, token);
+    result.samples += 1;
+    if (!sample.reachable) {
+      result.downtimeObserved = true;
+      continue;
+    }
+    result.finalUptime = sample.uptime;
+    if (sample.uptime !== null && sample.uptime < baseline.uptime) {
+      result.uptimeReset = true;
+      result.observed = true;
+      return result;
+    }
+    if (result.downtimeObserved && sample.uptime !== null) {
+      // Came back after an observed outage: that is a process lifecycle event
+      // even if the uptime unit is too coarse to have gone backwards.
+      result.observed = true;
+      return result;
+    }
+  }
+  result.reason = result.downtimeObserved
+    ? 'gateway went unreachable inside the restart window but never came back before the deadline'
+    : 'gateway /status uptime never reset and the endpoint never dropped inside the restart window: no operator restart was observed';
+  return result;
+}
+
+/**
  * PASS-candidate only when every required receipt fired, every negative check
  * held, and any declared orchestration precondition was observed.
+ *
+ * Also publishes the verdict onto `proof_row_pass` / `proof_row_partial` so
+ * `handleSummary` cannot invent a different one.
  */
 export function computeVerdict(evidence, requiredReceipts) {
   const missing = requiredReceipts.filter((name) => !evidence.receipts[name]);
@@ -175,6 +372,9 @@ export function computeVerdict(evidence, requiredReceipts) {
     missing.length === 0 && violated.length === 0 && orchestrationOk
       ? 'PASS-candidate'
       : 'PARTIAL-candidate';
+  rowIterationCounter.add(1);
+  if (evidence.verdict === 'PASS-candidate') rowPassCounter.add(1);
+  else rowPartialCounter.add(1);
   return evidence.verdict;
 }
 
@@ -186,20 +386,41 @@ export function logEvidence(evidence) {
   console.log(`\n[${evidence.row}] VERDICT: ${evidence.verdict}`);
 }
 
-/** Standard handleSummary payload for this row family. */
+/**
+ * Standard handleSummary payload for this row family.
+ *
+ * The verdict is READ from the metric `computeVerdict` published, never
+ * re-derived from `proof_failures`: the orchestration-gated rows deliberately
+ * do not raise that counter, so a failures-only derivation would print PASS
+ * while the authoritative row verdict is PARTIAL.
+ */
 export function rowSummary(params) {
   const { row, data, durationMetric, summaryFile } = params;
   const failures = data.metrics.proof_failures?.values?.count || 0;
+  const passes = data.metrics.proof_row_pass?.values?.count || 0;
+  const partials = data.metrics.proof_row_partial?.values?.count || 0;
+  const iterations = data.metrics.proof_row_iterations?.values?.count || 0;
+  // PASS only when the iteration ran, published PASS, published no PARTIAL,
+  // and raised no failure. A missing verdict metric means the iteration never
+  // reached computeVerdict, which is not a pass.
+  const verdict =
+    iterations > 0 && passes === iterations && partials === 0 && failures === 0
+      ? 'PASS-candidate'
+      : 'PARTIAL-candidate';
   const summary = {
     row,
     issue: 491,
     sha: __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
     seat: __ENV.OPENCLAW_SEAT_NAME || 'rune-rog-ally',
     timestamp: new Date().toISOString(),
-    verdict: failures === 0 ? 'PASS-candidate' : 'PARTIAL-candidate',
+    verdict,
+    verdictSource: 'proof_row_pass metric published by computeVerdict',
     metrics: {
       duration_ms: data.metrics[durationMetric]?.values || null,
       failures,
+      iterations,
+      row_pass: passes,
+      row_partial: partials,
     },
   };
   return {

--- a/tools/k6-proofs/lib/k6-log-evidence.mjs
+++ b/tools/k6-proofs/lib/k6-log-evidence.mjs
@@ -1,0 +1,152 @@
+/**
+ * Decode-aware extraction of proof evidence blocks from k6 output.
+ *
+ * k6 does not print `console.log` output verbatim. Every call is emitted as one
+ * logrus record:
+ *
+ *   time="2026-07-30T20:15:52Z" level=info msg="=== K6-PROOF-EVIDENCE ===" source=console
+ *   time="2026-07-30T20:15:52Z" level=info msg="{\n  \"row\": \"R-CD-IN-1\",\n ...}" source=console
+ *   time="2026-07-30T20:15:52Z" level=info msg="--- END EVIDENCE ---" source=console
+ *
+ * so the whole evidence JSON lives inside a single JSON-escaped `msg=` value on
+ * one physical line. Any consumer that applies a block regex to the raw file
+ * finds zero records and silently degrades — the failure mode the #493 runtime
+ * review reproduced in both `sanitize-k6-artifacts.mjs` and `evidence-writer.mjs`.
+ *
+ * This module is the single decode-aware extractor for every consumer. It also
+ * accepts bare (already-decoded) marker lines so unit fixtures and locally
+ * captured logs keep working, and it reports whether an evidence marker was seen
+ * at all so callers can fail closed instead of attesting "0 evidence blocks".
+ */
+
+/**
+ * Decode one k6 output line into the message the scenario actually printed.
+ * Lines that are not logrus-framed are returned unchanged; a framed line whose
+ * `msg=` value does not decode returns null (it cannot be trusted).
+ */
+export function decodeK6Message(line) {
+  const marker = ' msg=';
+  const start = line.indexOf(marker);
+  if (start < 0) return line;
+  const encodedStart = start + marker.length;
+  const source = line.lastIndexOf(' source=');
+  const encoded = line.slice(encodedStart, source > encodedStart ? source : undefined).trim();
+  if (!encoded) return null;
+  if (!encoded.startsWith('"')) return encoded;
+  try {
+    return JSON.parse(encoded);
+  } catch {
+    return null;
+  }
+}
+
+export function parseJsonCandidate(value) {
+  const text = String(value || '').trim();
+  if (!text.startsWith('{')) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+const EVIDENCE_MARKER = /\bEVIDENCE SUMMARY\b|===\s*K6-PROOF-EVIDENCE\s*===/;
+const EVIDENCE_END_MARKER = /---\s*END EVIDENCE\s*---|===\s*END K6-PROOF-EVIDENCE\s*===/;
+const INLINE_EVIDENCE = /(?:[A-Z0-9_-]+_EVIDENCE|===\s*K6-PROOF-EVIDENCE\s*===)\s+(\{[\s\S]*\})$/;
+
+/**
+ * Extract every evidence record from a k6 log.
+ *
+ * Handles, in one pass:
+ *   - logrus-framed blocks (production k6 stdout);
+ *   - bare marker + single-line JSON (unit fixtures);
+ *   - bare marker + pretty-printed multi-line JSON (locally captured logs);
+ *   - inline `<ROW>_EVIDENCE { ... }` single-message form.
+ *
+ * @returns {{records: object[], lines: string[], markerSeen: boolean, markerCount: number}}
+ */
+export function extractEvidenceData(logText) {
+  const records = [];
+  const lines = [];
+  let markerCount = 0;
+  let awaitingRecord = false;
+  let buffer = [];
+  let bufferLines = [];
+
+  const flushBuffer = () => {
+    awaitingRecord = false;
+    buffer = [];
+    bufferLines = [];
+  };
+
+  for (const line of String(logText || '').split(/\r?\n/)) {
+    const message = decodeK6Message(line);
+    if (message === null || message === undefined) continue;
+    const text = String(message).trim();
+
+    const inline = text.match(INLINE_EVIDENCE);
+    if (inline) {
+      markerCount += 1;
+      const record = parseJsonCandidate(inline[1]);
+      if (record) {
+        records.push(record);
+        lines.push(line);
+      }
+      flushBuffer();
+      continue;
+    }
+
+    if (EVIDENCE_MARKER.test(text)) {
+      markerCount += 1;
+      lines.push(line);
+      flushBuffer();
+      // The banner and the JSON can share one console.log call.
+      const sameMessageJson = text.match(/(?:SUMMARY\b[^\n]*|===)\s*[\r\n]+(\{[\s\S]*\})/);
+      const record = sameMessageJson ? parseJsonCandidate(sameMessageJson[1]) : null;
+      if (record) {
+        records.push(record);
+      } else {
+        awaitingRecord = true;
+      }
+      continue;
+    }
+
+    if (EVIDENCE_END_MARKER.test(text)) {
+      // Last chance for a multi-line bare block that has not parsed yet.
+      if (awaitingRecord && buffer.length > 0) {
+        const record = parseJsonCandidate(buffer.join('\n'));
+        if (record) {
+          records.push(record);
+          lines.push(...bufferLines);
+        }
+      }
+      flushBuffer();
+      continue;
+    }
+
+    if (!awaitingRecord) continue;
+
+    // Only start buffering at a real JSON opening; interleaved k6 progress
+    // output between the banner and the payload must not poison the parse.
+    if (buffer.length === 0 && !text.startsWith('{')) continue;
+    buffer.push(text);
+    bufferLines.push(line);
+    const record = parseJsonCandidate(buffer.join('\n'));
+    if (record) {
+      records.push(record);
+      lines.push(...bufferLines);
+      flushBuffer();
+    }
+  }
+
+  const uniqueRecords = [...new Map(
+    records.map((record) => [JSON.stringify(record), record]),
+  ).values()];
+
+  return {
+    records: uniqueRecords,
+    lines,
+    markerSeen: markerCount > 0,
+    markerCount,
+  };
+}

--- a/tools/k6-proofs/lib/manifest-loader.js
+++ b/tools/k6-proofs/lib/manifest-loader.js
@@ -42,6 +42,39 @@ export function resolveManifest(manifest) {
  * post-processor / Node-based validation; in k6 scenarios, inline the manifest
  * data or use open() + JSON.parse() at init time.
  */
+/**
+ * Normalize a manifest path into the form k6's `open()` can resolve.
+ *
+ * Every Node-side consumer (`live-run-guard.mjs`, `evidence-writer.mjs`, the
+ * workflow's `-f manifest_path` existence check) takes the REPO-ROOT form
+ * `tools/k6-proofs/manifests/<row>.json`. k6 resolves a relative `open()`
+ * against the running scenario's directory (`tools/k6-proofs/scenarios/`), so
+ * `'../' + <repo-root form>` yields `tools/k6-proofs/tools/k6-proofs/manifests/...`
+ * and `k6 archive` exits 107. Normalizing here means one manifest value can be
+ * exported as `OPENCLAW_ROW_MANIFEST` and consumed by both worlds.
+ *
+ * Accepts, and returns the k6-resolvable form for:
+ *   tools/k6-proofs/manifests/r-cd-in-1.json  ->  ../manifests/r-cd-in-1.json
+ *   ./manifests/r-cd-in-1.json                ->  ../manifests/r-cd-in-1.json
+ *   manifests/r-cd-in-1.json                  ->  ../manifests/r-cd-in-1.json
+ *   r-cd-in-1.json                            ->  ../manifests/r-cd-in-1.json
+ *   /abs/path/r-cd-in-1.json                  ->  /abs/path/r-cd-in-1.json
+ */
+export function normalizeManifestOpenPath(manifestPath) {
+  const raw = String(manifestPath == null ? '' : manifestPath).trim();
+  if (!raw) return null;
+  if (raw.charAt(0) === '/') return raw;
+
+  let relative = raw.replace(/^\.\//, '');
+  // Tolerate a repo-root prefix regardless of how many times a caller layered it.
+  while (relative.indexOf('tools/k6-proofs/') === 0) {
+    relative = relative.slice('tools/k6-proofs/'.length);
+  }
+  // A bare filename is documented as "call with the manifest filename".
+  if (relative.indexOf('/') < 0) relative = 'manifests/' + relative;
+  return '../' + relative;
+}
+
 export function loadManifestFromEnv() {
   const manifestPath = __ENV.OPENCLAW_ROW_MANIFEST;
   if (!manifestPath) {
@@ -49,7 +82,7 @@ export function loadManifestFromEnv() {
     return null;
   }
   // k6 open() reads at init time
-  const raw = open(manifestPath.startsWith('/') ? manifestPath : '../'+manifestPath);
+  const raw = open(normalizeManifestOpenPath(manifestPath));
   const parsed = JSON.parse(raw);
   return resolveManifest(parsed);
 }

--- a/tools/k6-proofs/manifests/r-cd-in-1.json
+++ b/tools/k6-proofs/manifests/r-cd-in-1.json
@@ -1,0 +1,75 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CD-IN-1",
+  "issue": 491,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-rune-rog-ally}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "websocket",
+  "toolSurface": "typed-tool",
+  "mutates": true,
+  "timeoutSeconds": 200,
+  "gateway": {
+    "wsEnv": "OPENCLAW_GATEWAY_WS",
+    "tokenEnv": "OPENCLAW_GATEWAY_TOKEN"
+  },
+  "scenario": {
+    "name": "r-cd-in-1-typed-input-snapshot",
+    "description": "Typed continue_delegate({attachments}) input snapshot: staged snapshot receipt on the parent, workspace-relative mount provenance in the child, and no attachment content on the wire.",
+    "methods": [
+      "sessions.create",
+      "sessions.messages.subscribe",
+      "sessions.send"
+    ],
+    "status": "runnable",
+    "file": "r-cd-in-1-typed-input-snapshot.js",
+    "notes": "Only the typed tool carries attachment blobs; the bracket [[CONTINUE_DELEGATE: ...]] form cannot, so the both-forms mandate is not applicable to this row."
+  },
+  "invocation": {
+    "tool": "continue_delegate",
+    "mode": "normal",
+    "delaySeconds": 1,
+    "attachmentCount": 1,
+    "attachmentEncoding": "utf8",
+    "idempotencyKeyPrefix": "R-CD-IN-1"
+  },
+  "expectedReceipts": [
+    { "name": "tool-invoke-accepted", "required": true, "description": "sessions.send dispatch accepted (agent turn triggered for typed continue_delegate with attachments)" },
+    { "name": "input-snapshot-staged", "required": true, "description": "CDIN1-SNAPSHOT-STAGED sentinel carrying the tool-result attachment count and byte total (never the content)", "pathHint": "gateway-events.ndjson" },
+    { "name": "child-mount-provenance", "required": true, "description": "CDIN1-CHILD-SAW sentinel naming the workspace-relative mount path the child received", "pathHint": "gateway-events.ndjson" },
+    { "name": "no-raw-attachment-bytes-on-the-wire", "required": true, "description": "Negative check: attachment content absent from every non-harness frame" },
+    { "name": "no-absolute-path-mount", "required": true, "description": "Negative check: the reported mount path is workspace-relative" },
+    { "name": "trace-id", "required": false, "description": "Trace ID for Tempo fetch when the dispatch response carries one" }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CD-IN-1",
+    "seat": "${OPENCLAW_SEAT_NAME:-rune-rog-ally}",
+    "runDirPrefix": "k6-run"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "PASS-candidate only when dispatch is accepted, the staged-snapshot receipt fires, the child reports a workspace-relative mount path, and both negative checks hold. Any missing receipt is PARTIAL-candidate."
+  },
+  "liveRunSafety": {
+    "classification": "k6-runnable",
+    "requiresLiveGatewayToken": true,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": true,
+    "sameSessionConcurrencySafe": false,
+    "expectedArtifactClass": "PASS-candidate",
+    "requiredReceipts": [
+      "seat-readiness",
+      "tool-invoke-accepted",
+      "input-snapshot-staged",
+      "child-mount-provenance",
+      "no-raw-attachment-bytes-on-the-wire",
+      "no-absolute-path-mount"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Spawns one delegate child with an inline attachment. Prefer OPENCLAW_CREATE_DISPOSABLE_SESSION=true. Serialize per session. Public-safe: the harness records a byte count and a truncated sha256 digest of the canary, never the canary content."
+  }
+}

--- a/tools/k6-proofs/manifests/r-cd-in-1.json
+++ b/tools/k6-proofs/manifests/r-cd-in-1.json
@@ -35,10 +35,14 @@
   },
   "expectedReceipts": [
     { "name": "tool-invoke-accepted", "required": true, "description": "sessions.send dispatch accepted (agent turn triggered for typed continue_delegate with attachments)" },
+    { "name": "typed-tool-record-observed", "required": true, "description": "Structured continue_delegate tool record observed on the wire, so the typed call is not credited from model prose alone", "pathHint": "gateway-events.ndjson" },
     { "name": "input-snapshot-staged", "required": true, "description": "CDIN1-SNAPSHOT-STAGED sentinel carrying the tool-result attachment count and byte total (never the content)", "pathHint": "gateway-events.ndjson" },
+    { "name": "child-session-bound", "required": true, "description": "A structured record binds a child session key to this row nonce (row-child-correlation authority)", "pathHint": "gateway-events.ndjson" },
     { "name": "child-mount-provenance", "required": true, "description": "CDIN1-CHILD-SAW sentinel naming the workspace-relative mount path the child received", "pathHint": "gateway-events.ndjson" },
+    { "name": "child-bytes-bound-to-canary", "required": true, "description": "The byte length and sha256 prefix the child reports for its mounted file equal the canary digest the harness staged: the mount path is bound to known bytes, not asserted", "pathHint": "gateway-events.ndjson" },
     { "name": "no-raw-attachment-bytes-on-the-wire", "required": true, "description": "Negative check: attachment content absent from every non-harness frame" },
     { "name": "no-absolute-path-mount", "required": true, "description": "Negative check: the reported mount path is workspace-relative" },
+    { "name": "child-bytes-match-the-known-canary", "required": true, "description": "Negative check: a child-reported digest/size that differs from the staged canary breaks the row" },
     { "name": "trace-id", "required": false, "description": "Trace ID for Tempo fetch when the dispatch response carries one" }
   ],
   "artifactDestination": {
@@ -51,7 +55,7 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "PASS-candidate only when dispatch is accepted, the staged-snapshot receipt fires, the child reports a workspace-relative mount path, and both negative checks hold. Any missing receipt is PARTIAL-candidate."
+    "notes": "PASS-candidate only when dispatch is accepted, a structured continue_delegate record is observed, the staged-snapshot receipt fires, a child session is bound to the row nonce, and the child reports a workspace-relative mount path whose bytes and sha256 prefix equal the canary the harness staged. Any missing receipt or broken negative is PARTIAL-candidate."
   },
   "liveRunSafety": {
     "classification": "k6-runnable",
@@ -64,10 +68,14 @@
     "requiredReceipts": [
       "seat-readiness",
       "tool-invoke-accepted",
+      "typed-tool-record-observed",
       "input-snapshot-staged",
+      "child-session-bound",
       "child-mount-provenance",
+      "child-bytes-bound-to-canary",
       "no-raw-attachment-bytes-on-the-wire",
-      "no-absolute-path-mount"
+      "no-absolute-path-mount",
+      "child-bytes-match-the-known-canary"
     ],
     "foldRequiresReview": true,
     "notes": "Spawns one delegate child with an inline attachment. Prefer OPENCLAW_CREATE_DISPOSABLE_SESSION=true. Serialize per session. Public-safe: the harness records a byte count and a truncated sha256 digest of the canary, never the canary content."

--- a/tools/k6-proofs/manifests/r-cd-in-recovery.json
+++ b/tools/k6-proofs/manifests/r-cd-in-recovery.json
@@ -8,7 +8,7 @@
   "transport": "websocket",
   "toolSurface": "typed-tool",
   "mutates": true,
-  "timeoutSeconds": 400,
+  "timeoutSeconds": 540,
   "gateway": {
     "wsEnv": "OPENCLAW_GATEWAY_WS",
     "tokenEnv": "OPENCLAW_GATEWAY_TOKEN"
@@ -33,12 +33,14 @@
     "idempotencyKeyPrefix": "R-CD-IN-RECOVERY"
   },
   "expectedReceipts": [
-    { "name": "tool-invoke-accepted", "required": true, "description": "sessions.send dispatch accepted for the delayed attachment-bearing delegate" },
-    { "name": "input-snapshot-queued", "required": true, "description": "CDINREC-QUEUED sentinel with the staged byte total, emitted while the delegate is still queued" },
-    { "name": "post-lifecycle-child-arrival", "required": true, "description": "CDINREC-CHILD-ARRIVED sentinel observed after the operator restart window" },
-    { "name": "snapshot-identity-preserved", "required": true, "description": "Arrived byte total equals the queued byte total: the child got the durable snapshot, not a re-read" },
+    { "name": "tool-invoke-accepted", "required": true, "description": "sessions.send dispatch accepted for the delayed typed continue_delegate" },
+    { "name": "input-snapshot-queued", "required": true, "description": "CDINREC-QUEUED sentinel reporting the staged snapshot byte total while the delegate is still queued", "pathHint": "gateway-events.ndjson" },
+    { "name": "gateway-restart-observed", "required": true, "description": "Externally observable gateway lifecycle change on the public /status surface (uptime reset, or endpoint drop and return) while the harness is disconnected. OPENCLAW_RESTART_ORCHESTRATED is an operator declaration and is never sufficient.", "pathHint": "k6-run.log" },
+    { "name": "reconnected-after-restart", "required": true, "description": "The harness opened a SECOND WebSocket connection after the restart window, so the row is proven to survive the socket teardown a real restart causes" },
+    { "name": "post-lifecycle-child-arrival", "required": true, "description": "CDINREC-CHILD-ARRIVED sentinel observed on the reconnected socket", "pathHint": "gateway-events.ndjson" },
+    { "name": "snapshot-identity-preserved", "required": true, "description": "The bytes and sha256 prefix the child received after the restart equal the canary staged before it" },
     { "name": "no-raw-attachment-bytes-on-the-wire", "required": true, "description": "Negative check: queued attachment content absent from every non-harness frame" },
-    { "name": "no-pre-lifecycle-spawn", "required": true, "description": "Negative check: the delayed delegate did not spawn before its queue window elapsed" }
+    { "name": "no-pre-lifecycle-spawn", "required": true, "description": "Negative check: the delayed delegate did not arrive before the restart window opened" }
   ],
   "artifactDestination": {
     "root": "PROOFS",
@@ -50,7 +52,7 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "PARTIAL-candidate is the expected artifact class unless an operator actually restarted the gateway inside the queue window. The scenario records the precise reason in evidence.orchestration.reason; a PASS without an observed restart must be rejected at fold."
+    "notes": "Orchestration-gated. PARTIAL-candidate is the expected artifact class unless an operator restart is OBSERVED on the gateway's public /status surface during the window and the reconnected socket then sees the child arrive with the same snapshot identity. The operator declaration OPENCLAW_RESTART_ORCHESTRATED is recorded but never credited as evidence."
   },
   "liveRunSafety": {
     "classification": "orchestration-required",
@@ -64,6 +66,8 @@
       "seat-readiness",
       "tool-invoke-accepted",
       "input-snapshot-queued",
+      "gateway-restart-observed",
+      "reconnected-after-restart",
       "post-lifecycle-child-arrival",
       "snapshot-identity-preserved"
     ],

--- a/tools/k6-proofs/manifests/r-cd-in-recovery.json
+++ b/tools/k6-proofs/manifests/r-cd-in-recovery.json
@@ -1,0 +1,73 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CD-IN-RECOVERY",
+  "issue": 491,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-rune-rog-ally}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "websocket",
+  "toolSurface": "typed-tool",
+  "mutates": true,
+  "timeoutSeconds": 400,
+  "gateway": {
+    "wsEnv": "OPENCLAW_GATEWAY_WS",
+    "tokenEnv": "OPENCLAW_GATEWAY_TOKEN"
+  },
+  "scenario": {
+    "name": "r-cd-in-recovery-queued-restart",
+    "description": "A queued typed delegate input snapshot survives an operator gateway restart and is handed to the child from durable state with identical snapshot identity.",
+    "methods": [
+      "sessions.create",
+      "sessions.messages.subscribe",
+      "sessions.send"
+    ],
+    "status": "runnable",
+    "file": "r-cd-in-recovery-queued-restart.js",
+    "notes": "Runnable harness, orchestration-gated verdict. The gateway restart is an operator step the harness must not perform; without OPENCLAW_RESTART_ORCHESTRATED=true the row is PARTIAL-candidate by construction."
+  },
+  "invocation": {
+    "tool": "continue_delegate",
+    "mode": "normal",
+    "delaySecondsEnv": "OPENCLAW_QUEUE_DELAY_SECONDS",
+    "attachmentCount": 1,
+    "idempotencyKeyPrefix": "R-CD-IN-RECOVERY"
+  },
+  "expectedReceipts": [
+    { "name": "tool-invoke-accepted", "required": true, "description": "sessions.send dispatch accepted for the delayed attachment-bearing delegate" },
+    { "name": "input-snapshot-queued", "required": true, "description": "CDINREC-QUEUED sentinel with the staged byte total, emitted while the delegate is still queued" },
+    { "name": "post-lifecycle-child-arrival", "required": true, "description": "CDINREC-CHILD-ARRIVED sentinel observed after the operator restart window" },
+    { "name": "snapshot-identity-preserved", "required": true, "description": "Arrived byte total equals the queued byte total: the child got the durable snapshot, not a re-read" },
+    { "name": "no-raw-attachment-bytes-on-the-wire", "required": true, "description": "Negative check: queued attachment content absent from every non-harness frame" },
+    { "name": "no-pre-lifecycle-spawn", "required": true, "description": "Negative check: the delayed delegate did not spawn before its queue window elapsed" }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CD-IN-RECOVERY",
+    "seat": "${OPENCLAW_SEAT_NAME:-rune-rog-ally}",
+    "runDirPrefix": "k6-run"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "PARTIAL-candidate is the expected artifact class unless an operator actually restarted the gateway inside the queue window. The scenario records the precise reason in evidence.orchestration.reason; a PASS without an observed restart must be rejected at fold."
+  },
+  "liveRunSafety": {
+    "classification": "orchestration-required",
+    "requiresLiveGatewayToken": true,
+    "requiresTargetSessionKey": true,
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": true,
+    "sameSessionConcurrencySafe": false,
+    "expectedArtifactClass": "PARTIAL-candidate",
+    "requiredReceipts": [
+      "seat-readiness",
+      "tool-invoke-accepted",
+      "input-snapshot-queued",
+      "post-lifecycle-child-arrival",
+      "snapshot-identity-preserved"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Requires an operator gateway restart during the queue window (OPENCLAW_QUEUE_DELAY_SECONDS, default 120). The harness never restarts anything. Set OPENCLAW_RESTART_ORCHESTRATED=true only when a restart genuinely happened."
+  }
+}

--- a/tools/k6-proofs/manifests/r-cd-in-revoke.json
+++ b/tools/k6-proofs/manifests/r-cd-in-revoke.json
@@ -1,0 +1,75 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CD-IN-REVOKE",
+  "issue": 491,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-rune-rog-ally}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "websocket",
+  "toolSurface": "mixed",
+  "mutates": true,
+  "timeoutSeconds": 200,
+  "gateway": {
+    "wsEnv": "OPENCLAW_GATEWAY_WS",
+    "tokenEnv": "OPENCLAW_GATEWAY_TOKEN"
+  },
+  "scenario": {
+    "name": "r-cd-in-revoke-no-spawn-scrub",
+    "description": "With the delegate-input attachment policy revoked, a typed attachment-bearing continue_delegate is refused at the tool boundary, spawns no child, and leaves no retained attachment state.",
+    "methods": [
+      "config.get",
+      "sessions.create",
+      "sessions.messages.subscribe",
+      "sessions.send"
+    ],
+    "status": "runnable",
+    "file": "r-cd-in-revoke-no-spawn-scrub.js",
+    "notes": "Mixed surface: the read-only operator config.get establishes the live policy precondition, then the typed tool is probed. The gateway exposes no config.set, so applying the revoke is an operator step."
+  },
+  "invocation": {
+    "tool": "continue_delegate",
+    "mode": "normal",
+    "delaySeconds": 1,
+    "attachmentCount": 1,
+    "policyKey": "tools.sessions_spawn.attachments.enabled",
+    "idempotencyKeyPrefix": "R-CD-IN-REVOKE"
+  },
+  "expectedReceipts": [
+    { "name": "operator-policy-snapshot", "required": true, "description": "config.get response recording tools.sessions_spawn.attachments.enabled (operator read-only surface)" },
+    { "name": "tool-invoke-accepted", "required": true, "description": "sessions.send dispatch accepted so the typed tool could be probed" },
+    { "name": "policy-revoke-refusal", "required": true, "description": "CDINREV-REFUSED sentinel: the attachment-bearing delegate was refused with a policy reason" },
+    { "name": "scrub-confirmed", "required": true, "description": "CDINREV-NO-STATE sentinel: no retained attachment state after the refusal" },
+    { "name": "no-child-spawn-under-revoke", "required": true, "description": "Negative check: no child session spawned under a revoked policy" },
+    { "name": "no-raw-attachment-bytes-on-the-wire", "required": true, "description": "Negative check: refused attachment content absent from every non-harness frame" }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CD-IN-REVOKE",
+    "seat": "${OPENCLAW_SEAT_NAME:-rune-rog-ally}",
+    "runDirPrefix": "k6-run"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "PARTIAL-candidate whenever config.get shows the attachment policy still enabled, or does not expose it at all. The scenario refuses to infer a default. Only a run against a genuinely revoked policy may be folded as PASS."
+  },
+  "liveRunSafety": {
+    "classification": "orchestration-required",
+    "requiresLiveGatewayToken": true,
+    "requiresTargetSessionKey": true,
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": true,
+    "sameSessionConcurrencySafe": false,
+    "expectedArtifactClass": "PARTIAL-candidate",
+    "requiredReceipts": [
+      "seat-readiness",
+      "operator-policy-snapshot",
+      "tool-invoke-accepted",
+      "policy-revoke-refusal",
+      "scrub-confirmed"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Requires an operator to have revoked tools.sessions_spawn.attachments.enabled on the target seat before the row fires. The harness only reads config.get; it never mutates configuration and never reloads or restarts a gateway."
+  }
+}

--- a/tools/k6-proofs/manifests/r-cd-in-revoke.json
+++ b/tools/k6-proofs/manifests/r-cd-in-revoke.json
@@ -35,11 +35,14 @@
     "idempotencyKeyPrefix": "R-CD-IN-REVOKE"
   },
   "expectedReceipts": [
-    { "name": "operator-policy-snapshot", "required": true, "description": "config.get response recording tools.sessions_spawn.attachments.enabled (operator read-only surface)" },
-    { "name": "tool-invoke-accepted", "required": true, "description": "sessions.send dispatch accepted so the typed tool could be probed" },
-    { "name": "policy-revoke-refusal", "required": true, "description": "CDINREV-REFUSED sentinel: the attachment-bearing delegate was refused with a policy reason" },
-    { "name": "scrub-confirmed", "required": true, "description": "CDINREV-NO-STATE sentinel: no retained attachment state after the refusal" },
-    { "name": "no-child-spawn-under-revoke", "required": true, "description": "Negative check: no child session spawned under a revoked policy" },
+    { "name": "operator-policy-snapshot", "required": true, "description": "config.get read of tools.sessions_spawn.attachments.enabled establishing the live precondition" },
+    { "name": "tool-invoke-accepted", "required": true, "description": "sessions.send dispatch accepted for the refused probe" },
+    { "name": "pre-probe-session-inventory", "required": true, "description": "sessions.list taken BEFORE the probe, so \"no child was spawned\" is a diff against an observed baseline rather than a default-true absence" },
+    { "name": "policy-revoke-tool-refusal", "required": true, "description": "A structured continue_delegate tool record carrying an error/refusal. Model prose naming a refusal is corroboration, not the receipt.", "pathHint": "gateway-events.ndjson" },
+    { "name": "no-child-session-observed", "required": true, "description": "sessions.list taken AFTER the probe shows no added session and no session bound to the row nonce" },
+    { "name": "durable-state-scrubbed", "required": true, "description": "The follow-up continue_delegate tool record is observed on the wire and no observed record still carries delegate attachment state", "pathHint": "gateway-events.ndjson" },
+    { "name": "no-child-spawn-under-revoke", "required": true, "description": "Negative check: no child session bound to this row and no session inventory growth" },
+    { "name": "no-retained-attachment-state", "required": true, "description": "Negative check: no observed continue_delegate record still carries delegate attachment state" },
     { "name": "no-raw-attachment-bytes-on-the-wire", "required": true, "description": "Negative check: refused attachment content absent from every non-harness frame" }
   ],
   "artifactDestination": {
@@ -52,7 +55,7 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "PARTIAL-candidate whenever config.get shows the attachment policy still enabled, or does not expose it at all. The scenario refuses to infer a default. Only a run against a genuinely revoked policy may be folded as PASS."
+    "notes": "Orchestration-gated on an operator config revoke the gateway exposes no API for. Every behavioral leg is credited from an authoritative surface: a structured continue_delegate error record for the refusal, a before/after sessions.list diff for no-spawn, and the follow-up tool record for the scrub. Prose sentinels only sequence the probe."
   },
   "liveRunSafety": {
     "classification": "orchestration-required",
@@ -66,8 +69,10 @@
       "seat-readiness",
       "operator-policy-snapshot",
       "tool-invoke-accepted",
-      "policy-revoke-refusal",
-      "scrub-confirmed"
+      "pre-probe-session-inventory",
+      "policy-revoke-tool-refusal",
+      "no-child-session-observed",
+      "durable-state-scrubbed"
     ],
     "foldRequiresReview": true,
     "notes": "Requires an operator to have revoked tools.sessions_spawn.attachments.enabled on the target seat before the row fires. The harness only reads config.get; it never mutates configuration and never reloads or restarts a gateway."

--- a/tools/k6-proofs/manifests/r-cd-io-neg.json
+++ b/tools/k6-proofs/manifests/r-cd-io-neg.json
@@ -1,0 +1,80 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CD-IO-NEG",
+  "issue": 491,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-rune-rog-ally}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "websocket",
+  "toolSurface": "typed-tool",
+  "mutates": true,
+  "timeoutSeconds": 300,
+  "gateway": {
+    "wsEnv": "OPENCLAW_GATEWAY_WS",
+    "tokenEnv": "OPENCLAW_GATEWAY_TOKEN"
+  },
+  "scenario": {
+    "name": "r-cd-io-negative-boundary",
+    "description": "Negative boundary for the #491 non-goals: after a claim is announced and with no explicit recipient action, there is no raw-byte mount, no automatic materialization, no Discord/native-media upload, no generic render or forward, and no prompt injection.",
+    "methods": [
+      "sessions.create",
+      "sessions.messages.subscribe",
+      "sessions.send"
+    ],
+    "status": "runnable",
+    "file": "r-cd-io-negative-boundary.js",
+    "notes": "The claim announcement is the positive control: without it the negative window would be vacuously clean."
+  },
+  "invocation": {
+    "tool": "delegate_artifacts_publish",
+    "viaTool": "continue_delegate",
+    "mode": "normal",
+    "delaySeconds": 1,
+    "observationWindowEnv": "OPENCLAW_NEGATIVE_WINDOW_MS",
+    "idempotencyKeyPrefix": "R-CD-IO-NEG"
+  },
+  "expectedReceipts": [
+    { "name": "tool-invoke-accepted", "required": true, "description": "sessions.send dispatch accepted" },
+    { "name": "claim-announced-positive-control", "required": true, "description": "CDNEG-ANNOUNCED sentinel: a real claim was announced, so the negative window is not vacuous" },
+    { "name": "negative-window-elapsed", "required": true, "description": "The bounded observation window ran to term with no violation" },
+    { "name": "no-automatic-raw-byte-mount", "required": true, "description": "Negative check: artifact bytes never crossed the wire unasked" },
+    { "name": "no-automatic-materialization", "required": true, "description": "Negative check: no materialized state without an explicit recipient call" },
+    { "name": "no-native-media-upload", "required": true, "description": "Negative check: no Discord/native-media or channel attachment delivery" },
+    { "name": "no-generic-render-or-forward", "required": true, "description": "Negative check: artifact content never rendered into reply text" },
+    { "name": "no-prompt-injection", "required": true, "description": "Negative check: the announcement carried no injected instruction field" }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CD-IO-NEG",
+    "seat": "${OPENCLAW_SEAT_NAME:-rune-rog-ally}",
+    "runDirPrefix": "k6-run"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "A clean negative window without the positive control is not evidence. Fold only when claim-announced-positive-control and negative-window-elapsed both fired."
+  },
+  "liveRunSafety": {
+    "classification": "k6-runnable",
+    "requiresLiveGatewayToken": true,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": true,
+    "sameSessionConcurrencySafe": false,
+    "expectedArtifactClass": "PASS-candidate",
+    "requiredReceipts": [
+      "seat-readiness",
+      "tool-invoke-accepted",
+      "claim-announced-positive-control",
+      "negative-window-elapsed",
+      "no-automatic-raw-byte-mount",
+      "no-automatic-materialization",
+      "no-native-media-upload",
+      "no-generic-render-or-forward",
+      "no-prompt-injection"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Takes no delegate_artifacts action at all — the recipient is instructed to stop after acknowledging the claim. Nothing is written to the recipient workspace. Prefer OPENCLAW_CREATE_DISPOSABLE_SESSION=true."
+  }
+}

--- a/tools/k6-proofs/manifests/r-cd-out-claim.json
+++ b/tools/k6-proofs/manifests/r-cd-out-claim.json
@@ -1,0 +1,81 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CD-OUT-CLAIM",
+  "issue": 491,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-rune-rog-ally}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "websocket",
+  "toolSurface": "typed-tool",
+  "mutates": true,
+  "timeoutSeconds": 320,
+  "gateway": {
+    "wsEnv": "OPENCLAW_GATEWAY_WS",
+    "tokenEnv": "OPENCLAW_GATEWAY_TOKEN"
+  },
+  "scenario": {
+    "name": "r-cd-out-claim-lifecycle",
+    "description": "Recipient-bound delegate_artifacts lifecycle: list, inspect, recipient-authorized workspace-relative materialize, discard, and a post-discard inspect that must be rejected.",
+    "methods": [
+      "sessions.create",
+      "sessions.messages.subscribe",
+      "sessions.send"
+    ],
+    "status": "runnable",
+    "file": "r-cd-out-claim-lifecycle.js"
+  },
+  "invocation": {
+    "tool": "delegate_artifacts",
+    "actions": ["list", "inspect", "materialize", "discard"],
+    "viaTool": "continue_delegate",
+    "mode": "normal",
+    "delaySeconds": 1,
+    "destinationTemplate": "p86-materialized/{{nonce}}.txt",
+    "idempotencyKeyPrefix": "R-CD-OUT-CLAIM"
+  },
+  "expectedReceipts": [
+    { "name": "tool-invoke-accepted", "required": true, "description": "sessions.send dispatch accepted" },
+    { "name": "child-publish-accepted", "required": false, "description": "CDCLAIM-CHILD-PUBLISHED sentinel: context that the claim under test came from a real child publication" },
+    { "name": "claim-listed", "required": true, "description": "CDCLAIM-LISTED sentinel: delegate_artifacts action=list returned the recipient's claim id" },
+    { "name": "claim-inspected", "required": true, "description": "CDCLAIM-INSPECTED sentinel: metadata only (byte count and mime type), never content" },
+    { "name": "authorized-materialize", "required": true, "description": "CDCLAIM-MATERIALIZED sentinel: recipient-authorized materialize to a workspace-relative destination" },
+    { "name": "claim-discarded", "required": true, "description": "CDCLAIM-DISCARDED sentinel: the recipient discarded the claim" },
+    { "name": "no-read-after-discard", "required": true, "description": "Negative check: CDCLAIM-POSTDISCARD reported rejected, not ok" },
+    { "name": "materialize-destination-is-workspace-relative", "required": true, "description": "Negative check: the destination did not escape the workspace" },
+    { "name": "no-raw-artifact-bytes-on-the-wire", "required": true, "description": "Negative check: artifact content absent from every non-harness frame, including inspect results" }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CD-OUT-CLAIM",
+    "seat": "${OPENCLAW_SEAT_NAME:-rune-rog-ally}",
+    "runDirPrefix": "k6-run"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "Every lifecycle leg must be an explicit recipient action. A run where materialize happened without the list/inspect legs is PARTIAL, not PASS: the point of the row is that the recipient drives it."
+  },
+  "liveRunSafety": {
+    "classification": "k6-runnable",
+    "requiresLiveGatewayToken": true,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": true,
+    "sameSessionConcurrencySafe": false,
+    "expectedArtifactClass": "PASS-candidate",
+    "requiredReceipts": [
+      "seat-readiness",
+      "tool-invoke-accepted",
+      "claim-listed",
+      "claim-inspected",
+      "authorized-materialize",
+      "claim-discarded",
+      "no-read-after-discard",
+      "materialize-destination-is-workspace-relative",
+      "no-raw-artifact-bytes-on-the-wire"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Writes exactly one small file into the recipient workspace under p86-materialized/ as the authorized-materialize leg, then discards the claim. Prefer OPENCLAW_CREATE_DISPOSABLE_SESSION=true. Serialize per session."
+  }
+}

--- a/tools/k6-proofs/manifests/r-cd-out-claim.json
+++ b/tools/k6-proofs/manifests/r-cd-out-claim.json
@@ -42,7 +42,9 @@
     { "name": "claim-discarded", "required": true, "description": "CDCLAIM-DISCARDED sentinel: the recipient discarded the claim" },
     { "name": "no-read-after-discard", "required": true, "description": "Negative check: CDCLAIM-POSTDISCARD reported rejected, not ok" },
     { "name": "materialize-destination-is-workspace-relative", "required": true, "description": "Negative check: the destination did not escape the workspace" },
-    { "name": "no-raw-artifact-bytes-on-the-wire", "required": true, "description": "Negative check: artifact content absent from every non-harness frame, including inspect results" }
+    { "name": "no-raw-artifact-bytes-on-the-wire", "required": true, "description": "Negative check: artifact content absent from every non-harness frame, including inspect results" },
+    { "name": "post-discard-inspect-rejected", "required": true, "description": "CDCLAIM-POSTDISCARD names the SAME claim id, reports rejected, and a structured delegate_artifacts error record was observed: the discarded claim is proven unreadable rather than assumed", "pathHint": "gateway-events.ndjson" },
+    { "name": "discard-targets-the-listed-claim", "required": true, "description": "Negative check: the discarded claim id is the claim id that was listed and inspected" }
   ],
   "artifactDestination": {
     "root": "PROOFS",
@@ -54,7 +56,7 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Every lifecycle leg must be an explicit recipient action. A run where materialize happened without the list/inspect legs is PARTIAL, not PASS: the point of the row is that the recipient drives it."
+    "notes": "Every lifecycle leg must be an explicit recipient action. A run where materialize happened without the list/inspect legs is PARTIAL, not PASS: the point of the row is that the recipient drives it. The post-discard leg is required, not advisory: without a claim-id-bound rejection receipt backed by a structured delegate_artifacts error record, the row could PASS while the discarded claim is still readable."
   },
   "liveRunSafety": {
     "classification": "k6-runnable",
@@ -73,7 +75,9 @@
       "claim-discarded",
       "no-read-after-discard",
       "materialize-destination-is-workspace-relative",
-      "no-raw-artifact-bytes-on-the-wire"
+      "no-raw-artifact-bytes-on-the-wire",
+      "post-discard-inspect-rejected",
+      "discard-targets-the-listed-claim"
     ],
     "foldRequiresReview": true,
     "notes": "Writes exactly one small file into the recipient workspace under p86-materialized/ as the authorized-materialize leg, then discards the claim. Prefer OPENCLAW_CREATE_DISPOSABLE_SESSION=true. Serialize per session."

--- a/tools/k6-proofs/manifests/r-cd-out-publish.json
+++ b/tools/k6-proofs/manifests/r-cd-out-publish.json
@@ -1,0 +1,75 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CD-OUT-PUBLISH",
+  "issue": 491,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-rune-rog-ally}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "websocket",
+  "toolSurface": "typed-tool",
+  "mutates": true,
+  "timeoutSeconds": 260,
+  "gateway": {
+    "wsEnv": "OPENCLAW_GATEWAY_WS",
+    "tokenEnv": "OPENCLAW_GATEWAY_TOKEN"
+  },
+  "scenario": {
+    "name": "r-cd-out-publish-claim",
+    "description": "Delegate child writes into its delegate-artifacts output root and calls delegate_artifacts_publish; the resulting claim is announced to the originating recipient session with a claim id and no artifact bytes.",
+    "methods": [
+      "sessions.create",
+      "sessions.messages.subscribe",
+      "sessions.send"
+    ],
+    "status": "runnable",
+    "file": "r-cd-out-publish-claim.js"
+  },
+  "invocation": {
+    "tool": "delegate_artifacts_publish",
+    "viaTool": "continue_delegate",
+    "mode": "normal",
+    "delaySeconds": 1,
+    "idempotencyKeyPrefix": "R-CD-OUT-PUBLISH"
+  },
+  "expectedReceipts": [
+    { "name": "tool-invoke-accepted", "required": true, "description": "sessions.send dispatch accepted (agent turn triggered for continue_delegate)" },
+    { "name": "child-publish-accepted", "required": true, "description": "CDOUT-PUBLISHED sentinel: the child's delegate_artifacts_publish call returned a claim id" },
+    { "name": "recipient-bound-claim-announced", "required": true, "description": "CDOUT-CLAIM-ANNOUNCED sentinel on the originating session: the claim is bound to its recipient, not broadcast" },
+    { "name": "claim-id-provenance", "required": true, "description": "The announced claim id matches the published claim id" },
+    { "name": "no-raw-artifact-bytes-on-the-wire", "required": true, "description": "Negative check: artifact content absent from every non-harness frame" },
+    { "name": "no-materialize-without-explicit-action", "required": true, "description": "Negative check: publication alone materialized nothing" },
+    { "name": "trace-id", "required": false, "description": "Trace ID for Tempo fetch when the dispatch response carries one" }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CD-OUT-PUBLISH",
+    "seat": "${OPENCLAW_SEAT_NAME:-rune-rog-ally}",
+    "runDirPrefix": "k6-run"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "PASS-candidate only when publish, recipient-bound announcement, and claim-id provenance all fire and both negative checks hold. The socket is deliberately held open past the last receipt so an automatic materialization would still be caught."
+  },
+  "liveRunSafety": {
+    "classification": "k6-runnable",
+    "requiresLiveGatewayToken": true,
+    "requiresTargetSessionKey": false,
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": true,
+    "sameSessionConcurrencySafe": false,
+    "expectedArtifactClass": "PASS-candidate",
+    "requiredReceipts": [
+      "seat-readiness",
+      "tool-invoke-accepted",
+      "child-publish-accepted",
+      "recipient-bound-claim-announced",
+      "claim-id-provenance",
+      "no-raw-artifact-bytes-on-the-wire",
+      "no-materialize-without-explicit-action"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Spawns one delegate child that writes a small text file inside its own workspace output root. Nothing is written to the recipient workspace. Prefer OPENCLAW_CREATE_DISPOSABLE_SESSION=true. Serialize per session."
+  }
+}

--- a/tools/k6-proofs/manifests/r-cd-out-replay.json
+++ b/tools/k6-proofs/manifests/r-cd-out-replay.json
@@ -1,0 +1,74 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CD-OUT-REPLAY",
+  "issue": 491,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-rune-rog-ally}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "websocket",
+  "toolSurface": "typed-tool",
+  "mutates": true,
+  "timeoutSeconds": 420,
+  "gateway": {
+    "wsEnv": "OPENCLAW_GATEWAY_WS",
+    "tokenEnv": "OPENCLAW_GATEWAY_TOKEN"
+  },
+  "scenario": {
+    "name": "r-cd-out-restart-replay",
+    "description": "A published claim survives an operator gateway restart with stable claim identity and idempotent replay: one publication yields exactly one claim, and replay materializes nothing.",
+    "methods": [
+      "sessions.messages.subscribe",
+      "sessions.send"
+    ],
+    "status": "runnable",
+    "file": "r-cd-out-restart-replay.js",
+    "notes": "Runnable harness, orchestration-gated verdict. The scenario logs when its restart window opens; the operator restarts the gateway during that window."
+  },
+  "invocation": {
+    "tool": "delegate_artifacts",
+    "actions": ["list"],
+    "viaTool": "continue_delegate",
+    "mode": "normal",
+    "delaySeconds": 1,
+    "idempotencyKeyPrefix": "R-CD-OUT-REPLAY"
+  },
+  "expectedReceipts": [
+    { "name": "pre-restart-claim-established", "required": true, "description": "CDREPLAY-PRE sentinel: claim id captured before the restart window" },
+    { "name": "post-restart-claim-listed", "required": true, "description": "CDREPLAY-POST sentinel: the claim is still listable after the restart window" },
+    { "name": "claim-identity-stable", "required": true, "description": "Post-restart claim id equals the pre-restart claim id" },
+    { "name": "replay-is-idempotent", "required": true, "description": "Exactly one claim carries the row nonce after replay" },
+    { "name": "no-duplicate-claim-after-replay", "required": true, "description": "Negative check: replay minted no second claim" },
+    { "name": "no-auto-materialize-on-replay", "required": true, "description": "Negative check: replay materialized nothing without an explicit recipient call" },
+    { "name": "no-raw-artifact-bytes-on-the-wire", "required": true, "description": "Negative check: artifact content absent from every non-harness frame across replay" }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CD-OUT-REPLAY",
+    "seat": "${OPENCLAW_SEAT_NAME:-rune-rog-ally}",
+    "runDirPrefix": "k6-run"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "PARTIAL-candidate unless an operator genuinely cycled the gateway inside the restart window. The pre-restart legs are still recorded, so a PARTIAL artifact from this row is informative rather than empty."
+  },
+  "liveRunSafety": {
+    "classification": "orchestration-required",
+    "requiresLiveGatewayToken": true,
+    "requiresTargetSessionKey": true,
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": true,
+    "sameSessionConcurrencySafe": false,
+    "expectedArtifactClass": "PARTIAL-candidate",
+    "requiredReceipts": [
+      "seat-readiness",
+      "pre-restart-claim-established",
+      "post-restart-claim-listed",
+      "claim-identity-stable",
+      "replay-is-idempotent"
+    ],
+    "foldRequiresReview": true,
+    "notes": "Requires an operator gateway restart inside OPENCLAW_RESTART_WINDOW_MS (default 120000). The harness never restarts anything. Set OPENCLAW_RESTART_ORCHESTRATED=true only when a restart genuinely happened."
+  }
+}

--- a/tools/k6-proofs/manifests/r-cd-out-replay.json
+++ b/tools/k6-proofs/manifests/r-cd-out-replay.json
@@ -8,7 +8,7 @@
   "transport": "websocket",
   "toolSurface": "typed-tool",
   "mutates": true,
-  "timeoutSeconds": 420,
+  "timeoutSeconds": 660,
   "gateway": {
     "wsEnv": "OPENCLAW_GATEWAY_WS",
     "tokenEnv": "OPENCLAW_GATEWAY_TOKEN"
@@ -33,12 +33,14 @@
     "idempotencyKeyPrefix": "R-CD-OUT-REPLAY"
   },
   "expectedReceipts": [
-    { "name": "pre-restart-claim-established", "required": true, "description": "CDREPLAY-PRE sentinel: claim id captured before the restart window" },
-    { "name": "post-restart-claim-listed", "required": true, "description": "CDREPLAY-POST sentinel: the claim is still listable after the restart window" },
-    { "name": "claim-identity-stable", "required": true, "description": "Post-restart claim id equals the pre-restart claim id" },
+    { "name": "pre-restart-claim-established", "required": true, "description": "CDREPLAY-PRE sentinel naming the claim id before the restart window opens", "pathHint": "gateway-events.ndjson" },
+    { "name": "gateway-restart-observed", "required": true, "description": "Externally observable gateway lifecycle change on the public /status surface (uptime reset, or endpoint drop and return) while the harness is disconnected. OPENCLAW_RESTART_ORCHESTRATED is an operator declaration and is never sufficient.", "pathHint": "k6-run.log" },
+    { "name": "reconnected-after-restart", "required": true, "description": "The harness opened a SECOND WebSocket connection after the restart window, so a real restart cannot fail the row by dropping the original socket" },
+    { "name": "post-restart-claim-listed", "required": true, "description": "CDREPLAY-POST sentinel observed on the reconnected socket", "pathHint": "gateway-events.ndjson" },
+    { "name": "claim-identity-stable", "required": true, "description": "The post-restart claim id equals the pre-restart claim id" },
     { "name": "replay-is-idempotent", "required": true, "description": "Exactly one claim carries the row nonce after replay" },
-    { "name": "no-duplicate-claim-after-replay", "required": true, "description": "Negative check: replay minted no second claim" },
-    { "name": "no-auto-materialize-on-replay", "required": true, "description": "Negative check: replay materialized nothing without an explicit recipient call" },
+    { "name": "no-duplicate-claim-after-replay", "required": true, "description": "Negative check: replay minted no second claim and no different claim id" },
+    { "name": "no-auto-materialize-on-replay", "required": true, "description": "Negative check: no materialized state appeared without an explicit recipient action" },
     { "name": "no-raw-artifact-bytes-on-the-wire", "required": true, "description": "Negative check: artifact content absent from every non-harness frame across replay" }
   ],
   "artifactDestination": {
@@ -51,7 +53,7 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "PARTIAL-candidate unless an operator genuinely cycled the gateway inside the restart window. The pre-restart legs are still recorded, so a PARTIAL artifact from this row is informative rather than empty."
+    "notes": "Orchestration-gated. PARTIAL-candidate is the expected artifact class unless an operator restart is OBSERVED on the gateway's public /status surface while the harness is disconnected, and the reconnected socket then re-lists the same claim exactly once. The operator declaration OPENCLAW_RESTART_ORCHESTRATED is recorded but never credited as evidence."
   },
   "liveRunSafety": {
     "classification": "orchestration-required",
@@ -64,6 +66,8 @@
     "requiredReceipts": [
       "seat-readiness",
       "pre-restart-claim-established",
+      "gateway-restart-observed",
+      "reconnected-after-restart",
       "post-restart-claim-listed",
       "claim-identity-stable",
       "replay-is-idempotent"

--- a/tools/k6-proofs/manifests/r-cd-out-unauthorized.json
+++ b/tools/k6-proofs/manifests/r-cd-out-unauthorized.json
@@ -1,0 +1,76 @@
+{
+  "schema": "openclaw.k6.proof-row-manifest.v1",
+  "rowId": "R-CD-OUT-UNAUTHORIZED",
+  "issue": 491,
+  "candidateSha": "${OPENCLAW_CANDIDATE_SHA}",
+  "seat": "${OPENCLAW_SEAT_NAME:-rune-rog-ally}",
+  "sessionKey": "${OPENCLAW_SESSION_KEY:-main}",
+  "transport": "websocket",
+  "toolSurface": "typed-tool",
+  "mutates": true,
+  "timeoutSeconds": 320,
+  "gateway": {
+    "wsEnv": "OPENCLAW_GATEWAY_WS",
+    "tokenEnv": "OPENCLAW_GATEWAY_TOKEN"
+  },
+  "scenario": {
+    "name": "r-cd-out-unauthorized-reject",
+    "description": "A non-recipient session holding a valid claim id is rejected on both inspect and materialize, while the true recipient can still inspect — proving recipient binding rather than bearer authorization.",
+    "methods": [
+      "sessions.create",
+      "sessions.messages.subscribe",
+      "sessions.send"
+    ],
+    "status": "runnable",
+    "file": "r-cd-out-unauthorized-reject.js",
+    "notes": "Two sessions: the named recipient session (OPENCLAW_SESSION_KEY) and a disposable non-recipient session created by the scenario."
+  },
+  "invocation": {
+    "tool": "delegate_artifacts",
+    "actions": ["list", "inspect", "materialize"],
+    "viaTool": "continue_delegate",
+    "mode": "normal",
+    "delaySeconds": 1,
+    "idempotencyKeyPrefix": "R-CD-OUT-UNAUTHORIZED"
+  },
+  "expectedReceipts": [
+    { "name": "recipient-claim-established", "required": true, "description": "CDUNAUTH-CLAIM sentinel: the recipient session holds a real claim id" },
+    { "name": "non-recipient-inspect-rejected", "required": true, "description": "CDUNAUTH-INSPECT sentinel reported rejected from the non-recipient session" },
+    { "name": "non-recipient-materialize-rejected", "required": true, "description": "CDUNAUTH-MATERIALIZE sentinel reported rejected from the non-recipient session" },
+    { "name": "recipient-positive-control", "required": true, "description": "CDUNAUTH-OWNER sentinel reported ok: the rejection was authorization, not a dead claim" },
+    { "name": "claim-is-not-bearer-authorized", "required": true, "description": "Negative check: possession of the claim id granted the non-recipient nothing" },
+    { "name": "no-raw-artifact-bytes-on-the-wire", "required": true, "description": "Negative check: artifact content absent from every non-harness frame" }
+  ],
+  "artifactDestination": {
+    "root": "PROOFS",
+    "sha": "${OPENCLAW_CANDIDATE_SHA}",
+    "row": "R-CD-OUT-UNAUTHORIZED",
+    "seat": "${OPENCLAW_SEAT_NAME:-rune-rog-ally}",
+    "runDirPrefix": "k6-run"
+  },
+  "review": {
+    "candidateOnly": true,
+    "foldRequiresReview": true,
+    "notes": "The positive control is mandatory. Without CDUNAUTH-OWNER=ok the rejections are uninterpretable — the claim could simply have expired — so the row stays PARTIAL-candidate."
+  },
+  "liveRunSafety": {
+    "classification": "k6-runnable",
+    "requiresLiveGatewayToken": true,
+    "requiresTargetSessionKey": true,
+    "requiresCandidateSha": true,
+    "requiresExternalAgentOrToolInvocation": true,
+    "sameSessionConcurrencySafe": false,
+    "expectedArtifactClass": "PASS-candidate",
+    "requiredReceipts": [
+      "seat-readiness",
+      "recipient-claim-established",
+      "non-recipient-inspect-rejected",
+      "non-recipient-materialize-rejected",
+      "recipient-positive-control",
+      "claim-is-not-bearer-authorized",
+      "no-raw-artifact-bytes-on-the-wire"
+    ],
+    "foldRequiresReview": true,
+    "notes": "OPENCLAW_SESSION_KEY must name the recipient session explicitly; the non-recipient session is created disposable by the scenario. Serialize per session."
+  }
+}

--- a/tools/k6-proofs/scenarios/r-cd-in-1-typed-input-snapshot.js
+++ b/tools/k6-proofs/scenarios/r-cd-in-1-typed-input-snapshot.js
@@ -1,0 +1,256 @@
+/**
+ * Scenario: R-CD-IN-1 — typed continue_delegate INPUT snapshot + provenance.
+ *
+ * Proves the typed delegate-input surface assembled at the candidate:
+ *   1. A typed `continue_delegate({ attachments: [...] })` call is accepted.
+ *   2. The tool result reports a staged input snapshot (count/bytes/digest),
+ *      NOT the attachment content.
+ *   3. The spawned child observes the snapshot at a workspace-relative mount
+ *      path — the provenance leg.
+ *   4. Negative: the attachment content never appears on a non-harness frame.
+ *
+ * Only the typed tool carries attachment blobs; the bracket
+ * `[[CONTINUE_DELEGATE: ...]]` form cannot, so this row has no token sibling.
+ *
+ * References:
+ *   - Issue: karmaterminal/karmaterminal-openclaw-docs#491
+ *   - Manifest: tools/k6-proofs/manifests/r-cd-in-1.json
+ *   - Runtime: src/agents/tools/continue-delegate-tool.ts,
+ *              src/auto-reply/continuation/delegate-flow-store.ts
+ */
+import ws from 'k6/ws';
+import { check } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+import { connectFrame, nonce, RequestTracker } from '../lib/gateway-ws.js';
+import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+import { closeSocketAfterDelay } from '../lib/socket-close.js';
+import {
+  baseEvidence,
+  boolEnv,
+  breakNegative,
+  canaryFor,
+  capture,
+  computeVerdict,
+  contentReceipt,
+  declareNegative,
+  fire,
+  logEvidence,
+  matchGroup,
+  rowSummary,
+  scanRawBytes,
+} from '../lib/delegate-attachment-io.js';
+
+const ROW = 'R-CD-IN-1';
+
+export const options = {
+  scenarios: {
+    r_cd_in_1_typed_input_snapshot: {
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 1,
+      maxDuration: '200s',
+    },
+  },
+  thresholds: {
+    proof_failures: ['count==0'],
+    r_cd_in_1_duration: ['p(95)<180000'],
+  },
+};
+
+const failures = new Counter('proof_failures');
+const duration = new Trend('r_cd_in_1_duration');
+
+const manifest = loadManifestFromEnv();
+
+const REQUIRED = [
+  'tool-invoke-accepted',
+  'input-snapshot-staged',
+  'child-mount-provenance',
+];
+
+export default function () {
+  const url = __ENV.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
+  const token = __ENV.OPENCLAW_GATEWAY_TOKEN;
+  const requestedSessionKey = manifest?.sessionKey || __ENV.OPENCLAW_SESSION_KEY || 'main';
+  let sessionKey = requestedSessionKey;
+  const seat = manifest?.seat || __ENV.OPENCLAW_SEAT_NAME || 'rune-rog-ally';
+  const createDisposableSession = boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSION');
+  const rowNonce = nonce(ROW);
+  const canary = canaryFor(rowNonce);
+
+  if (!token) {
+    console.error('OPENCLAW_GATEWAY_TOKEN is required');
+    failures.add(1);
+    return;
+  }
+  if (manifest) {
+    const errors = validateManifest(manifest);
+    if (errors.length > 0) console.warn(`Manifest validation warnings: ${errors.join('; ')}`);
+  }
+
+  const evidence = baseEvidence({
+    row: ROW,
+    nonce: rowNonce,
+    seat,
+    requestedSessionKey,
+    sessionKey,
+    manifest,
+  });
+  evidence.content_receipt = contentReceipt(canary);
+  declareNegative(
+    evidence,
+    'no-raw-attachment-bytes-on-the-wire',
+    'attachment content must never appear on a non-harness gateway frame',
+  );
+  declareNegative(
+    evidence,
+    'no-absolute-path-mount',
+    'the child mount path must be workspace-relative, never an absolute host path',
+  );
+
+  const started = Date.now();
+
+  const res = ws.connect(url, {}, (socket) => {
+    const tracker = new RequestTracker();
+    let closeScheduled = false;
+
+    function maybeClose() {
+      if (closeScheduled) return;
+      if (REQUIRED.some((name) => !evidence.receipts[name])) return;
+      closeScheduled = true;
+      closeSocketAfterDelay(socket, Number(__ENV.OPENCLAW_TRACE_INGEST_GRACE_MS || 10000), () => {
+        console.log(`${ROW}: required receipts gathered, closing`);
+      });
+    }
+
+    function startProofFlow() {
+      tracker.send(socket, 'sessions.messages.subscribe', { key: sessionKey });
+      socket.setTimeout(() => {
+        const instruction =
+          `[k6-proof-harness] Call continue_delegate exactly once with ` +
+          `task="Reply exactly: CDIN1-CHILD-SAW ${rowNonce} <mountRelPath> where <mountRelPath> is the ` +
+          `workspace-relative path of the attachment you were handed. Do not print the file contents. ` +
+          `Do not mutate any other file.", ` +
+          `mode="normal", delaySeconds=1, ` +
+          `attachments=[{name:"p86-in-${rowNonce}.txt", content:"${canary}", encoding:"utf8", mimeType:"text/plain"}]. ` +
+          `After the tool result reports the delegate is scheduled, reply exactly ` +
+          `CDIN1-SNAPSHOT-STAGED ${rowNonce} <count> <bytes> — where <count> and <bytes> come from the ` +
+          `tool result's attachment snapshot receipt. Never echo the attachment content. ` +
+          `This is a proof run — no other action needed.`;
+        tracker.send(socket, 'sessions.send', {
+          key: sessionKey,
+          message: instruction,
+          idempotencyKey: `${ROW}-DISPATCH-${rowNonce}`,
+        });
+      }, 500);
+      socket.setTimeout(() => socket.close(), 180000);
+    }
+
+    socket.on('open', () => {
+      socket.send(connectFrame(token));
+      if (createDisposableSession) {
+        socket.setTimeout(() => {
+          const disposableKey = `r-cd-in-1-${rowNonce}`.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+          tracker.send(socket, 'sessions.create', { key: disposableKey, label: `k6 ${ROW}` });
+        }, 250);
+      } else {
+        socket.setTimeout(startProofFlow, 500);
+      }
+    });
+
+    socket.on('message', (raw) => {
+      try {
+        const msg = JSON.parse(raw);
+        const classified = tracker.classify(msg);
+        const body = capture(evidence, classified);
+
+        if (classified.kind === 'response' && classified.method === 'sessions.create') {
+          if (classified.ok && classified.payload) {
+            sessionKey = classified.payload.key || sessionKey;
+            evidence.sessionKey = sessionKey;
+            evidence.session_created = true;
+            evidence.created_session_key = sessionKey;
+            startProofFlow();
+          } else {
+            console.error('sessions.create rejected');
+            failures.add(1);
+            socket.close();
+          }
+          return;
+        }
+
+        if (classified.kind === 'response' && classified.method === 'sessions.send') {
+          if (classified.ok) {
+            fire(evidence, 'tool-invoke-accepted');
+            if (classified.payload?.traceId) evidence.provenance.trace_id = classified.payload.traceId;
+          } else {
+            console.error('sessions.send rejected');
+            failures.add(1);
+          }
+          return;
+        }
+
+        if (classified.kind !== 'event' || !body) return;
+
+        scanRawBytes(evidence, body, rowNonce, 'no-raw-attachment-bytes-on-the-wire');
+
+        const staged = body.match(
+          new RegExp(`CDIN1-SNAPSHOT-STAGED ${rowNonce} (\\\\d+) (\\\\d+)`),
+        );
+        if (staged) {
+          fire(evidence, 'input-snapshot-staged');
+          evidence.snapshot_reported = { count: Number(staged[1]), bytes: Number(staged[2]) };
+        }
+
+        const mount = matchGroup(body, new RegExp(`CDIN1-CHILD-SAW ${rowNonce} ([^"\\\\s\\\\\\\\]+)`));
+        if (mount) {
+          fire(evidence, 'child-mount-provenance');
+          evidence.provenance.mount_rel_path = mount;
+          if (mount.startsWith('/') || /^[A-Za-z]:/.test(mount)) {
+            breakNegative(evidence, 'no-absolute-path-mount', `mount path is absolute: ${mount}`);
+          }
+        }
+
+        const childKey = matchGroup(body, /"childSessionKey"\s*:\s*"([^"]+)"/);
+        if (childKey) evidence.provenance.child_session_key = childKey;
+        const flowId = matchGroup(body, /"flowId"\s*:\s*"([^"]+)"/);
+        if (flowId) evidence.provenance.flow_id = flowId;
+
+        maybeClose();
+      } catch (e) {
+        console.warn(`parse error: ${e}`);
+      }
+    });
+
+    socket.on('error', (e) => {
+      console.error(`ws error: ${e && e.error ? e.error() : e}`);
+      failures.add(1);
+    });
+  });
+
+  evidence.duration_ms = Date.now() - started;
+  duration.add(evidence.duration_ms);
+  const verdict = computeVerdict(evidence, REQUIRED);
+
+  check(res, { 'websocket connected': (r) => r && r.status === 101 });
+  check(null, {
+    'typed continue_delegate dispatch accepted': () => !!evidence.receipts['tool-invoke-accepted'],
+    'input snapshot staged receipt observed': () => !!evidence.receipts['input-snapshot-staged'],
+    'child observed workspace-relative mount': () => !!evidence.receipts['child-mount-provenance'],
+    'no raw attachment bytes on the wire': () =>
+      evidence.negative_checks['no-raw-attachment-bytes-on-the-wire'].held,
+    'mount path is workspace-relative': () => evidence.negative_checks['no-absolute-path-mount'].held,
+  });
+
+  if (verdict !== 'PASS-candidate') failures.add(1);
+  logEvidence(evidence);
+}
+
+export function handleSummary(data) {
+  return rowSummary({
+    row: ROW,
+    data,
+    durationMetric: 'r_cd_in_1_duration',
+    summaryFile: 'r-cd-in-1-typed-input-snapshot-summary.json',
+  });
+}

--- a/tools/k6-proofs/scenarios/r-cd-in-1-typed-input-snapshot.js
+++ b/tools/k6-proofs/scenarios/r-cd-in-1-typed-input-snapshot.js
@@ -2,12 +2,17 @@
  * Scenario: R-CD-IN-1 — typed continue_delegate INPUT snapshot + provenance.
  *
  * Proves the typed delegate-input surface assembled at the candidate:
- *   1. A typed `continue_delegate({ attachments: [...] })` call is accepted.
- *   2. The tool result reports a staged input snapshot (count/bytes/digest),
- *      NOT the attachment content.
- *   3. The spawned child observes the snapshot at a workspace-relative mount
- *      path — the provenance leg.
- *   4. Negative: the attachment content never appears on a non-harness frame.
+ *   1. A typed `continue_delegate({ attachments: [...] })` call is accepted and
+ *      a STRUCTURED continue_delegate tool record appears on the wire.
+ *   2. The tool result reports a staged input snapshot (count/bytes), NOT the
+ *      attachment content.
+ *   3. A structured record binds a child session key to this row's nonce.
+ *   4. The child reports the workspace-relative mount path together with the
+ *      byte length and sha256 prefix of the file it was handed, and those must
+ *      equal the canary digest the harness staged. The canary is known only to
+ *      this run, so a matching digest cannot be produced without reading the
+ *      staged bytes at the named path: that is the provenance binding.
+ *   5. Negative: the attachment content never appears on a non-harness frame.
  *
  * Only the typed tool carries attachment blobs; the bracket
  * `[[CONTINUE_DELEGATE: ...]]` form cannot, so this row has no token sibling.
@@ -24,6 +29,7 @@ import { Counter, Trend } from 'k6/metrics';
 import { connectFrame, nonce, RequestTracker } from '../lib/gateway-ws.js';
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
 import { closeSocketAfterDelay } from '../lib/socket-close.js';
+import { childSessionKeysForRow } from '../lib/row-child-correlation.mjs';
 import {
   baseEvidence,
   boolEnv,
@@ -35,9 +41,10 @@ import {
   declareNegative,
   fire,
   logEvidence,
-  matchGroup,
   rowSummary,
   scanRawBytes,
+  sentinel,
+  toolResultRecords,
 } from '../lib/delegate-attachment-io.js';
 
 const ROW = 'R-CD-IN-1';
@@ -64,8 +71,11 @@ const manifest = loadManifestFromEnv();
 
 const REQUIRED = [
   'tool-invoke-accepted',
+  'typed-tool-record-observed',
   'input-snapshot-staged',
+  'child-session-bound',
   'child-mount-provenance',
+  'child-bytes-bound-to-canary',
 ];
 
 export default function () {
@@ -107,6 +117,11 @@ export default function () {
     'no-absolute-path-mount',
     'the child mount path must be workspace-relative, never an absolute host path',
   );
+  declareNegative(
+    evidence,
+    'child-bytes-match-the-known-canary',
+    'the digest/size the child reports for its mounted file must equal the canary the harness staged',
+  );
 
   const started = Date.now();
 
@@ -128,9 +143,11 @@ export default function () {
       socket.setTimeout(() => {
         const instruction =
           `[k6-proof-harness] Call continue_delegate exactly once with ` +
-          `task="Reply exactly: CDIN1-CHILD-SAW ${rowNonce} <mountRelPath> where <mountRelPath> is the ` +
-          `workspace-relative path of the attachment you were handed. Do not print the file contents. ` +
-          `Do not mutate any other file.", ` +
+          `task="Locate the attachment you were handed. Reply exactly: ` +
+          `CDIN1-CHILD-SAW ${rowNonce} <mountRelPath> <byteLength> <sha256First16> where <mountRelPath> is the ` +
+          `workspace-relative path of that file, <byteLength> is its size in bytes, and <sha256First16> is the ` +
+          `first 16 hex characters of its sha256 digest (run: sha256sum <mountRelPath>). ` +
+          `Do not print the file contents. Do not mutate any other file.", ` +
           `mode="normal", delaySeconds=1, ` +
           `attachments=[{name:"p86-in-${rowNonce}.txt", content:"${canary}", encoding:"utf8", mimeType:"text/plain"}]. ` +
           `After the tool result reports the delegate is scheduled, reply exactly ` +
@@ -194,27 +211,58 @@ export default function () {
 
         scanRawBytes(evidence, body, rowNonce, 'no-raw-attachment-bytes-on-the-wire');
 
-        const staged = body.match(
-          new RegExp(`CDIN1-SNAPSHOT-STAGED ${rowNonce} (\\\\d+) (\\\\d+)`),
-        );
+        // Structured authority: a continue_delegate tool record must exist on
+        // the wire. A prose sentinel alone can be produced by a model that
+        // never called the tool.
+        const toolRecords = toolResultRecords(classified.data, 'continue_delegate');
+        if (toolRecords.length > 0) {
+          fire(evidence, 'typed-tool-record-observed');
+          evidence.typed_tool_records = (evidence.typed_tool_records || 0) + toolRecords.length;
+        }
+
+        // Structured child binding: only a record that ties childSessionKey to
+        // this row's nonce is authority for "the delegate child exists".
+        const childKeys = childSessionKeysForRow(classified.data, rowNonce);
+        if (childKeys.length === 1) {
+          fire(evidence, 'child-session-bound');
+          evidence.provenance.child_session_key = childKeys[0];
+        }
+
+        const staged = body.match(sentinel('CDIN1-SNAPSHOT-STAGED', rowNonce, ' ([0-9]+) ([0-9]+)'));
         if (staged) {
           fire(evidence, 'input-snapshot-staged');
           evidence.snapshot_reported = { count: Number(staged[1]), bytes: Number(staged[2]) };
         }
 
-        const mount = matchGroup(body, new RegExp(`CDIN1-CHILD-SAW ${rowNonce} ([^"\\\\s\\\\\\\\]+)`));
-        if (mount) {
+        const saw = body.match(
+          sentinel('CDIN1-CHILD-SAW', rowNonce, ' ([^"\\s\\\\]+) ([0-9]+) ([0-9a-f]{16})'),
+        );
+        if (saw) {
+          const mount = saw[1];
+          const reportedBytes = Number(saw[2]);
+          const reportedDigest = saw[3];
           fire(evidence, 'child-mount-provenance');
           evidence.provenance.mount_rel_path = mount;
+          evidence.child_reported = { bytes: reportedBytes, sha256_prefix: reportedDigest };
           if (mount.startsWith('/') || /^[A-Za-z]:/.test(mount)) {
             breakNegative(evidence, 'no-absolute-path-mount', `mount path is absolute: ${mount}`);
           }
+          // The canary is known to the harness only. A child that reports the
+          // same size AND the same digest necessarily read the staged bytes at
+          // the mount path it named; a hallucinated path cannot produce this.
+          const bytesMatch = reportedBytes === evidence.content_receipt.bytes;
+          const digestMatch = reportedDigest === evidence.content_receipt.sha256_prefix;
+          if (bytesMatch && digestMatch) {
+            fire(evidence, 'child-bytes-bound-to-canary');
+          } else {
+            breakNegative(
+              evidence,
+              'child-bytes-match-the-known-canary',
+              `child reported bytes=${reportedBytes}/digest=${reportedDigest}, harness staged ` +
+                `bytes=${evidence.content_receipt.bytes}/digest=${evidence.content_receipt.sha256_prefix}`,
+            );
+          }
         }
-
-        const childKey = matchGroup(body, /"childSessionKey"\s*:\s*"([^"]+)"/);
-        if (childKey) evidence.provenance.child_session_key = childKey;
-        const flowId = matchGroup(body, /"flowId"\s*:\s*"([^"]+)"/);
-        if (flowId) evidence.provenance.flow_id = flowId;
 
         maybeClose();
       } catch (e) {
@@ -235,11 +283,18 @@ export default function () {
   check(res, { 'websocket connected': (r) => r && r.status === 101 });
   check(null, {
     'typed continue_delegate dispatch accepted': () => !!evidence.receipts['tool-invoke-accepted'],
+    'structured continue_delegate tool record observed': () =>
+      !!evidence.receipts['typed-tool-record-observed'],
     'input snapshot staged receipt observed': () => !!evidence.receipts['input-snapshot-staged'],
+    'child session bound to the row nonce': () => !!evidence.receipts['child-session-bound'],
     'child observed workspace-relative mount': () => !!evidence.receipts['child-mount-provenance'],
+    'child bytes/digest bound to the staged canary': () =>
+      !!evidence.receipts['child-bytes-bound-to-canary'],
     'no raw attachment bytes on the wire': () =>
       evidence.negative_checks['no-raw-attachment-bytes-on-the-wire'].held,
     'mount path is workspace-relative': () => evidence.negative_checks['no-absolute-path-mount'].held,
+    'child bytes match the known canary': () =>
+      evidence.negative_checks['child-bytes-match-the-known-canary'].held,
   });
 
   if (verdict !== 'PASS-candidate') failures.add(1);

--- a/tools/k6-proofs/scenarios/r-cd-in-recovery-queued-restart.js
+++ b/tools/k6-proofs/scenarios/r-cd-in-recovery-queued-restart.js
@@ -12,34 +12,44 @@
  *
  * ORCHESTRATION GATE — read this before reading a verdict:
  *   The gateway restart is an operator step. This harness cannot and must not
- *   restart a seat. When `OPENCLAW_RESTART_ORCHESTRATED=true` is not set, or the
- *   post-lifecycle child arrival is not observed, the row terminates
- *   PARTIAL-candidate with an explicit reason. It never reports PASS on an
- *   unperformed precondition.
+ *   restart a seat, and it must not take the operator's word for it either:
+ *   `OPENCLAW_RESTART_ORCHESTRATED=true` is a DECLARATION, never the evidence.
+ *   The restart is credited only from the gateway's own public `/status`
+ *   surface (uptime going backwards, or the endpoint dropping and returning)
+ *   observed between two SEPARATE WebSocket connections — the row deliberately
+ *   disconnects before the window and reconnects after it, so a real restart
+ *   cannot break the run and a missing restart cannot be papered over.
+ *   Without that receipt the row terminates PARTIAL-candidate with a verbatim
+ *   reason. It never reports PASS on an unperformed precondition.
  *
  * References:
  *   - Issue: karmaterminal/karmaterminal-openclaw-docs#491
  *   - Manifest: tools/k6-proofs/manifests/r-cd-in-recovery.json
  */
 import ws from 'k6/ws';
-import { check } from 'k6';
+import { check, sleep } from 'k6';
 import { Counter, Trend } from 'k6/metrics';
 import { connectFrame, nonce, RequestTracker } from '../lib/gateway-ws.js';
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
 import {
   baseEvidence,
   boolEnv,
+  breakNegative,
   canaryFor,
   capture,
   computeVerdict,
   contentReceipt,
   declareNegative,
   fire,
+  httpBaseFromWs,
   logEvidence,
   matchGroup,
+  observeGatewayRestart,
   orchestrationGate,
   rowSummary,
+  sampleGatewayStatus,
   scanRawBytes,
+  sentinel,
 } from '../lib/delegate-attachment-io.js';
 
 const ROW = 'R-CD-IN-RECOVERY';
@@ -50,11 +60,11 @@ export const options = {
       executor: 'shared-iterations',
       vus: 1,
       iterations: 1,
-      maxDuration: '400s',
+      maxDuration: '540s',
     },
   },
   thresholds: {
-    r_cd_in_recovery_duration: ['p(95)<380000'],
+    r_cd_in_recovery_duration: ['p(95)<520000'],
   },
 };
 
@@ -66,6 +76,8 @@ const manifest = loadManifestFromEnv();
 const REQUIRED = [
   'tool-invoke-accepted',
   'input-snapshot-queued',
+  'gateway-restart-observed',
+  'reconnected-after-restart',
   'post-lifecycle-child-arrival',
   'snapshot-identity-preserved',
 ];
@@ -79,6 +91,7 @@ export default function () {
   const createDisposableSession = boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSION');
   const restartOrchestrated = boolEnv('OPENCLAW_RESTART_ORCHESTRATED');
   const queueDelaySeconds = Number(__ENV.OPENCLAW_QUEUE_DELAY_SECONDS || 120);
+  const restartWindowMs = Number(__ENV.OPENCLAW_RESTART_WINDOW_MS || 120000);
   const rowNonce = nonce(ROW);
   const canary = canaryFor(rowNonce);
 
@@ -103,6 +116,9 @@ export default function () {
   });
   evidence.content_receipt = contentReceipt(canary);
   evidence.queue_delay_seconds = queueDelaySeconds;
+  evidence.restart_window_ms = restartWindowMs;
+  evidence.restart_declared_by_operator = restartOrchestrated;
+  evidence.lifecycle = { baseline: null, observation: null };
   declareNegative(
     evidence,
     'no-raw-attachment-bytes-on-the-wire',
@@ -115,18 +131,24 @@ export default function () {
   );
 
   const started = Date.now();
+  const httpBase = httpBaseFromWs(url);
 
-  const res = ws.connect(url, {}, (socket) => {
+  // --- Phase 0: external lifecycle baseline (before anything is dispatched) ---
+  const baseline = sampleGatewayStatus(httpBase, token);
+  evidence.lifecycle.baseline = { reachable: baseline.reachable, uptime: baseline.uptime };
+
+  // --- Phase 1: dispatch and observe the queued snapshot, then DISCONNECT ---
+  const phase1 = ws.connect(url, {}, (socket) => {
     const tracker = new RequestTracker();
-    let queuedAtMs = null;
 
     function startProofFlow() {
       tracker.send(socket, 'sessions.messages.subscribe', { key: sessionKey });
       socket.setTimeout(() => {
         const instruction =
           `[k6-proof-harness] Call continue_delegate exactly once with ` +
-          `task="Reply exactly: CDINREC-CHILD-ARRIVED ${rowNonce} <bytes> where <bytes> is the byte length ` +
-          `of the attachment you were handed. Do not print the file contents.", ` +
+          `task="Reply exactly: CDINREC-CHILD-ARRIVED ${rowNonce} <bytes> <sha256First16> where <bytes> is the ` +
+          `byte length of the attachment you were handed and <sha256First16> is the first 16 hex characters ` +
+          `of its sha256 digest. Do not print the file contents.", ` +
           `mode="normal", delaySeconds=${queueDelaySeconds}, ` +
           `attachments=[{name:"p86-rec-${rowNonce}.txt", content:"${canary}", encoding:"utf8", mimeType:"text/plain"}]. ` +
           `After the tool result reports the delegate is scheduled, reply exactly ` +
@@ -138,7 +160,7 @@ export default function () {
           idempotencyKey: `${ROW}-DISPATCH-${rowNonce}`,
         });
       }, 500);
-      socket.setTimeout(() => socket.close(), 360000);
+      socket.setTimeout(() => socket.close(), 90000);
     }
 
     socket.on('open', () => {
@@ -183,30 +205,26 @@ export default function () {
 
         scanRawBytes(evidence, body, rowNonce, 'no-raw-attachment-bytes-on-the-wire');
 
-        const queuedBytes = matchGroup(body, new RegExp(`CDINREC-QUEUED ${rowNonce} ([0-9]+)`));
+        const queuedBytes = matchGroup(body, sentinel('CDINREC-QUEUED', rowNonce, ' ([0-9]+)'));
         if (queuedBytes) {
           fire(evidence, 'input-snapshot-queued');
-          queuedAtMs = queuedAtMs || Date.now();
           evidence.queued_snapshot_bytes = Number(queuedBytes);
+          evidence.queued_at_ms = Date.now();
+          // Disconnect deliberately: the row must survive an operator restart
+          // that would otherwise tear this socket down mid-run.
+          socket.close();
         }
 
-        const arrivedBytes = matchGroup(body, new RegExp(`CDINREC-CHILD-ARRIVED ${rowNonce} ([0-9]+)`));
-        if (arrivedBytes) {
-          const elapsedMs = queuedAtMs ? Date.now() - queuedAtMs : null;
-          evidence.child_arrival_elapsed_ms = elapsedMs;
-          if (elapsedMs !== null && elapsedMs < queueDelaySeconds * 1000 * 0.5) {
-            // Arrival far inside the queue window means the row never actually
-            // exercised durable recovery; record it rather than crediting it.
-            evidence.early_arrival = true;
-          }
-          fire(evidence, 'post-lifecycle-child-arrival');
-          evidence.arrived_snapshot_bytes = Number(arrivedBytes);
-          if (
-            evidence.queued_snapshot_bytes !== undefined &&
-            Number(arrivedBytes) === evidence.queued_snapshot_bytes
-          ) {
-            fire(evidence, 'snapshot-identity-preserved');
-          }
+        const early = body.match(sentinel('CDINREC-CHILD-ARRIVED', rowNonce, ' ([0-9]+)'));
+        if (early) {
+          // Arrival before the restart window means durable recovery was never
+          // exercised. Record it; do not credit it.
+          evidence.early_arrival = true;
+          breakNegative(
+            evidence,
+            'no-pre-lifecycle-spawn',
+            'the delayed delegate arrived before the restart window opened',
+          );
           socket.close();
         }
       } catch (e) {
@@ -215,36 +233,136 @@ export default function () {
     });
 
     socket.on('error', (e) => {
-      console.error(`ws error: ${e && e.error ? e.error() : e}`);
+      console.error(`ws error (phase 1): ${e && e.error ? e.error() : e}`);
       failures.add(1);
     });
   });
+
+  // --- Phase 2: externally observable restart window, socket intentionally down ---
+  if (evidence.receipts['input-snapshot-queued']) {
+    console.log(
+      `${ROW}: snapshot queued and harness disconnected. Operator restart window is OPEN for ` +
+        `${restartWindowMs}ms — restart the gateway now to exercise durable input recovery.`,
+    );
+    const observation = observeGatewayRestart({
+      httpBase,
+      token,
+      baseline,
+      windowMs: restartWindowMs,
+      pollMs: Number(__ENV.OPENCLAW_RESTART_POLL_MS || 5000),
+      sleep,
+    });
+    evidence.lifecycle.observation = observation;
+    if (observation.observed) fire(evidence, 'gateway-restart-observed');
+  } else {
+    evidence.lifecycle.observation = {
+      observed: false,
+      reason: 'the queued-snapshot receipt never fired, so the restart window was never opened',
+    };
+  }
+
+  // --- Phase 3: RECONNECT on a fresh socket and wait for the child arrival ---
+  let phase2 = null;
+  if (evidence.receipts['gateway-restart-observed']) {
+    phase2 = ws.connect(url, {}, (socket) => {
+      const tracker = new RequestTracker();
+
+      socket.on('open', () => {
+        fire(evidence, 'reconnected-after-restart');
+        socket.send(connectFrame(token));
+        socket.setTimeout(() => {
+          tracker.send(socket, 'sessions.messages.subscribe', { key: sessionKey });
+        }, 500);
+        socket.setTimeout(() => socket.close(), Math.max(30000, queueDelaySeconds * 1000 + 60000));
+      });
+
+      socket.on('message', (raw) => {
+        try {
+          const msg = JSON.parse(raw);
+          const classified = tracker.classify(msg);
+          const body = capture(evidence, classified);
+          if (classified.kind !== 'event' || !body) return;
+
+          scanRawBytes(evidence, body, rowNonce, 'no-raw-attachment-bytes-on-the-wire');
+
+          const arrived = body.match(
+            sentinel('CDINREC-CHILD-ARRIVED', rowNonce, ' ([0-9]+) ([0-9a-f]{16})'),
+          );
+          if (arrived) {
+            const arrivedBytes = Number(arrived[1]);
+            const arrivedDigest = arrived[2];
+            evidence.child_arrival_elapsed_ms = evidence.queued_at_ms
+              ? Date.now() - evidence.queued_at_ms
+              : null;
+            evidence.arrived_snapshot = { bytes: arrivedBytes, sha256_prefix: arrivedDigest };
+            fire(evidence, 'post-lifecycle-child-arrival');
+            // Identity is preserved only when the bytes the child received
+            // still digest to the canary this run staged BEFORE the restart.
+            if (
+              arrivedBytes === evidence.content_receipt.bytes &&
+              arrivedDigest === evidence.content_receipt.sha256_prefix &&
+              (evidence.queued_snapshot_bytes === undefined ||
+                arrivedBytes === evidence.queued_snapshot_bytes)
+            ) {
+              fire(evidence, 'snapshot-identity-preserved');
+            } else {
+              evidence.identity_mismatch = {
+                staged: evidence.content_receipt,
+                queued_bytes: evidence.queued_snapshot_bytes,
+                arrived: evidence.arrived_snapshot,
+              };
+            }
+            socket.close();
+          }
+        } catch (e) {
+          console.warn(`parse error: ${e}`);
+        }
+      });
+
+      socket.on('error', (e) => {
+        console.error(`ws error (phase 3): ${e && e.error ? e.error() : e}`);
+      });
+    });
+  }
 
   evidence.duration_ms = Date.now() - started;
   duration.add(evidence.duration_ms);
 
   orchestrationGate(
     evidence,
-    restartOrchestrated && !!evidence.receipts['post-lifecycle-child-arrival'] && !evidence.early_arrival,
-    restartOrchestrated
-      ? 'operator restart was declared but no post-lifecycle child arrival outside the queue window was observed'
-      : 'OPENCLAW_RESTART_ORCHESTRATED was not set: no operator gateway restart happened during the queue window, so durable input recovery was not exercised',
+    !!evidence.receipts['gateway-restart-observed'] &&
+      !!evidence.receipts['reconnected-after-restart'] &&
+      !!evidence.receipts['post-lifecycle-child-arrival'] &&
+      !evidence.early_arrival,
+    evidence.receipts['gateway-restart-observed']
+      ? 'a gateway restart was observed but the reconnected socket saw no post-lifecycle child arrival for this row'
+      : `no gateway restart was observable on ${httpBase}/status inside the window` +
+        (restartOrchestrated
+          ? ' even though OPENCLAW_RESTART_ORCHESTRATED was declared: the declaration is not evidence'
+          : '') +
+        `: ${evidence.lifecycle.observation?.reason || 'no lifecycle change detected'}`,
   );
 
   const verdict = computeVerdict(evidence, REQUIRED);
 
-  check(res, { 'websocket connected': (r) => r && r.status === 101 });
+  check(phase1, { 'websocket connected': (r) => r && r.status === 101 });
   check(null, {
     'typed continue_delegate dispatch accepted': () => !!evidence.receipts['tool-invoke-accepted'],
     'input snapshot reported queued': () => !!evidence.receipts['input-snapshot-queued'],
+    'gateway restart observed on the public status surface': () =>
+      !!evidence.receipts['gateway-restart-observed'],
+    'harness reconnected after the restart': () =>
+      !!evidence.receipts['reconnected-after-restart'],
     'no raw attachment bytes on the wire': () =>
       evidence.negative_checks['no-raw-attachment-bytes-on-the-wire'].held,
+    'no pre-lifecycle spawn': () => evidence.negative_checks['no-pre-lifecycle-spawn'].held,
   });
+  if (phase2) check(phase2, { 'reconnect websocket connected': (r) => r && r.status === 101 });
 
   logEvidence(evidence);
   if (verdict !== 'PASS-candidate') {
     console.log(
-      `[${ROW}] PARTIAL is the honest outcome here unless an operator restart was orchestrated: ` +
+      `[${ROW}] PARTIAL is the honest outcome here unless an operator restart was observed: ` +
         `${evidence.orchestration.reason || 'see missing_receipts'}`,
     );
   }

--- a/tools/k6-proofs/scenarios/r-cd-in-recovery-queued-restart.js
+++ b/tools/k6-proofs/scenarios/r-cd-in-recovery-queued-restart.js
@@ -1,0 +1,260 @@
+/**
+ * Scenario: R-CD-IN-RECOVERY — queued/restart delegate INPUT recovery.
+ *
+ * Proves that a typed `continue_delegate` input snapshot which is still QUEUED
+ * (delayed beyond the observation window, or staged post-compaction) survives a
+ * gateway lifecycle event and is handed to the child from durable state — the
+ * same snapshot identity, not a re-read of live workspace files.
+ *
+ * Durable surface under test:
+ *   src/auto-reply/continuation/delegate-flow-store.ts
+ *     (persisted attachment state + hasStoredDelegateAttachmentState)
+ *
+ * ORCHESTRATION GATE — read this before reading a verdict:
+ *   The gateway restart is an operator step. This harness cannot and must not
+ *   restart a seat. When `OPENCLAW_RESTART_ORCHESTRATED=true` is not set, or the
+ *   post-lifecycle child arrival is not observed, the row terminates
+ *   PARTIAL-candidate with an explicit reason. It never reports PASS on an
+ *   unperformed precondition.
+ *
+ * References:
+ *   - Issue: karmaterminal/karmaterminal-openclaw-docs#491
+ *   - Manifest: tools/k6-proofs/manifests/r-cd-in-recovery.json
+ */
+import ws from 'k6/ws';
+import { check } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+import { connectFrame, nonce, RequestTracker } from '../lib/gateway-ws.js';
+import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+import {
+  baseEvidence,
+  boolEnv,
+  canaryFor,
+  capture,
+  computeVerdict,
+  contentReceipt,
+  declareNegative,
+  fire,
+  logEvidence,
+  matchGroup,
+  orchestrationGate,
+  rowSummary,
+  scanRawBytes,
+} from '../lib/delegate-attachment-io.js';
+
+const ROW = 'R-CD-IN-RECOVERY';
+
+export const options = {
+  scenarios: {
+    r_cd_in_recovery: {
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 1,
+      maxDuration: '400s',
+    },
+  },
+  thresholds: {
+    r_cd_in_recovery_duration: ['p(95)<380000'],
+  },
+};
+
+const failures = new Counter('proof_failures');
+const duration = new Trend('r_cd_in_recovery_duration');
+
+const manifest = loadManifestFromEnv();
+
+const REQUIRED = [
+  'tool-invoke-accepted',
+  'input-snapshot-queued',
+  'post-lifecycle-child-arrival',
+  'snapshot-identity-preserved',
+];
+
+export default function () {
+  const url = __ENV.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
+  const token = __ENV.OPENCLAW_GATEWAY_TOKEN;
+  const requestedSessionKey = manifest?.sessionKey || __ENV.OPENCLAW_SESSION_KEY || 'main';
+  let sessionKey = requestedSessionKey;
+  const seat = manifest?.seat || __ENV.OPENCLAW_SEAT_NAME || 'rune-rog-ally';
+  const createDisposableSession = boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSION');
+  const restartOrchestrated = boolEnv('OPENCLAW_RESTART_ORCHESTRATED');
+  const queueDelaySeconds = Number(__ENV.OPENCLAW_QUEUE_DELAY_SECONDS || 120);
+  const rowNonce = nonce(ROW);
+  const canary = canaryFor(rowNonce);
+
+  if (!token) {
+    console.error('OPENCLAW_GATEWAY_TOKEN is required');
+    failures.add(1);
+    return;
+  }
+  if (manifest) {
+    const errors = validateManifest(manifest);
+    if (errors.length > 0) console.warn(`Manifest validation warnings: ${errors.join('; ')}`);
+  }
+
+  const evidence = baseEvidence({
+    row: ROW,
+    nonce: rowNonce,
+    seat,
+    requestedSessionKey,
+    sessionKey,
+    manifest,
+    orchestrationRequired: 'operator gateway restart while the delegate input snapshot is queued',
+  });
+  evidence.content_receipt = contentReceipt(canary);
+  evidence.queue_delay_seconds = queueDelaySeconds;
+  declareNegative(
+    evidence,
+    'no-raw-attachment-bytes-on-the-wire',
+    'queued attachment content must never appear on a non-harness gateway frame',
+  );
+  declareNegative(
+    evidence,
+    'no-pre-lifecycle-spawn',
+    'the delayed delegate must not spawn before its queue window elapses',
+  );
+
+  const started = Date.now();
+
+  const res = ws.connect(url, {}, (socket) => {
+    const tracker = new RequestTracker();
+    let queuedAtMs = null;
+
+    function startProofFlow() {
+      tracker.send(socket, 'sessions.messages.subscribe', { key: sessionKey });
+      socket.setTimeout(() => {
+        const instruction =
+          `[k6-proof-harness] Call continue_delegate exactly once with ` +
+          `task="Reply exactly: CDINREC-CHILD-ARRIVED ${rowNonce} <bytes> where <bytes> is the byte length ` +
+          `of the attachment you were handed. Do not print the file contents.", ` +
+          `mode="normal", delaySeconds=${queueDelaySeconds}, ` +
+          `attachments=[{name:"p86-rec-${rowNonce}.txt", content:"${canary}", encoding:"utf8", mimeType:"text/plain"}]. ` +
+          `After the tool result reports the delegate is scheduled, reply exactly ` +
+          `CDINREC-QUEUED ${rowNonce} <bytes> — <bytes> from the tool result snapshot receipt. ` +
+          `Never echo the attachment content. This is a proof run — no other action needed.`;
+        tracker.send(socket, 'sessions.send', {
+          key: sessionKey,
+          message: instruction,
+          idempotencyKey: `${ROW}-DISPATCH-${rowNonce}`,
+        });
+      }, 500);
+      socket.setTimeout(() => socket.close(), 360000);
+    }
+
+    socket.on('open', () => {
+      socket.send(connectFrame(token));
+      if (createDisposableSession) {
+        socket.setTimeout(() => {
+          const disposableKey = `r-cd-in-recovery-${rowNonce}`.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+          tracker.send(socket, 'sessions.create', { key: disposableKey, label: `k6 ${ROW}` });
+        }, 250);
+      } else {
+        socket.setTimeout(startProofFlow, 500);
+      }
+    });
+
+    socket.on('message', (raw) => {
+      try {
+        const msg = JSON.parse(raw);
+        const classified = tracker.classify(msg);
+        const body = capture(evidence, classified);
+
+        if (classified.kind === 'response' && classified.method === 'sessions.create') {
+          if (classified.ok && classified.payload) {
+            sessionKey = classified.payload.key || sessionKey;
+            evidence.sessionKey = sessionKey;
+            evidence.session_created = true;
+            evidence.created_session_key = sessionKey;
+            startProofFlow();
+          } else {
+            failures.add(1);
+            socket.close();
+          }
+          return;
+        }
+
+        if (classified.kind === 'response' && classified.method === 'sessions.send') {
+          if (classified.ok) fire(evidence, 'tool-invoke-accepted');
+          else failures.add(1);
+          return;
+        }
+
+        if (classified.kind !== 'event' || !body) return;
+
+        scanRawBytes(evidence, body, rowNonce, 'no-raw-attachment-bytes-on-the-wire');
+
+        const queuedBytes = matchGroup(body, new RegExp(`CDINREC-QUEUED ${rowNonce} ([0-9]+)`));
+        if (queuedBytes) {
+          fire(evidence, 'input-snapshot-queued');
+          queuedAtMs = queuedAtMs || Date.now();
+          evidence.queued_snapshot_bytes = Number(queuedBytes);
+        }
+
+        const arrivedBytes = matchGroup(body, new RegExp(`CDINREC-CHILD-ARRIVED ${rowNonce} ([0-9]+)`));
+        if (arrivedBytes) {
+          const elapsedMs = queuedAtMs ? Date.now() - queuedAtMs : null;
+          evidence.child_arrival_elapsed_ms = elapsedMs;
+          if (elapsedMs !== null && elapsedMs < queueDelaySeconds * 1000 * 0.5) {
+            // Arrival far inside the queue window means the row never actually
+            // exercised durable recovery; record it rather than crediting it.
+            evidence.early_arrival = true;
+          }
+          fire(evidence, 'post-lifecycle-child-arrival');
+          evidence.arrived_snapshot_bytes = Number(arrivedBytes);
+          if (
+            evidence.queued_snapshot_bytes !== undefined &&
+            Number(arrivedBytes) === evidence.queued_snapshot_bytes
+          ) {
+            fire(evidence, 'snapshot-identity-preserved');
+          }
+          socket.close();
+        }
+      } catch (e) {
+        console.warn(`parse error: ${e}`);
+      }
+    });
+
+    socket.on('error', (e) => {
+      console.error(`ws error: ${e && e.error ? e.error() : e}`);
+      failures.add(1);
+    });
+  });
+
+  evidence.duration_ms = Date.now() - started;
+  duration.add(evidence.duration_ms);
+
+  orchestrationGate(
+    evidence,
+    restartOrchestrated && !!evidence.receipts['post-lifecycle-child-arrival'] && !evidence.early_arrival,
+    restartOrchestrated
+      ? 'operator restart was declared but no post-lifecycle child arrival outside the queue window was observed'
+      : 'OPENCLAW_RESTART_ORCHESTRATED was not set: no operator gateway restart happened during the queue window, so durable input recovery was not exercised',
+  );
+
+  const verdict = computeVerdict(evidence, REQUIRED);
+
+  check(res, { 'websocket connected': (r) => r && r.status === 101 });
+  check(null, {
+    'typed continue_delegate dispatch accepted': () => !!evidence.receipts['tool-invoke-accepted'],
+    'input snapshot reported queued': () => !!evidence.receipts['input-snapshot-queued'],
+    'no raw attachment bytes on the wire': () =>
+      evidence.negative_checks['no-raw-attachment-bytes-on-the-wire'].held,
+  });
+
+  logEvidence(evidence);
+  if (verdict !== 'PASS-candidate') {
+    console.log(
+      `[${ROW}] PARTIAL is the honest outcome here unless an operator restart was orchestrated: ` +
+        `${evidence.orchestration.reason || 'see missing_receipts'}`,
+    );
+  }
+}
+
+export function handleSummary(data) {
+  return rowSummary({
+    row: ROW,
+    data,
+    durationMetric: 'r_cd_in_recovery_duration',
+    summaryFile: 'r-cd-in-recovery-queued-restart-summary.json',
+  });
+}

--- a/tools/k6-proofs/scenarios/r-cd-in-revoke-no-spawn-scrub.js
+++ b/tools/k6-proofs/scenarios/r-cd-in-revoke-no-spawn-scrub.js
@@ -1,0 +1,272 @@
+/**
+ * Scenario: R-CD-IN-REVOKE — policy revoke terminalizes with no spawn and scrubs.
+ *
+ * Proves that when the delegate-input attachment policy is revoked
+ * (`tools.sessions_spawn.attachments.enabled = false`), a typed
+ * `continue_delegate({ attachments: [...] })`:
+ *   1. is refused at the tool boundary with a policy reason,
+ *   2. spawns NO child, and
+ *   3. leaves no attachment state behind — the durable snapshot is scrubbed.
+ *
+ * Runtime surface: src/agents/tools/continue-delegate-tool.ts (policy refusal),
+ * src/auto-reply/continuation/delegate-flow-store.ts
+ * (`scrubStoredDelegateAttachmentState`).
+ *
+ * ORCHESTRATION GATE — read this before reading a verdict:
+ *   The gateway exposes `config.get` but no `config.set`. Flipping the policy to
+ *   revoked is an operator step this harness must not perform. The scenario
+ *   reads `config.get` to establish the live precondition:
+ *     - policy already revoked  -> the behavioral legs are asserted for real.
+ *     - policy still enabled    -> PARTIAL-candidate with an explicit reason.
+ *   It never reports PASS against a precondition that was not in place.
+ *
+ * References:
+ *   - Issue: karmaterminal/karmaterminal-openclaw-docs#491
+ *   - Manifest: tools/k6-proofs/manifests/r-cd-in-revoke.json
+ */
+import ws from 'k6/ws';
+import { check } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+import { connectFrame, nonce, RequestTracker } from '../lib/gateway-ws.js';
+import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+import {
+  baseEvidence,
+  boolEnv,
+  breakNegative,
+  canaryFor,
+  capture,
+  computeVerdict,
+  contentReceipt,
+  declareNegative,
+  fire,
+  logEvidence,
+  orchestrationGate,
+  rowSummary,
+  scanRawBytes,
+} from '../lib/delegate-attachment-io.js';
+
+const ROW = 'R-CD-IN-REVOKE';
+
+export const options = {
+  scenarios: {
+    r_cd_in_revoke: {
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 1,
+      maxDuration: '200s',
+    },
+  },
+  thresholds: {
+    r_cd_in_revoke_duration: ['p(95)<180000'],
+  },
+};
+
+const failures = new Counter('proof_failures');
+const duration = new Trend('r_cd_in_revoke_duration');
+
+const manifest = loadManifestFromEnv();
+
+const REQUIRED = [
+  'operator-policy-snapshot',
+  'tool-invoke-accepted',
+  'policy-revoke-refusal',
+  'scrub-confirmed',
+];
+
+/**
+ * Read the delegate-input attachment policy out of a config.get payload.
+ * Returns true/false when the policy is explicitly present, null when the
+ * surface did not carry it (which is a PARTIAL, not an assumed default).
+ */
+export function readAttachmentPolicy(configPayload) {
+  const spawn = configPayload?.config?.tools?.sessions_spawn ?? configPayload?.tools?.sessions_spawn;
+  const enabled = spawn?.attachments?.enabled;
+  return typeof enabled === 'boolean' ? enabled : null;
+}
+
+export default function () {
+  const url = __ENV.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
+  const token = __ENV.OPENCLAW_GATEWAY_TOKEN;
+  const requestedSessionKey = manifest?.sessionKey || __ENV.OPENCLAW_SESSION_KEY || 'main';
+  let sessionKey = requestedSessionKey;
+  const seat = manifest?.seat || __ENV.OPENCLAW_SEAT_NAME || 'rune-rog-ally';
+  const createDisposableSession = boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSION');
+  const rowNonce = nonce(ROW);
+  const canary = canaryFor(rowNonce);
+
+  if (!token) {
+    console.error('OPENCLAW_GATEWAY_TOKEN is required');
+    failures.add(1);
+    return;
+  }
+  if (manifest) {
+    const errors = validateManifest(manifest);
+    if (errors.length > 0) console.warn(`Manifest validation warnings: ${errors.join('; ')}`);
+  }
+
+  const evidence = baseEvidence({
+    row: ROW,
+    nonce: rowNonce,
+    seat,
+    requestedSessionKey,
+    sessionKey,
+    manifest,
+    orchestrationRequired:
+      'operator config revoke of tools.sessions_spawn.attachments.enabled before the row fires',
+  });
+  evidence.content_receipt = contentReceipt(canary);
+  // Operator read-only surface row: config.get establishes the precondition.
+  Object.assign(evidence, { operator_surface: true });
+  evidence.attachment_policy_enabled = null;
+  declareNegative(
+    evidence,
+    'no-child-spawn-under-revoke',
+    'a revoked delegate-input policy must spawn no child session',
+  );
+  declareNegative(
+    evidence,
+    'no-raw-attachment-bytes-on-the-wire',
+    'refused attachment content must never appear on a non-harness gateway frame',
+  );
+
+  const started = Date.now();
+
+  const res = ws.connect(url, {}, (socket) => {
+    const tracker = new RequestTracker();
+
+    function dispatchRevokeProbe() {
+      tracker.send(socket, 'sessions.messages.subscribe', { key: sessionKey });
+      socket.setTimeout(() => {
+        const instruction =
+          `[k6-proof-harness] Call continue_delegate exactly once with ` +
+          `task="CDINREV probe ${rowNonce} — do nothing.", mode="normal", delaySeconds=1, ` +
+          `attachments=[{name:"p86-rev-${rowNonce}.txt", content:"${canary}", encoding:"utf8", mimeType:"text/plain"}]. ` +
+          `If the tool refuses, reply exactly CDINREV-REFUSED ${rowNonce} <reasonWord> using a single ` +
+          `word from the refusal reason, then reply exactly CDINREV-NO-STATE ${rowNonce} if a follow-up ` +
+          `continue_delegate with no attachments reports no retained attachment state. ` +
+          `If the tool succeeds instead, reply exactly CDINREV-ACCEPTED ${rowNonce}. ` +
+          `Never echo the attachment content. This is a proof run — no other action needed.`;
+        tracker.send(socket, 'sessions.send', {
+          key: sessionKey,
+          message: instruction,
+          idempotencyKey: `${ROW}-DISPATCH-${rowNonce}`,
+        });
+      }, 500);
+      socket.setTimeout(() => socket.close(), 170000);
+    }
+
+    socket.on('open', () => {
+      socket.send(connectFrame(token));
+      // Operator read-only surface first: establish the live policy precondition.
+      socket.setTimeout(() => tracker.send(socket, 'config.get', {}), 250);
+    });
+
+    socket.on('message', (raw) => {
+      try {
+        const msg = JSON.parse(raw);
+        const classified = tracker.classify(msg);
+        const body = capture(evidence, classified);
+
+        if (classified.kind === 'response' && classified.method === 'config.get') {
+          if (classified.ok) {
+            fire(evidence, 'operator-policy-snapshot');
+            evidence.attachment_policy_enabled = readAttachmentPolicy(classified.payload);
+          } else {
+            failures.add(1);
+          }
+          if (createDisposableSession) {
+            const disposableKey = `r-cd-in-revoke-${rowNonce}`.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+            tracker.send(socket, 'sessions.create', { key: disposableKey, label: `k6 ${ROW}` });
+          } else {
+            dispatchRevokeProbe();
+          }
+          return;
+        }
+
+        if (classified.kind === 'response' && classified.method === 'sessions.create') {
+          if (classified.ok && classified.payload) {
+            sessionKey = classified.payload.key || sessionKey;
+            evidence.sessionKey = sessionKey;
+            evidence.session_created = true;
+            evidence.created_session_key = sessionKey;
+            dispatchRevokeProbe();
+          } else {
+            failures.add(1);
+            socket.close();
+          }
+          return;
+        }
+
+        if (classified.kind === 'response' && classified.method === 'sessions.send') {
+          if (classified.ok) fire(evidence, 'tool-invoke-accepted');
+          else failures.add(1);
+          return;
+        }
+
+        if (classified.kind !== 'event' || !body) return;
+
+        scanRawBytes(evidence, body, rowNonce, 'no-raw-attachment-bytes-on-the-wire');
+
+        if (body.includes(`CDINREV-REFUSED ${rowNonce}`)) {
+          fire(evidence, 'policy-revoke-refusal');
+        }
+        if (body.includes(`CDINREV-NO-STATE ${rowNonce}`)) {
+          fire(evidence, 'scrub-confirmed');
+          socket.close();
+        }
+        if (body.includes(`CDINREV-ACCEPTED ${rowNonce}`)) {
+          evidence.attachment_delegate_accepted = true;
+          breakNegative(
+            evidence,
+            'no-child-spawn-under-revoke',
+            'delegate with attachments was accepted — the revoke precondition was not in place',
+          );
+          socket.close();
+        }
+      } catch (e) {
+        console.warn(`parse error: ${e}`);
+      }
+    });
+
+    socket.on('error', (e) => {
+      console.error(`ws error: ${e && e.error ? e.error() : e}`);
+      failures.add(1);
+    });
+  });
+
+  evidence.duration_ms = Date.now() - started;
+  duration.add(evidence.duration_ms);
+
+  orchestrationGate(
+    evidence,
+    evidence.attachment_policy_enabled === false,
+    evidence.attachment_policy_enabled === null
+      ? 'config.get did not expose tools.sessions_spawn.attachments.enabled, so the revoke precondition could not be established'
+      : 'tools.sessions_spawn.attachments.enabled is still true: no operator revoke was applied, so no-spawn/scrub was not exercised',
+  );
+
+  const verdict = computeVerdict(evidence, REQUIRED);
+
+  check(res, { 'websocket connected': (r) => r && r.status === 101 });
+  check(null, {
+    'operator policy snapshot captured': () => !!evidence.receipts['operator-policy-snapshot'],
+    'no child spawned under revoke': () =>
+      evidence.negative_checks['no-child-spawn-under-revoke'].held,
+    'no raw attachment bytes on the wire': () =>
+      evidence.negative_checks['no-raw-attachment-bytes-on-the-wire'].held,
+  });
+
+  logEvidence(evidence);
+  if (verdict !== 'PASS-candidate') {
+    console.log(`[${ROW}] ${evidence.orchestration.reason || 'see missing_receipts'}`);
+  }
+}
+
+export function handleSummary(data) {
+  return rowSummary({
+    row: ROW,
+    data,
+    durationMetric: 'r_cd_in_revoke_duration',
+    summaryFile: 'r-cd-in-revoke-no-spawn-scrub-summary.json',
+  });
+}

--- a/tools/k6-proofs/scenarios/r-cd-in-revoke-no-spawn-scrub.js
+++ b/tools/k6-proofs/scenarios/r-cd-in-revoke-no-spawn-scrub.js
@@ -4,9 +4,15 @@
  * Proves that when the delegate-input attachment policy is revoked
  * (`tools.sessions_spawn.attachments.enabled = false`), a typed
  * `continue_delegate({ attachments: [...] })`:
- *   1. is refused at the tool boundary with a policy reason,
- *   2. spawns NO child, and
- *   3. leaves no attachment state behind — the durable snapshot is scrubbed.
+ *   1. is refused at the tool boundary — credited from a STRUCTURED
+ *      continue_delegate tool record carrying an error/refusal, never from
+ *      model prose alone,
+ *   2. spawns NO child — credited from a gateway `sessions.list` inventory
+ *      taken before and after the probe, so "no child" is an observation and
+ *      not a default-true absence, and
+ *   3. leaves no attachment state behind — credited only when the follow-up
+ *      continue_delegate record is observed on the wire and no observed record
+ *      still carries delegate attachment state.
  *
  * Runtime surface: src/agents/tools/continue-delegate-tool.ts (policy refusal),
  * src/auto-reply/continuation/delegate-flow-store.ts
@@ -29,6 +35,7 @@ import { check } from 'k6';
 import { Counter, Trend } from 'k6/metrics';
 import { connectFrame, nonce, RequestTracker } from '../lib/gateway-ws.js';
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+import { childSessionKeysForRow } from '../lib/row-child-correlation.mjs';
 import {
   baseEvidence,
   boolEnv,
@@ -41,8 +48,12 @@ import {
   fire,
   logEvidence,
   orchestrationGate,
+  recordCarriesAttachmentState,
   rowSummary,
   scanRawBytes,
+  sessionKeysFromList,
+  toolRecordRejected,
+  toolResultRecords,
 } from '../lib/delegate-attachment-io.js';
 
 const ROW = 'R-CD-IN-REVOKE';
@@ -69,8 +80,10 @@ const manifest = loadManifestFromEnv();
 const REQUIRED = [
   'operator-policy-snapshot',
   'tool-invoke-accepted',
-  'policy-revoke-refusal',
-  'scrub-confirmed',
+  'pre-probe-session-inventory',
+  'policy-revoke-tool-refusal',
+  'no-child-session-observed',
+  'durable-state-scrubbed',
 ];
 
 /**
@@ -118,10 +131,17 @@ export default function () {
   // Operator read-only surface row: config.get establishes the precondition.
   Object.assign(evidence, { operator_surface: true });
   evidence.attachment_policy_enabled = null;
+  evidence.session_inventory = { pre: null, post: null, added: [] };
+  evidence.continue_delegate_records = { total: 0, rejected: 0, carrying_attachment_state: 0 };
   declareNegative(
     evidence,
     'no-child-spawn-under-revoke',
     'a revoked delegate-input policy must spawn no child session',
+  );
+  declareNegative(
+    evidence,
+    'no-retained-attachment-state',
+    'no continue_delegate record may still carry delegate attachment state after the refusal',
   );
   declareNegative(
     evidence,
@@ -133,6 +153,15 @@ export default function () {
 
   const res = ws.connect(url, {}, (socket) => {
     const tracker = new RequestTracker();
+    let postInventoryRequested = false;
+
+    function requestPostInventory() {
+      if (postInventoryRequested) return;
+      postInventoryRequested = true;
+      // Give the runtime a moment to have spawned anything it was going to
+      // spawn, then take the authoritative post-probe session inventory.
+      socket.setTimeout(() => tracker.send(socket, 'sessions.list', { limit: 200 }), 5000);
+    }
 
     function dispatchRevokeProbe() {
       tracker.send(socket, 'sessions.messages.subscribe', { key: sessionKey });
@@ -142,9 +171,10 @@ export default function () {
           `task="CDINREV probe ${rowNonce} — do nothing.", mode="normal", delaySeconds=1, ` +
           `attachments=[{name:"p86-rev-${rowNonce}.txt", content:"${canary}", encoding:"utf8", mimeType:"text/plain"}]. ` +
           `If the tool refuses, reply exactly CDINREV-REFUSED ${rowNonce} <reasonWord> using a single ` +
-          `word from the refusal reason, then reply exactly CDINREV-NO-STATE ${rowNonce} if a follow-up ` +
-          `continue_delegate with no attachments reports no retained attachment state. ` +
-          `If the tool succeeds instead, reply exactly CDINREV-ACCEPTED ${rowNonce}. ` +
+          `word from the refusal reason, then call continue_delegate a second time with ` +
+          `task="CDINREV followup ${rowNonce} — do nothing." and no attachments, and reply exactly ` +
+          `CDINREV-NO-STATE ${rowNonce} if that second tool result reports no retained attachment state. ` +
+          `If the first tool call succeeds instead, reply exactly CDINREV-ACCEPTED ${rowNonce}. ` +
           `Never echo the attachment content. This is a proof run — no other action needed.`;
         tracker.send(socket, 'sessions.send', {
           key: sessionKey,
@@ -174,12 +204,47 @@ export default function () {
           } else {
             failures.add(1);
           }
-          if (createDisposableSession) {
-            const disposableKey = `r-cd-in-revoke-${rowNonce}`.toLowerCase().replace(/[^a-z0-9-]/g, '-');
-            tracker.send(socket, 'sessions.create', { key: disposableKey, label: `k6 ${ROW}` });
-          } else {
-            dispatchRevokeProbe();
+          // Authoritative pre-probe session inventory before anything is sent.
+          tracker.send(socket, 'sessions.list', { limit: 200 });
+          return;
+        }
+
+        if (classified.kind === 'response' && classified.method === 'sessions.list') {
+          if (!classified.ok) {
+            failures.add(1);
+            return;
           }
+          const keys = sessionKeysFromList(classified.payload);
+          if (evidence.session_inventory.pre === null) {
+            evidence.session_inventory.pre = keys;
+            fire(evidence, 'pre-probe-session-inventory');
+            if (createDisposableSession) {
+              const disposableKey = `r-cd-in-revoke-${rowNonce}`.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+              tracker.send(socket, 'sessions.create', { key: disposableKey, label: `k6 ${ROW}` });
+            } else {
+              dispatchRevokeProbe();
+            }
+            return;
+          }
+          evidence.session_inventory.post = keys;
+          const known = evidence.session_inventory.pre.concat(
+            evidence.created_session_key ? [evidence.created_session_key] : [],
+          );
+          const added = keys.filter((key) => known.indexOf(key) === -1);
+          evidence.session_inventory.added = added;
+          const nonceBound = keys.filter((key) => key.indexOf(rowNonce) !== -1);
+          if (added.length > 0 || nonceBound.length > 0) {
+            breakNegative(
+              evidence,
+              'no-child-spawn-under-revoke',
+              `sessions.list grew by ${added.length} session(s) after the refused probe: ${added.join(', ')}`,
+            );
+          } else {
+            // Positive evidence, not an assumed default: the gateway's own
+            // session inventory was read after the probe and shows no child.
+            fire(evidence, 'no-child-session-observed');
+          }
+          socket.close();
           return;
         }
 
@@ -207,21 +272,64 @@ export default function () {
 
         scanRawBytes(evidence, body, rowNonce, 'no-raw-attachment-bytes-on-the-wire');
 
-        if (body.includes(`CDINREV-REFUSED ${rowNonce}`)) {
-          fire(evidence, 'policy-revoke-refusal');
+        // Authoritative refusal: a structured continue_delegate tool record
+        // that carries an error/refusal. Model prose is corroboration only.
+        const toolRecords = toolResultRecords(classified.data, 'continue_delegate');
+        for (const record of toolRecords) {
+          evidence.continue_delegate_records.total += 1;
+          if (toolRecordRejected(record)) {
+            evidence.continue_delegate_records.rejected += 1;
+            fire(evidence, 'policy-revoke-tool-refusal');
+          }
+          if (recordCarriesAttachmentState(record)) {
+            evidence.continue_delegate_records.carrying_attachment_state += 1;
+            breakNegative(
+              evidence,
+              'no-retained-attachment-state',
+              'a continue_delegate record still carried delegate attachment state after the refusal',
+            );
+          }
         }
-        if (body.includes(`CDINREV-NO-STATE ${rowNonce}`)) {
-          fire(evidence, 'scrub-confirmed');
-          socket.close();
+
+        // A child bound to this row's nonce is a spawn, whatever the prose says.
+        const childKeys = childSessionKeysForRow(classified.data, rowNonce);
+        if (childKeys.length > 0) {
+          breakNegative(
+            evidence,
+            'no-child-spawn-under-revoke',
+            `a child session was bound to this row despite the refusal: ${childKeys.join(', ')}`,
+          );
         }
-        if (body.includes(`CDINREV-ACCEPTED ${rowNonce}`)) {
+
+        if (body.indexOf(`CDINREV-REFUSED ${rowNonce}`) !== -1) {
+          evidence.refusal_prose_observed = true;
+          requestPostInventory();
+        }
+        if (body.indexOf(`CDINREV-NO-STATE ${rowNonce}`) !== -1) {
+          evidence.scrub_prose_observed = true;
+          // The receipt requires the follow-up tool record too: a second
+          // continue_delegate record must have been observed and none of the
+          // records may still carry attachment state.
+          if (
+            evidence.continue_delegate_records.total >= 2 &&
+            evidence.continue_delegate_records.carrying_attachment_state === 0
+          ) {
+            fire(evidence, 'durable-state-scrubbed');
+          } else {
+            evidence.scrub_unbound_reason =
+              'the follow-up continue_delegate tool record was not observed on the wire, so the ' +
+              'scrubbed durable state is asserted only in model prose and is not receipt-bound';
+          }
+          requestPostInventory();
+        }
+        if (body.indexOf(`CDINREV-ACCEPTED ${rowNonce}`) !== -1) {
           evidence.attachment_delegate_accepted = true;
           breakNegative(
             evidence,
             'no-child-spawn-under-revoke',
             'delegate with attachments was accepted — the revoke precondition was not in place',
           );
-          socket.close();
+          requestPostInventory();
         }
       } catch (e) {
         console.warn(`parse error: ${e}`);
@@ -250,8 +358,16 @@ export default function () {
   check(res, { 'websocket connected': (r) => r && r.status === 101 });
   check(null, {
     'operator policy snapshot captured': () => !!evidence.receipts['operator-policy-snapshot'],
+    'pre-probe session inventory captured': () =>
+      !!evidence.receipts['pre-probe-session-inventory'],
+    'refusal came from a structured continue_delegate record': () =>
+      !!evidence.receipts['policy-revoke-tool-refusal'],
+    'post-probe session inventory shows no child': () =>
+      !!evidence.receipts['no-child-session-observed'],
     'no child spawned under revoke': () =>
       evidence.negative_checks['no-child-spawn-under-revoke'].held,
+    'no retained attachment state': () =>
+      evidence.negative_checks['no-retained-attachment-state'].held,
     'no raw attachment bytes on the wire': () =>
       evidence.negative_checks['no-raw-attachment-bytes-on-the-wire'].held,
   });

--- a/tools/k6-proofs/scenarios/r-cd-io-negative-boundary.js
+++ b/tools/k6-proofs/scenarios/r-cd-io-negative-boundary.js
@@ -1,0 +1,278 @@
+/**
+ * Scenario: R-CD-IO-NEG — negative boundary for delegate attachment I/O.
+ *
+ * This row exists to prove the things that must NOT happen. It is the guard on
+ * the #491 non-goals: a managed delegate artifact is a CLAIM, not a delivery.
+ *
+ * Positive control (so the negatives are not vacuous):
+ *   - a claim IS published and IS announced to its recipient session.
+ *
+ * Negative boundary, asserted over a bounded observation window after the
+ * announcement, with NO explicit recipient action taken:
+ *   1. no automatic raw-byte mount — artifact content never crosses the wire
+ *   2. no automatic materialization into the recipient workspace
+ *   3. no Discord / native-media upload or channel attachment delivery
+ *   4. no generic render / forward of the artifact into the reply text
+ *   5. no prompt injection — the announcement is an explicit-action notice, not
+ *      an instruction the recipient is made to obey
+ *
+ * Runtime surface: src/agents/internal-events.ts (the explicit-action footer),
+ * src/agents/tools/delegate-artifacts-tool.ts (materialize is caller-driven).
+ *
+ * References:
+ *   - Issue: karmaterminal/karmaterminal-openclaw-docs#491
+ *   - Manifest: tools/k6-proofs/manifests/r-cd-io-neg.json
+ */
+import ws from 'k6/ws';
+import { check } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+import { connectFrame, nonce, RequestTracker } from '../lib/gateway-ws.js';
+import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+import { closeSocketAfterDelay } from '../lib/socket-close.js';
+import {
+  baseEvidence,
+  boolEnv,
+  breakNegative,
+  canaryFor,
+  capture,
+  computeVerdict,
+  contentReceipt,
+  declareNegative,
+  fire,
+  logEvidence,
+  matchGroup,
+  rowSummary,
+  scanRawBytes,
+} from '../lib/delegate-attachment-io.js';
+
+const ROW = 'R-CD-IO-NEG';
+
+export const options = {
+  scenarios: {
+    r_cd_io_neg: {
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 1,
+      maxDuration: '300s',
+    },
+  },
+  thresholds: {
+    proof_failures: ['count==0'],
+    r_cd_io_neg_duration: ['p(95)<280000'],
+  },
+};
+
+const failures = new Counter('proof_failures');
+const duration = new Trend('r_cd_io_neg_duration');
+
+const manifest = loadManifestFromEnv();
+
+const REQUIRED = ['tool-invoke-accepted', 'claim-announced-positive-control', 'negative-window-elapsed'];
+
+/** Event names/fields that would indicate a native-media or channel upload. */
+const MEDIA_DELIVERY_SIGNALS = [
+  '"attachments":[{',
+  '"mediaUrl"',
+  '"discordAttachment"',
+  '"upload"',
+  '"nativeMedia"',
+];
+
+export default function () {
+  const url = __ENV.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
+  const token = __ENV.OPENCLAW_GATEWAY_TOKEN;
+  const requestedSessionKey = manifest?.sessionKey || __ENV.OPENCLAW_SESSION_KEY || 'main';
+  let sessionKey = requestedSessionKey;
+  const seat = manifest?.seat || __ENV.OPENCLAW_SEAT_NAME || 'rune-rog-ally';
+  const createDisposableSession = boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSION');
+  const negativeWindowMs = Number(__ENV.OPENCLAW_NEGATIVE_WINDOW_MS || 45000);
+  const rowNonce = nonce(ROW);
+  const canary = canaryFor(rowNonce);
+
+  if (!token) {
+    console.error('OPENCLAW_GATEWAY_TOKEN is required');
+    failures.add(1);
+    return;
+  }
+  if (manifest) {
+    const errors = validateManifest(manifest);
+    if (errors.length > 0) console.warn(`Manifest validation warnings: ${errors.join('; ')}`);
+  }
+
+  const evidence = baseEvidence({
+    row: ROW,
+    nonce: rowNonce,
+    seat,
+    requestedSessionKey,
+    sessionKey,
+    manifest,
+  });
+  evidence.content_receipt = contentReceipt(canary);
+  evidence.negative_window_ms = negativeWindowMs;
+  declareNegative(evidence, 'no-automatic-raw-byte-mount', 'artifact bytes must never cross the wire unasked');
+  declareNegative(evidence, 'no-automatic-materialization', 'no materialize without an explicit recipient call');
+  declareNegative(evidence, 'no-native-media-upload', 'no Discord/native-media or channel attachment delivery');
+  declareNegative(evidence, 'no-generic-render-or-forward', 'artifact content must not be rendered into reply text');
+  declareNegative(evidence, 'no-prompt-injection', 'the announcement must not instruct the recipient to act on its behalf');
+
+  const started = Date.now();
+
+  const res = ws.connect(url, {}, (socket) => {
+    const tracker = new RequestTracker();
+    let windowOpenedAt = null;
+
+    function startProofFlow() {
+      tracker.send(socket, 'sessions.messages.subscribe', { key: sessionKey });
+      socket.setTimeout(() => {
+        const instruction =
+          `[k6-proof-harness] Call continue_delegate exactly once with ` +
+          `task="Write the single line ${canary} into delegate-artifacts/p86-neg-${rowNonce}.txt in your ` +
+          `own workspace, then call delegate_artifacts_publish with paths=[\\"p86-neg-${rowNonce}.txt\\"]. ` +
+          `Reply exactly CDNEG-PUBLISHED ${rowNonce}. Do not print the file contents.", ` +
+          `mode="normal", delaySeconds=1. ` +
+          `When the delegate return announces an artifact claim, reply exactly ` +
+          `CDNEG-ANNOUNCED ${rowNonce} <claimId> and then STOP. ` +
+          `Do NOT call delegate_artifacts at all. Do NOT materialize, upload, forward, render, ` +
+          `or quote the artifact. This is a proof run — no other action needed.`;
+        tracker.send(socket, 'sessions.send', {
+          key: sessionKey,
+          message: instruction,
+          idempotencyKey: `${ROW}-DISPATCH-${rowNonce}`,
+        });
+      }, 500);
+      socket.setTimeout(() => socket.close(), 280000);
+    }
+
+    socket.on('open', () => {
+      socket.send(connectFrame(token));
+      if (createDisposableSession) {
+        socket.setTimeout(() => {
+          const disposableKey = `r-cd-io-neg-${rowNonce}`.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+          tracker.send(socket, 'sessions.create', { key: disposableKey, label: `k6 ${ROW}` });
+        }, 250);
+      } else {
+        socket.setTimeout(startProofFlow, 500);
+      }
+    });
+
+    socket.on('message', (raw) => {
+      try {
+        const msg = JSON.parse(raw);
+        const classified = tracker.classify(msg);
+        const body = capture(evidence, classified);
+
+        if (classified.kind === 'response' && classified.method === 'sessions.create') {
+          if (classified.ok && classified.payload) {
+            sessionKey = classified.payload.key || sessionKey;
+            evidence.sessionKey = sessionKey;
+            evidence.session_created = true;
+            evidence.created_session_key = sessionKey;
+            startProofFlow();
+          } else {
+            failures.add(1);
+            socket.close();
+          }
+          return;
+        }
+
+        if (classified.kind === 'response' && classified.method === 'sessions.send') {
+          if (classified.ok) fire(evidence, 'tool-invoke-accepted');
+          else failures.add(1);
+          return;
+        }
+
+        if (classified.kind !== 'event' || !body) return;
+
+        // (1) raw-byte mount / (4) render-or-forward share the same canary probe:
+        // the artifact content must not appear on any non-harness frame.
+        scanRawBytes(evidence, body, rowNonce, 'no-automatic-raw-byte-mount');
+        if (body.includes(canary)) {
+          breakNegative(evidence, 'no-generic-render-or-forward', 'artifact content rendered into a reply frame');
+        }
+
+        // (2) automatic materialization
+        if (body.includes('"materialized"') || body.includes('"materializedPath"')) {
+          breakNegative(
+            evidence,
+            'no-automatic-materialization',
+            'a materialized state appeared with no explicit delegate_artifacts materialize call',
+          );
+        }
+
+        // (3) native-media / channel upload
+        for (const signal of MEDIA_DELIVERY_SIGNALS) {
+          if (body.includes(signal) && body.includes(rowNonce)) {
+            breakNegative(
+              evidence,
+              'no-native-media-upload',
+              `channel/native-media delivery signal observed: ${signal}`,
+            );
+          }
+        }
+
+        // (5) prompt injection: the announcement must describe an explicit action,
+        // never issue an imperative the recipient is made to obey.
+        if (
+          body.includes(rowNonce) &&
+          /"(?:injectedInstruction|systemDirective|autoInstruction)"/.test(body)
+        ) {
+          breakNegative(
+            evidence,
+            'no-prompt-injection',
+            'the claim announcement carried an injected instruction field',
+          );
+        }
+
+        const announced = matchGroup(body, new RegExp(`CDNEG-ANNOUNCED ${rowNonce} ([A-Za-z0-9_.:-]+)`));
+        if (announced && !windowOpenedAt) {
+          fire(evidence, 'claim-announced-positive-control');
+          evidence.provenance.claim_id = announced;
+          windowOpenedAt = Date.now();
+          console.log(`${ROW}: negative observation window open for ${negativeWindowMs}ms`);
+          closeSocketAfterDelay(socket, negativeWindowMs, () => {
+            fire(evidence, 'negative-window-elapsed');
+            console.log(`${ROW}: negative observation window elapsed with no violation escalation`);
+          });
+        }
+      } catch (e) {
+        console.warn(`parse error: ${e}`);
+      }
+    });
+
+    socket.on('error', (e) => {
+      console.error(`ws error: ${e && e.error ? e.error() : e}`);
+      failures.add(1);
+    });
+  });
+
+  evidence.duration_ms = Date.now() - started;
+  duration.add(evidence.duration_ms);
+  // The window receipt is only credible when the window actually ran to term.
+  if (evidence.receipts['claim-announced-positive-control'] && !evidence.receipts['negative-window-elapsed']) {
+    console.warn(`${ROW}: negative window did not run to term; the row stays PARTIAL`);
+  }
+  const verdict = computeVerdict(evidence, REQUIRED);
+
+  check(res, { 'websocket connected': (r) => r && r.status === 101 });
+  check(null, {
+    'positive control: claim announced': () =>
+      !!evidence.receipts['claim-announced-positive-control'],
+    'no automatic raw-byte mount': () => evidence.negative_checks['no-automatic-raw-byte-mount'].held,
+    'no automatic materialization': () => evidence.negative_checks['no-automatic-materialization'].held,
+    'no native-media/channel upload': () => evidence.negative_checks['no-native-media-upload'].held,
+    'no generic render or forward': () => evidence.negative_checks['no-generic-render-or-forward'].held,
+    'no prompt injection in the announcement': () => evidence.negative_checks['no-prompt-injection'].held,
+  });
+
+  if (verdict !== 'PASS-candidate') failures.add(1);
+  logEvidence(evidence);
+}
+
+export function handleSummary(data) {
+  return rowSummary({
+    row: ROW,
+    data,
+    durationMetric: 'r_cd_io_neg_duration',
+    summaryFile: 'r-cd-io-negative-boundary-summary.json',
+  });
+}

--- a/tools/k6-proofs/scenarios/r-cd-out-claim-lifecycle.js
+++ b/tools/k6-proofs/scenarios/r-cd-out-claim-lifecycle.js
@@ -39,6 +39,9 @@ import {
   matchGroup,
   rowSummary,
   scanRawBytes,
+  sentinel,
+  toolRecordRejected,
+  toolResultRecords,
 } from '../lib/delegate-attachment-io.js';
 
 const ROW = 'R-CD-OUT-CLAIM';
@@ -69,6 +72,7 @@ const REQUIRED = [
   'claim-inspected',
   'authorized-materialize',
   'claim-discarded',
+  'post-discard-inspect-rejected',
 ];
 
 export default function () {
@@ -115,7 +119,12 @@ export default function () {
   declareNegative(
     evidence,
     'no-read-after-discard',
-    'a discarded claim must not remain readable',
+    'a discarded claim must not remain readable, and the post-discard probe must name that same claim',
+  );
+  declareNegative(
+    evidence,
+    'discard-targets-the-listed-claim',
+    'the discarded claim id must be the claim id that was listed and inspected',
   );
 
   const started = Date.now();
@@ -148,9 +157,10 @@ export default function () {
           `(b) action="inspect", claimId=<claimId> then reply CDCLAIM-INSPECTED ${rowNonce} <bytes> <mimeType>; ` +
           `(c) action="materialize", claimId=<claimId>, destination="${destination}" then reply ` +
           `CDCLAIM-MATERIALIZED ${rowNonce} <destination>; ` +
-          `(d) action="discard", claimId=<claimId> then reply CDCLAIM-DISCARDED ${rowNonce}; ` +
+          `(d) action="discard", claimId=<claimId> then reply CDCLAIM-DISCARDED ${rowNonce} <claimId>; ` +
           `finally call action="inspect" with the same claimId once more and reply ` +
-          `CDCLAIM-POSTDISCARD ${rowNonce} <ok|rejected>. ` +
+          `CDCLAIM-POSTDISCARD ${rowNonce} <claimId> <ok|rejected> <reasonWord> — where <reasonWord> is a ` +
+          `single word taken from that final tool result (use "none" only if it succeeded). ` +
           `Never print the artifact contents. This is a proof run — no other action needed.`;
         tracker.send(socket, 'sessions.send', {
           key: sessionKey,
@@ -209,7 +219,7 @@ export default function () {
 
         const listedClaim = matchGroup(
           body,
-          new RegExp(`CDCLAIM-LISTED ${rowNonce} ([A-Za-z0-9_.:-]+)`),
+          sentinel('CDCLAIM-LISTED', rowNonce, ' ([A-Za-z0-9_.:-]+)'),
         );
         if (listedClaim) {
           fire(evidence, 'claim-listed');
@@ -217,7 +227,7 @@ export default function () {
         }
 
         const inspected = body.match(
-          new RegExp(`CDCLAIM-INSPECTED ${rowNonce} ([0-9]+) ([A-Za-z0-9_./+-]+)`),
+          sentinel('CDCLAIM-INSPECTED', rowNonce, ' ([0-9]+) ([A-Za-z0-9_./+-]+)'),
         );
         if (inspected) {
           fire(evidence, 'claim-inspected');
@@ -226,7 +236,7 @@ export default function () {
 
         const materialized = matchGroup(
           body,
-          new RegExp(`CDCLAIM-MATERIALIZED ${rowNonce} ([^"\\\\s\\\\\\\\]+)`),
+          sentinel('CDCLAIM-MATERIALIZED', rowNonce, ' ([^"\\s\\\\]+)'),
         );
         if (materialized) {
           fire(evidence, 'authorized-materialize');
@@ -240,22 +250,65 @@ export default function () {
           }
         }
 
-        if (body.includes(`CDCLAIM-DISCARDED ${rowNonce}`)) {
-          fire(evidence, 'claim-discarded');
+        const discarded = matchGroup(
+          body,
+          sentinel('CDCLAIM-DISCARDED', rowNonce, ' ([A-Za-z0-9_.:-]+)'),
+        );
+        if (discarded) {
+          evidence.discarded_claim_id = discarded;
+          if (evidence.provenance.claim_id && discarded !== evidence.provenance.claim_id) {
+            breakNegative(
+              evidence,
+              'discard-targets-the-listed-claim',
+              `discarded ${discarded} but the listed claim was ${evidence.provenance.claim_id}`,
+            );
+          } else {
+            fire(evidence, 'claim-discarded');
+          }
         }
 
-        const postDiscard = matchGroup(
-          body,
-          new RegExp(`CDCLAIM-POSTDISCARD ${rowNonce} ([A-Za-z]+)`),
+        // A structured rejection on the post-discard delegate_artifacts call is
+        // the authority for "the claim is unreadable". Prose alone is not.
+        const rejectedRecords = toolResultRecords(classified.data, 'delegate_artifacts')
+          .filter((record) => toolRecordRejected(record));
+        if (rejectedRecords.length > 0 && evidence.receipts['claim-discarded']) {
+          evidence.post_discard_tool_rejection = true;
+        }
+
+        const postDiscard = body.match(
+          sentinel('CDCLAIM-POSTDISCARD', rowNonce, ' ([A-Za-z0-9_.:-]+) ([A-Za-z]+) ([A-Za-z0-9_-]+)'),
         );
         if (postDiscard) {
-          evidence.post_discard_inspect = postDiscard;
-          if (postDiscard.toLowerCase() === 'ok') {
+          const [, postClaimId, outcome, reasonWord] = postDiscard;
+          evidence.post_discard_inspect = {
+            claimId: postClaimId,
+            outcome: outcome.toLowerCase(),
+            reasonWord,
+            toolRejectionObserved: evidence.post_discard_tool_rejection === true,
+          };
+          const claimIdMatches =
+            !!evidence.provenance.claim_id && postClaimId === evidence.provenance.claim_id;
+          if (!claimIdMatches) {
+            breakNegative(
+              evidence,
+              'no-read-after-discard',
+              `post-discard inspect named ${postClaimId}, not the discarded claim ` +
+                `${evidence.provenance.claim_id || '(none listed)'}`,
+            );
+          } else if (outcome.toLowerCase() === 'ok') {
             breakNegative(
               evidence,
               'no-read-after-discard',
               'inspect still succeeded after the claim was discarded',
             );
+          } else if (evidence.post_discard_tool_rejection === true) {
+            // Bound on three axes: the same claim id, an explicit rejected
+            // outcome, and a structured delegate_artifacts error record.
+            fire(evidence, 'post-discard-inspect-rejected');
+          } else {
+            evidence.post_discard_unbound_reason =
+              'the recipient reported a rejection but no structured delegate_artifacts error record was ' +
+              'observed on the wire, so the rejection is not receipt-bound';
           }
           socket.close();
         }
@@ -282,9 +335,13 @@ export default function () {
     'recipient inspected the claim': () => !!evidence.receipts['claim-inspected'],
     'recipient-authorized materialize succeeded': () => !!evidence.receipts['authorized-materialize'],
     'recipient discarded the claim': () => !!evidence.receipts['claim-discarded'],
+    'post-discard inspect was rejected for the same claim': () =>
+      !!evidence.receipts['post-discard-inspect-rejected'],
     'materialize destination stayed workspace-relative': () =>
       evidence.negative_checks['materialize-destination-is-workspace-relative'].held,
     'no read after discard': () => evidence.negative_checks['no-read-after-discard'].held,
+    'discard targeted the listed claim': () =>
+      evidence.negative_checks['discard-targets-the-listed-claim'].held,
     'no raw artifact bytes on the wire': () =>
       evidence.negative_checks['no-raw-artifact-bytes-on-the-wire'].held,
   });

--- a/tools/k6-proofs/scenarios/r-cd-out-claim-lifecycle.js
+++ b/tools/k6-proofs/scenarios/r-cd-out-claim-lifecycle.js
@@ -1,0 +1,303 @@
+/**
+ * Scenario: R-CD-OUT-CLAIM — recipient-bound list / inspect / authorized
+ * materialize / discard.
+ *
+ * Proves the managed delegate OUTPUT claim lifecycle end to end from the
+ * recipient side, using only the typed `delegate_artifacts` tool:
+ *   list -> inspect -> materialize (workspace-relative destination) -> discard
+ *
+ * Each leg must be an EXPLICIT action. Nothing in this row may be reached by
+ * automatic delivery: the artifact only lands in the recipient workspace because
+ * the recipient asked for it, at a path the recipient named.
+ *
+ * Runtime surface: src/agents/tools/delegate-artifacts-tool.ts
+ * (`action: list|inspect|materialize|discard`, `destination` constrained to safe
+ * workspace-relative segments), src/agents/delegate-artifacts.ts
+ * (`markDelegateArtifactMaterialized`, `discardDelegateArtifactForRecipient`).
+ *
+ * References:
+ *   - Issue: karmaterminal/karmaterminal-openclaw-docs#491
+ *   - Manifest: tools/k6-proofs/manifests/r-cd-out-claim.json
+ */
+import ws from 'k6/ws';
+import { check } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+import { connectFrame, nonce, RequestTracker } from '../lib/gateway-ws.js';
+import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+import { closeSocketAfterDelay } from '../lib/socket-close.js';
+import {
+  baseEvidence,
+  boolEnv,
+  breakNegative,
+  canaryFor,
+  capture,
+  computeVerdict,
+  contentReceipt,
+  declareNegative,
+  fire,
+  logEvidence,
+  matchGroup,
+  rowSummary,
+  scanRawBytes,
+} from '../lib/delegate-attachment-io.js';
+
+const ROW = 'R-CD-OUT-CLAIM';
+
+export const options = {
+  scenarios: {
+    r_cd_out_claim: {
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 1,
+      maxDuration: '320s',
+    },
+  },
+  thresholds: {
+    proof_failures: ['count==0'],
+    r_cd_out_claim_duration: ['p(95)<300000'],
+  },
+};
+
+const failures = new Counter('proof_failures');
+const duration = new Trend('r_cd_out_claim_duration');
+
+const manifest = loadManifestFromEnv();
+
+const REQUIRED = [
+  'tool-invoke-accepted',
+  'claim-listed',
+  'claim-inspected',
+  'authorized-materialize',
+  'claim-discarded',
+];
+
+export default function () {
+  const url = __ENV.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
+  const token = __ENV.OPENCLAW_GATEWAY_TOKEN;
+  const requestedSessionKey = manifest?.sessionKey || __ENV.OPENCLAW_SESSION_KEY || 'main';
+  let sessionKey = requestedSessionKey;
+  const seat = manifest?.seat || __ENV.OPENCLAW_SEAT_NAME || 'rune-rog-ally';
+  const createDisposableSession = boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSION');
+  const rowNonce = nonce(ROW);
+  const canary = canaryFor(rowNonce);
+  const destination = `p86-materialized/${rowNonce}.txt`;
+
+  if (!token) {
+    console.error('OPENCLAW_GATEWAY_TOKEN is required');
+    failures.add(1);
+    return;
+  }
+  if (manifest) {
+    const errors = validateManifest(manifest);
+    if (errors.length > 0) console.warn(`Manifest validation warnings: ${errors.join('; ')}`);
+  }
+
+  const evidence = baseEvidence({
+    row: ROW,
+    nonce: rowNonce,
+    seat,
+    requestedSessionKey,
+    sessionKey,
+    manifest,
+  });
+  evidence.content_receipt = contentReceipt(canary);
+  evidence.requested_destination = destination;
+  declareNegative(
+    evidence,
+    'no-raw-artifact-bytes-on-the-wire',
+    'artifact content must never appear on a non-harness gateway frame, including inspect results',
+  );
+  declareNegative(
+    evidence,
+    'materialize-destination-is-workspace-relative',
+    'the materialize destination must stay workspace-relative, never absolute or traversing',
+  );
+  declareNegative(
+    evidence,
+    'no-read-after-discard',
+    'a discarded claim must not remain readable',
+  );
+
+  const started = Date.now();
+
+  const res = ws.connect(url, {}, (socket) => {
+    const tracker = new RequestTracker();
+    let closeScheduled = false;
+
+    function maybeClose() {
+      if (closeScheduled) return;
+      if (REQUIRED.some((name) => !evidence.receipts[name])) return;
+      closeScheduled = true;
+      closeSocketAfterDelay(socket, Number(__ENV.OPENCLAW_NEGATIVE_WINDOW_MS || 15000), () => {
+        console.log(`${ROW}: lifecycle receipts gathered, closing`);
+      });
+    }
+
+    function startProofFlow() {
+      tracker.send(socket, 'sessions.messages.subscribe', { key: sessionKey });
+      socket.setTimeout(() => {
+        const instruction =
+          `[k6-proof-harness] Step 1: call continue_delegate exactly once with ` +
+          `task="Write the single line ${canary} into delegate-artifacts/p86-claim-${rowNonce}.txt in your ` +
+          `own workspace, then call delegate_artifacts_publish with paths=[\\"p86-claim-${rowNonce}.txt\\"]. ` +
+          `Reply exactly CDCLAIM-CHILD-PUBLISHED ${rowNonce}. Do not print the file contents.", ` +
+          `mode="normal", delaySeconds=1. ` +
+          `Step 2, only after the delegate returns and announces a claim, run these four ` +
+          `delegate_artifacts calls in order and acknowledge each one on its own line: ` +
+          `(a) action="list" then reply CDCLAIM-LISTED ${rowNonce} <claimId>; ` +
+          `(b) action="inspect", claimId=<claimId> then reply CDCLAIM-INSPECTED ${rowNonce} <bytes> <mimeType>; ` +
+          `(c) action="materialize", claimId=<claimId>, destination="${destination}" then reply ` +
+          `CDCLAIM-MATERIALIZED ${rowNonce} <destination>; ` +
+          `(d) action="discard", claimId=<claimId> then reply CDCLAIM-DISCARDED ${rowNonce}; ` +
+          `finally call action="inspect" with the same claimId once more and reply ` +
+          `CDCLAIM-POSTDISCARD ${rowNonce} <ok|rejected>. ` +
+          `Never print the artifact contents. This is a proof run — no other action needed.`;
+        tracker.send(socket, 'sessions.send', {
+          key: sessionKey,
+          message: instruction,
+          idempotencyKey: `${ROW}-DISPATCH-${rowNonce}`,
+        });
+      }, 500);
+      socket.setTimeout(() => socket.close(), 300000);
+    }
+
+    socket.on('open', () => {
+      socket.send(connectFrame(token));
+      if (createDisposableSession) {
+        socket.setTimeout(() => {
+          const disposableKey = `r-cd-out-claim-${rowNonce}`.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+          tracker.send(socket, 'sessions.create', { key: disposableKey, label: `k6 ${ROW}` });
+        }, 250);
+      } else {
+        socket.setTimeout(startProofFlow, 500);
+      }
+    });
+
+    socket.on('message', (raw) => {
+      try {
+        const msg = JSON.parse(raw);
+        const classified = tracker.classify(msg);
+        const body = capture(evidence, classified);
+
+        if (classified.kind === 'response' && classified.method === 'sessions.create') {
+          if (classified.ok && classified.payload) {
+            sessionKey = classified.payload.key || sessionKey;
+            evidence.sessionKey = sessionKey;
+            evidence.session_created = true;
+            evidence.created_session_key = sessionKey;
+            startProofFlow();
+          } else {
+            failures.add(1);
+            socket.close();
+          }
+          return;
+        }
+
+        if (classified.kind === 'response' && classified.method === 'sessions.send') {
+          if (classified.ok) fire(evidence, 'tool-invoke-accepted');
+          else failures.add(1);
+          return;
+        }
+
+        if (classified.kind !== 'event' || !body) return;
+
+        scanRawBytes(evidence, body, rowNonce, 'no-raw-artifact-bytes-on-the-wire');
+
+        if (body.includes(`CDCLAIM-CHILD-PUBLISHED ${rowNonce}`)) {
+          fire(evidence, 'child-publish-accepted');
+        }
+
+        const listedClaim = matchGroup(
+          body,
+          new RegExp(`CDCLAIM-LISTED ${rowNonce} ([A-Za-z0-9_.:-]+)`),
+        );
+        if (listedClaim) {
+          fire(evidence, 'claim-listed');
+          evidence.provenance.claim_id = listedClaim;
+        }
+
+        const inspected = body.match(
+          new RegExp(`CDCLAIM-INSPECTED ${rowNonce} ([0-9]+) ([A-Za-z0-9_./+-]+)`),
+        );
+        if (inspected) {
+          fire(evidence, 'claim-inspected');
+          evidence.inspect_receipt = { bytes: Number(inspected[1]), mimeType: inspected[2] };
+        }
+
+        const materialized = matchGroup(
+          body,
+          new RegExp(`CDCLAIM-MATERIALIZED ${rowNonce} ([^"\\\\s\\\\\\\\]+)`),
+        );
+        if (materialized) {
+          fire(evidence, 'authorized-materialize');
+          evidence.provenance.materialized_destination = materialized;
+          if (materialized.startsWith('/') || materialized.includes('..') || /^[A-Za-z]:/.test(materialized)) {
+            breakNegative(
+              evidence,
+              'materialize-destination-is-workspace-relative',
+              `destination escaped the workspace: ${materialized}`,
+            );
+          }
+        }
+
+        if (body.includes(`CDCLAIM-DISCARDED ${rowNonce}`)) {
+          fire(evidence, 'claim-discarded');
+        }
+
+        const postDiscard = matchGroup(
+          body,
+          new RegExp(`CDCLAIM-POSTDISCARD ${rowNonce} ([A-Za-z]+)`),
+        );
+        if (postDiscard) {
+          evidence.post_discard_inspect = postDiscard;
+          if (postDiscard.toLowerCase() === 'ok') {
+            breakNegative(
+              evidence,
+              'no-read-after-discard',
+              'inspect still succeeded after the claim was discarded',
+            );
+          }
+          socket.close();
+        }
+
+        maybeClose();
+      } catch (e) {
+        console.warn(`parse error: ${e}`);
+      }
+    });
+
+    socket.on('error', (e) => {
+      console.error(`ws error: ${e && e.error ? e.error() : e}`);
+      failures.add(1);
+    });
+  });
+
+  evidence.duration_ms = Date.now() - started;
+  duration.add(evidence.duration_ms);
+  const verdict = computeVerdict(evidence, REQUIRED);
+
+  check(res, { 'websocket connected': (r) => r && r.status === 101 });
+  check(null, {
+    'recipient listed the claim': () => !!evidence.receipts['claim-listed'],
+    'recipient inspected the claim': () => !!evidence.receipts['claim-inspected'],
+    'recipient-authorized materialize succeeded': () => !!evidence.receipts['authorized-materialize'],
+    'recipient discarded the claim': () => !!evidence.receipts['claim-discarded'],
+    'materialize destination stayed workspace-relative': () =>
+      evidence.negative_checks['materialize-destination-is-workspace-relative'].held,
+    'no read after discard': () => evidence.negative_checks['no-read-after-discard'].held,
+    'no raw artifact bytes on the wire': () =>
+      evidence.negative_checks['no-raw-artifact-bytes-on-the-wire'].held,
+  });
+
+  if (verdict !== 'PASS-candidate') failures.add(1);
+  logEvidence(evidence);
+}
+
+export function handleSummary(data) {
+  return rowSummary({
+    row: ROW,
+    data,
+    durationMetric: 'r_cd_out_claim_duration',
+    summaryFile: 'r-cd-out-claim-lifecycle-summary.json',
+  });
+}

--- a/tools/k6-proofs/scenarios/r-cd-out-publish-claim.js
+++ b/tools/k6-proofs/scenarios/r-cd-out-publish-claim.js
@@ -1,0 +1,274 @@
+/**
+ * Scenario: R-CD-OUT-PUBLISH — child publication/finalization to a recipient-bound claim.
+ *
+ * Proves the managed delegate OUTPUT entry point:
+ *   1. A delegate child writes a file under its `delegate-artifacts/` output root
+ *      and calls `delegate_artifacts_publish({ paths: [...] })`.
+ *   2. Publication is bound to the ORIGINATING (recipient) session — the claim is
+ *      announced to the parent, not broadcast.
+ *   3. The announcement carries a claim id (provenance), not artifact bytes.
+ *   4. Negative: publication alone materializes nothing and forwards nothing.
+ *
+ * Runtime surface: src/agents/tools/delegate-artifacts-tool.ts
+ * (`delegate_artifacts_publish`), src/agents/delegate-artifact-store.ts,
+ * src/agents/internal-events.ts (explicit-action announcement).
+ *
+ * References:
+ *   - Issue: karmaterminal/karmaterminal-openclaw-docs#491
+ *   - Manifest: tools/k6-proofs/manifests/r-cd-out-publish.json
+ */
+import ws from 'k6/ws';
+import { check } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+import { connectFrame, nonce, RequestTracker } from '../lib/gateway-ws.js';
+import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+import { closeSocketAfterDelay } from '../lib/socket-close.js';
+import {
+  baseEvidence,
+  boolEnv,
+  breakNegative,
+  canaryFor,
+  capture,
+  computeVerdict,
+  contentReceipt,
+  declareNegative,
+  fire,
+  logEvidence,
+  matchGroup,
+  rowSummary,
+  scanRawBytes,
+} from '../lib/delegate-attachment-io.js';
+
+const ROW = 'R-CD-OUT-PUBLISH';
+
+export const options = {
+  scenarios: {
+    r_cd_out_publish: {
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 1,
+      maxDuration: '260s',
+    },
+  },
+  thresholds: {
+    proof_failures: ['count==0'],
+    r_cd_out_publish_duration: ['p(95)<240000'],
+  },
+};
+
+const failures = new Counter('proof_failures');
+const duration = new Trend('r_cd_out_publish_duration');
+
+const manifest = loadManifestFromEnv();
+
+const REQUIRED = [
+  'tool-invoke-accepted',
+  'child-publish-accepted',
+  'recipient-bound-claim-announced',
+  'claim-id-provenance',
+];
+
+export default function () {
+  const url = __ENV.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
+  const token = __ENV.OPENCLAW_GATEWAY_TOKEN;
+  const requestedSessionKey = manifest?.sessionKey || __ENV.OPENCLAW_SESSION_KEY || 'main';
+  let sessionKey = requestedSessionKey;
+  const seat = manifest?.seat || __ENV.OPENCLAW_SEAT_NAME || 'rune-rog-ally';
+  const createDisposableSession = boolEnv('OPENCLAW_CREATE_DISPOSABLE_SESSION');
+  const rowNonce = nonce(ROW);
+  const canary = canaryFor(rowNonce);
+
+  if (!token) {
+    console.error('OPENCLAW_GATEWAY_TOKEN is required');
+    failures.add(1);
+    return;
+  }
+  if (manifest) {
+    const errors = validateManifest(manifest);
+    if (errors.length > 0) console.warn(`Manifest validation warnings: ${errors.join('; ')}`);
+  }
+
+  const evidence = baseEvidence({
+    row: ROW,
+    nonce: rowNonce,
+    seat,
+    requestedSessionKey,
+    sessionKey,
+    manifest,
+  });
+  evidence.content_receipt = contentReceipt(canary);
+  declareNegative(
+    evidence,
+    'no-raw-artifact-bytes-on-the-wire',
+    'published artifact content must never appear on a non-harness gateway frame',
+  );
+  declareNegative(
+    evidence,
+    'no-materialize-without-explicit-action',
+    'publication alone must not materialize the artifact into the recipient workspace',
+  );
+
+  const started = Date.now();
+
+  const res = ws.connect(url, {}, (socket) => {
+    const tracker = new RequestTracker();
+    let closeScheduled = false;
+
+    function maybeClose() {
+      if (closeScheduled) return;
+      if (REQUIRED.some((name) => !evidence.receipts[name])) return;
+      closeScheduled = true;
+      // Hold the socket open past the last receipt so an unsolicited automatic
+      // materialization/forward would still be captured by the negative checks.
+      closeSocketAfterDelay(socket, Number(__ENV.OPENCLAW_NEGATIVE_WINDOW_MS || 20000), () => {
+        console.log(`${ROW}: receipts gathered, negative window elapsed, closing`);
+      });
+    }
+
+    function startProofFlow() {
+      tracker.send(socket, 'sessions.messages.subscribe', { key: sessionKey });
+      socket.setTimeout(() => {
+        const instruction =
+          `[k6-proof-harness] Call continue_delegate exactly once with ` +
+          `task="Write the single line ${canary} into delegate-artifacts/p86-out-${rowNonce}.txt inside your ` +
+          `own workspace, then call delegate_artifacts_publish with paths=[\\"p86-out-${rowNonce}.txt\\"]. ` +
+          `Then reply exactly CDOUT-PUBLISHED ${rowNonce} <claimId> using the claim id from the publish ` +
+          `result. Do not print the file contents.", mode="normal", delaySeconds=1. ` +
+          `When the delegate return announces an artifact claim for THIS session, reply exactly ` +
+          `CDOUT-CLAIM-ANNOUNCED ${rowNonce} <claimId>. Do not call delegate_artifacts materialize. ` +
+          `This is a proof run — no other action needed.`;
+        tracker.send(socket, 'sessions.send', {
+          key: sessionKey,
+          message: instruction,
+          idempotencyKey: `${ROW}-DISPATCH-${rowNonce}`,
+        });
+      }, 500);
+      socket.setTimeout(() => socket.close(), 240000);
+    }
+
+    socket.on('open', () => {
+      socket.send(connectFrame(token));
+      if (createDisposableSession) {
+        socket.setTimeout(() => {
+          const disposableKey = `r-cd-out-publish-${rowNonce}`.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+          tracker.send(socket, 'sessions.create', { key: disposableKey, label: `k6 ${ROW}` });
+        }, 250);
+      } else {
+        socket.setTimeout(startProofFlow, 500);
+      }
+    });
+
+    socket.on('message', (raw) => {
+      try {
+        const msg = JSON.parse(raw);
+        const classified = tracker.classify(msg);
+        const body = capture(evidence, classified);
+
+        if (classified.kind === 'response' && classified.method === 'sessions.create') {
+          if (classified.ok && classified.payload) {
+            sessionKey = classified.payload.key || sessionKey;
+            evidence.sessionKey = sessionKey;
+            evidence.session_created = true;
+            evidence.created_session_key = sessionKey;
+            startProofFlow();
+          } else {
+            failures.add(1);
+            socket.close();
+          }
+          return;
+        }
+
+        if (classified.kind === 'response' && classified.method === 'sessions.send') {
+          if (classified.ok) {
+            fire(evidence, 'tool-invoke-accepted');
+            if (classified.payload?.traceId) evidence.provenance.trace_id = classified.payload.traceId;
+          } else {
+            failures.add(1);
+          }
+          return;
+        }
+
+        if (classified.kind !== 'event' || !body) return;
+
+        scanRawBytes(evidence, body, rowNonce, 'no-raw-artifact-bytes-on-the-wire');
+
+        const publishedClaim = matchGroup(
+          body,
+          new RegExp(`CDOUT-PUBLISHED ${rowNonce} ([A-Za-z0-9_.:-]+)`),
+        );
+        if (publishedClaim) {
+          fire(evidence, 'child-publish-accepted');
+          evidence.provenance.claim_id = evidence.provenance.claim_id || publishedClaim;
+        }
+
+        const announcedClaim = matchGroup(
+          body,
+          new RegExp(`CDOUT-CLAIM-ANNOUNCED ${rowNonce} ([A-Za-z0-9_.:-]+)`),
+        );
+        if (announcedClaim) {
+          fire(evidence, 'recipient-bound-claim-announced');
+          evidence.announced_claim_id = announcedClaim;
+          if (evidence.provenance.claim_id && announcedClaim === evidence.provenance.claim_id) {
+            fire(evidence, 'claim-id-provenance');
+          } else if (!evidence.provenance.claim_id) {
+            evidence.provenance.claim_id = announcedClaim;
+            fire(evidence, 'claim-id-provenance');
+          } else {
+            evidence.claim_id_mismatch = true;
+          }
+        }
+
+        if (body.includes('"materialized"') && !evidence.receipts['explicit-materialize-requested']) {
+          breakNegative(
+            evidence,
+            'no-materialize-without-explicit-action',
+            'a materialized state appeared without any explicit delegate_artifacts materialize call',
+          );
+        }
+
+        const flowId = matchGroup(body, /"flowId"\s*:\s*"([^"]+)"/);
+        if (flowId) evidence.provenance.flow_id = flowId;
+        const childKey = matchGroup(body, /"childSessionKey"\s*:\s*"([^"]+)"/);
+        if (childKey) evidence.provenance.child_session_key = childKey;
+
+        maybeClose();
+      } catch (e) {
+        console.warn(`parse error: ${e}`);
+      }
+    });
+
+    socket.on('error', (e) => {
+      console.error(`ws error: ${e && e.error ? e.error() : e}`);
+      failures.add(1);
+    });
+  });
+
+  evidence.duration_ms = Date.now() - started;
+  duration.add(evidence.duration_ms);
+  const verdict = computeVerdict(evidence, REQUIRED);
+
+  check(res, { 'websocket connected': (r) => r && r.status === 101 });
+  check(null, {
+    'delegate dispatch accepted': () => !!evidence.receipts['tool-invoke-accepted'],
+    'child publish accepted': () => !!evidence.receipts['child-publish-accepted'],
+    'claim announced to the originating recipient session': () =>
+      !!evidence.receipts['recipient-bound-claim-announced'],
+    'claim id provenance recorded': () => !!evidence.receipts['claim-id-provenance'],
+    'no raw artifact bytes on the wire': () =>
+      evidence.negative_checks['no-raw-artifact-bytes-on-the-wire'].held,
+    'no materialization without an explicit action': () =>
+      evidence.negative_checks['no-materialize-without-explicit-action'].held,
+  });
+
+  if (verdict !== 'PASS-candidate') failures.add(1);
+  logEvidence(evidence);
+}
+
+export function handleSummary(data) {
+  return rowSummary({
+    row: ROW,
+    data,
+    durationMetric: 'r_cd_out_publish_duration',
+    summaryFile: 'r-cd-out-publish-claim-summary.json',
+  });
+}

--- a/tools/k6-proofs/scenarios/r-cd-out-restart-replay.js
+++ b/tools/k6-proofs/scenarios/r-cd-out-restart-replay.js
@@ -13,17 +13,22 @@
  *
  * ORCHESTRATION GATE — read this before reading a verdict:
  *   The gateway restart is an operator step. This harness must not restart a
- *   seat. Set `OPENCLAW_RESTART_ORCHESTRATED=true` only when an operator
- *   actually cycled the gateway between the pre- and post-phase of this run.
- *   Without it, the row terminates PARTIAL-candidate naming the missing step;
- *   the pre-restart legs it did observe are still recorded as receipts.
+ *   seat, and `OPENCLAW_RESTART_ORCHESTRATED=true` is a DECLARATION, never the
+ *   evidence. The restart is credited only from the gateway's own public
+ *   `/status` surface (uptime going backwards, or the endpoint dropping and
+ *   returning), observed while this harness is deliberately DISCONNECTED
+ *   between the pre- and post-phase sockets. A real restart therefore cannot
+ *   fail the run by dropping a socket, and a missing restart cannot be
+ *   declared away. Without that receipt the row terminates PARTIAL-candidate
+ *   naming the missing step; the pre-restart legs it did observe are still
+ *   recorded as receipts.
  *
  * References:
  *   - Issue: karmaterminal/karmaterminal-openclaw-docs#491
  *   - Manifest: tools/k6-proofs/manifests/r-cd-out-replay.json
  */
 import ws from 'k6/ws';
-import { check } from 'k6';
+import { check, sleep } from 'k6';
 import { Counter, Trend } from 'k6/metrics';
 import { connectFrame, nonce, RequestTracker } from '../lib/gateway-ws.js';
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
@@ -37,11 +42,15 @@ import {
   contentReceipt,
   declareNegative,
   fire,
+  httpBaseFromWs,
   logEvidence,
   matchGroup,
+  observeGatewayRestart,
   orchestrationGate,
   rowSummary,
+  sampleGatewayStatus,
   scanRawBytes,
+  sentinel,
 } from '../lib/delegate-attachment-io.js';
 
 const ROW = 'R-CD-OUT-REPLAY';
@@ -52,11 +61,11 @@ export const options = {
       executor: 'shared-iterations',
       vus: 1,
       iterations: 1,
-      maxDuration: '420s',
+      maxDuration: '660s',
     },
   },
   thresholds: {
-    r_cd_out_replay_duration: ['p(95)<400000'],
+    r_cd_out_replay_duration: ['p(95)<640000'],
   },
 };
 
@@ -67,6 +76,8 @@ const manifest = loadManifestFromEnv();
 
 const REQUIRED = [
   'pre-restart-claim-established',
+  'gateway-restart-observed',
+  'reconnected-after-restart',
   'post-restart-claim-listed',
   'claim-identity-stable',
   'replay-is-idempotent',
@@ -120,22 +131,17 @@ export default function () {
   );
 
   const started = Date.now();
+  const httpBase = httpBaseFromWs(url);
+  evidence.restart_declared_by_operator = restartOrchestrated;
+  evidence.lifecycle = { baseline: null, observation: null };
 
-  const res = ws.connect(url, {}, (socket) => {
+  // --- Phase 0: external lifecycle baseline, before anything is published ---
+  const baseline = sampleGatewayStatus(httpBase, token);
+  evidence.lifecycle.baseline = { reachable: baseline.reachable, uptime: baseline.uptime };
+
+  // --- Phase 1: publish + list the claim, then DISCONNECT for the window ---
+  const phase1 = ws.connect(url, {}, (socket) => {
     const tracker = new RequestTracker();
-
-    function askPostRestartList() {
-      const instruction =
-        `[k6-proof-harness] Call delegate_artifacts with action="list" and reply exactly ` +
-        `CDREPLAY-POST ${rowNonce} <claimId> <count> where <claimId> is the claim whose name contains ` +
-        `${rowNonce} and <count> is how many claims carry that nonce. Do not materialize anything. ` +
-        `This is a proof run — no other action needed.`;
-      tracker.send(socket, 'sessions.send', {
-        key: recipientSessionKey,
-        message: instruction,
-        idempotencyKey: `${ROW}-POST-${rowNonce}`,
-      });
-    }
 
     socket.on('open', () => {
       socket.send(connectFrame(token));
@@ -155,7 +161,7 @@ export default function () {
           idempotencyKey: `${ROW}-DISPATCH-${rowNonce}`,
         });
       }, 400);
-      socket.setTimeout(() => socket.close(), 400000);
+      socket.setTimeout(() => socket.close(), 240000);
     });
 
     socket.on('message', (raw) => {
@@ -173,41 +179,17 @@ export default function () {
 
         scanRawBytes(evidence, body, rowNonce, 'no-raw-artifact-bytes-on-the-wire');
 
-        const preClaim = matchGroup(body, new RegExp(`CDREPLAY-PRE ${rowNonce} ([A-Za-z0-9_.:-]+)`));
+        const preClaim = matchGroup(body, sentinel('CDREPLAY-PRE', rowNonce, ' ([A-Za-z0-9_.:-]+)'));
         if (preClaim && !evidence.pre_restart_claim_id) {
           evidence.pre_restart_claim_id = preClaim;
           evidence.provenance.claim_id = preClaim;
           fire(evidence, 'pre-restart-claim-established');
-          console.log(
-            `${ROW}: pre-restart claim captured. Operator restart window opens now ` +
-              `(${restartWindowMs}ms) — restart the gateway to exercise durable replay.`,
-          );
-          socket.setTimeout(askPostRestartList, restartWindowMs);
-        }
-
-        const post = body.match(
-          new RegExp(`CDREPLAY-POST ${rowNonce} ([A-Za-z0-9_.:-]+) ([0-9]+)`),
-        );
-        if (post) {
-          fire(evidence, 'post-restart-claim-listed');
-          evidence.post_restart_claim_id = post[1];
-          evidence.post_restart_claim_count = Number(post[2]);
-          if (evidence.pre_restart_claim_id && post[1] === evidence.pre_restart_claim_id) {
-            fire(evidence, 'claim-identity-stable');
-          }
-          if (Number(post[2]) === 1) {
-            fire(evidence, 'replay-is-idempotent');
-          } else if (Number(post[2]) > 1) {
-            breakNegative(
-              evidence,
-              'no-duplicate-claim-after-replay',
-              `replay produced ${post[2]} claims for one publication`,
-            );
-          }
+          // Disconnect on purpose: the operator restart must be survivable, and
+          // a socket held open across it would fail the run for the wrong reason.
           socket.close();
         }
 
-        if (body.includes('"materialized"')) {
+        if (body.indexOf('"materialized"') !== -1) {
           breakNegative(
             evidence,
             'no-auto-materialize-on-replay',
@@ -215,32 +197,152 @@ export default function () {
           );
         }
       } catch (e) {
-        console.warn(`parse error: ${e}`);
+        console.warn(`ws error (phase 1): ${e}`);
       }
     });
 
     socket.on('error', (e) => {
-      console.error(`ws error: ${e && e.error ? e.error() : e}`);
+      console.error(`ws error (phase 1): ${e && e.error ? e.error() : e}`);
       failures.add(1);
     });
   });
+
+  // --- Phase 2: externally observable restart window, socket intentionally down ---
+  if (evidence.receipts['pre-restart-claim-established']) {
+    console.log(
+      `${ROW}: pre-restart claim captured and harness disconnected. Operator restart window is OPEN ` +
+        `for ${restartWindowMs}ms — restart the gateway to exercise durable replay.`,
+    );
+    const observation = observeGatewayRestart({
+      httpBase,
+      token,
+      baseline,
+      windowMs: restartWindowMs,
+      pollMs: Number(__ENV.OPENCLAW_RESTART_POLL_MS || 5000),
+      sleep,
+    });
+    evidence.lifecycle.observation = observation;
+    if (observation.observed) fire(evidence, 'gateway-restart-observed');
+  } else {
+    evidence.lifecycle.observation = {
+      observed: false,
+      reason: 'the pre-restart claim was never established, so the restart window was never opened',
+    };
+  }
+
+  // --- Phase 3: RECONNECT and re-list the claim from durable state ---
+  let phase2 = null;
+  if (evidence.receipts['gateway-restart-observed']) {
+    phase2 = ws.connect(url, {}, (socket) => {
+      const tracker = new RequestTracker();
+
+      socket.on('open', () => {
+        fire(evidence, 'reconnected-after-restart');
+        socket.send(connectFrame(token));
+        socket.setTimeout(() => {
+          tracker.send(socket, 'sessions.messages.subscribe', { key: recipientSessionKey });
+          const instruction =
+            `[k6-proof-harness] Call delegate_artifacts with action="list" and reply exactly ` +
+            `CDREPLAY-POST ${rowNonce} <claimId> <count> where <claimId> is the claim whose name contains ` +
+            `${rowNonce} and <count> is how many claims carry that nonce. Do not materialize anything. ` +
+            `This is a proof run — no other action needed.`;
+          tracker.send(socket, 'sessions.send', {
+            key: recipientSessionKey,
+            message: instruction,
+            idempotencyKey: `${ROW}-POST-${rowNonce}`,
+          });
+        }, 500);
+        socket.setTimeout(() => socket.close(), 180000);
+      });
+
+      socket.on('message', (raw) => {
+        try {
+          const msg = JSON.parse(raw);
+          const classified = tracker.classify(msg);
+          const body = capture(evidence, classified);
+
+          if (classified.kind === 'response' && classified.method === 'sessions.send') {
+            if (!classified.ok) failures.add(1);
+            return;
+          }
+
+          if (classified.kind !== 'event' || !body) return;
+
+          scanRawBytes(evidence, body, rowNonce, 'no-raw-artifact-bytes-on-the-wire');
+
+          const post = body.match(
+            sentinel('CDREPLAY-POST', rowNonce, ' ([A-Za-z0-9_.:-]+) ([0-9]+)'),
+          );
+          if (post) {
+            fire(evidence, 'post-restart-claim-listed');
+            evidence.post_restart_claim_id = post[1];
+            evidence.post_restart_claim_count = Number(post[2]);
+            if (evidence.pre_restart_claim_id && post[1] === evidence.pre_restart_claim_id) {
+              fire(evidence, 'claim-identity-stable');
+            } else {
+              breakNegative(
+                evidence,
+                'no-duplicate-claim-after-replay',
+                `post-restart claim ${post[1]} does not match the pre-restart claim ` +
+                  `${evidence.pre_restart_claim_id}`,
+              );
+            }
+            if (Number(post[2]) === 1) {
+              fire(evidence, 'replay-is-idempotent');
+            } else if (Number(post[2]) > 1) {
+              breakNegative(
+                evidence,
+                'no-duplicate-claim-after-replay',
+                `replay produced ${post[2]} claims for one publication`,
+              );
+            }
+            socket.close();
+          }
+
+          if (body.indexOf('"materialized"') !== -1) {
+            breakNegative(
+              evidence,
+              'no-auto-materialize-on-replay',
+              'a materialized state appeared without any explicit recipient materialize call',
+            );
+          }
+        } catch (e) {
+          console.warn(`parse error: ${e}`);
+        }
+      });
+
+      socket.on('error', (e) => {
+        console.error(`ws error (phase 3): ${e && e.error ? e.error() : e}`);
+      });
+    });
+  }
 
   evidence.duration_ms = Date.now() - started;
   duration.add(evidence.duration_ms);
 
   orchestrationGate(
     evidence,
-    restartOrchestrated && !!evidence.receipts['post-restart-claim-listed'],
-    restartOrchestrated
-      ? 'operator restart was declared but no post-restart claim listing was observed'
-      : 'OPENCLAW_RESTART_ORCHESTRATED was not set: no operator gateway restart happened inside the restart window, so durable replay was not exercised',
+    !!evidence.receipts['gateway-restart-observed'] &&
+      !!evidence.receipts['reconnected-after-restart'] &&
+      !!evidence.receipts['post-restart-claim-listed'],
+    evidence.receipts['gateway-restart-observed']
+      ? 'a gateway restart was observed but the reconnected socket saw no post-restart claim listing'
+      : `no gateway restart was observable on ${httpBase}/status inside the window` +
+        (restartOrchestrated
+          ? ' even though OPENCLAW_RESTART_ORCHESTRATED was declared: the declaration is not evidence'
+          : '') +
+        `: ${evidence.lifecycle.observation?.reason || 'no lifecycle change detected'}`,
   );
 
   const verdict = computeVerdict(evidence, REQUIRED);
 
-  check(res, { 'websocket connected': (r) => r && r.status === 101 });
+  check(phase1, { 'websocket connected': (r) => r && r.status === 101 });
   check(null, {
     'pre-restart claim established': () => !!evidence.receipts['pre-restart-claim-established'],
+    'gateway restart observed on the public status surface': () =>
+      !!evidence.receipts['gateway-restart-observed'],
+    'harness reconnected after the restart': () =>
+      !!evidence.receipts['reconnected-after-restart'],
     'no duplicate claim after replay': () =>
       evidence.negative_checks['no-duplicate-claim-after-replay'].held,
     'no automatic materialization on replay': () =>
@@ -248,6 +350,7 @@ export default function () {
     'no raw artifact bytes on the wire': () =>
       evidence.negative_checks['no-raw-artifact-bytes-on-the-wire'].held,
   });
+  if (phase2) check(phase2, { 'reconnect websocket connected': (r) => r && r.status === 101 });
 
   logEvidence(evidence);
   if (verdict !== 'PASS-candidate') {

--- a/tools/k6-proofs/scenarios/r-cd-out-restart-replay.js
+++ b/tools/k6-proofs/scenarios/r-cd-out-restart-replay.js
@@ -1,0 +1,265 @@
+/**
+ * Scenario: R-CD-OUT-REPLAY — claim survives restart and replays exactly once.
+ *
+ * Proves the durability half of the managed delegate OUTPUT lifecycle:
+ *   1. A claim is published and announced to its recipient session.
+ *   2. Across a gateway lifecycle event, the claim is still listable and
+ *      inspectable by the recipient — the binding is durable, not in-memory.
+ *   3. The replay delivery is idempotent: the recipient sees the SAME claim id,
+ *      not a duplicate claim and not a second materialization.
+ *
+ * Runtime surface: src/agents/delegate-artifact-delivery.ts (delivery phases
+ * attempt | replay | acknowledged), src/state/delegate-artifacts-schema.ts.
+ *
+ * ORCHESTRATION GATE — read this before reading a verdict:
+ *   The gateway restart is an operator step. This harness must not restart a
+ *   seat. Set `OPENCLAW_RESTART_ORCHESTRATED=true` only when an operator
+ *   actually cycled the gateway between the pre- and post-phase of this run.
+ *   Without it, the row terminates PARTIAL-candidate naming the missing step;
+ *   the pre-restart legs it did observe are still recorded as receipts.
+ *
+ * References:
+ *   - Issue: karmaterminal/karmaterminal-openclaw-docs#491
+ *   - Manifest: tools/k6-proofs/manifests/r-cd-out-replay.json
+ */
+import ws from 'k6/ws';
+import { check } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+import { connectFrame, nonce, RequestTracker } from '../lib/gateway-ws.js';
+import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+import {
+  baseEvidence,
+  boolEnv,
+  breakNegative,
+  canaryFor,
+  capture,
+  computeVerdict,
+  contentReceipt,
+  declareNegative,
+  fire,
+  logEvidence,
+  matchGroup,
+  orchestrationGate,
+  rowSummary,
+  scanRawBytes,
+} from '../lib/delegate-attachment-io.js';
+
+const ROW = 'R-CD-OUT-REPLAY';
+
+export const options = {
+  scenarios: {
+    r_cd_out_replay: {
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 1,
+      maxDuration: '420s',
+    },
+  },
+  thresholds: {
+    r_cd_out_replay_duration: ['p(95)<400000'],
+  },
+};
+
+const failures = new Counter('proof_failures');
+const duration = new Trend('r_cd_out_replay_duration');
+
+const manifest = loadManifestFromEnv();
+
+const REQUIRED = [
+  'pre-restart-claim-established',
+  'post-restart-claim-listed',
+  'claim-identity-stable',
+  'replay-is-idempotent',
+];
+
+export default function () {
+  const url = __ENV.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
+  const token = __ENV.OPENCLAW_GATEWAY_TOKEN;
+  const recipientSessionKey = manifest?.sessionKey || __ENV.OPENCLAW_SESSION_KEY || 'main';
+  const seat = manifest?.seat || __ENV.OPENCLAW_SEAT_NAME || 'rune-rog-ally';
+  const restartOrchestrated = boolEnv('OPENCLAW_RESTART_ORCHESTRATED');
+  const restartWindowMs = Number(__ENV.OPENCLAW_RESTART_WINDOW_MS || 120000);
+  const rowNonce = nonce(ROW);
+  const canary = canaryFor(rowNonce);
+
+  if (!token) {
+    console.error('OPENCLAW_GATEWAY_TOKEN is required');
+    failures.add(1);
+    return;
+  }
+  if (manifest) {
+    const errors = validateManifest(manifest);
+    if (errors.length > 0) console.warn(`Manifest validation warnings: ${errors.join('; ')}`);
+  }
+
+  const evidence = baseEvidence({
+    row: ROW,
+    nonce: rowNonce,
+    seat,
+    requestedSessionKey: recipientSessionKey,
+    sessionKey: recipientSessionKey,
+    manifest,
+    orchestrationRequired: 'operator gateway restart between the pre- and post-phase of this run',
+  });
+  evidence.content_receipt = contentReceipt(canary);
+  evidence.restart_window_ms = restartWindowMs;
+  declareNegative(
+    evidence,
+    'no-raw-artifact-bytes-on-the-wire',
+    'artifact content must never appear on a non-harness gateway frame across replay',
+  );
+  declareNegative(
+    evidence,
+    'no-duplicate-claim-after-replay',
+    'replay must not mint a second claim for the same publication',
+  );
+  declareNegative(
+    evidence,
+    'no-auto-materialize-on-replay',
+    'replay must not materialize the artifact without an explicit recipient action',
+  );
+
+  const started = Date.now();
+
+  const res = ws.connect(url, {}, (socket) => {
+    const tracker = new RequestTracker();
+
+    function askPostRestartList() {
+      const instruction =
+        `[k6-proof-harness] Call delegate_artifacts with action="list" and reply exactly ` +
+        `CDREPLAY-POST ${rowNonce} <claimId> <count> where <claimId> is the claim whose name contains ` +
+        `${rowNonce} and <count> is how many claims carry that nonce. Do not materialize anything. ` +
+        `This is a proof run — no other action needed.`;
+      tracker.send(socket, 'sessions.send', {
+        key: recipientSessionKey,
+        message: instruction,
+        idempotencyKey: `${ROW}-POST-${rowNonce}`,
+      });
+    }
+
+    socket.on('open', () => {
+      socket.send(connectFrame(token));
+      socket.setTimeout(() => {
+        tracker.send(socket, 'sessions.messages.subscribe', { key: recipientSessionKey });
+        const instruction =
+          `[k6-proof-harness] Call continue_delegate exactly once with ` +
+          `task="Write the single line ${canary} into delegate-artifacts/p86-replay-${rowNonce}.txt in your ` +
+          `own workspace, then call delegate_artifacts_publish with paths=[\\"p86-replay-${rowNonce}.txt\\"]. ` +
+          `Reply exactly CDREPLAY-PUBLISHED ${rowNonce}. Do not print the file contents.", ` +
+          `mode="normal", delaySeconds=1. After the delegate returns, call delegate_artifacts with ` +
+          `action="list" and reply exactly CDREPLAY-PRE ${rowNonce} <claimId>. Do not materialize anything. ` +
+          `This is a proof run — no other action needed.`;
+        tracker.send(socket, 'sessions.send', {
+          key: recipientSessionKey,
+          message: instruction,
+          idempotencyKey: `${ROW}-DISPATCH-${rowNonce}`,
+        });
+      }, 400);
+      socket.setTimeout(() => socket.close(), 400000);
+    });
+
+    socket.on('message', (raw) => {
+      try {
+        const msg = JSON.parse(raw);
+        const classified = tracker.classify(msg);
+        const body = capture(evidence, classified);
+
+        if (classified.kind === 'response' && classified.method === 'sessions.send') {
+          if (!classified.ok) failures.add(1);
+          return;
+        }
+
+        if (classified.kind !== 'event' || !body) return;
+
+        scanRawBytes(evidence, body, rowNonce, 'no-raw-artifact-bytes-on-the-wire');
+
+        const preClaim = matchGroup(body, new RegExp(`CDREPLAY-PRE ${rowNonce} ([A-Za-z0-9_.:-]+)`));
+        if (preClaim && !evidence.pre_restart_claim_id) {
+          evidence.pre_restart_claim_id = preClaim;
+          evidence.provenance.claim_id = preClaim;
+          fire(evidence, 'pre-restart-claim-established');
+          console.log(
+            `${ROW}: pre-restart claim captured. Operator restart window opens now ` +
+              `(${restartWindowMs}ms) — restart the gateway to exercise durable replay.`,
+          );
+          socket.setTimeout(askPostRestartList, restartWindowMs);
+        }
+
+        const post = body.match(
+          new RegExp(`CDREPLAY-POST ${rowNonce} ([A-Za-z0-9_.:-]+) ([0-9]+)`),
+        );
+        if (post) {
+          fire(evidence, 'post-restart-claim-listed');
+          evidence.post_restart_claim_id = post[1];
+          evidence.post_restart_claim_count = Number(post[2]);
+          if (evidence.pre_restart_claim_id && post[1] === evidence.pre_restart_claim_id) {
+            fire(evidence, 'claim-identity-stable');
+          }
+          if (Number(post[2]) === 1) {
+            fire(evidence, 'replay-is-idempotent');
+          } else if (Number(post[2]) > 1) {
+            breakNegative(
+              evidence,
+              'no-duplicate-claim-after-replay',
+              `replay produced ${post[2]} claims for one publication`,
+            );
+          }
+          socket.close();
+        }
+
+        if (body.includes('"materialized"')) {
+          breakNegative(
+            evidence,
+            'no-auto-materialize-on-replay',
+            'a materialized state appeared without any explicit recipient materialize call',
+          );
+        }
+      } catch (e) {
+        console.warn(`parse error: ${e}`);
+      }
+    });
+
+    socket.on('error', (e) => {
+      console.error(`ws error: ${e && e.error ? e.error() : e}`);
+      failures.add(1);
+    });
+  });
+
+  evidence.duration_ms = Date.now() - started;
+  duration.add(evidence.duration_ms);
+
+  orchestrationGate(
+    evidence,
+    restartOrchestrated && !!evidence.receipts['post-restart-claim-listed'],
+    restartOrchestrated
+      ? 'operator restart was declared but no post-restart claim listing was observed'
+      : 'OPENCLAW_RESTART_ORCHESTRATED was not set: no operator gateway restart happened inside the restart window, so durable replay was not exercised',
+  );
+
+  const verdict = computeVerdict(evidence, REQUIRED);
+
+  check(res, { 'websocket connected': (r) => r && r.status === 101 });
+  check(null, {
+    'pre-restart claim established': () => !!evidence.receipts['pre-restart-claim-established'],
+    'no duplicate claim after replay': () =>
+      evidence.negative_checks['no-duplicate-claim-after-replay'].held,
+    'no automatic materialization on replay': () =>
+      evidence.negative_checks['no-auto-materialize-on-replay'].held,
+    'no raw artifact bytes on the wire': () =>
+      evidence.negative_checks['no-raw-artifact-bytes-on-the-wire'].held,
+  });
+
+  logEvidence(evidence);
+  if (verdict !== 'PASS-candidate') {
+    console.log(`[${ROW}] ${evidence.orchestration.reason || 'see missing_receipts'}`);
+  }
+}
+
+export function handleSummary(data) {
+  return rowSummary({
+    row: ROW,
+    data,
+    durationMetric: 'r_cd_out_replay_duration',
+    summaryFile: 'r-cd-out-restart-replay-summary.json',
+  });
+}

--- a/tools/k6-proofs/scenarios/r-cd-out-unauthorized-reject.js
+++ b/tools/k6-proofs/scenarios/r-cd-out-unauthorized-reject.js
@@ -1,0 +1,300 @@
+/**
+ * Scenario: R-CD-OUT-UNAUTHORIZED — non-recipient claim access is rejected.
+ *
+ * Proves the authorization boundary of the managed delegate OUTPUT claim:
+ *   1. Session A originates a delegate whose child publishes an artifact.
+ *      The resulting claim is bound to A.
+ *   2. Session B (a disposable, non-recipient session) is handed the SAME claim
+ *      id and calls `delegate_artifacts` inspect and materialize.
+ *   3. Both must be REJECTED. A claim is recipient-bound, not bearer-authorized:
+ *      knowing the claim id must not be sufficient.
+ *   4. Session A (the true recipient) can still inspect — this is the positive
+ *      control that proves the rejection was authorization, not a dead claim.
+ *
+ * Runtime surface: src/agents/delegate-artifact-store.ts (claim/binding status,
+ * including `revoked`), src/agents/delegate-artifact-recipient.ts.
+ *
+ * References:
+ *   - Issue: karmaterminal/karmaterminal-openclaw-docs#491
+ *   - Manifest: tools/k6-proofs/manifests/r-cd-out-unauthorized.json
+ */
+import ws from 'k6/ws';
+import { check } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+import { connectFrame, nonce, RequestTracker } from '../lib/gateway-ws.js';
+import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+import { closeSocketAfterDelay } from '../lib/socket-close.js';
+import {
+  baseEvidence,
+  breakNegative,
+  canaryFor,
+  capture,
+  computeVerdict,
+  contentReceipt,
+  declareNegative,
+  fire,
+  logEvidence,
+  matchGroup,
+  rowSummary,
+  scanRawBytes,
+} from '../lib/delegate-attachment-io.js';
+
+const ROW = 'R-CD-OUT-UNAUTHORIZED';
+
+export const options = {
+  scenarios: {
+    r_cd_out_unauthorized: {
+      executor: 'shared-iterations',
+      vus: 1,
+      iterations: 1,
+      maxDuration: '320s',
+    },
+  },
+  thresholds: {
+    proof_failures: ['count==0'],
+    r_cd_out_unauthorized_duration: ['p(95)<300000'],
+  },
+};
+
+const failures = new Counter('proof_failures');
+const duration = new Trend('r_cd_out_unauthorized_duration');
+
+const manifest = loadManifestFromEnv();
+
+const REQUIRED = [
+  'recipient-claim-established',
+  'non-recipient-inspect-rejected',
+  'non-recipient-materialize-rejected',
+  'recipient-positive-control',
+];
+
+export default function () {
+  const url = __ENV.OPENCLAW_GATEWAY_WS || 'ws://127.0.0.1:18789';
+  const token = __ENV.OPENCLAW_GATEWAY_TOKEN;
+  const recipientSessionKey = manifest?.sessionKey || __ENV.OPENCLAW_SESSION_KEY || 'main';
+  const seat = manifest?.seat || __ENV.OPENCLAW_SEAT_NAME || 'rune-rog-ally';
+  const rowNonce = nonce(ROW);
+  const canary = canaryFor(rowNonce);
+  let intruderSessionKey = null;
+
+  if (!token) {
+    console.error('OPENCLAW_GATEWAY_TOKEN is required');
+    failures.add(1);
+    return;
+  }
+  if (!__ENV.OPENCLAW_SESSION_KEY) {
+    console.warn(
+      `${ROW}: OPENCLAW_SESSION_KEY should be set explicitly — this row binds a claim to a named recipient session`,
+    );
+  }
+  if (manifest) {
+    const errors = validateManifest(manifest);
+    if (errors.length > 0) console.warn(`Manifest validation warnings: ${errors.join('; ')}`);
+  }
+
+  const evidence = baseEvidence({
+    row: ROW,
+    nonce: rowNonce,
+    seat,
+    requestedSessionKey: recipientSessionKey,
+    sessionKey: recipientSessionKey,
+    manifest,
+  });
+  evidence.content_receipt = contentReceipt(canary);
+  declareNegative(
+    evidence,
+    'no-raw-artifact-bytes-on-the-wire',
+    'artifact content must never appear on a non-harness gateway frame',
+  );
+  declareNegative(
+    evidence,
+    'claim-is-not-bearer-authorized',
+    'possession of a claim id must not grant a non-recipient session access',
+  );
+
+  const started = Date.now();
+
+  const res = ws.connect(url, {}, (socket) => {
+    const tracker = new RequestTracker();
+    let closeScheduled = false;
+
+    function maybeClose() {
+      if (closeScheduled) return;
+      if (REQUIRED.some((name) => !evidence.receipts[name])) return;
+      closeScheduled = true;
+      closeSocketAfterDelay(socket, Number(__ENV.OPENCLAW_NEGATIVE_WINDOW_MS || 15000), () => {
+        console.log(`${ROW}: authorization receipts gathered, closing`);
+      });
+    }
+
+    function askIntruder(claimId) {
+      const instruction =
+        `[k6-proof-harness] You are NOT the recipient of artifact claim ${claimId}. ` +
+        `Call delegate_artifacts with action="inspect", claimId="${claimId}" and reply exactly ` +
+        `CDUNAUTH-INSPECT ${rowNonce} <ok|rejected>. Then call delegate_artifacts with ` +
+        `action="materialize", claimId="${claimId}", destination="p86-intrusion/${rowNonce}.txt" and reply ` +
+        `exactly CDUNAUTH-MATERIALIZE ${rowNonce} <ok|rejected>. ` +
+        `Report the honest outcome of each call. This is a proof run — no other action needed.`;
+      tracker.send(socket, 'sessions.send', {
+        key: intruderSessionKey,
+        message: instruction,
+        idempotencyKey: `${ROW}-INTRUDER-${rowNonce}`,
+      });
+    }
+
+    function askRecipientPositiveControl(claimId) {
+      const instruction =
+        `[k6-proof-harness] Call delegate_artifacts with action="inspect", claimId="${claimId}" and reply ` +
+        `exactly CDUNAUTH-OWNER ${rowNonce} <ok|rejected>. Do not print the artifact contents. ` +
+        `This is a proof run — no other action needed.`;
+      tracker.send(socket, 'sessions.send', {
+        key: recipientSessionKey,
+        message: instruction,
+        idempotencyKey: `${ROW}-OWNER-${rowNonce}`,
+      });
+    }
+
+    socket.on('open', () => {
+      socket.send(connectFrame(token));
+      socket.setTimeout(() => {
+        tracker.send(socket, 'sessions.messages.subscribe', { key: recipientSessionKey });
+        const intruderKey = `r-cd-out-unauth-${rowNonce}`.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+        tracker.send(socket, 'sessions.create', { key: intruderKey, label: `k6 ${ROW} non-recipient` });
+      }, 400);
+      socket.setTimeout(() => socket.close(), 300000);
+    });
+
+    socket.on('message', (raw) => {
+      try {
+        const msg = JSON.parse(raw);
+        const classified = tracker.classify(msg);
+        const body = capture(evidence, classified);
+
+        if (classified.kind === 'response' && classified.method === 'sessions.create') {
+          if (classified.ok && classified.payload) {
+            intruderSessionKey = classified.payload.key;
+            evidence.intruder_session_key = intruderSessionKey;
+            tracker.send(socket, 'sessions.messages.subscribe', { key: intruderSessionKey });
+            const instruction =
+              `[k6-proof-harness] Call continue_delegate exactly once with ` +
+              `task="Write the single line ${canary} into delegate-artifacts/p86-auth-${rowNonce}.txt in your ` +
+              `own workspace, then call delegate_artifacts_publish with paths=[\\"p86-auth-${rowNonce}.txt\\"]. ` +
+              `Reply exactly CDUNAUTH-PUBLISHED ${rowNonce}. Do not print the file contents.", ` +
+              `mode="normal", delaySeconds=1. After the delegate returns, call delegate_artifacts with ` +
+              `action="list" and reply exactly CDUNAUTH-CLAIM ${rowNonce} <claimId>. ` +
+              `This is a proof run — no other action needed.`;
+            tracker.send(socket, 'sessions.send', {
+              key: recipientSessionKey,
+              message: instruction,
+              idempotencyKey: `${ROW}-DISPATCH-${rowNonce}`,
+            });
+          } else {
+            failures.add(1);
+            socket.close();
+          }
+          return;
+        }
+
+        if (classified.kind === 'response' && classified.method === 'sessions.send') {
+          if (!classified.ok) failures.add(1);
+          return;
+        }
+
+        if (classified.kind !== 'event' || !body) return;
+
+        scanRawBytes(evidence, body, rowNonce, 'no-raw-artifact-bytes-on-the-wire');
+
+        const claimId = matchGroup(body, new RegExp(`CDUNAUTH-CLAIM ${rowNonce} ([A-Za-z0-9_.:-]+)`));
+        if (claimId && !evidence.provenance.claim_id) {
+          evidence.provenance.claim_id = claimId;
+          fire(evidence, 'recipient-claim-established');
+          if (intruderSessionKey) askIntruder(claimId);
+        }
+
+        const intruderInspect = matchGroup(
+          body,
+          new RegExp(`CDUNAUTH-INSPECT ${rowNonce} ([A-Za-z]+)`),
+        );
+        if (intruderInspect) {
+          evidence.intruder_inspect_outcome = intruderInspect;
+          if (intruderInspect.toLowerCase() === 'rejected') {
+            fire(evidence, 'non-recipient-inspect-rejected');
+          } else {
+            breakNegative(
+              evidence,
+              'claim-is-not-bearer-authorized',
+              'a non-recipient session successfully inspected the claim',
+            );
+          }
+        }
+
+        const intruderMaterialize = matchGroup(
+          body,
+          new RegExp(`CDUNAUTH-MATERIALIZE ${rowNonce} ([A-Za-z]+)`),
+        );
+        if (intruderMaterialize) {
+          evidence.intruder_materialize_outcome = intruderMaterialize;
+          if (intruderMaterialize.toLowerCase() === 'rejected') {
+            fire(evidence, 'non-recipient-materialize-rejected');
+          } else {
+            breakNegative(
+              evidence,
+              'claim-is-not-bearer-authorized',
+              'a non-recipient session successfully materialized the claim',
+            );
+          }
+          if (evidence.provenance.claim_id) askRecipientPositiveControl(evidence.provenance.claim_id);
+        }
+
+        const owner = matchGroup(body, new RegExp(`CDUNAUTH-OWNER ${rowNonce} ([A-Za-z]+)`));
+        if (owner) {
+          evidence.recipient_inspect_outcome = owner;
+          if (owner.toLowerCase() === 'ok') {
+            fire(evidence, 'recipient-positive-control');
+          } else {
+            evidence.positive_control_failed = true;
+          }
+        }
+
+        maybeClose();
+      } catch (e) {
+        console.warn(`parse error: ${e}`);
+      }
+    });
+
+    socket.on('error', (e) => {
+      console.error(`ws error: ${e && e.error ? e.error() : e}`);
+      failures.add(1);
+    });
+  });
+
+  evidence.duration_ms = Date.now() - started;
+  duration.add(evidence.duration_ms);
+  const verdict = computeVerdict(evidence, REQUIRED);
+
+  check(res, { 'websocket connected': (r) => r && r.status === 101 });
+  check(null, {
+    'recipient-bound claim established': () => !!evidence.receipts['recipient-claim-established'],
+    'non-recipient inspect rejected': () => !!evidence.receipts['non-recipient-inspect-rejected'],
+    'non-recipient materialize rejected': () =>
+      !!evidence.receipts['non-recipient-materialize-rejected'],
+    'recipient positive control still succeeds': () =>
+      !!evidence.receipts['recipient-positive-control'],
+    'claim id alone grants nothing': () =>
+      evidence.negative_checks['claim-is-not-bearer-authorized'].held,
+    'no raw artifact bytes on the wire': () =>
+      evidence.negative_checks['no-raw-artifact-bytes-on-the-wire'].held,
+  });
+
+  if (verdict !== 'PASS-candidate') failures.add(1);
+  logEvidence(evidence);
+}
+
+export function handleSummary(data) {
+  return rowSummary({
+    row: ROW,
+    data,
+    durationMetric: 'r_cd_out_unauthorized_duration',
+    summaryFile: 'r-cd-out-unauthorized-reject-summary.json',
+  });
+}

--- a/tools/k6-proofs/scripts/__tests__/delegate-attachment-io-rows.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/delegate-attachment-io-rows.test.mjs
@@ -1,0 +1,313 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+const manifestsDir = path.join(repoRoot, 'tools/k6-proofs/manifests');
+const scenariosDir = path.join(repoRoot, 'tools/k6-proofs/scenarios');
+const libPath = path.join(repoRoot, 'tools/k6-proofs/lib/delegate-attachment-io.js');
+const docPath = path.join(repoRoot, 'tools/k6-proofs/docs/DELEGATE-ATTACHMENT-IO-ROWS.md');
+const workflowPath = path.join(repoRoot, '.github/workflows/k6-proof.yml');
+
+/**
+ * The P86 delegate attachment I/O row family (docs#491).
+ *
+ * `orchestrationGated` rows depend on an operator step a k6 harness cannot
+ * perform (config revoke, gateway restart). They must never declare a
+ * PASS-candidate expectation, and their scenario must route the verdict through
+ * `orchestrationGate` so an unperformed precondition cannot be silently upgraded.
+ */
+const ROWS = [
+  {
+    rowId: 'R-CD-IN-1',
+    manifest: 'r-cd-in-1.json',
+    scenario: 'r-cd-in-1-typed-input-snapshot.js',
+    orchestrationGated: false,
+  },
+  {
+    rowId: 'R-CD-IN-RECOVERY',
+    manifest: 'r-cd-in-recovery.json',
+    scenario: 'r-cd-in-recovery-queued-restart.js',
+    orchestrationGated: true,
+  },
+  {
+    rowId: 'R-CD-IN-REVOKE',
+    manifest: 'r-cd-in-revoke.json',
+    scenario: 'r-cd-in-revoke-no-spawn-scrub.js',
+    orchestrationGated: true,
+  },
+  {
+    rowId: 'R-CD-OUT-PUBLISH',
+    manifest: 'r-cd-out-publish.json',
+    scenario: 'r-cd-out-publish-claim.js',
+    orchestrationGated: false,
+  },
+  {
+    rowId: 'R-CD-OUT-CLAIM',
+    manifest: 'r-cd-out-claim.json',
+    scenario: 'r-cd-out-claim-lifecycle.js',
+    orchestrationGated: false,
+  },
+  {
+    rowId: 'R-CD-OUT-UNAUTHORIZED',
+    manifest: 'r-cd-out-unauthorized.json',
+    scenario: 'r-cd-out-unauthorized-reject.js',
+    orchestrationGated: false,
+  },
+  {
+    rowId: 'R-CD-OUT-REPLAY',
+    manifest: 'r-cd-out-replay.json',
+    scenario: 'r-cd-out-restart-replay.js',
+    orchestrationGated: true,
+  },
+  {
+    rowId: 'R-CD-IO-NEG',
+    manifest: 'r-cd-io-neg.json',
+    scenario: 'r-cd-io-negative-boundary.js',
+    orchestrationGated: false,
+  },
+];
+
+async function readManifest(file) {
+  return JSON.parse(await readFile(path.join(manifestsDir, file), 'utf8'));
+}
+
+async function readScenario(file) {
+  return readFile(path.join(scenariosDir, file), 'utf8');
+}
+
+for (const row of ROWS) {
+  test(`${row.rowId} manifest binds to docs#491 and the candidate SHA`, async () => {
+    const manifest = await readManifest(row.manifest);
+    assert.equal(manifest.schema, 'openclaw.k6.proof-row-manifest.v1');
+    assert.equal(manifest.rowId, row.rowId);
+    assert.equal(manifest.issue, 491, 'every row in this family binds to docs#491');
+    assert.equal(manifest.candidateSha, '${OPENCLAW_CANDIDATE_SHA}');
+    assert.equal(manifest.artifactDestination.row, row.rowId);
+    assert.equal(manifest.review.candidateOnly, true);
+    assert.equal(manifest.review.foldRequiresReview, true);
+    assert.equal(manifest.liveRunSafety.foldRequiresReview, true);
+    assert.equal(
+      manifest.liveRunSafety.requiresCandidateSha,
+      true,
+      'a receipt is only meaningful when pinned to the SHA it was fired against',
+    );
+    assert.equal(
+      manifest.liveRunSafety.sameSessionConcurrencySafe,
+      false,
+      'these rows mutate delegate/claim state and must be serialized per session',
+    );
+  });
+
+  test(`${row.rowId} manifest points at its runnable scenario`, async () => {
+    const manifest = await readManifest(row.manifest);
+    assert.equal(manifest.scenario.status, 'runnable');
+    assert.equal(manifest.scenario.file, row.scenario);
+    await readScenario(row.scenario); // throws when the file is missing
+  });
+
+  test(`${row.rowId} requiredReceipts all resolve to declared expectedReceipts`, async () => {
+    const manifest = await readManifest(row.manifest);
+    const declared = new Set(manifest.expectedReceipts.map((receipt) => receipt.name));
+    for (const name of manifest.liveRunSafety.requiredReceipts) {
+      if (name === 'seat-readiness') continue;
+      assert.ok(
+        declared.has(name),
+        `${row.rowId}: requiredReceipts names '${name}' with no matching expectedReceipts entry`,
+      );
+    }
+  });
+
+  test(`${row.rowId} scenario never writes attachment content into evidence`, async () => {
+    const source = await readScenario(row.scenario);
+    assert.match(
+      source,
+      /contentReceipt\(canary\)/,
+      'the canary must be reduced to a byte count and digest, never stored',
+    );
+    assert.doesNotMatch(
+      source,
+      /content_receipt\s*=\s*canary/,
+      'the canary content must never be assigned into evidence directly',
+    );
+    assert.match(source, /capture\(evidence, classified\)/, 'every frame goes through the redacting capture');
+    assert.doesNotMatch(
+      source,
+      /redacted_events\.push/,
+      'scenarios must not bypass capture() to push unredacted frames',
+    );
+  });
+
+  test(`${row.rowId} scenario carries at least one negative boundary check`, async () => {
+    const source = await readScenario(row.scenario);
+    assert.match(source, /declareNegative\(/, `${row.rowId} must declare a negative check`);
+    assert.match(
+      source,
+      /computeVerdict\(evidence, REQUIRED\)/,
+      'the verdict must come from the shared honesty gate, not an ad-hoc boolean',
+    );
+  });
+
+  test(`${row.rowId} orchestration gating matches its declared artifact class`, async () => {
+    const manifest = await readManifest(row.manifest);
+    const source = await readScenario(row.scenario);
+    if (row.orchestrationGated) {
+      assert.equal(
+        manifest.liveRunSafety.classification,
+        'orchestration-required',
+        `${row.rowId} depends on an operator step and must be orchestration-required`,
+      );
+      assert.equal(
+        manifest.liveRunSafety.expectedArtifactClass,
+        'PARTIAL-candidate',
+        `${row.rowId} must not advertise PASS for an operator step the harness cannot perform`,
+      );
+      assert.match(
+        source,
+        /orchestrationGate\(/,
+        `${row.rowId} must route its verdict through orchestrationGate`,
+      );
+    } else {
+      assert.equal(manifest.liveRunSafety.classification, 'k6-runnable');
+      assert.equal(manifest.liveRunSafety.expectedArtifactClass, 'PASS-candidate');
+    }
+  });
+}
+
+test('no row in the family can be forced to PASS by an environment variable', async () => {
+  for (const row of ROWS) {
+    const source = await readScenario(row.scenario);
+    assert.doesNotMatch(
+      source,
+      /verdict\s*=\s*['"]PASS-candidate['"]/,
+      `${row.rowId} must not assign PASS-candidate directly`,
+    );
+    assert.doesNotMatch(
+      source,
+      /FORCE_PASS|OPENCLAW_ASSUME_|SKIP_NEGATIVE/,
+      `${row.rowId} must expose no verdict override switch`,
+    );
+  }
+});
+
+test('computeVerdict only returns PASS when receipts, negatives and orchestration all hold', async () => {
+  const source = await readFile(libPath, 'utf8');
+  assert.match(source, /missing\.length === 0 && violated\.length === 0 && orchestrationOk/);
+  assert.match(source, /\? 'PASS-candidate'\s*\n?\s*:\s*'PARTIAL-candidate'/);
+  assert.doesNotMatch(
+    source,
+    /HONEST-LIMIT-candidate/,
+    'HONEST-LIMIT is reserved for R-RC-2 and must not leak into this family',
+  );
+});
+
+test('the shared lib never records raw payload content', async () => {
+  const source = await readFile(libPath, 'utf8');
+  assert.match(source, /sha256_prefix/);
+  assert.match(source, /bytes: text\.length/);
+  assert.doesNotMatch(
+    source,
+    /content:\s*text/,
+    'contentReceipt must not carry the payload itself',
+  );
+  assert.match(source, /import \{ redactEvent \} from '\.\/gateway-ws\.js'/);
+});
+
+test('the harness-echo exclusion is explicit and counted, not silent', async () => {
+  const source = await readFile(libPath, 'utf8');
+  assert.match(source, /prompt_echoes_ignored \+= 1/);
+  assert.match(source, /HARNESS_MARKER/);
+});
+
+test('the OUT rows exercise the real delegate_artifacts controller actions', async () => {
+  const lifecycle = await readScenario('r-cd-out-claim-lifecycle.js');
+  for (const action of ['list', 'inspect', 'materialize', 'discard']) {
+    assert.match(
+      lifecycle,
+      new RegExp(`action="${action}"`),
+      `R-CD-OUT-CLAIM must drive the real delegate_artifacts action=${action}`,
+    );
+  }
+  const publish = await readScenario('r-cd-out-publish-claim.js');
+  assert.match(publish, /delegate_artifacts_publish/);
+});
+
+test('the IN rows exercise the typed attachment-bearing continue_delegate surface', async () => {
+  for (const file of [
+    'r-cd-in-1-typed-input-snapshot.js',
+    'r-cd-in-recovery-queued-restart.js',
+    'r-cd-in-revoke-no-spawn-scrub.js',
+  ]) {
+    const source = await readScenario(file);
+    assert.match(source, /continue_delegate/, `${file} must call continue_delegate`);
+    assert.match(source, /attachments=\[\{/, `${file} must carry a typed inline attachment`);
+  }
+});
+
+test('R-CD-IN-REVOKE reads the live policy and refuses to assume a default', async () => {
+  const source = await readScenario('r-cd-in-revoke-no-spawn-scrub.js');
+  assert.match(source, /tracker\.send\(socket, 'config\.get', \{\}\)/);
+  assert.match(source, /operator_surface: true/);
+  assert.match(
+    source,
+    /typeof enabled === 'boolean' \? enabled : null/,
+    'an absent policy field must read as null (PARTIAL), never as a presumed default',
+  );
+  assert.match(source, /attachment_policy_enabled === false/);
+});
+
+test('R-CD-IO-NEG keeps a positive control so its negatives are not vacuous', async () => {
+  const source = await readScenario('r-cd-io-negative-boundary.js');
+  assert.match(source, /claim-announced-positive-control/);
+  assert.match(source, /negative-window-elapsed/);
+  const manifest = await readManifest('r-cd-io-neg.json');
+  assert.ok(
+    manifest.liveRunSafety.requiredReceipts.includes('claim-announced-positive-control'),
+    'the positive control must be a required receipt',
+  );
+  for (const negative of [
+    'no-automatic-raw-byte-mount',
+    'no-automatic-materialization',
+    'no-native-media-upload',
+    'no-generic-render-or-forward',
+    'no-prompt-injection',
+  ]) {
+    assert.ok(
+      manifest.liveRunSafety.requiredReceipts.includes(negative),
+      `${negative} must be a required receipt on R-CD-IO-NEG`,
+    );
+  }
+});
+
+test('R-CD-OUT-UNAUTHORIZED keeps a recipient positive control', async () => {
+  const manifest = await readManifest('r-cd-out-unauthorized.json');
+  assert.ok(manifest.liveRunSafety.requiredReceipts.includes('recipient-positive-control'));
+  const source = await readScenario('r-cd-out-unauthorized-reject.js');
+  assert.match(source, /askRecipientPositiveControl/);
+});
+
+test('every row is a dispatch choice in the k6 PROOF row workflow', async () => {
+  const workflow = await readFile(workflowPath, 'utf8');
+  for (const row of ROWS) {
+    const choice = row.scenario.replace(/\.js$/u, '');
+    assert.ok(
+      workflow.includes(`- ${choice}\n`),
+      `${row.rowId}: '${choice}' is missing from the workflow scenario choices`,
+    );
+  }
+});
+
+test('the family doc names every row and its runtime controller', async () => {
+  const doc = await readFile(docPath, 'utf8');
+  assert.match(doc, /issues\/491/);
+  for (const row of ROWS) {
+    assert.ok(doc.includes(row.rowId), `family doc is missing ${row.rowId}`);
+    assert.ok(doc.includes(row.manifest), `family doc is missing ${row.manifest}`);
+    assert.ok(doc.includes(row.scenario), `family doc is missing ${row.scenario}`);
+  }
+  assert.match(doc, /delegate_artifacts_publish/);
+  assert.match(doc, /scrubStoredDelegateAttachmentState/);
+  assert.match(doc, /delegate-artifact-delivery\.ts/);
+});

--- a/tools/k6-proofs/scripts/__tests__/delegate-attachment-io-rows.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/delegate-attachment-io-rows.test.mjs
@@ -311,3 +311,335 @@ test('the family doc names every row and its runtime controller', async () => {
   assert.match(doc, /scrubStoredDelegateAttachmentState/);
   assert.match(doc, /delegate-artifact-delivery\.ts/);
 });
+
+// --- PR #493 exact-head review corrections (scribe-dandelion-cult) ---
+
+test('handleSummary reads the authoritative verdict, never proof_failures alone', async () => {
+  const source = await readFile(libPath, 'utf8');
+  assert.match(
+    source,
+    /proof_row_pass/,
+    'the verdict must travel to handleSummary on a metric, because module state does not',
+  );
+  assert.match(source, /iterations > 0 && passes === iterations && partials === 0 && failures === 0/);
+  assert.doesNotMatch(
+    source,
+    /verdict:\s*failures === 0 \?/,
+    'a failures-only derivation prints PASS for orchestration-gated rows that never raise the counter',
+  );
+  assert.match(
+    source,
+    /rowPassCounter\.add\(1\)/,
+    'computeVerdict must publish the verdict it computed',
+  );
+});
+
+test('no scenario in the family carries an over-escaped sentinel regex', async () => {
+  for (const row of ROWS) {
+    const source = await readScenario(row.scenario);
+    assert.doesNotMatch(
+      source,
+      /\\\\\\\\[dsw]/,
+      `${row.rowId}: a template-literal RegExp with \\\\\\\\d matches a literal backslash, so the receipt could never fire`,
+    );
+  }
+});
+
+test('R-CD-IN-1 binds the child report to the known canary rather than trusting it', async () => {
+  const manifest = await readManifest('r-cd-in-1.json');
+  const source = await readScenario('r-cd-in-1-typed-input-snapshot.js');
+  for (const name of [
+    'typed-tool-record-observed',
+    'child-session-bound',
+    'child-bytes-bound-to-canary',
+  ]) {
+    assert.ok(
+      manifest.liveRunSafety.requiredReceipts.includes(name),
+      `R-CD-IN-1 must require '${name}'`,
+    );
+  }
+  assert.match(
+    source,
+    /reportedDigest === evidence\.content_receipt\.sha256_prefix/,
+    'the child-reported digest must be compared against the canary the harness staged',
+  );
+  assert.match(source, /toolResultRecords\(classified\.data, 'continue_delegate'\)/);
+  assert.match(source, /childSessionKeysForRow\(classified\.data, rowNonce\)/);
+});
+
+test('R-CD-OUT-CLAIM requires a claim-bound post-discard rejection', async () => {
+  const manifest = await readManifest('r-cd-out-claim.json');
+  assert.ok(
+    manifest.liveRunSafety.requiredReceipts.includes('post-discard-inspect-rejected'),
+    'without this receipt the row can PASS while the discarded claim is still readable',
+  );
+  const source = await readScenario('r-cd-out-claim-lifecycle.js');
+  assert.match(source, /CDCLAIM-POSTDISCARD \$\{rowNonce\} <claimId> <ok\|rejected>/);
+  assert.match(
+    source,
+    /postClaimId === evidence\.provenance\.claim_id/,
+    'the post-discard probe must name the same claim that was discarded',
+  );
+  assert.match(
+    source,
+    /evidence\.post_discard_tool_rejection === true/,
+    'the rejection must be bound to a structured delegate_artifacts error record',
+  );
+});
+
+test('R-CD-IN-REVOKE credits refusal, no-spawn and scrub from authoritative surfaces', async () => {
+  const manifest = await readManifest('r-cd-in-revoke.json');
+  for (const name of [
+    'pre-probe-session-inventory',
+    'policy-revoke-tool-refusal',
+    'no-child-session-observed',
+    'durable-state-scrubbed',
+  ]) {
+    assert.ok(
+      manifest.liveRunSafety.requiredReceipts.includes(name),
+      `R-CD-IN-REVOKE must require '${name}'`,
+    );
+  }
+  const source = await readScenario('r-cd-in-revoke-no-spawn-scrub.js');
+  assert.match(source, /toolResultRecords\(classified\.data, 'continue_delegate'\)/);
+  assert.match(source, /toolRecordRejected\(record\)/);
+  assert.match(source, /tracker\.send\(socket, 'sessions\.list'/);
+  assert.match(source, /sessionKeysFromList\(classified\.payload\)/);
+  assert.match(source, /recordCarriesAttachmentState\(record\)/);
+  assert.doesNotMatch(
+    source,
+    /fire\(evidence, 'policy-revoke-refusal'\)/,
+    'the refusal receipt must not be fired from a prose sentinel',
+  );
+});
+
+for (const restartRow of ['r-cd-in-recovery-queued-restart.js', 'r-cd-out-restart-replay.js']) {
+  test(`${restartRow} requires an observed restart plus disconnect/reconnect`, async () => {
+    const source = await readScenario(restartRow);
+    assert.match(source, /observeGatewayRestart\(\{/, 'the restart must be observed, not declared');
+    assert.match(source, /'gateway-restart-observed'/);
+    assert.match(source, /'reconnected-after-restart'/);
+    const connects = source.match(/ws\.connect\(url, \{\}, \(socket\) => \{/g) || [];
+    assert.equal(
+      connects.length,
+      2,
+      'the row must disconnect before the restart window and reconnect after it',
+    );
+    assert.doesNotMatch(
+      source,
+      /orchestrationGate\(\s*evidence,\s*restartOrchestrated &&/,
+      'OPENCLAW_RESTART_ORCHESTRATED is an operator declaration and must not gate the verdict by itself',
+    );
+    assert.match(
+      source,
+      /the declaration is not evidence/,
+      'the recorded reason must say why a declaration alone is not credited',
+    );
+  });
+}
+
+for (const restartManifest of ['r-cd-in-recovery.json', 'r-cd-out-replay.json']) {
+  test(`${restartManifest} requires the lifecycle and reconnect receipts`, async () => {
+    const manifest = await readManifest(restartManifest);
+    for (const name of ['gateway-restart-observed', 'reconnected-after-restart']) {
+      assert.ok(
+        manifest.liveRunSafety.requiredReceipts.includes(name),
+        `${restartManifest} must require '${name}'`,
+      );
+    }
+  });
+}
+
+test('the k6 PROOF workflow dry run never executes a mutating scenario', async () => {
+  const workflow = await readFile(workflowPath, 'utf8');
+  const dryRunStep = workflow.slice(
+    workflow.indexOf('- name: Dry run — validate without executing'),
+    workflow.indexOf('- name: Compute live-run lock identity'),
+  );
+  assert.ok(dryRunStep.length > 0, 'the dry-run step must exist');
+  assert.doesNotMatch(dryRunStep, /\bk6 run\b/, 'a dry run must not execute the scenario');
+  assert.match(dryRunStep, /k6 archive/, 'a dry run compiles and inspects instead of executing');
+  const liveStep = workflow.slice(workflow.indexOf('- name: Run k6 scenario (live)'));
+  assert.match(liveStep, /if: \$\{\{ github\.event\.inputs\.dry_run != 'true' \}\}/);
+});
+
+test('the k6 PROOF workflow serializes on the target session and takes both locks', async () => {
+  const workflow = await readFile(workflowPath, 'utf8');
+  assert.match(
+    workflow,
+    /group: k6-proof-session-\$\{\{ github\.event\.inputs\.gateway_ws \}\}-\$\{\{ github\.event\.inputs\.session_key \}\}/,
+    'the concurrency group must be keyed on the target session, not on row+seat',
+  );
+  assert.match(workflow, /live-run-guard\.mjs --manifest "\$MANIFEST_PATH" --shell --require-lock/);
+  assert.match(workflow, /flock --nonblock --conflict-exit-code 75 "\$SESSION_LOCK_PATH"/);
+  assert.match(workflow, /flock --nonblock --conflict-exit-code 75 "\$ROW_LOCK_PATH"/);
+  assert.match(
+    workflow,
+    /manifest_path is required when dry_run=false/,
+    'a live run without a manifest can compute neither its lock identity nor its safety contract',
+  );
+});
+
+test('the k6 PROOF workflow binds manifest/scenario identity and uploads only sanitized logs', async () => {
+  const workflow = await readFile(workflowPath, 'utf8');
+  assert.match(workflow, /--manifest "\$MANIFEST_PATH"/);
+  assert.match(workflow, /--scenario "\$\{SCENARIO\}\.js"/);
+  assert.match(workflow, /sanitize-k6-artifacts\.mjs \\\n\s+--log-input \/tmp\/k6-out\/run\.txt/);
+  assert.match(workflow, /rm -f \/tmp\/k6-out\/run\.txt/);
+  assert.doesNotMatch(
+    workflow,
+    /path: \|\n(?:.*\n)*?\s+\/tmp\/k6-out\/run\.txt\n/,
+    'the raw k6 console log must never be uploaded',
+  );
+});
+
+test('the k6 PROOF workflow readiness preflight cannot return success into a live run', async () => {
+  const workflow = await readFile(workflowPath, 'utf8');
+  const preflight = workflow.slice(
+    workflow.indexOf('- name: Seat readiness preflight'),
+    workflow.indexOf('- name: Dry run — validate without executing'),
+  );
+  assert.match(preflight, /this dry run validates artifacts only and executes nothing/);
+  assert.match(preflight, /exit 1/, 'a live run must fail closed on readiness failure');
+});
+
+// --- evidence-writer must consume the receipt-map shape, not the legacy flags ---
+
+const { mkdtemp, writeFile, readFile: readFileAsync, rm } = await import('node:fs/promises');
+const { spawnSync } = await import('node:child_process');
+const os = await import('node:os');
+
+const writerPath = path.join(repoRoot, 'tools/k6-proofs/scripts/evidence-writer.mjs');
+const CANDIDATE_SHA = '374ad60c6d34d3c710ddab3a13ce2189e1fd09fb';
+
+function receiptMapEvidence(overrides = {}) {
+  return {
+    row: 'R-CD-IN-1',
+    issue: 491,
+    manifest_loaded: true,
+    receipts: Object.fromEntries(
+      [
+        'tool-invoke-accepted',
+        'typed-tool-record-observed',
+        'input-snapshot-staged',
+        'child-session-bound',
+        'child-mount-provenance',
+        'child-bytes-bound-to-canary',
+      ].map((name) => [name, { observed: true, at_ms: 1 }]),
+    ),
+    negative_checks: {
+      'no-raw-attachment-bytes-on-the-wire': { held: true },
+      'no-absolute-path-mount': { held: true },
+      'child-bytes-match-the-known-canary': { held: true },
+    },
+    orchestration: { required: null, observed: false, reason: null },
+    missing_receipts: [],
+    violated_negative_checks: [],
+    redacted_events: [{ ts: 1, kind: 'event', event: 'x', data: { ok: true } }],
+    verdict: 'PASS-candidate',
+    ...overrides,
+  };
+}
+
+async function runWriter(evidence, extraArgs = []) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'p86-writer-'));
+  const input = path.join(dir, 'run.txt');
+  await writeFile(
+    input,
+    `--- ${evidence.row} EVIDENCE SUMMARY ---\n${JSON.stringify(evidence)}\n--- END EVIDENCE ---\n`,
+  );
+  const run = spawnSync(
+    process.execPath,
+    [
+      writerPath,
+      '--input', input,
+      '--row', evidence.row,
+      '--seat', 'rune-rog-ally',
+      '--sha', CANDIDATE_SHA,
+      ...extraArgs,
+    ],
+    { cwd: dir, encoding: 'utf8' },
+  );
+  return { dir, run };
+}
+
+test('evidence-writer publishes the receipt-map verdict instead of FAIL-candidate', async () => {
+  const { dir, run } = await runWriter(receiptMapEvidence(), [
+    '--manifest', path.join(manifestsDir, 'r-cd-in-1.json'),
+    '--scenario', 'r-cd-in-1-typed-input-snapshot.js',
+  ]);
+  try {
+    assert.equal(run.status, 0, run.stderr);
+    const { runDir } = JSON.parse(run.stdout);
+    const result = JSON.parse(await readFileAsync(path.join(dir, runDir, 'row-result.json'), 'utf8'));
+    assert.equal(result.outcome, 'PASS-candidate');
+    assert.equal(result.verdictSource, 'receipt-map-recomputed');
+    assert.equal(result.scenario, 'r-cd-in-1-typed-input-snapshot.js');
+    assert.deepEqual(result.receiptAudit.missingReceipts, []);
+    const log = await readFileAsync(path.join(dir, runDir, 'k6-run.log'), 'utf8');
+    assert.match(log, /PUBLIC_EVIDENCE/, 'the run log is published only through the sanitizer');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('evidence-writer refuses a PASS the receipt map does not support', async () => {
+  const weakened = receiptMapEvidence();
+  delete weakened.receipts['child-bytes-bound-to-canary'];
+  const { dir, run } = await runWriter(weakened, [
+    '--manifest', path.join(manifestsDir, 'r-cd-in-1.json'),
+  ]);
+  try {
+    assert.equal(run.status, 1);
+    assert.match(run.stderr, /receipt map does not support it/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('evidence-writer keeps an unobserved orchestration precondition at PARTIAL', async () => {
+  const gated = receiptMapEvidence({
+    row: 'R-CD-OUT-REPLAY',
+    receipts: Object.fromEntries(
+      [
+        'pre-restart-claim-established',
+        'gateway-restart-observed',
+        'reconnected-after-restart',
+        'post-restart-claim-listed',
+        'claim-identity-stable',
+        'replay-is-idempotent',
+      ].map((name) => [name, { observed: true, at_ms: 1 }]),
+    ),
+    negative_checks: {
+      'no-duplicate-claim-after-replay': { held: true },
+      'no-auto-materialize-on-replay': { held: true },
+      'no-raw-artifact-bytes-on-the-wire': { held: true },
+    },
+    orchestration: { required: 'operator gateway restart', observed: false, reason: 'no restart observed' },
+    verdict: 'PARTIAL-candidate',
+  });
+  const { dir, run } = await runWriter(gated, [
+    '--manifest', path.join(manifestsDir, 'r-cd-out-replay.json'),
+  ]);
+  try {
+    assert.equal(run.status, 0, run.stderr);
+    const { runDir } = JSON.parse(run.stdout);
+    const result = JSON.parse(await readFileAsync(path.join(dir, runDir, 'row-result.json'), 'utf8'));
+    assert.equal(result.outcome, 'PARTIAL-candidate');
+    assert.equal(result.receiptAudit.orchestrationObserved, false);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('evidence-writer refuses a row/manifest identity mismatch', async () => {
+  const { dir, run } = await runWriter(receiptMapEvidence(), [
+    '--manifest', path.join(manifestsDir, 'r-cd-out-claim.json'),
+  ]);
+  try {
+    assert.equal(run.status, 1);
+    assert.match(run.stderr, /does not match --row/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tools/k6-proofs/scripts/__tests__/k6-log-framing.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/k6-log-framing.test.mjs
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -275,6 +276,12 @@ test('evidence-writer refuses an unsupported PASS through production framing too
   try {
     assert.equal(run.status, 1);
     assert.match(run.stderr, /receipt map does not support it/);
+    const proofsRoot = path.join(dir, 'PROOFS');
+    await assert.rejects(
+      readFile(proofsRoot),
+      /ENOENT/,
+      'a rejected PASS must not leave an uploadable success-shaped run directory',
+    );
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -345,6 +352,33 @@ test('manifest-loader normalizes every accepted manifest_path form for k6 open()
   }
 });
 
+test('k6 archive receives a present manifest env and rejects malformed JSON in init context', async (t) => {
+  const k6Bin = process.env.K6_BIN || '/home/figs/bin/k6';
+  if (!existsSync(k6Bin)) {
+    t.skip('k6 binary unavailable at ' + k6Bin);
+    return;
+  }
+
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'p86-k6-archive-'));
+  const malformedManifest = path.join(dir, 'malformed.json');
+  try {
+    await writeFile(malformedManifest, '{ this is not JSON');
+    const run = spawnSync(
+      k6Bin,
+      [
+        'archive',
+        '-e', 'OPENCLAW_ROW_MANIFEST=' + malformedManifest,
+        path.join(k6Root, 'scenarios', 'r-cd-in-1-typed-input-snapshot.js'),
+        '-O', path.join(dir, 'archive.tar'),
+      ],
+      { cwd: repoRoot, encoding: 'utf8' },
+    );
+    assert.equal(run.status, 107, run.stdout + '\\n' + run.stderr);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 // --- workflow contract -------------------------------------------------------
 
 test('the workflow normalizes manifest_path once and exercises it in dry-run archive', async () => {
@@ -366,8 +400,8 @@ test('the workflow normalizes manifest_path once and exercises it in dry-run arc
   );
   assert.match(
     workflow,
-    /OPENCLAW_ROW_MANIFEST="\$MANIFEST_PATH" \\\n\s*k6 archive/,
-    'the dry run must compile with the exact manifest env a live run would use',
+    /k6 archive \\\n\s*-e "OPENCLAW_ROW_MANIFEST=\$MANIFEST_PATH"/,
+    'the dry run must pass the manifest through k6, whose archive mode excludes system env by default',
   );
 });
 

--- a/tools/k6-proofs/scripts/__tests__/k6-log-framing.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/k6-log-framing.test.mjs
@@ -1,0 +1,390 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { extractEvidenceData } from '../../lib/k6-log-evidence.mjs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const k6Root = path.resolve(here, '../..');
+const repoRoot = path.resolve(k6Root, '../..');
+const writerPath = path.join(k6Root, 'scripts/evidence-writer.mjs');
+const sanitizerPath = path.join(k6Root, 'scripts/sanitize-k6-artifacts.mjs');
+const manifestsDir = path.join(k6Root, 'manifests');
+const CANDIDATE_SHA = '374ad60c6d34d3c710ddab3a13ce2189e1fd09fb';
+
+// --- production framing ------------------------------------------------------
+//
+// k6 never prints console.log output verbatim. Each call becomes one logrus
+// record and a multi-line JSON payload is escaped into a single `msg="..."`
+// value. Every fixture in this file is built through this helper so the tests
+// exercise the framing the CI workflow actually feeds the consumers.
+function k6Line(message, level = 'info') {
+  return `time="2026-07-30T20:15:52Z" level=${level} msg=${JSON.stringify(message)} source=console`;
+}
+
+const NONCE = 'R-CD-IN-1-1785640552000-canary';
+const SESSION_KEY = 'agent:main:p86';
+const CHILD_SESSION = `agent:main:r-cd-in-1-${NONCE}`;
+
+function inEvidence(overrides = {}) {
+  return {
+    row: 'R-CD-IN-1',
+    issue: 491,
+    manifest_loaded: true,
+    nonce: NONCE,
+    sessionKey: SESSION_KEY,
+    child_session: CHILD_SESSION,
+    mount_path: 'workspace/attachments/p86-canary.txt',
+    content_receipt: { bytes: 42, sha256_prefix: 'ab12cd34ef56' },
+    receipts: Object.fromEntries(
+      [
+        'tool-invoke-accepted',
+        'typed-tool-record-observed',
+        'input-snapshot-staged',
+        'child-session-bound',
+        'child-mount-provenance',
+        'child-bytes-bound-to-canary',
+      ].map((name) => [name, { observed: true, at_ms: 1 }]),
+    ),
+    negative_checks: {
+      'no-raw-attachment-bytes-on-the-wire': { held: true },
+      'no-absolute-path-mount': { held: true },
+      'child-bytes-match-the-known-canary': { held: true },
+    },
+    orchestration: { required: null, observed: false, reason: null },
+    missing_receipts: [],
+    violated_negative_checks: [],
+    redacted_events: [{ ts: 1, kind: 'event', event: 'session.updated', data: { ok: true } }],
+    verdict: 'PASS-candidate',
+    ...overrides,
+  };
+}
+
+/** The exact three-call shape `logEvidence()` emits, as k6 frames it. */
+function productionRunLog(evidence) {
+  return [
+    k6Line(`starting proof row ${evidence.row} against session ${SESSION_KEY}`),
+    k6Line(`[k6-proof-harness] dispatch nonce ${NONCE}`),
+    k6Line(`\n--- ${evidence.row} EVIDENCE SUMMARY ---`),
+    k6Line(JSON.stringify(evidence, null, 2)),
+    k6Line('--- END EVIDENCE ---'),
+    k6Line(`\n[${evidence.row}] VERDICT: ${evidence.verdict}`),
+    '',
+  ].join('\n');
+}
+
+test('extractEvidenceData parses the logrus framing k6 actually emits', () => {
+  const evidence = inEvidence();
+  const { records, markerSeen } = extractEvidenceData(productionRunLog(evidence));
+  assert.equal(markerSeen, true);
+  assert.equal(records.length, 1);
+  assert.equal(records[0].row, 'R-CD-IN-1');
+  assert.equal(records[0].verdict, 'PASS-candidate');
+  assert.deepEqual(Object.keys(records[0].receipts).length, 6);
+});
+
+test('extractEvidenceData still parses bare and pretty-printed fixtures', () => {
+  const evidence = inEvidence();
+  const bareSingleLine = `--- R-CD-IN-1 EVIDENCE SUMMARY ---\n${JSON.stringify(evidence)}\n--- END EVIDENCE ---\n`;
+  const barePretty = `=== K6-PROOF-EVIDENCE ===\n${JSON.stringify(evidence, null, 2)}\n=== END K6-PROOF-EVIDENCE ===\n`;
+  for (const fixture of [bareSingleLine, barePretty]) {
+    const { records, markerSeen } = extractEvidenceData(fixture);
+    assert.equal(markerSeen, true);
+    assert.equal(records.length, 1, 'bare fixtures must keep working');
+    assert.equal(records[0].row, 'R-CD-IN-1');
+  }
+});
+
+test('extractEvidenceData reports markers with zero records instead of silent success', () => {
+  const truncated = [
+    k6Line('\n--- R-CD-IN-1 EVIDENCE SUMMARY ---'),
+    k6Line('{ "row": "R-CD-IN-1", "receipts":'),
+    '',
+  ].join('\n');
+  const { records, markerSeen } = extractEvidenceData(truncated);
+  assert.equal(markerSeen, true);
+  assert.equal(records.length, 0);
+});
+
+// --- sanitizer: log-only mode over production framing -------------------------
+
+async function runSanitizerLogOnly(logText) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'p86-sanitize-'));
+  const input = path.join(dir, 'run.txt');
+  await writeFile(input, logText);
+  const run = spawnSync(
+    process.execPath,
+    [
+      sanitizerPath,
+      '--log-input', input,
+      '--log-out', path.join(dir, 'run.public.txt'),
+      '--receipt-out', path.join(dir, 'run-log-redaction.json'),
+    ],
+    { cwd: dir, encoding: 'utf8', env: { ...process.env, OPENCLAW_SESSION_KEY: SESSION_KEY } },
+  );
+  return { dir, run };
+}
+
+test('log-only sanitizer parses real k6 framing and scrubs its derived tokens', async () => {
+  const { dir, run } = await runSanitizerLogOnly(productionRunLog(inEvidence()));
+  try {
+    assert.equal(run.status, 0, run.stderr);
+    const stdout = JSON.parse(run.stdout);
+    assert.equal(stdout.evidenceBlocks, 1, 'production framing must not parse as zero records');
+    assert.ok(stdout.removedSensitiveValues > 0, 'tokens must be derived from the parsed record');
+
+    const publicLog = await readFile(path.join(dir, 'run.public.txt'), 'utf8');
+    assert.match(publicLog, /PUBLIC_EVIDENCE/, 'the evidence block is re-emitted from its sanitized parse');
+    assert.doesNotMatch(publicLog, new RegExp(NONCE), 'the nonce must not survive into the public log');
+    assert.doesNotMatch(publicLog, new RegExp(CHILD_SESSION.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    assert.ok(!publicLog.includes(SESSION_KEY), 'the target session key must not survive');
+    assert.ok(
+      !/msg="\{/.test(publicLog),
+      'the raw framed evidence payload line must be suppressed, not passed through',
+    );
+    assert.equal(
+      publicLog.split('\n').filter((line) => line.startsWith('PUBLIC_EVIDENCE')).length,
+      1,
+      'exactly one sanitized record replaces the block',
+    );
+
+    const receipt = JSON.parse(await readFile(path.join(dir, 'run-log-redaction.json'), 'utf8'));
+    assert.equal(receipt.evidenceBlocks, 1);
+    assert.equal(receipt.evidenceMarkersSeen, true);
+    assert.ok(receipt.removedSensitiveValues > 0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('log-only sanitizer fails closed on evidence markers with zero parsed records', async () => {
+  const broken = [
+    k6Line(`starting proof row against session ${SESSION_KEY}`),
+    k6Line('\n--- R-CD-IN-1 EVIDENCE SUMMARY ---'),
+    k6Line(`{ "row": "R-CD-IN-1", "nonce": "${NONCE}",`),
+    k6Line('--- END EVIDENCE ---'),
+    '',
+  ].join('\n');
+  const { dir, run } = await runSanitizerLogOnly(broken);
+  try {
+    assert.equal(run.status, 1, 'an unparseable evidence block must not be attested as clean');
+    assert.match(run.stderr, /no evidence record parsed/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('log-only sanitizer still handles a log with no evidence markers at all', async () => {
+  const { dir, run } = await runSanitizerLogOnly(
+    [k6Line('== dry run: no scenario execution, no live session contact =='), ''].join('\n'),
+  );
+  try {
+    assert.equal(run.status, 0, run.stderr);
+    const stdout = JSON.parse(run.stdout);
+    assert.equal(stdout.evidenceMarkersSeen, false);
+    assert.equal(stdout.evidenceBlocks, 0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('log-only sanitizer suppresses the tail of a pretty-printed bare block', async () => {
+  const evidence = inEvidence();
+  const bare = [
+    `some harness line for session ${SESSION_KEY}`,
+    '=== K6-PROOF-EVIDENCE ===',
+    JSON.stringify(evidence, null, 2),
+    '=== END K6-PROOF-EVIDENCE ===',
+    '',
+  ].join('\n');
+  const { dir, run } = await runSanitizerLogOnly(bare);
+  try {
+    assert.equal(run.status, 0, run.stderr);
+    const publicLog = await readFile(path.join(dir, 'run.public.txt'), 'utf8');
+    assert.match(publicLog, /PUBLIC_EVIDENCE/);
+    assert.ok(
+      !/^\s+"mount_path"/m.test(publicLog),
+      'no line of the raw pretty-printed block may pass through as ordinary log text',
+    );
+    assert.ok(!publicLog.includes(NONCE));
+    assert.ok(!publicLog.includes(CHILD_SESSION));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// --- evidence-writer over the workflow's raw k6 log ---------------------------
+
+async function runWriterOnLog(logText, extraArgs) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'p86-writer-framing-'));
+  const input = path.join(dir, 'run.txt');
+  await writeFile(input, logText);
+  const run = spawnSync(
+    process.execPath,
+    [
+      writerPath,
+      '--input', input,
+      '--row', 'R-CD-IN-1',
+      '--seat', 'rune-rog-ally',
+      '--sha', CANDIDATE_SHA,
+      ...extraArgs,
+    ],
+    { cwd: dir, encoding: 'utf8' },
+  );
+  return { dir, run };
+}
+
+test('evidence-writer consumes the raw logrus k6 log the workflow feeds it', async () => {
+  const { dir, run } = await runWriterOnLog(productionRunLog(inEvidence()), [
+    '--manifest', path.join(manifestsDir, 'r-cd-in-1.json'),
+    '--scenario', 'r-cd-in-1-typed-input-snapshot.js',
+  ]);
+  try {
+    assert.equal(run.status, 0, run.stderr);
+    const { runDir } = JSON.parse(run.stdout);
+    const result = JSON.parse(await readFile(path.join(dir, runDir, 'row-result.json'), 'utf8'));
+
+    // The seams the writer previously exited before reaching.
+    assert.equal(result.outcome, 'PASS-candidate');
+    assert.equal(result.verdictSource, 'receipt-map-recomputed');
+    assert.equal(result.rowId, 'R-CD-IN-1');
+    assert.equal(result.scenario, 'r-cd-in-1-typed-input-snapshot.js');
+    assert.deepEqual(result.receiptAudit.missingReceipts, []);
+    assert.ok(result.liveRunSafety, 'liveRunSafety must be captured from the manifest');
+    assert.equal(result.liveRunSafety.foldRequiresReview, true);
+
+    const runLog = await readFile(path.join(dir, runDir, 'k6-run.log'), 'utf8');
+    assert.match(runLog, /PUBLIC_EVIDENCE/);
+    assert.ok(!runLog.includes(NONCE), 'the sanitized run log must not carry the nonce');
+    assert.ok(!runLog.includes(CHILD_SESSION), 'the sanitized run log must not carry the child key');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('evidence-writer refuses an unsupported PASS through production framing too', async () => {
+  const weakened = inEvidence();
+  delete weakened.receipts['child-bytes-bound-to-canary'];
+  const { dir, run } = await runWriterOnLog(productionRunLog(weakened), [
+    '--manifest', path.join(manifestsDir, 'r-cd-in-1.json'),
+  ]);
+  try {
+    assert.equal(run.status, 1);
+    assert.match(run.stderr, /receipt map does not support it/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('evidence-writer names the marker-without-record case distinctly', async () => {
+  const truncated = [
+    k6Line('\n--- R-CD-IN-1 EVIDENCE SUMMARY ---'),
+    k6Line('{ "row": "R-CD-IN-1",'),
+    k6Line('--- END EVIDENCE ---'),
+    '',
+  ].join('\n');
+  const { dir, run } = await runWriterOnLog(truncated, []);
+  try {
+    assert.equal(run.status, 1);
+    assert.match(run.stderr, /no evidence record parsed/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// --- manifest path normalization ---------------------------------------------
+
+let normalizeManifestOpenPath;
+
+test('manifest-loader normalizes every accepted manifest_path form for k6 open()', async () => {
+  // manifest-loader.js imports `k6/data`, which Node cannot resolve. Load the
+  // shipped source with only that import removed so the assertions run against
+  // the exact function k6 executes.
+  const source = await readFile(path.join(k6Root, 'lib/manifest-loader.js'), 'utf8');
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'p86-manifest-loader-'));
+  const modulePath = path.join(dir, 'manifest-loader.mjs');
+  await writeFile(modulePath, source.replace(/^import .*'k6\/data';$/m, ''));
+  try {
+    ({ normalizeManifestOpenPath } = await import(pathToFileURL(modulePath).href));
+
+    // The repo-root form the workflow, live-run-guard and evidence-writer use.
+    assert.equal(
+      normalizeManifestOpenPath('tools/k6-proofs/manifests/r-cd-in-1.json'),
+      '../manifests/r-cd-in-1.json',
+    );
+    // Previously this produced tools/k6-proofs/tools/k6-proofs/manifests/... .
+    assert.doesNotMatch(
+      normalizeManifestOpenPath('tools/k6-proofs/manifests/r-cd-in-1.json'),
+      /tools\/k6-proofs/,
+    );
+    assert.equal(normalizeManifestOpenPath('./tools/k6-proofs/manifests/r-cd-in-1.json'), '../manifests/r-cd-in-1.json');
+    assert.equal(normalizeManifestOpenPath('manifests/r-cd-in-1.json'), '../manifests/r-cd-in-1.json');
+    assert.equal(normalizeManifestOpenPath('./manifests/r-cd-in-1.json'), '../manifests/r-cd-in-1.json');
+    assert.equal(normalizeManifestOpenPath('r-cd-in-1.json'), '../manifests/r-cd-in-1.json');
+    assert.equal(normalizeManifestOpenPath('/srv/manifests/r-cd-in-1.json'), '/srv/manifests/r-cd-in-1.json');
+    assert.equal(normalizeManifestOpenPath(''), null);
+    assert.equal(normalizeManifestOpenPath(undefined), null);
+
+    // Production-shaped proof: k6 resolves a relative open() against the
+    // running scenario's directory, so the normalized value must land on the
+    // real manifest file on disk for the exact value the workflow exports.
+    const scenarioDir = path.join(k6Root, 'scenarios');
+    const resolved = path.resolve(
+      scenarioDir,
+      normalizeManifestOpenPath('tools/k6-proofs/manifests/r-cd-in-1.json'),
+    );
+    assert.equal(resolved, path.join(manifestsDir, 'r-cd-in-1.json'));
+    const loaded = JSON.parse(await readFile(resolved, 'utf8'));
+    assert.equal(loaded.rowId, 'R-CD-IN-1');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// --- workflow contract -------------------------------------------------------
+
+test('the workflow normalizes manifest_path once and exercises it in dry-run archive', async () => {
+  const workflow = await readFile(path.join(repoRoot, '.github/workflows/k6-proof.yml'), 'utf8');
+
+  assert.match(workflow, /id: inputs/, 'the validate step must publish the normalized value');
+  assert.match(workflow, /echo "manifest_path=\$normalized" >> "\$GITHUB_OUTPUT"/);
+
+  // Every downstream consumer must read the normalized output, never the raw input.
+  const downstream = workflow.slice(workflow.indexOf('- name: Dry run'));
+  assert.ok(
+    !/MANIFEST_PATH: \$\{\{ github\.event\.inputs\.manifest_path \}\}/.test(downstream),
+    'no consumer may read the un-normalized manifest_path input',
+  );
+  assert.match(
+    workflow,
+    /OPENCLAW_ROW_MANIFEST: \$\{\{ steps\.inputs\.outputs\.manifest_path \}\}/,
+    'the live run must export the normalized manifest',
+  );
+  assert.match(
+    workflow,
+    /OPENCLAW_ROW_MANIFEST="\$MANIFEST_PATH" \\\n\s*k6 archive/,
+    'the dry run must compile with the exact manifest env a live run would use',
+  );
+});
+
+test('the workflow uploads artifacts on the failure path', async () => {
+  const workflow = await readFile(path.join(repoRoot, '.github/workflows/k6-proof.yml'), 'utf8');
+  const uploadProof = workflow.slice(workflow.indexOf('- name: Upload proof artifacts'));
+  assert.match(uploadProof, /if: \$\{\{ !cancelled\(\)/, 'a failing row must still publish its artifact');
+  assert.match(uploadProof, /if-no-files-found: warn/);
+
+  const writeEvidence = workflow.slice(
+    workflow.indexOf('- name: Write evidence artifacts'),
+    workflow.indexOf('- name: Sanitize run log for upload'),
+  );
+  assert.match(writeEvidence, /!cancelled\(\)/, 'evidence must be written for a failing row too');
+  assert.match(
+    writeEvidence,
+    /steps\.k6run\.outputs\.conflict != 'true'/,
+    'a flock-75 coordination failure must not be written as row evidence',
+  );
+});

--- a/tools/k6-proofs/scripts/__tests__/live-run-guard.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/live-run-guard.test.mjs
@@ -164,7 +164,10 @@ test('R-CW-6 stays process-local and fixture-gated while static variants cannot 
   const liveSuite = spawnSync(process.execPath, [rowListScript, '--live-suite'], { cwd: repoRoot, encoding: 'utf8' });
   assert.equal(liveSuite.status, 0, liveSuite.stderr || liveSuite.stdout);
   const liveRows = liveSuite.stdout.trim().split(',');
-  assert.equal(liveRows.length, 34);
+  // 34 baseline + the 5 k6-runnable P86 delegate attachment I/O rows (docs#491).
+  // The 3 orchestration-required rows of that family (R-CD-IN-RECOVERY,
+  // R-CD-IN-REVOKE, R-CD-OUT-REPLAY) are correctly excluded from the live suite.
+  assert.equal(liveRows.length, 39);
   assert.equal(liveRows[0], 'preflight');
   assert.doesNotMatch(liveSuite.stdout, /R-CW-5(?:,|$)/);
   assert.doesNotMatch(liveSuite.stdout, /R-CW-6(?:,|$)/);

--- a/tools/k6-proofs/scripts/evidence-writer.mjs
+++ b/tools/k6-proofs/scripts/evidence-writer.mjs
@@ -155,44 +155,21 @@ const events = evidence.redacted_events || [];
 const { sanitized: [summary], orderedTokens } = sanitizeEvidenceRecords([evidence]);
 const { sanitized: safeEvents } = sanitizeEvidenceRecords(events, orderedTokens);
 
-// Build output directory
+// Validate all public-safe data and resolve the verdict BEFORE creating a run
+// directory. A rejected scenario-reported PASS must leave no uploadable
+// success-shaped summary behind.
 const runId = `k6-run-${stamp()}`;
 const outDir = join('PROOFS', args.sha, args.row, args.seat, runId);
-mkdirSync(join(outDir, 'artifacts'), { recursive: true });
 
 let authoritativeReceiptDigest = null;
 if (authoritativeReceipt) {
   const raw = readFileSync(args['authoritative-receipt']);
   authoritativeReceiptDigest = createHash('sha256').update(raw).digest('hex');
-  writeFileSync(join(outDir, 'r-cd-2-authoritative-receipt.json'), raw);
 }
-
-if (args['seat-readiness']) {
-  copyFileSync(args['seat-readiness'], join(outDir, 'seat-readiness.json'));
-}
-if (authoritativeReceipt) {
-  // Carry the signed authority alongside every public candidate surface so a
-  // report/envelope cannot cite an uninspectable generic PASS.
-  copyFileSync(args['authoritative-receipt'], join(outDir, 'r-cd-2-authoritative-receipt.json'));
-}
-
-// Write k6-summary.json through the same public-safe boundary as run-proofs.sh.
-writeFileSync(join(outDir, 'k6-summary.json'), JSON.stringify(summary, null, 2) + '\n');
-
-// Write gateway-events.ndjson (redacted only)
-if (safeEvents.length > 0) {
-  const ndjson = safeEvents.map((e) => JSON.stringify(e)).join('\n') + '\n';
-  writeFileSync(join(outDir, 'gateway-events.ndjson'), ndjson);
-}
-writeFileSync(join(outDir, 'evidence-redaction.json'), JSON.stringify({
-  schema: 'openclaw.k6.public-evidence-redaction.v1',
-  generatedAt: new Date().toISOString(),
-  removedSensitiveValues: orderedTokens.length,
-  records: 1,
-}, null, 2) + '\n');
 
 // The raw k6 console log carries session keys, claim ids, child keys and paths.
-// It is published only through the shared sanitizer, never verbatim.
+// Prepare it through the shared sanitizer now, but do not write it until the
+// authoritative verdict validation below has accepted the candidate output.
 const publicRunLog = sanitizeLog(raw, [summary], orderedTokens);
 for (const [token] of orderedTokens) {
   if (publicRunLog.includes(token)) {
@@ -200,7 +177,6 @@ for (const [token] of orderedTokens) {
     process.exit(1);
   }
 }
-writeFileSync(join(outDir, 'k6-run.log'), publicRunLog);
 
 // --- VERDICT RESOLUTION ---
 //
@@ -277,6 +253,32 @@ if (authoritativeReceipt) {
     : 'FAIL-candidate');
   verdictSource = 'generic-evidence';
 }
+
+// Only an accepted verdict may materialize public candidate artifacts. This is
+// deliberately below the unsupported-PASS refusal: the workflow uploads its
+// failure path, so a partial directory without row-result.json would otherwise
+// look like an accepted PASS to downstream reviewers.
+mkdirSync(join(outDir, 'artifacts'), { recursive: true });
+if (args['seat-readiness']) {
+  copyFileSync(args['seat-readiness'], join(outDir, 'seat-readiness.json'));
+}
+if (authoritativeReceipt) {
+  // Carry the signed authority alongside every public candidate surface so a
+  // report/envelope cannot cite an uninspectable generic PASS.
+  copyFileSync(args['authoritative-receipt'], join(outDir, 'r-cd-2-authoritative-receipt.json'));
+}
+writeFileSync(join(outDir, 'k6-summary.json'), JSON.stringify(summary, null, 2) + '\n');
+if (safeEvents.length > 0) {
+  const ndjson = safeEvents.map((e) => JSON.stringify(e)).join('\n') + '\n';
+  writeFileSync(join(outDir, 'gateway-events.ndjson'), ndjson);
+}
+writeFileSync(join(outDir, 'evidence-redaction.json'), JSON.stringify({
+  schema: 'openclaw.k6.public-evidence-redaction.v1',
+  generatedAt: new Date().toISOString(),
+  removedSensitiveValues: orderedTokens.length,
+  records: 1,
+}, null, 2) + '\n');
+writeFileSync(join(outDir, 'k6-run.log'), publicRunLog);
 
 
 // Write row-result.json

--- a/tools/k6-proofs/scripts/evidence-writer.mjs
+++ b/tools/k6-proofs/scripts/evidence-writer.mjs
@@ -35,6 +35,7 @@ import { createHash } from 'node:crypto';
 import { join } from 'node:path';
 import { sanitizeEvidenceRecords, sanitizeLog } from './sanitize-k6-artifacts.mjs';
 import { validateRcd2AuthoritativeReceipt } from '../lib/r-cd-2-authoritative-receipt.mjs';
+import { extractEvidenceData } from '../lib/k6-log-evidence.mjs';
 
 function parseArgs(argv) {
   const out = {};
@@ -94,41 +95,37 @@ const raw = readFileSync(args.input, 'utf-8');
 
 // Extract the evidence JSON block from k6 console output.
 //
-// Historical scenarios emitted row-scoped banners such as:
-//   --- R-CD-2 EVIDENCE SUMMARY ---
-//   { ... }
-//   --- END EVIDENCE ---
+// The workflow feeds this writer the RAW k6 log (`/tmp/k6-out/run.txt`), which
+// is logrus-framed:
+//   time="..." level=info msg="--- R-CD-IN-1 EVIDENCE SUMMARY ---" source=console
+//   time="..." level=info msg="{\n  \"row\": \"R-CD-IN-1\", ...}" source=console
+//   time="..." level=info msg="--- END EVIDENCE ---" source=console
 //
-// The live R-CD-1/R-CD-TOKEN scenarios emit the generic proof banner:
-//   === K6-PROOF-EVIDENCE ===
-//   { ... }
-//   --- END EVIDENCE ---
-//
-// Keep the writer tolerant at the scenario↔writer seam: one post-processor
-// should be able to consume candidate output from every k6 proof scenario.
-const evidencePatterns = [
-  /---\s+[^\n]*\bEVIDENCE SUMMARY\b[^\n]*---\s*\n([\s\S]*?)\n---\s+END EVIDENCE\s+---/,
-  /===\s+K6-PROOF-EVIDENCE\s+===\s*\n([\s\S]*?)\n---\s+END EVIDENCE\s+---/,
-  /===\s+K6-PROOF-EVIDENCE\s+===\s*\n([\s\S]*?)\n===\s+END K6-PROOF-EVIDENCE\s+===/,
-];
-
-const evidenceMatch = evidencePatterns.map((pattern) => raw.match(pattern)).find(Boolean);
-if (!evidenceMatch) {
-  console.error('ERROR: Could not find evidence summary block in k6 output');
-  console.error('Supported markers:');
-  console.error('  --- <ROW> EVIDENCE SUMMARY --- ... --- END EVIDENCE ---');
-  console.error('  === K6-PROOF-EVIDENCE === ... --- END EVIDENCE ---');
-  console.error('  === K6-PROOF-EVIDENCE === ... === END K6-PROOF-EVIDENCE ===');
+// Matching bare marker lines against that text finds nothing, and the writer
+// exits before identity binding, receipt-map recomputation, liveRunSafety
+// capture and sanitized-log writing. The shared decode-aware extractor consumes
+// production framing, bare single-line fixtures and pretty-printed bare blocks
+// alike, so one post-processor can consume candidate output from every scenario.
+const extracted = extractEvidenceData(raw);
+if (extracted.records.length === 0) {
+  if (extracted.markerSeen) {
+    console.error('ERROR: evidence marker found in k6 output but no evidence record parsed');
+    console.error('The block between the markers must be a single JSON object.');
+  } else {
+    console.error('ERROR: Could not find evidence summary block in k6 output');
+    console.error('Supported markers (bare or k6 logrus-framed msg="..." lines):');
+    console.error('  --- <ROW> EVIDENCE SUMMARY --- ... --- END EVIDENCE ---');
+    console.error('  === K6-PROOF-EVIDENCE === ... --- END EVIDENCE ---');
+    console.error('  === K6-PROOF-EVIDENCE === ... === END K6-PROOF-EVIDENCE ===');
+  }
   process.exit(1);
 }
 
-let evidence;
-try {
-  evidence = JSON.parse(evidenceMatch[1]);
-} catch (err) {
-  console.error(`ERROR: Evidence block was found but did not parse as JSON: ${err.message}`);
-  process.exit(1);
-}
+// A run log may carry more than one record (e.g. a re-emitted summary). Prefer
+// the one that names the row under test; identity binding below rejects any
+// other mismatch.
+const evidence = extracted.records.find((record) => record.row === args.row)
+  || extracted.records[0];
 
 if (evidence.row && evidence.row !== args.row) {
   console.error(`ERROR: evidence block row "${evidence.row}" does not match --row "${args.row}"`);

--- a/tools/k6-proofs/scripts/evidence-writer.mjs
+++ b/tools/k6-proofs/scripts/evidence-writer.mjs
@@ -12,13 +12,20 @@
  *     --row R-CD-1 \
  *     --seat ronan-dgx \
  *     --sha <40-char-hex> \
- *     [--manifest tools/k6-proofs/manifests/r-cd-1.json]
+ *     [--manifest tools/k6-proofs/manifests/r-cd-1.json] \
+ *     [--scenario r-cd-1.js]
+ *
+ * Identity binding: when --manifest is supplied, manifest.rowId, the evidence
+ * block's own `row`, and --row must agree, and --scenario (when supplied) must
+ * match manifest.scenario.file. A run directory that files one row's behavior
+ * under another row's name is not evidence.
  *
  * Writes:
  *   PROOFS/<sha>/<row>/<seat>/k6-run-<timestamp>/
  *     ├── EVIDENCE.md
  *     ├── k6-summary.json
  *     ├── gateway-events.ndjson  (redacted only)
+ *     ├── k6-run.log             (sanitized console log)
  *     ├── row-result.json
  *     └── seat-readiness.json  (when --seat-readiness is supplied)
  */
@@ -26,7 +33,7 @@
 import { copyFileSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { join } from 'node:path';
-import { sanitizeEvidenceRecords } from './sanitize-k6-artifacts.mjs';
+import { sanitizeEvidenceRecords, sanitizeLog } from './sanitize-k6-artifacts.mjs';
 import { validateRcd2AuthoritativeReceipt } from '../lib/r-cd-2-authoritative-receipt.mjs';
 
 function parseArgs(argv) {
@@ -48,7 +55,7 @@ function stamp() {
 }
 
 function usage() {
-  console.error(`Usage: node evidence-writer.mjs --input <k6-output> --row <ROW> --seat <SEAT> --sha <SHA> [--manifest <row-manifest.json>]`);
+  console.error(`Usage: node evidence-writer.mjs --input <k6-output> --row <ROW> --seat <SEAT> --sha <SHA> [--manifest <row-manifest.json>] [--scenario <scenario-file.js>]`);
   process.exit(2);
 }
 
@@ -65,6 +72,21 @@ if (!/^[0-9a-f]{40}$/.test(args.sha)) {
 const manifest = args.manifest ? JSON.parse(readFileSync(args.manifest, 'utf-8')) : null;
 if (manifest && (manifest.review?.foldRequiresReview !== true || manifest.liveRunSafety?.foldRequiresReview === false)) {
   console.error('ERROR: manifest must keep foldRequiresReview=true for candidate evidence');
+  process.exit(1);
+}
+
+// --- IDENTITY BINDING ---
+// A run directory is named by (row, seat, sha). If the manifest, the scenario
+// and the evidence block do not all agree on the row, the artifact would file
+// one row's behavior under another row's name.
+if (manifest && manifest.rowId !== args.row) {
+  console.error(`ERROR: manifest rowId "${manifest.rowId}" does not match --row "${args.row}"`);
+  process.exit(1);
+}
+if (args.scenario && manifest?.scenario?.file && manifest.scenario.file !== args.scenario) {
+  console.error(
+    `ERROR: --scenario "${args.scenario}" does not match manifest scenario.file "${manifest.scenario.file}"`,
+  );
   process.exit(1);
 }
 
@@ -105,6 +127,11 @@ try {
   evidence = JSON.parse(evidenceMatch[1]);
 } catch (err) {
   console.error(`ERROR: Evidence block was found but did not parse as JSON: ${err.message}`);
+  process.exit(1);
+}
+
+if (evidence.row && evidence.row !== args.row) {
+  console.error(`ERROR: evidence block row "${evidence.row}" does not match --row "${args.row}"`);
   process.exit(1);
 }
 
@@ -167,10 +194,93 @@ writeFileSync(join(outDir, 'evidence-redaction.json'), JSON.stringify({
   records: 1,
 }, null, 2) + '\n');
 
-// Determine verdict
-const verdict = authoritativeReceipt ? authoritativeReceipt.verdict : (evidence.tool_accepted || evidence.prompt_sent
-  ? (evidence.task_created || evidence.child_spawned ? 'PASS-candidate' : 'PARTIAL-candidate')
-  : 'FAIL-candidate');
+// The raw k6 console log carries session keys, claim ids, child keys and paths.
+// It is published only through the shared sanitizer, never verbatim.
+const publicRunLog = sanitizeLog(raw, [summary], orderedTokens);
+for (const [token] of orderedTokens) {
+  if (publicRunLog.includes(token)) {
+    console.error('ERROR: sanitized k6 run log still contains a sensitive value');
+    process.exit(1);
+  }
+}
+writeFileSync(join(outDir, 'k6-run.log'), publicRunLog);
+
+// --- VERDICT RESOLUTION ---
+//
+// Three evidence shapes reach this writer:
+//   1. an R-CD-2 authoritative receipt (signed, row-scoped) — highest authority;
+//   2. the receipt-map shape (`verdict` + `receipts` + `negative_checks` +
+//      `orchestration`) used by the delegate attachment I/O family;
+//   3. the legacy flag shape (`tool_accepted` / `task_created` / ...).
+//
+// Shape 2 must NOT be read with shape 3's rules: a valid PASS-candidate would
+// be rewritten to FAIL-candidate because it carries no `tool_accepted` flag.
+// When the receipt map is present the writer recomputes the verdict from it
+// and from the manifest's requiredReceipts, and refuses to publish a verdict
+// stronger than what the receipts support.
+function hasReceiptMap(record) {
+  return (
+    record
+    && typeof record.verdict === 'string'
+    && record.receipts
+    && typeof record.receipts === 'object'
+  );
+}
+
+function recomputeReceiptMapVerdict(record, manifestDoc) {
+  const receipts = record.receipts || {};
+  const negatives = record.negative_checks || {};
+  const manifestRequired = (manifestDoc?.liveRunSafety?.requiredReceipts || [])
+    // `seat-readiness` is produced by the preflight, not by the scenario.
+    .filter((name) => name !== 'seat-readiness');
+  const declaredRequired = Array.isArray(record.missing_receipts) ? record.missing_receipts : [];
+  const missing = [
+    ...declaredRequired,
+    ...manifestRequired.filter((name) => !receipts[name] && !(name in negatives)),
+  ];
+  const violated = Object.keys(negatives).filter((name) => negatives[name]?.held !== true);
+  const orchestrationRequired = Boolean(record.orchestration?.required);
+  const orchestrationObserved = record.orchestration?.observed === true;
+  const uniqueMissing = [...new Set(missing)];
+  const ok = uniqueMissing.length === 0
+    && violated.length === 0
+    && (!orchestrationRequired || orchestrationObserved);
+  return {
+    verdict: ok ? 'PASS-candidate' : 'PARTIAL-candidate',
+    missingReceipts: uniqueMissing,
+    violatedNegativeChecks: violated,
+    orchestrationRequired,
+    orchestrationObserved,
+    orchestrationReason: record.orchestration?.reason || null,
+  };
+}
+
+let verdict;
+let verdictSource;
+let receiptAudit = null;
+if (authoritativeReceipt) {
+  verdict = authoritativeReceipt.verdict;
+  verdictSource = 'r-cd-2-authoritative-receipt';
+} else if (hasReceiptMap(evidence)) {
+  receiptAudit = recomputeReceiptMapVerdict(evidence, manifest);
+  verdict = receiptAudit.verdict;
+  verdictSource = 'receipt-map-recomputed';
+  if (evidence.verdict === 'PASS-candidate' && verdict !== 'PASS-candidate') {
+    console.error(
+      `ERROR: scenario reported PASS-candidate but the receipt map does not support it ` +
+        `(missing: ${receiptAudit.missingReceipts.join(', ') || 'none'}; ` +
+        `violated: ${receiptAudit.violatedNegativeChecks.join(', ') || 'none'}; ` +
+        `orchestration observed: ${receiptAudit.orchestrationObserved}).`,
+    );
+    process.exit(1);
+  }
+} else {
+  verdict = (evidence.tool_accepted || evidence.prompt_sent
+    ? (evidence.task_created || evidence.child_spawned ? 'PASS-candidate' : 'PARTIAL-candidate')
+    : 'FAIL-candidate');
+  verdictSource = 'generic-evidence';
+}
+
 
 // Write row-result.json
 const result = {
@@ -181,7 +291,11 @@ const result = {
   candidateSha: args.sha,
   seat: args.seat,
   outcome: verdict,
-  verdictSource: authoritativeReceipt ? 'r-cd-2-authoritative-receipt' : 'generic-evidence',
+  verdictSource,
+  scenario: manifest?.scenario?.file || args.scenario || null,
+  manifest: args.manifest || null,
+  scenarioReportedVerdict: hasReceiptMap(evidence) ? evidence.verdict : null,
+  ...(receiptAudit ? { receiptAudit } : {}),
   ...(authoritativeReceiptDigest ? { authoritativeReceipt: {
     schema: authoritativeReceipt.schema, validated: true, source: 'r-cd-2-row-scoped-resolver',
     file: 'r-cd-2-authoritative-receipt.json', sha256: authoritativeReceiptDigest,
@@ -221,15 +335,29 @@ const md = `# ${args.row} — ${args.seat} — ${verdict}
 
 **${verdict}**
 
+- Verdict source: \`${verdictSource}\`
+- Scenario: \`${result.scenario || 'not supplied'}\`
+- Manifest: \`${args.manifest || 'not supplied to writer'}\`
+
 ## Evidence receipts
 
-| Check | Result |
+${receiptAudit ? `| Receipt | Result |
+|---------|--------|
+${Object.keys(evidence.receipts).map((name) => `| \`${name}\` | ✓ |`).join('\n') || '| _(none fired)_ | ✗ |'}
+${receiptAudit.missingReceipts.map((name) => `| \`${name}\` | ✗ missing |`).join('\n')}
+
+| Negative check | Held |
+|----------------|------|
+${Object.entries(evidence.negative_checks || {}).map(([name, entry]) => `| \`${name}\` | ${entry.held ? '✓' : `✗ — ${entry.violation || 'violated'}`} |`).join('\n') || '| _(none declared)_ | — |'}
+
+- Orchestration precondition: ${receiptAudit.orchestrationRequired ? `\`${evidence.orchestration.required}\`` : 'none'}
+- Orchestration observed: ${receiptAudit.orchestrationRequired ? (receiptAudit.orchestrationObserved ? 'yes' : `no — ${receiptAudit.orchestrationReason || 'reason not recorded'}`) : 'n/a'}` : `| Check | Result |
 |-------|--------|
 | Tool/prompt accepted | ${evidence.tool_accepted || evidence.prompt_sent ? '✓' : '✗'} |
 | Task/child created | ${evidence.task_created || evidence.child_spawned ? '✓' : '✗'} |
 | Parent return observed | ${evidence.parent_return ? '✓' : '✗'} |
 | Safe reason fingerprint | \`${summary.reason_hash || 'N/A'}\` / length \`${summary.reason_length || 'N/A'}\` |
-| Manifest loaded | ${evidence.manifest_loaded ? '✓' : '✗ (defaults used)'} |
+| Manifest loaded | ${evidence.manifest_loaded ? '✓' : '✗ (defaults used)'} |`}
 
 ## Artifacts
 
@@ -237,6 +365,7 @@ const md = `# ${args.row} — ${args.seat} — ${verdict}
 - \`gateway-events.ndjson\` — redacted WS frames (${safeEvents.length} captured)
 - \`evidence-redaction.json\` — public-safe redaction receipt
 - \`row-result.json\` — normalized outcome
+- \`k6-run.log\` — sanitized k6 console log (${args.input ? 'written' : 'not available'})
 - \`seat-readiness.json\` — public-safe seat/tooling preflight (${args['seat-readiness'] ? 'captured' : 'not supplied to writer'})
 - \`artifacts/\` — optional copied receipts (Tempo trace, logs)
 

--- a/tools/k6-proofs/scripts/extract-k6-evidence.mjs
+++ b/tools/k6-proofs/scripts/extract-k6-evidence.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { readFile, writeFile } from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
+import { extractEvidenceData } from '../lib/k6-log-evidence.mjs';
 
 function usage() {
   console.error('Usage: node extract-k6-evidence.mjs --input <k6.log> --out <evidence.jsonl> [--lines-out <evidence-lines.log>]');
@@ -17,82 +18,6 @@ function parseArgs(argv) {
     i += 1;
   }
   return out;
-}
-
-function decodeMessage(line) {
-  const marker = ' msg=';
-  const start = line.indexOf(marker);
-  if (start < 0) return line;
-  const encodedStart = start + marker.length;
-  const source = line.lastIndexOf(' source=');
-  const encoded = line.slice(encodedStart, source > encodedStart ? source : undefined).trim();
-  if (!encoded) return null;
-  if (!encoded.startsWith('"')) return encoded;
-  try {
-    return JSON.parse(encoded);
-  } catch {
-    return null;
-  }
-}
-
-function parseJsonCandidate(value) {
-  const text = String(value || '').trim();
-  if (!text.startsWith('{')) return null;
-  try {
-    return JSON.parse(text);
-  } catch {
-    return null;
-  }
-}
-
-function extractEvidenceData(logText) {
-  const records = [];
-  const lines = [];
-  let awaitingRecord = false;
-
-  for (const line of String(logText || '').split(/\r?\n/)) {
-    const message = decodeMessage(line);
-    if (!message) continue;
-    const text = String(message).trim();
-
-    const inline = text.match(/(?:[A-Z0-9_-]+_EVIDENCE|===\s*K6-PROOF-EVIDENCE\s*===)\s+(\{[\s\S]*\})$/);
-    if (inline) {
-      const record = parseJsonCandidate(inline[1]);
-      if (record) {
-        records.push(record);
-        lines.push(line);
-      }
-      awaitingRecord = false;
-      continue;
-    }
-
-    if (/\bEVIDENCE SUMMARY\b|===\s*K6-PROOF-EVIDENCE\s*===/.test(text)) {
-      lines.push(line);
-      const sameMessageJson = text.match(/(?:SUMMARY\b|===)\s*[\r\n]+(\{[\s\S]*\})/);
-      const record = sameMessageJson ? parseJsonCandidate(sameMessageJson[1]) : null;
-      if (record) {
-        records.push(record);
-        awaitingRecord = false;
-      } else {
-        awaitingRecord = true;
-      }
-      continue;
-    }
-
-    if (awaitingRecord) {
-      const record = parseJsonCandidate(text);
-      if (record) {
-        records.push(record);
-        lines.push(line);
-        awaitingRecord = false;
-      }
-    }
-  }
-
-  const uniqueRecords = [...new Map(
-    records.map((record) => [JSON.stringify(record), record]),
-  ).values()];
-  return { records: uniqueRecords, lines };
 }
 
 export function extractEvidence(logText) {

--- a/tools/k6-proofs/scripts/sanitize-k6-artifacts.mjs
+++ b/tools/k6-proofs/scripts/sanitize-k6-artifacts.mjs
@@ -2,6 +2,7 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { decodeK6Message, extractEvidenceData } from '../lib/k6-log-evidence.mjs';
 
 const RAW_PAYLOAD_KEYS = new Set([
   'agentinstruction',
@@ -138,51 +139,51 @@ function assertPublicSafe(value, orderedTokens) {
   visit(value);
 }
 
-function decodeMessage(line) {
-  const marker = ' msg=';
-  const start = line.indexOf(marker);
-  if (start < 0) return line;
-  const encodedStart = start + marker.length;
-  const source = line.lastIndexOf(' source=');
-  const encoded = line.slice(encodedStart, source > encodedStart ? source : undefined).trim();
-  if (!encoded.startsWith('"')) return encoded;
-  try {
-    return JSON.parse(encoded);
-  } catch {
-    return null;
-  }
-}
-
 function sanitizeLog(logText, sanitizedRecords, orderedTokens) {
   const out = [];
-  let awaitingEvidenceRecord = false;
+  let insideEvidenceBlock = false;
+  let emittedForCurrentBlock = false;
   let recordIndex = 0;
 
+  const emitRecord = () => {
+    if (emittedForCurrentBlock) return;
+    if (sanitizedRecords[recordIndex]) {
+      out.push(`PUBLIC_EVIDENCE ${JSON.stringify(sanitizedRecords[recordIndex])}`);
+      recordIndex += 1;
+    }
+    emittedForCurrentBlock = true;
+  };
+
   for (const line of String(logText || '').split(/\r?\n/)) {
-    const message = decodeMessage(line);
+    const message = decodeK6Message(line);
     const text = String(message || '').trim();
     const inlineEvidence = /(?:[A-Z0-9_-]+_EVIDENCE|===\s*K6-PROOF-EVIDENCE\s*===)\s+\{/.test(text);
 
     if (inlineEvidence) {
-      if (sanitizedRecords[recordIndex]) {
-        out.push(`PUBLIC_EVIDENCE ${JSON.stringify(sanitizedRecords[recordIndex])}`);
-        recordIndex += 1;
-      }
+      insideEvidenceBlock = false;
+      emittedForCurrentBlock = false;
+      emitRecord();
       continue;
     }
     if (/\bEVIDENCE SUMMARY\b|===\s*K6-PROOF-EVIDENCE\s*===/.test(text)) {
-      awaitingEvidenceRecord = true;
+      insideEvidenceBlock = true;
+      emittedForCurrentBlock = false;
       continue;
     }
-    if (awaitingEvidenceRecord && text.startsWith('{')) {
-      if (sanitizedRecords[recordIndex]) {
-        out.push(`PUBLIC_EVIDENCE ${JSON.stringify(sanitizedRecords[recordIndex])}`);
-        recordIndex += 1;
-      }
-      awaitingEvidenceRecord = false;
+    if (/---\s*END EVIDENCE\s*---|===\s*END K6-PROOF-EVIDENCE\s*===/.test(text)) {
+      // A block that produced no sanitized record is still fully suppressed.
+      insideEvidenceBlock = false;
+      emittedForCurrentBlock = false;
       continue;
     }
-    if (/---\s*END EVIDENCE\s*---|===\s*END K6-PROOF-EVIDENCE\s*===/.test(text)) continue;
+    if (insideEvidenceBlock) {
+      // Every line between the banner and the terminator belongs to the raw
+      // evidence payload. Emit the sanitized record once and drop the rest:
+      // a pretty-printed multi-line block must not have its tail passed
+      // through as ordinary log text.
+      if (text.startsWith('{')) emitRecord();
+      continue;
+    }
     if (text.includes('[k6-proof-harness]')) {
       out.push('[k6-proof-harness] <redacted-dispatch>');
       continue;
@@ -236,21 +237,20 @@ export { sanitizeLog };
  */
 async function mainLogOnly(args) {
   const logText = await readFile(args.logInput, 'utf8');
-  const records = [];
-  const blockPatterns = [
-    /---\s+[^\n]*\bEVIDENCE SUMMARY\b[^\n]*---\s*\n([\s\S]*?)\n---\s+END EVIDENCE\s+---/g,
-    /===\s+K6-PROOF-EVIDENCE\s+===\s*\n([\s\S]*?)\n(?:---\s+END EVIDENCE\s+---|===\s+END K6-PROOF-EVIDENCE\s+===)/g,
-  ];
-  for (const pattern of blockPatterns) {
-    for (const match of logText.matchAll(pattern)) {
-      try {
-        records.push(JSON.parse(match[1]));
-      } catch {
-        // A block that does not parse cannot be re-emitted safely; the log
-        // sanitizer drops the block entirely rather than passing it through.
-      }
-    }
+
+  // Real k6 stdout is logrus-framed: the whole evidence JSON lives inside one
+  // escaped `msg="..."` value. A block regex over the raw file parses zero
+  // records there, which would silently discard the evidence block, derive no
+  // session/claim/path tokens, and attest `evidenceBlocks: 0` over a log that
+  // still carried the sensitive values. Use the shared decode-aware extractor.
+  const { records, markerSeen } = extractEvidenceData(logText);
+  if (markerSeen && records.length === 0) {
+    throw new Error(
+      'k6 log contains evidence markers but no evidence record parsed; refusing to publish a log '
+      + 'whose sensitive values could not be derived (fail closed)',
+    );
   }
+
   const extraTokens = process.env.OPENCLAW_SESSION_KEY
     ? [[process.env.OPENCLAW_SESSION_KEY, '<redacted-session-key>']]
     : [];
@@ -265,6 +265,7 @@ async function mainLogOnly(args) {
       schema: 'openclaw.k6.public-log-redaction.v1',
       generatedAt: new Date().toISOString(),
       mode: 'log-only',
+      evidenceMarkersSeen: markerSeen,
       evidenceBlocks: sanitized.length,
       removedSensitiveValues: orderedTokens.length,
       output: path.basename(args.logOut),
@@ -272,6 +273,7 @@ async function mainLogOnly(args) {
   }
   console.log(JSON.stringify({
     mode: 'log-only',
+    evidenceMarkersSeen: markerSeen,
     evidenceBlocks: sanitized.length,
     removedSensitiveValues: orderedTokens.length,
   }));
@@ -306,6 +308,13 @@ async function main() {
     : [];
   const { sanitized, orderedTokens } = sanitizeEvidenceRecords(records, extraTokens);
   const logText = await readFile(args.logInput, 'utf8');
+  const logEvidence = extractEvidenceData(logText);
+  if (logEvidence.markerSeen && logEvidence.records.length === 0 && records.length === 0) {
+    throw new Error(
+      'k6 log contains evidence markers but no evidence record parsed; refusing to publish a log '
+      + 'whose sensitive values could not be derived (fail closed)',
+    );
+  }
   const publicLog = sanitizeLog(logText, sanitized, orderedTokens);
   for (const [token] of orderedTokens) {
     if (publicLog.includes(token)) throw new Error('sanitized k6 log still contains a sensitive value');

--- a/tools/k6-proofs/scripts/sanitize-k6-artifacts.mjs
+++ b/tools/k6-proofs/scripts/sanitize-k6-artifacts.mjs
@@ -23,7 +23,13 @@ function usage() {
   --log-input <private-k6.log> --log-out <k6.log> \\
   [--service-log-input <private-gateway.log> \\
    --service-log-out <gateway-journal.log> \\
-   --service-log-receipt-out <gateway-journal-redaction.json>]`);
+   --service-log-receipt-out <gateway-journal-redaction.json>]
+
+Log-only mode (no private evidence JSONL available, e.g. dry runs and the CI
+upload path). Evidence blocks embedded in the log are re-emitted from their
+sanitized parse; everything else is token-scrubbed:
+  node sanitize-k6-artifacts.mjs --log-input <raw.txt> --log-out <public.txt> \\
+    [--receipt-out <log-redaction.json>]`);
 }
 
 function parseArgs(argv) {
@@ -220,8 +226,63 @@ export function sanitizeEvidenceRecords(records, extraTokens = []) {
   return { sanitized, orderedTokens };
 }
 
+export { sanitizeLog };
+
+/**
+ * Log-only mode: sanitize a raw k6 console log when there is no separate
+ * private evidence JSONL to pair with it (dry runs, and the CI upload path).
+ * The evidence block embedded in the log is re-emitted from the sanitized
+ * parse of that same block, so no raw run text is ever published.
+ */
+async function mainLogOnly(args) {
+  const logText = await readFile(args.logInput, 'utf8');
+  const records = [];
+  const blockPatterns = [
+    /---\s+[^\n]*\bEVIDENCE SUMMARY\b[^\n]*---\s*\n([\s\S]*?)\n---\s+END EVIDENCE\s+---/g,
+    /===\s+K6-PROOF-EVIDENCE\s+===\s*\n([\s\S]*?)\n(?:---\s+END EVIDENCE\s+---|===\s+END K6-PROOF-EVIDENCE\s+===)/g,
+  ];
+  for (const pattern of blockPatterns) {
+    for (const match of logText.matchAll(pattern)) {
+      try {
+        records.push(JSON.parse(match[1]));
+      } catch {
+        // A block that does not parse cannot be re-emitted safely; the log
+        // sanitizer drops the block entirely rather than passing it through.
+      }
+    }
+  }
+  const extraTokens = process.env.OPENCLAW_SESSION_KEY
+    ? [[process.env.OPENCLAW_SESSION_KEY, '<redacted-session-key>']]
+    : [];
+  const { sanitized, orderedTokens } = sanitizeEvidenceRecords(records, extraTokens);
+  const publicLog = sanitizeLog(logText, sanitized, orderedTokens);
+  for (const [token] of orderedTokens) {
+    if (publicLog.includes(token)) throw new Error('sanitized k6 log still contains a sensitive value');
+  }
+  await writeFile(args.logOut, publicLog);
+  if (args.receiptOut) {
+    await writeFile(args.receiptOut, JSON.stringify({
+      schema: 'openclaw.k6.public-log-redaction.v1',
+      generatedAt: new Date().toISOString(),
+      mode: 'log-only',
+      evidenceBlocks: sanitized.length,
+      removedSensitiveValues: orderedTokens.length,
+      output: path.basename(args.logOut),
+    }, null, 2) + '\n');
+  }
+  console.log(JSON.stringify({
+    mode: 'log-only',
+    evidenceBlocks: sanitized.length,
+    removedSensitiveValues: orderedTokens.length,
+  }));
+}
+
 async function main() {
   const args = parseArgs(process.argv);
+  if (!args.input && args.logInput && args.logOut) {
+    await mainLogOnly(args);
+    return;
+  }
   if (!args.input || !args.out || !args.linesOut || !args.receiptOut || !args.logInput || !args.logOut) {
     usage();
     process.exitCode = 2;


### PR DESCRIPTION
Closes part of karmaterminal/karmaterminal-openclaw-docs#491 (acceptance item 4).

## What this is

Project 86's 38-row plan had **no** row for delegate attachment I/O. Every existing `R-CD-*` row proves scheduling, wake, return, or model propagation; none of them touch the typed `continue_delegate` input snapshot surface or the managed `delegate_artifacts` claim lifecycle. #491 asks for reviewable automation producing public-safe receipts for exactly those.

This PR adds **eight rows** in the existing harness shape — same manifest schema, same evidence writer, same validator, same fold contract. No new tooling, no new run path.

| Row | Manifest | Scenario | Class | Expected |
|---|---|---|---|---|
| R-CD-IN-1 | `r-cd-in-1.json` | `r-cd-in-1-typed-input-snapshot.js` | k6-runnable | PASS-candidate |
| R-CD-IN-RECOVERY | `r-cd-in-recovery.json` | `r-cd-in-recovery-queued-restart.js` | orchestration-required | **PARTIAL-candidate** |
| R-CD-IN-REVOKE | `r-cd-in-revoke.json` | `r-cd-in-revoke-no-spawn-scrub.js` | orchestration-required | **PARTIAL-candidate** |
| R-CD-OUT-PUBLISH | `r-cd-out-publish.json` | `r-cd-out-publish-claim.js` | k6-runnable | PASS-candidate |
| R-CD-OUT-CLAIM | `r-cd-out-claim.json` | `r-cd-out-claim-lifecycle.js` | k6-runnable | PASS-candidate |
| R-CD-OUT-UNAUTHORIZED | `r-cd-out-unauthorized.json` | `r-cd-out-unauthorized-reject.js` | k6-runnable | PASS-candidate |
| R-CD-OUT-REPLAY | `r-cd-out-replay.json` | `r-cd-out-restart-replay.js` | orchestration-required | **PARTIAL-candidate** |
| R-CD-IO-NEG | `r-cd-io-neg.json` | `r-cd-io-negative-boundary.js` | k6-runnable | PASS-candidate |

## Runtime controllers verified present at the candidate

Checked against assembly candidate `374ad60c6d34d3c710ddab3a13ce2189e1fd09fb` before writing a single row, so no row asserts against a surface that does not exist:

- `src/agents/tools/continue-delegate-tool.ts` — typed `attachments` / `attachAs`
- `src/auto-reply/continuation/delegate-flow-store.ts` — durable snapshot state, `scrubStoredDelegateAttachmentState`
- `src/agents/tools/delegate-artifacts-tool.ts` — `delegate_artifacts_publish` and `delegate_artifacts({action: list|inspect|materialize|discard})`
- `src/agents/delegate-artifact-store.ts` / `delegate-artifact-recipient.ts` — claim + binding status incl. `revoked`
- `src/agents/delegate-artifact-delivery.ts` — delivery phases `attempt` / `replay` / `acknowledged`
- `src/agents/internal-events.ts` — the explicit-action announcement footer

## The honesty contract is code, not convention

`computeVerdict` returns `PASS-candidate` **only** when every required receipt fired **and** every negative check held **and** any declared orchestration precondition was observed. Anything else is `PARTIAL-candidate`. There is no override env var, and the contract test asserts none exists.

Two preconditions cannot be produced by a k6 harness and are **not** faked:

1. **Policy revoke** — the gateway exposes `config.get` but no `config.set`. `R-CD-IN-REVOKE` reads the live `tools.sessions_spawn.attachments.enabled`. Still `true`, or absent from the surface? PARTIAL, with the reason recorded verbatim in `evidence.orchestration.reason`. It never assumes a default.
2. **Gateway restart** — an operator action. `R-CD-IN-RECOVERY` and `R-CD-OUT-REPLAY` log when their window opens and otherwise do nothing. Without `OPENCLAW_RESTART_ORCHESTRATED=true` *and* an observed post-window receipt, PARTIAL.

A PARTIAL from these rows is still informative: the legs that did fire are recorded, so the artifact says how far the run got and exactly which operator step was missing.

**Positive controls** are mandatory where a negative would otherwise be vacuous:
- `R-CD-OUT-UNAUTHORIZED` requires `recipient-positive-control` — the true recipient must still be able to inspect, or the rejections could just mean a dead claim.
- `R-CD-IO-NEG` requires `claim-announced-positive-control` — a real claim must have been announced, or a clean negative window proves nothing.

## Redaction boundary

- Probe payload is a synthetic `P86-CANARY-<nonce>` — never a secret, never user content, never a transcript.
- Evidence records only `{ bytes, sha256_prefix }` for it. The content is never written to an artifact.
- Every frame passes through `redactEvent` before entering `redacted_events`; the allowlist has no `text`/`content` key.
- The harness must name the canary in its own instruction, so `[k6-proof-harness]` frames are excluded from the raw-byte scan — the established R-CD-1 convention — and counted in `prompt_echoes_ignored` rather than silently dropped.

## Negative boundary (the #491 non-goals)

`R-CD-IO-NEG` holds a bounded window open after the claim announcement, with no explicit recipient action, and asserts: no automatic raw-byte mount, no automatic materialization, no Discord/native-media upload, no generic render or forward, no prompt injection.

## Validation run on this branch

```
node --test "tools/k6-proofs/scripts/__tests__/*.test.mjs"   ->  304 pass / 0 fail
node tools/k6-proofs/scripts/check-manifest-scenarios.mjs    ->  exit 0 (46 manifests, 43 scenarios)
node tools/k6-proofs/scripts/check-scenario-alignment.mjs     ->  ok: true, errors: []
node tools/k6-proofs/scripts/check-proof-row-manifests.mjs    ->  exit 0, missing manifests: 0
```

New contract test `delegate-attachment-io-rows.test.mjs` contributes 59 of those, pinning: #491 binding on every manifest, manifest to scenario resolution, `requiredReceipts` to `expectedReceipts` resolution, the no-content-in-evidence rule, the orchestration-gating to artifact-class match, absence of any PASS override, and workflow-choice + doc coverage for all eight rows.

`live-run-guard.test.mjs` live-suite count moves 34 -> 39: the 5 k6-runnable rows join, the 3 orchestration-required rows are correctly excluded.

## Deliberately not in this PR

- **No PROOFS artifacts.** `k6` is not installed on this seat and these are live-gateway rows; firing them against a gateway that is not deployed to the candidate would produce gateway-lacks-feature failures, not behavior evidence. This PR is the reviewable automation; the receipts are a separate row PR per CONTRIBUTING-ROWS.md.
- **No `PROOFS/INDEX.json` or `proofs-manifest.json` edits** — those are the coordinator's fold, per CONTRIBUTING-ROWS.md.
- No deploy, no restart, no config mutation, no issue mutation.

## Both-forms mandate: not applicable

Only the typed tool carries attachment blobs. The candidate documents this itself in `src/agents/system-prompt.ts`: *"Bracket `[[CONTINUE_DELEGATE: ...]]` syntax cannot carry attachment blobs; reference an existing workspace file instead."* So these rows have no token-form sibling and a single-surface row is complete — same shape as the R-OBS-1 not-applicable ruling.

Docs: [`tools/k6-proofs/docs/DELEGATE-ATTACHMENT-IO-ROWS.md`](tools/k6-proofs/docs/DELEGATE-ATTACHMENT-IO-ROWS.md)