### PR TITLE
WO-P86-495/496: close catalog roots and bind harness provenance

### DIFF
--- a/.github/workflows/project81-k6-proof.yml
+++ b/.github/workflows/project81-k6-proof.yml
@@ -86,10 +86,14 @@ jobs:
       OPENCLAW_CREATE_DISPOSABLE_SESSIONS: ${{ inputs.create_disposable_sessions }}
       OPENCLAW_ALT_MODEL: ${{ inputs.openclaw_alt_model }}
       OPENCLAW_PROOFS_K6_OTLP_ENDPOINT: ${{ inputs.metrics_otlp_endpoint }}
+      OPENCLAW_PROOFS_DOCS_REPOSITORY: ${{ github.repository }}
+      DOCS_REF: ${{ github.sha }}
       K6_PROOF_OUT_DIR: ${{ github.workspace }}/project81-k6-proof-artifacts
     steps:
       - name: Checkout proof catalog
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
 
       - name: Validate catalog and resolve rows
         id: rows
@@ -110,9 +114,11 @@ jobs:
           fi
           node --check tools/k6-proofs/scripts/list-runnable-rows.mjs
           node --check tools/k6-proofs/scripts/summarize-review-debt.mjs
-          node tools/k6-proofs/scripts/check-manifest-scenarios.mjs
-          node tools/k6-proofs/scripts/check-scenario-alignment.mjs
-          node tools/k6-proofs/scripts/check-proof-row-manifests.mjs
+          # One repository-root contract (#495): these produce identical results
+          # from the repository root and from tools/k6-proofs.
+          node tools/k6-proofs/scripts/check-manifest-scenarios.mjs --repo-root "$GITHUB_WORKSPACE"
+          node tools/k6-proofs/scripts/check-scenario-alignment.mjs --repo-root "$GITHUB_WORKSPACE"
+          node tools/k6-proofs/scripts/check-proof-row-manifests.mjs --repo-root "$GITHUB_WORKSPACE"
           if [[ "$ROWS_INPUT" == "live-suite" ]]; then
             rows="$(node tools/k6-proofs/scripts/list-runnable-rows.mjs --live-suite)"
           elif [[ "$ROWS_INPUT" == "all" ]]; then
@@ -144,7 +150,10 @@ jobs:
           if [[ "${{ inputs.metrics_push }}" != "true" ]]; then
             unset OPENCLAW_PROOFS_K6_OTLP_ENDPOINT
           fi
-          ./scripts/run-proofs.sh "$mode" "${{ steps.rows.outputs.rows }}" "${OPENCLAW_CANDIDATE_SHA:-}"
+          # Bind the matrix to the exact immutable docs/harness commit this job
+          # checked out (#496). The runner freezes it before any row fires and
+          # fails closed as harness infrastructure if the tree is stale or dirty.
+          ./scripts/run-proofs.sh "$mode" --docs-ref "$DOCS_REF" "${{ steps.rows.outputs.rows }}" "${OPENCLAW_CANDIDATE_SHA:-}"
 
       - name: Summarize review debt
         if: ${{ always() && !inputs.dry_run }}

--- a/RUNBOOKS/project-81/EXECUTABLE-SUITE.md
+++ b/RUNBOOKS/project-81/EXECUTABLE-SUITE.md
@@ -95,7 +95,8 @@ preflight (`check-manifest-scenarios`, `check-scenario-alignment`,
 Artifacts are written under `${K6_PROOF_OUT_DIR:-/tmp/k6-proof-runs}`:
 
 ```text
-<out-dir>/harness-provenance.json
+<out-dir>/harness-provenance.json              # newest matrix
+<out-dir>/harness-provenance/<matrix-id>.json  # immutable per-matrix copy
 <out-dir>/<candidate-sha>/<ROW>/<seat>/<timestamp-row>/
 ```
 

--- a/RUNBOOKS/project-81/EXECUTABLE-SUITE.md
+++ b/RUNBOOKS/project-81/EXECUTABLE-SUITE.md
@@ -78,16 +78,33 @@ Use disposable sessions unless you are deliberately proving behavior on a named 
 ```bash
 export OPENCLAW_CREATE_DISPOSABLE_SESSION=true
 export OPENCLAW_CREATE_DISPOSABLE_SESSIONS=true
-./scripts/run-proofs.sh --live "$ROWS"
+export OPENCLAW_PROOFS_DOCS_REF="$(git rev-parse HEAD)"
+./scripts/run-proofs.sh --live --docs-ref "$OPENCLAW_PROOFS_DOCS_REF" "$ROWS"
 ```
+
+A live run is bound to one immutable docs/harness commit (#496). `--docs-ref`
+(or `OPENCLAW_PROOFS_DOCS_REF`) is required and frozen at startup; the runner
+refuses to fire when the ref is missing or malformed, when `HEAD` is not that
+ref, when tracked bytes under `tools/k6-proofs` are dirty, or when a selected
+row's manifest/scenario is not tracked at that commit. Those are harness
+infrastructure failures: one `harness-control-receipt.json`, exit 78, zero rows
+executed, no synthesized per-row verdict. The same applies when the catalog
+preflight (`check-manifest-scenarios`, `check-scenario-alignment`,
+`check-proof-row-manifests`) fails.
 
 Artifacts are written under `${K6_PROOF_OUT_DIR:-/tmp/k6-proof-runs}`:
 
 ```text
+<out-dir>/harness-provenance.json
 <out-dir>/<candidate-sha>/<ROW>/<seat>/<timestamp-row>/
 ```
 
-Each row emits `row-manifest.json`, `runner-metadata.json`, `k6.log`, `evidence-lines.log`, `evidence.jsonl`, `run-result.json`, metrics files, and summary files when available. A review-complete row also emits `candidate-run-result.json` (`openclaw.k6.candidate-run-result.v1`): a public-safe routing envelope that binds the manifest, candidate SHA, docs ref, row, seat, and run identity. It remains candidate-only (`behaviorProof:false`, `canonicalFoldForbidden:true`); review-pending rows deliberately receive no envelope and remain in the review-debt queue.
+`harness-provenance.json` is written before the first row fires and records the
+approved docs ref, repository identity, candidate SHA, runtime identity receipt,
+runner script digest, row selection with per-row manifest/scenario digests, and
+the start time.
+
+Each row emits `row-manifest.json`, `row-scenario.js`, `runner-metadata.json`, `k6.log`, `evidence-lines.log`, `evidence.jsonl`, `run-result.json`, metrics files, and summary files when available. `runner-metadata.json` carries `docsRef`, `repository`, and the `manifestSha256` / `scenarioSha256` of the exact contract bytes that fired. A review-complete row also emits `candidate-run-result.json` (`openclaw.k6.candidate-run-result.v1`): a public-safe routing envelope that binds the manifest, candidate SHA, docs ref, harness source digests, row, seat, and run identity. It remains candidate-only (`behaviorProof:false`, `canonicalFoldForbidden:true`); review-pending rows deliberately receive no envelope and remain in the review-debt queue.
 
 ## 7. Review before folding
 

--- a/RUNBOOKS/project-81/README.md
+++ b/RUNBOOKS/project-81/README.md
@@ -90,21 +90,30 @@ Rows promoted as static committed-packet validators or honest-limit canaries may
      ./scripts/run-proofs.sh --dry-run <ROW-or-comma-list-or-all> <candidate-sha>
    ```
 
-4. Live-run only when the row runbook says it is safe:
+4. Live-run only when the row runbook says it is safe. A live run must be bound
+   to the exact immutable docs/harness commit it is running from (#496):
 
    ```bash
    cd tools/k6-proofs
    OPENCLAW_GATEWAY_TOKEN=*** \
    OPENCLAW_SESSION_KEY=<target-session-key> \
-     ./scripts/run-proofs.sh --live <ROW> <candidate-sha>
+     ./scripts/run-proofs.sh --live --docs-ref "$(git rev-parse HEAD)" <ROW> <candidate-sha>
    ```
+
+   The runner refuses to fire when the ref is missing/malformed, when `HEAD` is
+   not that ref, when tracked bytes under `tools/k6-proofs` are dirty, when a
+   selected row's manifest/scenario is untracked at that commit, or when the
+   catalog preflight fails. Each of those writes one
+   `<out-dir>/harness-control-receipt.json`, exits 78, and executes no rows.
 
 5. Preserve candidate output. For live runs, `run-proofs.sh` writes artifacts under `--out-dir` (default `/tmp/k6-proof-runs`):
 
    ```text
+   <out-dir>/harness-provenance.json   # docs ref, candidate, digests, row selection
    <out-dir>/<candidate-sha>/<ROW>/<seat>/<timestamp-row>/
    ├── row-manifest.json
-   ├── runner-metadata.json
+   ├── row-scenario.js                 # the exact scenario source that fired
+   ├── runner-metadata.json            # incl. docsRef / manifestSha256 / scenarioSha256
    ├── k6.log
    ├── evidence-lines.log
    ├── evidence.jsonl

--- a/RUNBOOKS/project-81/README.md
+++ b/RUNBOOKS/project-81/README.md
@@ -109,7 +109,8 @@ Rows promoted as static committed-packet validators or honest-limit canaries may
 5. Preserve candidate output. For live runs, `run-proofs.sh` writes artifacts under `--out-dir` (default `/tmp/k6-proof-runs`):
 
    ```text
-   <out-dir>/harness-provenance.json   # docs ref, candidate, digests, row selection
+   <out-dir>/harness-provenance.json             # docs ref, candidate, digests, row selection
+   <out-dir>/harness-provenance/<matrix-id>.json # immutable per-matrix copy
    <out-dir>/<candidate-sha>/<ROW>/<seat>/<timestamp-row>/
    ├── row-manifest.json
    ├── row-scenario.js                 # the exact scenario source that fired

--- a/output.md
+++ b/output.md
@@ -152,7 +152,7 @@ Review-boundary invariants are unchanged: `candidateOnly:true`,
 
 ---
 
-## 2. Exact changed files (20 files, +1524 / −62)
+## 2. Exact changed files (22 files, +3163 / −134)
 
 New:
 
@@ -198,7 +198,7 @@ was installed.
 ```
 node --test tools/k6-proofs/scripts/__tests__/*.test.mjs
   baseline @ fb9d26b1 : 263 pass / 0 fail
-  final    @ HEAD     : 318 pass / 0 fail   (+55)
+  final    @ HEAD     : 319 pass / 0 fail   (+56)
 
 node --test tools/k6-proofs/tests/*.test.mjs
   baseline @ fb9d26b1 :  31 pass / 0 fail
@@ -327,8 +327,10 @@ approved run's full provenance receipt.
 
 Existing suites that would otherwise have started passing for the wrong reason
 were repaired rather than left green: the `report-render` and `review-debt`
-envelope-consumption fixtures now carry a valid harness identity, so they still
-exercise the acceptance path.
+envelope-consumption fixtures now carry the complete canonical envelope shape
+and valid harness identity. The report fixture proves the accepted sidecar path
+by suppressing raw-only timing output, while the debt fixture directly verifies
+the acceptance predicate before checking that the raw sibling is not counted.
 
 ---
 

--- a/output.md
+++ b/output.md
@@ -1,0 +1,387 @@
+# WO-P86-495/496 — Close Catalog Roots and Harness Provenance
+
+Branch: `codeagent/p86-495-496-harness-provenance`
+Base: `fb9d26b10a0fe90f24146015d3800efc60a3fa75` (docs `main`)
+Scope: harness/docs only. No `PROOFS/**` corpus, `proofs-manifest.json`, or
+`PROOFS/INDEX.json` bytes were touched. No product (`karmaterminal/openclaw`)
+change. No live row fired, no gateway restarted, no prince seat touched.
+
+---
+
+## 1. What changed
+
+### 1.1 One repository-root contract (#495)
+
+**New:** `tools/k6-proofs/lib/repo-root.mjs`
+
+Resolution order, applied identically by every catalog reader:
+
+1. `--repo-root <dir>` (also `--repo-root=<dir>`);
+2. `OPENCLAW_PROOFS_REPO_ROOT`;
+3. the nearest ancestor-or-self of the working directory that contains a
+   `tools/k6-proofs` directory.
+
+Rule 3 makes the repository root, `tools/k6-proofs`, and
+`tools/k6-proofs/scripts` all resolve to the same root, so the tool prefix can
+never be joined twice. There is deliberately **no** fallback to the checkout that
+happens to contain the module: a caller standing outside any harness fails closed
+with an explicit contract error instead of silently validating an unrelated
+catalog (or, as before, reporting an infrastructure ENOENT as an empty catalog).
+
+**Migrated to the shared resolver** (each previously used `process.cwd()` or
+caller-specific path stripping):
+
+- `tools/k6-proofs/scripts/check-manifest-scenarios.mjs`
+- `tools/k6-proofs/scripts/check-scenario-alignment.mjs`
+- `tools/k6-proofs/scripts/check-proof-row-manifests.mjs`
+- `tools/k6-proofs/scripts/list-runnable-rows.mjs` — this one carried the
+  `process.cwd().endsWith('/tools/k6-proofs') ? … : join(cwd, 'tools/k6-proofs')`
+  stripping the workorder explicitly forbids; it is now the same contract as the
+  other three.
+
+`run-proofs.sh` also resolves its own harness root from its script location and
+`cd`s there, so the runner is no longer sensitive to the caller's directory
+either. `--out-dir` is made absolute before that `cd`.
+
+### 1.1b Ordered verification stages
+
+A live matrix now proceeds strictly as: **byte-only identity** (no catalog is
+parsed) → **immutable snapshot** (`git archive` of `tools/k6-proofs`, `PROOFS`
+and `.github`, then `exec` into the snapshot's own `run-proofs.sh` with an
+authenticated ownership handoff) → **catalog preflight** (validators run from the
+snapshot under `env -i`) → **row selection and contract binding** → **credential
+and session resolution** → **seat readiness** → **provenance** → **rows**.
+
+Nothing the matrix consumes is read from the operator's mutable checkout after
+the snapshot exists, and no credential is present in the process while unproven
+bytes are executing.
+
+### 1.2 Catalog preflight is harness infrastructure, not a product verdict (#495)
+
+`run-proofs.sh` now runs all three catalog validators (with an explicit
+`--repo-root`) **before any row work**. On failure it:
+
+- writes exactly one `"$OUT_ROOT"/harness-control-receipt.json`
+  (`openclaw.k6.harness-control-receipt.v1`, `classification:
+  "harness-infrastructure"`, `rowsExecuted: 0`, `rowVerdictsSynthesized: false`,
+  `productVerdict: null`, `stage`, `reason`, `detail`, `rowSelection`);
+- preserves the raw validator output as `catalog-preflight.log`;
+- exits `78` (`EX_CONFIG`), deliberately distinct from any row's effective exit
+  code so a setup fault can never be read as a candidate outcome;
+- executes **no** rows and synthesizes **no** per-row FAIL/BAD_PROOF.
+
+On success any stale control receipt is removed.
+
+### 1.3 Immutable harness identity (#496)
+
+`run-proofs.sh --docs-ref <40-hex>` (env equivalent `OPENCLAW_PROOFS_DOCS_REF`).
+A **live** run refuses to fire — same control receipt, same exit 78, zero rows —
+unless all of:
+
+| check | `detail.check` |
+| --- | --- |
+| approved ref is a 40-char lowercase SHA | `docs-ref-shape` |
+| repository `HEAD` equals that ref | `head-equals-docs-ref` |
+| every tracked byte under `tools/k6-proofs`, `PROOFS` and `.github` hashes to the approved blob (`git hash-object --no-filters`, never `git status`) | `harness-tree-clean` |
+| the candidate SHA is exact 40-hex | `candidate-sha-shape` |
+| the extracted snapshot matches the approved ref | `harness-snapshot-matches-docs-ref` |
+| the executing runner is the snapshot's own, with a valid ownership sentinel | `snapshot-handoff-authentic` |
+| every selected row is recorded at the approved ref | `row-recorded-at-docs-ref` |
+| a public-safe `<owner>/<repo>` identity exists | `repository-identity` |
+| each selected runnable row's scenario file exists | `scenario-present` |
+| each selected manifest + scenario is tracked at that commit | `tracked-at-docs-ref` |
+| those tracked bytes equal the working-tree bytes | `bytes-match-docs-ref` |
+
+The ref and the per-row `manifestSha256` / `scenarioSha256` are resolved and
+frozen once at startup into read-only state; the row loop refuses to fire any row
+that is not in the frozen binding. The previous ambient
+`DOCS_REF="$(git rev-parse HEAD)"` — which ran **after** each row had already
+executed — is gone.
+
+New/changed artifacts:
+
+- `"$OUT_ROOT"/harness-provenance.json` (`openclaw.k6.harness-provenance.v1`),
+  written before the first row fires: docs ref + source, repository identity,
+  candidate SHA, runtime identity receipt (seat, runtime build SHA,
+  candidate/runtime match, `seat-readiness.json` digest), runner script path +
+  sha256, row selection, per-row manifest/scenario paths + sha256, `mode`,
+  `harnessIdentityVerified`, `candidateOnly`, `foldRequiresReview`, `startedAt`.
+- every `runner-metadata.json` gains `docsRef`, `repository`, `manifestPath`,
+  `manifestSha256`, `scenarioPath`, `scenarioSha256`.
+- every live run directory gains `row-scenario.js` — the exact scenario source
+  bytes that fired, next to the already-copied `row-manifest.json`.
+
+### 1.4 Candidate envelope binding (#496)
+
+`validate-candidate-run-result.mjs` (emit side) now requires the metadata to
+carry `docsRef` (equal to the approved `--docs-ref`), a safe `<owner>/<repo>`
+`repository`, and both 64-hex digests; it recomputes the digests from the copied
+`row-manifest.json` and `row-scenario.js` and refuses to emit on any mismatch or
+omission. The envelope gains a `harness` block carrying those values plus the
+artifact names it bound.
+
+`candidate-run-result-contract.mjs` (`candidateEnvelopeMatchesSiblings`, the
+consumer side used by `summarize-review-debt.mjs` and `render-run-report.mjs`)
+performs the same re-verification, so a sidecar whose harness identity is
+omitted, mismatched, or whose copied source was mutated after capture can no
+longer suppress raw review debt or reach the report as ready-for-human-review.
+
+Review-boundary invariants are unchanged: `candidateOnly:true`,
+`foldRequiresReview:true`, `canonicalFoldForbidden:true`, `behaviorProof:false`.
+
+### 1.5 Public-safety
+
+- The control receipt records only `"malformed"` for a badly-shaped
+  operator-supplied docs ref; it never echoes an arbitrary input string.
+- Repository identity is derived only from a real remote (scheme or scp form) or
+  the explicit `OPENCLAW_PROOFS_DOCS_REPOSITORY` override, so a local clone path
+  can never reach a public receipt. A local-path remote yields no identity and a
+  live run fails closed instead.
+- All new receipt fields are repo-relative paths, SHAs, digests, booleans, and
+  timestamps. No token, session key, prompt, private path, or raw process output
+  is added to any public artifact.
+
+### 1.6 CI
+
+`.github/workflows/project81-k6-proof.yml`:
+
+- `actions/checkout@v4` pinned to `ref: ${{ github.sha }}`;
+- `DOCS_REF: ${{ github.sha }}` and `OPENCLAW_PROOFS_DOCS_REPOSITORY: ${{ github.repository }}`;
+- the runner is invoked with `--docs-ref "$DOCS_REF"`;
+- the catalog validators are invoked with `--repo-root "$GITHUB_WORKSPACE"`.
+
+---
+
+## 2. Exact changed files (20 files, +1524 / −62)
+
+New:
+
+```
+tools/k6-proofs/lib/repo-root.mjs
+tools/k6-proofs/scripts/__tests__/catalog-root-contract.test.mjs
+tools/k6-proofs/scripts/__tests__/harness-provenance-runner.test.mjs
+tools/k6-proofs/scripts/__tests__/helpers/harness-checkout.mjs
+```
+
+Modified:
+
+```
+.github/workflows/project81-k6-proof.yml
+RUNBOOKS/project-81/EXECUTABLE-SUITE.md
+RUNBOOKS/project-81/README.md
+tools/k6-proofs/README.md
+tools/k6-proofs/docs/PROOF-RUN-METHOD.md
+tools/k6-proofs/scripts/candidate-run-result-contract.mjs
+tools/k6-proofs/scripts/check-manifest-scenarios.mjs
+tools/k6-proofs/scripts/check-proof-row-manifests.mjs
+tools/k6-proofs/scripts/check-scenario-alignment.mjs
+tools/k6-proofs/scripts/list-runnable-rows.mjs
+tools/k6-proofs/scripts/run-proofs.sh
+tools/k6-proofs/scripts/validate-candidate-run-result.mjs
+tools/k6-proofs/scripts/__tests__/candidate-run-result.test.mjs
+tools/k6-proofs/scripts/__tests__/continuation-row-contract.test.mjs
+tools/k6-proofs/scripts/__tests__/report-render.test.mjs
+tools/k6-proofs/scripts/__tests__/review-debt.test.mjs
+```
+
+---
+
+## 3. Validation
+
+### 3.1 Full-suite tally
+
+The repository has no `scripts/test-projects.mjs` and no `package.json`; the
+sanctioned complete k6 proof-script surface documented in
+`tools/k6-proofs/docs/PROOF-RUN-METHOD.md` is `node --test`. No new test runner
+was installed.
+
+```
+node --test tools/k6-proofs/scripts/__tests__/*.test.mjs
+  baseline @ fb9d26b1 : 263 pass / 0 fail
+  final    @ HEAD     : 318 pass / 0 fail   (+55)
+
+node --test tools/k6-proofs/tests/*.test.mjs
+  baseline @ fb9d26b1 :  31 pass / 0 fail
+  final    @ HEAD     :  31 pass / 0 fail
+```
+
+`bash -n` clean. `shellcheck -S warning` reports only the two pre-existing SC2155
+warnings. `git diff --check` clean. `PROOFS/**` diff is empty (0 files).
+
+### 3.2 Exact commands
+
+```bash
+# full k6 proof-script surface (completion signal)
+node --test tools/k6-proofs/scripts/__tests__/*.test.mjs
+node --test tools/k6-proofs/tests/*.test.mjs
+
+# targeted new suites
+node --test tools/k6-proofs/scripts/__tests__/catalog-root-contract.test.mjs
+node --test tools/k6-proofs/scripts/__tests__/harness-provenance-runner.test.mjs
+
+# targeted changed suites
+node --test tools/k6-proofs/scripts/__tests__/candidate-run-result.test.mjs
+node --test tools/k6-proofs/scripts/__tests__/continuation-row-contract.test.mjs
+node --test tools/k6-proofs/scripts/__tests__/report-render.test.mjs
+node --test tools/k6-proofs/scripts/__tests__/review-debt.test.mjs
+node --test tools/k6-proofs/scripts/__tests__/check-proof-row-manifests.test.mjs
+
+# #495 parity, by hand, against the real catalog
+for s in check-manifest-scenarios check-scenario-alignment check-proof-row-manifests list-runnable-rows; do
+  diff <(node tools/k6-proofs/scripts/$s.mjs 2>&1; echo "exit=$?") \
+       <(cd tools/k6-proofs && node scripts/$s.mjs 2>&1; echo "exit=$?") && echo "$s IDENTICAL"
+done
+
+# runner smoke, from both directories
+./tools/k6-proofs/scripts/run-proofs.sh --dry-run --out-dir /tmp/p86-dry all <40-hex>
+(cd tools/k6-proofs && ./scripts/run-proofs.sh --dry-run --out-dir /tmp/p86-dry2 all <40-hex>)
+
+bash -n tools/k6-proofs/scripts/run-proofs.sh
+shellcheck -S warning tools/k6-proofs/scripts/run-proofs.sh   # only pre-existing SC2155
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/project81-k6-proof.yml'))"
+git --no-pager diff --check
+```
+
+### 3.3 Defect reproduction, before and after
+
+**#495 — empirically confirmed, not assumed.** The pre-change validator was
+extracted from the base commit and run against the same fixture:
+
+```bash
+git show fb9d26b1:tools/k6-proofs/scripts/check-manifest-scenarios.mjs > /tmp/old.mjs
+# from the repository root:        "check passed: 1 manifests; 1 scenario files."
+# from tools/k6-proofs:            ENOENT crash (doubled prefix)
+# new script from tools/k6-proofs: identical to the repository-root run
+```
+
+**#496 — the exact Cael failure mode now fails closed.** Firing with the stale
+detached runner commit while `HEAD` is current docs `main`:
+
+```
+$ ./scripts/run-proofs.sh --live --docs-ref 25d330ef558eefce124fe3b5a787d426e6adf772 ... ; echo $?
+78
+{"stage":"harness-identity",
+ "reason":"harness checkout does not match the approved docs ref; refusing to fire a stale or mixed harness",
+ "detail":{"check":"head-equals-docs-ref",
+           "head":"fb9d26b10a0fe90f24146015d3800efc60a3fa75",
+           "approved":"25d330ef558eefce124fe3b5a787d426e6adf772"},
+ "rowsExecuted":0,"rowVerdictsSynthesized":false,"productVerdict":null}
+```
+
+### 3.4 Adversarial review
+
+The branch went through **seven** rounds with an independent reviewer before it
+was declared shippable. Findings that were real defects, all fixed and each
+pinned by a regression test:
+
+| # | Defect | Round |
+| --- | --- | --- |
+| 1 | Catalog validators executed with the gateway token in their environment, and their raw output was published | 1 |
+| 2 | Digests were frozen at startup but k6 read the ambient worktree (TOCTOU) | 1 |
+| 3 | `git` honours `refs/replace/*`, so `rev-parse` and `cat-file` could describe different trees | 1 |
+| 4 | Failure receipts echoed rejected operator input verbatim | 1 |
+| 5 | The consumer envelope contract accepted unknown keys, so a sidecar could smuggle extra material past review | 1 |
+| 6 | The env-isolation test was vacuous; a denylist could not stop unrelated credentials | 2 |
+| 7 | Only the manifest and top-level scenario were re-hashed — a scenario's `lib/` imports were unguarded | 2 |
+| 8 | A missing file made the digest check abort under `set -e` with no control receipt and no exit 78 | 2 |
+| 9 | A pre-execution failure left a provisional run directory and could let the interruption writer contradict `rowsExecuted:0` | 2 |
+| 10 | `git status` is not byte integrity: `assume-unchanged` / `skip-worktree` hid a modified import | 3 |
+| 11 | The catalog was parsed before it was validated, so a malformed manifest aborted with no receipt | 3 |
+| 12 | `RUN_ID` was second-granular, so the provisional purge could delete a concurrent run's evidence | 3 |
+| 13 | `rowsExecuted:0` was hard-coded and false once a later row failed | 3 |
+| 14 | `git hash-object` applies clean filters by default — a filter could forge the approved blob hash and execute during the identity stage | 4 |
+| 15 | Bracketing hash assertions only narrow a check-then-use window; harness code had to execute from an immutable snapshot | 4 |
+| 16 | Unvalidated candidate input reached artifact paths and metadata | 4 |
+| 17 | `rowsExecuted` counted pre-dispatch gates that never dispatched | 4 |
+| 18 | Bash reads its own source incrementally, so the executing runner had to be the snapshot's copy | 5 |
+| 19 | `PROOFS` was symlinked unverified, and static rows read it — a clean harness could emit `PASS-candidate` from dirty corpus bytes | 5 |
+| 20 | The snapshot handoff was spoofable by setting the handoff variables and skipping `exec` | 6 |
+| 21 | The bootstrap invoked `openclaw` and resolved session state with credentials present | 6 |
+| 22 | **A rejected handoff `rm -rf`'d the directory it claimed** — introduced by the fix for #20 | 7 |
+
+Defect 22 was the most dangerous in the set and was introduced by this work, not
+inherited; it is now covered by a test asserting that an unrelated bystander
+directory claimed as a snapshot survives with its contents intact.
+
+### 3.5 New test coverage
+
+`catalog-root-contract.test.mjs` (6 tests) — all four catalog readers must
+produce byte-identical stdout, stderr and exit status from the repository root,
+from `tools/k6-proofs`, and from `tools/k6-proofs/scripts`, on both the passing
+and a genuine-defect path; `--repo-root` and `OPENCLAW_PROOFS_REPO_ROOT`
+overrides; fail-closed contract error outside any harness; decoy directories
+containing only `notes`, only `scenarios`, or only `manifests`; and an assertion
+that no output ever contains `tools/k6-proofs/tools/k6-proofs`.
+
+`harness-provenance-runner.test.mjs` (28 tests) — missing/malformed/mismatched
+docs refs; the env equivalent; index-hidden (`assume-unchanged`,
+`skip-worktree`) mutation of a shared import; a mutated proof-corpus evidence
+file; an unrecorded row; a catalog-preflight failure; an unvalidated candidate
+SHA; three spoofed-handoff shapes, each also asserting the claimed directory
+survives; mid-matrix mutation before capture and between capture and k6, the
+latter asserting the provisional directory is purged; `env -i` isolation proved
+by a probe validator; log scrubbing proved by that probe printing its own working
+directory; runner cwd-independence; a `git replace` decoy; direct observation
+that k6 executes from the snapshot with the approved scenario bytes; and an
+approved run's full provenance receipt.
+
+Existing suites that would otherwise have started passing for the wrong reason
+were repaired rather than left green: the `report-render` and `review-debt`
+envelope-consumption fixtures now carry a valid harness identity, so they still
+exercise the acceptance path.
+
+---
+
+## 4. Uncertainties and agreed follow-ups
+
+The reviewer explicitly confirmed all three of the following are correctly
+classified as follow-ups rather than blockers on this branch.
+
+1. **Committed symlinks, gitlinks and executable-mode changes are not type- or
+   mode-compared.** The verification compares blob content. No such entries
+   exist in the verified trees today, and they fail closed if introduced, but a
+   mode-only change would not be detected. Recommend a follow-up issue.
+
+2. **`analysis/project86-proof-issue-plan.corrected.json` was deliberately not
+   rewritten.** Its 23 emitted commands still read
+   `./scripts/run-proofs.sh --live <ROW> <FINAL_CANDIDATE_SHA>`. Those commands
+   now **fail closed** (exit 78, `docs-ref-shape`) unless the operator exports
+   `OPENCLAW_PROOFS_DOCS_REF` — the correct safety posture, but it means a matrix
+   generated verbatim from that plan will refuse to fire until the ref is
+   supplied. I left it alone because that file is guarded by
+   `apply-project86-plan-corrections.mjs` plus its idempotence and
+   lock-serialization tests, and because adding a `<DOCS_REF>` placeholder would
+   collide with the separate R-CD-2 runtime-selection correction the workorder
+   excludes from this branch. Recommend a follow-up issue.
+
+3. **Inherited-token trust boundary.** The bootstrap phase reads no credential
+   and invokes no product tooling, but if the caller has already exported
+   `OPENCLAW_GATEWAY_TOKEN` then that value is in the bootstrap process's
+   environment by construction and cannot be dropped from inside the same
+   script. The reviewer classified this as a trust-boundary hardening item, not
+   a demonstrated receipt bypass.
+
+Other notes:
+
+4. **Pre-existing candidate artifacts** produced before this change carry no
+   `docsRef`/digests and no `row-scenario.js`. Their sidecar envelopes will no
+   longer suppress raw review debt and will fall back to the raw
+   `run-result.json` path. That is the intended fail-closed behaviour — they
+   genuinely cannot prove which harness contract produced them — but reviewers
+   should expect existing bundles to reappear as review debt rather than
+   silently as ready-for-human-review.
+
+5. **New hard requirements for a live run**, each of which fails closed with a
+   control receipt: an approved `--docs-ref`; an exact 40-hex candidate SHA; a
+   public-safe `<owner>/<repo>` identity (set `OPENCLAW_PROOFS_DOCS_REPOSITORY`
+   when the clone has no public remote); and every selected row being recorded at
+   the approved ref. A live matrix also needs roughly 400MB of `TMPDIR` space for
+   the snapshot, which is removed on exit.
+
+6. **Not exercised end-to-end against a real gateway.** The workorder forbids
+   firing a live row. The R-CD-2 fixture drives the full pipeline — k6 → evidence
+   extraction → trace collection → resolver → sanitizer → candidate envelope →
+   metrics → report — but against a stubbed `k6` and a local HTTP endpoint.
+
+7. **`shellcheck -S warning`** still reports two pre-existing SC2155 warnings in
+   `run-proofs.sh`. They are untouched by this change and out of scope.

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -733,14 +733,17 @@ catalog is parsed before it is validated:
 1. **byte-only identity** — ref shape, `HEAD` equality, candidate SHA shape,
    repository identity, and the full tracked-tree hash comparison. No manifest is
    parsed here.
-2. **immutable snapshot** — the approved `tools/k6-proofs` tree is extracted with
-   `git archive` into a private temporary directory, and the runner then hands
-   execution to that extract's own `run-proofs.sh` with `exec`, before any
-   credential is loaded. Every harness component (the runner itself, the catalog
-   validators, seat readiness, k6, scenarios and their imports, the
-   evidence/receipt helpers) therefore executes from bytes that cannot change
-   once the matrix has started. The re-executed copy re-proves the snapshot
-   against the approved ref before trusting it.
+2. **immutable snapshot** — every consumed tree (`tools/k6-proofs`, `PROOFS`,
+   `.github`) is extracted with `git archive` into a private temporary directory,
+   and the runner then hands execution to that extract's own `run-proofs.sh`
+   with `exec`, before any credential is loaded or any external tool is invoked.
+   Every harness component (the runner itself, the catalog validators, seat
+   readiness, k6, scenarios and their imports, the evidence/receipt helpers) and
+   every corpus byte a static row reads therefore comes from bytes that cannot
+   change once the matrix has started. Nothing is symlinked back to the
+   operator's checkout. The re-executed copy proves it really is the snapshot's
+   own runner, that the snapshot is a distinct tree from the checkout, and that
+   the snapshot matches the approved ref, before trusting any of it.
 3. **catalog preflight** — the three validators run from the snapshot under
    `env -i` with a minimal allowlist.
 4. **row selection and contract binding** — `all` expansion and the per-row
@@ -748,7 +751,8 @@ catalog is parsed before it is validated:
    selected row with no manifest at the approved ref fails closed rather than
    being silently skipped.
 
-The gateway token is extracted only after all of those stages complete. The
+The gateway token, the deployed runtime stamp and the session key are all
+resolved only inside the verified snapshot runner, after those stages complete. The
 tracked-tree comparison is repeated before each row for a different reason: bash
 reads `run-proofs.sh` itself incrementally from the operator's checkout, so that
 one file must still match the approved ref while the matrix is running.

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -715,9 +715,27 @@ supplied through `--docs-ref <40-hex>` or `OPENCLAW_PROOFS_DOCS_REF`, and:
 
 - the ref is a 40-character lowercase SHA;
 - repository `HEAD` equals that ref;
-- tracked bytes under `tools/k6-proofs` are clean;
+- every tracked file under `tools/k6-proofs` hashes to the blob recorded in that
+  commit;
 - every selected runnable row's manifest and scenario are tracked at that exact
   commit with matching bytes.
+
+The tree check hashes working-tree bytes with `git hash-object` and compares them
+to `git ls-tree` of the approved commit. `git status` is deliberately not used:
+it consults the index, so an `assume-unchanged` or `skip-worktree` entry could
+hide a modified shared library that a scenario imports.
+
+Verification runs in three ordered stages so that no unproven byte is ever
+executed and no catalog is parsed before it is validated:
+
+1. **byte-only identity** — ref shape, `HEAD` equality, repository identity, and
+   the full tracked-tree hash comparison. No manifest is parsed here.
+2. **catalog preflight** — the three validators, now proven to be the approved
+   committed bytes, run under `env -i` with a minimal allowlist.
+3. **row selection and contract binding** — `all` expansion and the per-row
+   manifest/scenario digest freeze, on a catalog the validators have approved.
+
+The gateway token is extracted only after all three stages complete.
 
 All identity `git` calls run with `--no-replace-objects` / `GIT_NO_REPLACE_OBJECTS=1`
 and with ambient `GIT_DIR`/`GIT_WORK_TREE`-style overrides cleared, so a

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -752,10 +752,24 @@ catalog is parsed before it is validated:
    being silently skipped.
 
 The gateway token, the deployed runtime stamp and the session key are all
-resolved only inside the verified snapshot runner, after those stages complete. The
-tracked-tree comparison is repeated before each row for a different reason: bash
-reads `run-proofs.sh` itself incrementally from the operator's checkout, so that
-one file must still match the approved ref while the matrix is running.
+resolved only inside the verified snapshot runner, after those stages complete.
+The bootstrap phase — the copy of the runner the operator invoked — parses
+arguments, resolves roots, verifies bytes, extracts the snapshot and hands off.
+It reads no credential and invokes no product tooling, though it does of course
+use `git`, `jq`, `tar` and coreutils to do that work. A gateway token already
+exported by the caller is inherited by that process by construction and cannot be
+dropped from inside the same script.
+
+The handoff is authenticated rather than trusted: the re-executed process must be
+the snapshot's own runner, the snapshot must be a distinct tree outside the
+checkout, and it must carry an unguessable ownership sentinel written by the
+process that created it. A claimed snapshot failing any of those checks is never
+adopted, and therefore never becomes eligible for cleanup.
+
+The tree comparison is repeated before each row against both the snapshot and the
+operator's checkout. The snapshot side proves the executing bytes are still the
+approved ones; the checkout side reports that the operator's tree has drifted
+from the ref the matrix is bound to. Either fails closed as infrastructure.
 
 Failure receipts and provenance carry only validated values; the snapshot path,
 the checkout path, the artifact root and `$HOME` are replaced with placeholders

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -680,6 +680,54 @@ supplied. The script never mutates corpus data.
 manifests must point at an existing `tools/k6-proofs/scenarios/*.js`; rows with
 no runnable file must say `scenario.status` is `scaffold` or `construct-only`.
 
+### Repository-root contract for catalog validators (#495)
+
+`check-manifest-scenarios.mjs`, `check-scenario-alignment.mjs`, and
+`check-proof-row-manifests.mjs` share one repository-root contract
+(`tools/k6-proofs/lib/repo-root.mjs`) and join `tools/k6-proofs` exactly once.
+The root is resolved in this order:
+
+1. `--repo-root <dir>`;
+2. `OPENCLAW_PROOFS_REPO_ROOT`;
+3. the nearest ancestor-or-self of the working directory containing
+   `tools/k6-proofs`.
+
+Because of rule 3, running a validator from the repository root, from
+`tools/k6-proofs`, or from `tools/k6-proofs/scripts` inspects the same files and
+produces identical output and exit status. Standing outside any harness is an
+explicit contract error, never a silently empty catalog.
+
+### Immutable harness identity for live matrices (#496)
+
+`scripts/run-proofs.sh` runs the three catalog validators as a preflight before
+any row executes. A preflight failure is classified as harness infrastructure:
+the runner writes one `harness-control-receipt.json` under the artifact root,
+executes no rows, synthesizes no per-row verdict, and exits `78`.
+
+A live run additionally refuses to fire unless an approved docs/harness ref is
+supplied through `--docs-ref <40-hex>` or `OPENCLAW_PROOFS_DOCS_REF`, and:
+
+- the ref is a 40-character lowercase SHA;
+- repository `HEAD` equals that ref;
+- tracked bytes under `tools/k6-proofs` are clean;
+- every selected runnable row's manifest and scenario are tracked at that exact
+  commit with matching bytes.
+
+The ref is resolved and frozen once at startup; ambient `HEAD` is never re-read
+after rows have run. The runner then writes a public-safe
+`harness-provenance.json` (docs ref, repository identity, candidate SHA, runtime
+identity receipt, runner script digest, row selection with per-row
+manifest/scenario digests, start time) before the first row fires, and records
+`docsRef`, `repository`, `manifestPath`/`manifestSha256`, and
+`scenarioPath`/`scenarioSha256` in every `runner-metadata.json`. The exact
+scenario source travels with each receipt as `row-scenario.js`, and the
+candidate routing envelope is withheld unless those values bind to the approved
+ref and the copied manifest/scenario bytes.
+
+Set `OPENCLAW_PROOFS_DOCS_REPOSITORY=<owner>/<repo>` when the checkout has no
+public remote; only a real remote (or that override) is accepted, so a local
+clone path can never reach a public receipt.
+
 ## Coordination
 
 - Epic: [#106](https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/106)

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -725,17 +725,32 @@ to `git ls-tree` of the approved commit. `git status` is deliberately not used:
 it consults the index, so an `assume-unchanged` or `skip-worktree` entry could
 hide a modified shared library that a scenario imports.
 
-Verification runs in three ordered stages so that no unproven byte is ever
-executed and no catalog is parsed before it is validated:
+Verification runs in ordered stages so that no unproven byte is executed and no
+catalog is parsed before it is validated:
 
-1. **byte-only identity** — ref shape, `HEAD` equality, repository identity, and
-   the full tracked-tree hash comparison. No manifest is parsed here.
-2. **catalog preflight** — the three validators, now proven to be the approved
-   committed bytes, run under `env -i` with a minimal allowlist.
-3. **row selection and contract binding** — `all` expansion and the per-row
-   manifest/scenario digest freeze, on a catalog the validators have approved.
+1. **byte-only identity** — ref shape, `HEAD` equality, candidate SHA shape,
+   repository identity, and the full tracked-tree hash comparison. No manifest is
+   parsed here.
+2. **immutable snapshot** — the approved `tools/k6-proofs` tree is extracted with
+   `git archive` into a private temporary directory, and every harness component
+   (catalog validators, seat readiness, k6, scenarios and their imports, the
+   evidence/receipt helpers) executes from that extract. The operator's working
+   tree cannot change what runs once the matrix has started.
+3. **catalog preflight** — the three validators run from the snapshot under
+   `env -i` with a minimal allowlist.
+4. **row selection and contract binding** — `all` expansion and the per-row
+   manifest/scenario digest freeze, on a catalog the validators have approved. A
+   selected row with no manifest at the approved ref fails closed rather than
+   being silently skipped.
 
-The gateway token is extracted only after all three stages complete.
+The gateway token is extracted only after all of those stages complete. The
+tracked-tree comparison is repeated before each row for a different reason: bash
+reads `run-proofs.sh` itself incrementally from the operator's checkout, so that
+one file must still match the approved ref while the matrix is running.
+
+Failure receipts and provenance carry only validated values; the snapshot path,
+the checkout path, the artifact root and `$HOME` are replaced with placeholders
+in any captured text that becomes a public artifact.
 
 All identity `git` calls run with `--no-replace-objects` / `GIT_NO_REPLACE_OBJECTS=1`
 and with ambient `GIT_DIR`/`GIT_WORK_TREE`-style overrides cleared, so a

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -715,8 +715,10 @@ supplied through `--docs-ref <40-hex>` or `OPENCLAW_PROOFS_DOCS_REF`, and:
 
 - the ref is a 40-character lowercase SHA;
 - repository `HEAD` equals that ref;
-- every tracked file under `tools/k6-proofs` hashes to the blob recorded in that
-  commit;
+- every tracked file under `tools/k6-proofs`, `PROOFS`, and `.github` hashes to
+  the blob recorded in that commit — the proof corpus is included because static
+  rows read it, so a locally modified corpus must not be able to produce a
+  candidate verdict;
 - every selected runnable row's manifest and scenario are tracked at that exact
   commit with matching bytes.
 
@@ -732,10 +734,13 @@ catalog is parsed before it is validated:
    repository identity, and the full tracked-tree hash comparison. No manifest is
    parsed here.
 2. **immutable snapshot** — the approved `tools/k6-proofs` tree is extracted with
-   `git archive` into a private temporary directory, and every harness component
-   (catalog validators, seat readiness, k6, scenarios and their imports, the
-   evidence/receipt helpers) executes from that extract. The operator's working
-   tree cannot change what runs once the matrix has started.
+   `git archive` into a private temporary directory, and the runner then hands
+   execution to that extract's own `run-proofs.sh` with `exec`, before any
+   credential is loaded. Every harness component (the runner itself, the catalog
+   validators, seat readiness, k6, scenarios and their imports, the
+   evidence/receipt helpers) therefore executes from bytes that cannot change
+   once the matrix has started. The re-executed copy re-proves the snapshot
+   against the approved ref before trusting it.
 3. **catalog preflight** — the three validators run from the snapshot under
    `env -i` with a minimal allowlist.
 4. **row selection and contract binding** — `all` expansion and the per-row

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -149,7 +149,8 @@ layout as a live proof run:
 
 ```bash
 cd tools/k6-proofs
-OPENCLAW_GATEWAY_TOKEN="***" ./scripts/run-proofs.sh --live preflight <candidate-sha>
+OPENCLAW_GATEWAY_TOKEN="***" ./scripts/run-proofs.sh --live \
+  --docs-ref "$(git rev-parse HEAD)" preflight <candidate-sha>
 ```
 
 ### 3. Run an existing scenario (manifest-driven)
@@ -433,7 +434,7 @@ Callers that must honour both obligations nest them session-outer then row-inner
 ```bash
 flock --nonblock --conflict-exit-code 75 "$K6_PROOF_SESSION_LOCK_PATH" \
   flock --nonblock --conflict-exit-code 75 "$K6_PROOF_LOCK_PATH" \
-    ./scripts/run-proofs.sh --live <ROW> <SHA>
+    ./scripts/run-proofs.sh --live --docs-ref "$DOCS_REF" <ROW> <SHA>
 ```
 
 `--require-lock` lets a caller escalate a row whose manifest declares `sameSessionConcurrencySafe: true` but whose proof-round contract overrides it to serialized (for example `R-RC-2`). It can only **add** a lock requirement, never remove one, and sets `lockRequiredReason` to `caller-override` so the escalation is visible in the emitted variables.
@@ -700,9 +701,14 @@ explicit contract error, never a silently empty catalog.
 ### Immutable harness identity for live matrices (#496)
 
 `scripts/run-proofs.sh` runs the three catalog validators as a preflight before
-any row executes. A preflight failure is classified as harness infrastructure:
-the runner writes one `harness-control-receipt.json` under the artifact root,
-executes no rows, synthesizes no per-row verdict, and exits `78`.
+any row executes. The validators run with the gateway token and session material
+stripped from their environment (unproven harness code must never see live
+credentials), and their captured output is scrubbed of local filesystem
+locations before it is published as `catalog-preflight.log`. A preflight failure
+is classified as harness infrastructure: the runner writes one
+`harness-control-receipt.json` under the artifact root, executes no rows,
+synthesizes no per-row verdict, and exits `78`. Only validated values reach that
+receipt — rejected operator input is recorded as `malformed`, never echoed.
 
 A live run additionally refuses to fire unless an approved docs/harness ref is
 supplied through `--docs-ref <40-hex>` or `OPENCLAW_PROOFS_DOCS_REF`, and:
@@ -713,16 +719,30 @@ supplied through `--docs-ref <40-hex>` or `OPENCLAW_PROOFS_DOCS_REF`, and:
 - every selected runnable row's manifest and scenario are tracked at that exact
   commit with matching bytes.
 
+All identity `git` calls run with `--no-replace-objects` / `GIT_NO_REPLACE_OBJECTS=1`
+and with ambient `GIT_DIR`/`GIT_WORK_TREE`-style overrides cleared, so a
+`refs/replace/*` entry cannot make `rev-parse` and `cat-file` describe different
+trees.
+
 The ref is resolved and frozen once at startup; ambient `HEAD` is never re-read
-after rows have run. The runner then writes a public-safe
-`harness-provenance.json` (docs ref, repository identity, candidate SHA, runtime
-identity receipt, runner script digest, row selection with per-row
-manifest/scenario digests, start time) before the first row fires, and records
-`docsRef`, `repository`, `manifestPath`/`manifestSha256`, and
-`scenarioPath`/`scenarioSha256` in every `runner-metadata.json`. The exact
-scenario source travels with each receipt as `row-scenario.js`, and the
-candidate routing envelope is withheld unless those values bind to the approved
-ref and the copied manifest/scenario bytes.
+after rows have run. Because k6 and the scenario read the working tree at row
+time, the frozen digests are re-asserted immediately before capture and again
+immediately before k6 executes, and the copied artifacts are checked against
+them — a mid-matrix mutation fails closed as infrastructure rather than
+producing a receipt for unapproved source. `OPENCLAW_ROW_MANIFEST` points at the
+verified copy in the run directory, not at the mutable worktree manifest.
+
+The runner then writes a public-safe `harness-provenance.json` (matrix id, docs
+ref, repository identity, candidate SHA, runtime identity receipt, runner script
+digest, row selection with per-row manifest/scenario digests, start time) before
+the first row fires, plus an immutable per-matrix copy at
+`harness-provenance/<matrixId>.json` so a reused artifact root cannot lose the
+provenance of rows an earlier matrix wrote. Every `runner-metadata.json` records
+`docsRef`, `repository`, `matrixId`, `manifestPath`/`manifestSha256`, and
+`scenarioPath`/`scenarioSha256`. The exact scenario source travels with each
+receipt as `row-scenario.js`, and the candidate routing envelope is withheld
+unless those values bind to the approved ref and the copied manifest/scenario
+bytes.
 
 Set `OPENCLAW_PROOFS_DOCS_REPOSITORY=<owner>/<repo>` when the checkout has no
 public remote; only a real remote (or that override) is accepted, so a local

--- a/tools/k6-proofs/docs/PROOF-RUN-METHOD.md
+++ b/tools/k6-proofs/docs/PROOF-RUN-METHOD.md
@@ -123,12 +123,16 @@ commit. A stale, dirty, mixed, or unrecorded harness fails once as infrastructur
 (`harness-control-receipt.json`, exit 78) and never synthesizes a row verdict.
 
 An approved run writes `harness-provenance.json` at the artifact root before the
-first row fires (docs ref, repository, candidate SHA, runtime identity receipt,
-runner script digest, row selection and per-row manifest/scenario digests, start
-time), records `docsRef` / `repository` / `manifestSha256` / `scenarioSha256` in
-every `runner-metadata.json`, and copies the exact scenario source next to each
-receipt as `row-scenario.js`. A candidate routing envelope is withheld unless
-those values bind to the approved ref and the copied source bytes.
+first row fires (matrix id, docs ref, repository, candidate SHA, runtime identity
+receipt, runner script digest, row selection and per-row manifest/scenario
+digests, start time), keeps an immutable per-matrix copy under
+`harness-provenance/<matrix-id>.json`, records `docsRef` / `repository` /
+`matrixId` / `manifestSha256` / `scenarioSha256` in every
+`runner-metadata.json`, and copies the exact scenario source next to each receipt
+as `row-scenario.js`. Because the working tree is what k6 actually reads, the
+frozen digests are re-asserted immediately before capture and again immediately
+before k6 executes. A candidate routing envelope is withheld unless those values
+bind to the approved ref and the copied source bytes.
 
 Each row remains candidate evidence until reviewed and folded.
 

--- a/tools/k6-proofs/docs/PROOF-RUN-METHOD.md
+++ b/tools/k6-proofs/docs/PROOF-RUN-METHOD.md
@@ -47,6 +47,13 @@ node tools/k6-proofs/scripts/check-proof-row-manifests.mjs
 node tools/k6-proofs/scripts/validate-corpus.mjs --current
 ```
 
+The three catalog validators share one repository-root contract (#495), so the
+same commands produce identical results from `tools/k6-proofs` or
+`tools/k6-proofs/scripts`. Use `--repo-root <dir>` or `OPENCLAW_PROOFS_REPO_ROOT`
+to point them at an explicit checkout. `run-proofs.sh` runs all three as a
+preflight; a failure is harness infrastructure (`harness-control-receipt.json`,
+exit 78, zero rows executed), never a per-row product verdict.
+
 The “all” denominator includes `preflight`; the live-suite denominator may be smaller when it excludes static/support rows. Record which denominator you cite.
 
 ### 2. Offline artifact smoke
@@ -105,8 +112,23 @@ OPENCLAW_CANDIDATE_SHA=<40-char-sha> \
 OPENCLAW_SEAT_NAME=<seat> \
 OPENCLAW_CREATE_DISPOSABLE_SESSION=true \
 OPENCLAW_CREATE_DISPOSABLE_SESSIONS=true \
-./scripts/run-proofs.sh R-CD-2,R-CD-4 <40-char-sha>
+./scripts/run-proofs.sh --live --docs-ref <40-char-docs-sha> R-CD-2,R-CD-4 <40-char-sha>
 ```
+
+`--docs-ref` (or `OPENCLAW_PROOFS_DOCS_REF`) is mandatory for a live run (#496).
+It is resolved and frozen once at startup; the runner refuses to fire unless
+repository `HEAD` equals it, tracked bytes under `tools/k6-proofs` are clean, and
+every selected runnable row's manifest and scenario are tracked at that exact
+commit. A stale, dirty, mixed, or unrecorded harness fails once as infrastructure
+(`harness-control-receipt.json`, exit 78) and never synthesizes a row verdict.
+
+An approved run writes `harness-provenance.json` at the artifact root before the
+first row fires (docs ref, repository, candidate SHA, runtime identity receipt,
+runner script digest, row selection and per-row manifest/scenario digests, start
+time), records `docsRef` / `repository` / `manifestSha256` / `scenarioSha256` in
+every `runner-metadata.json`, and copies the exact scenario source next to each
+receipt as `row-scenario.js`. A candidate routing envelope is withheld unless
+those values bind to the approved ref and the copied source bytes.
 
 Each row remains candidate evidence until reviewed and folded.
 

--- a/tools/k6-proofs/lib/repo-root.mjs
+++ b/tools/k6-proofs/lib/repo-root.mjs
@@ -19,12 +19,16 @@
  * this module: a caller standing outside any proof harness fails closed with an
  * explicit contract error instead of validating an unrelated catalog.
  */
-import { statSync } from 'node:fs';
+import { realpathSync, statSync } from 'node:fs';
 import path from 'node:path';
 
 export const PROOFS_TOOL_DIR = path.join('tools', 'k6-proofs');
 export const REPO_ROOT_ENV_VAR = 'OPENCLAW_PROOFS_REPO_ROOT';
 export const REPO_ROOT_FLAG = '--repo-root';
+// A bare `tools/k6-proofs` directory is not enough: require at least one of the
+// catalog directories so an unrelated ancestor that merely happens to contain a
+// similarly named path cannot be mistaken for the harness root.
+const CATALOG_SENTINELS = ['manifests', 'scenarios'];
 
 function isDirectory(candidate) {
   try {
@@ -34,9 +38,23 @@ function isDirectory(candidate) {
   }
 }
 
-/** A directory is a repository root when it directly contains `tools/k6-proofs`. */
+function canonical(candidate) {
+  try {
+    return realpathSync(candidate);
+  } catch {
+    return path.resolve(candidate);
+  }
+}
+
+/**
+ * A directory is a repository root when it directly contains `tools/k6-proofs`
+ * and that directory holds a recognizable proof catalog.
+ */
 export function isRepositoryRoot(candidate) {
-  return Boolean(candidate) && isDirectory(path.join(candidate, PROOFS_TOOL_DIR));
+  if (!candidate) return false;
+  const toolDir = path.join(candidate, PROOFS_TOOL_DIR);
+  if (!isDirectory(toolDir)) return false;
+  return CATALOG_SENTINELS.some((sentinel) => isDirectory(path.join(toolDir, sentinel)));
 }
 
 /**
@@ -67,15 +85,16 @@ export function parseRepoRootArg(argv = []) {
 }
 
 function explicitRoot(value, source) {
-  const resolved = path.resolve(value);
+  const resolved = canonical(path.resolve(value));
   if (!isRepositoryRoot(resolved)) {
-    throw new Error(`${source} is not a repository root: no ${PROOFS_TOOL_DIR} directory under ${resolved}`);
+    throw new Error(`${source} is not a repository root: no ${PROOFS_TOOL_DIR} proof catalog under ${resolved}`);
   }
   return resolved;
 }
 
 function walkUpFrom(cwd) {
-  let current = path.resolve(cwd);
+  // Canonicalize first so a symlinked working directory walks the real tree.
+  let current = canonical(path.resolve(cwd));
   for (;;) {
     if (isRepositoryRoot(current)) return current;
     const parent = path.dirname(current);
@@ -101,7 +120,7 @@ export function resolveRepositoryRoot({ argv = [], cwd = process.cwd(), env = pr
   if (!discovered) {
     throw new Error(
       `unable to resolve a repository root from ${path.resolve(cwd)}: ` +
-      `no ancestor contains ${PROOFS_TOOL_DIR}. Pass ${REPO_ROOT_FLAG} <dir> or set ${REPO_ROOT_ENV_VAR}.`,
+      `no ancestor contains a ${PROOFS_TOOL_DIR} proof catalog. Pass ${REPO_ROOT_FLAG} <dir> or set ${REPO_ROOT_ENV_VAR}.`,
     );
   }
   return { root: discovered, source: 'cwd-ancestor', rest };

--- a/tools/k6-proofs/lib/repo-root.mjs
+++ b/tools/k6-proofs/lib/repo-root.mjs
@@ -25,10 +25,10 @@ import path from 'node:path';
 export const PROOFS_TOOL_DIR = path.join('tools', 'k6-proofs');
 export const REPO_ROOT_ENV_VAR = 'OPENCLAW_PROOFS_REPO_ROOT';
 export const REPO_ROOT_FLAG = '--repo-root';
-// A bare `tools/k6-proofs` directory is not enough: require at least one of the
-// catalog directories so an unrelated ancestor that merely happens to contain a
-// similarly named path cannot be mistaken for the harness root.
-const CATALOG_SENTINELS = ['manifests', 'scenarios'];
+// A bare `tools/k6-proofs` directory is not enough: the manifest catalog is the
+// defining artifact of a proof harness, so an unrelated ancestor that merely
+// happens to contain a similarly named path cannot be mistaken for the root.
+const CATALOG_SENTINEL = 'manifests';
 
 function isDirectory(candidate) {
   try {
@@ -48,13 +48,13 @@ function canonical(candidate) {
 
 /**
  * A directory is a repository root when it directly contains `tools/k6-proofs`
- * and that directory holds a recognizable proof catalog.
+ * and that directory holds a `manifests` proof catalog.
  */
 export function isRepositoryRoot(candidate) {
   if (!candidate) return false;
   const toolDir = path.join(candidate, PROOFS_TOOL_DIR);
   if (!isDirectory(toolDir)) return false;
-  return CATALOG_SENTINELS.some((sentinel) => isDirectory(path.join(toolDir, sentinel)));
+  return isDirectory(path.join(toolDir, CATALOG_SENTINEL));
 }
 
 /**

--- a/tools/k6-proofs/lib/repo-root.mjs
+++ b/tools/k6-proofs/lib/repo-root.mjs
@@ -25,10 +25,11 @@ import path from 'node:path';
 export const PROOFS_TOOL_DIR = path.join('tools', 'k6-proofs');
 export const REPO_ROOT_ENV_VAR = 'OPENCLAW_PROOFS_REPO_ROOT';
 export const REPO_ROOT_FLAG = '--repo-root';
-// A bare `tools/k6-proofs` directory is not enough: the manifest catalog is the
-// defining artifact of a proof harness, so an unrelated ancestor that merely
-// happens to contain a similarly named path cannot be mistaken for the root.
-const CATALOG_SENTINEL = 'manifests';
+// A bare `tools/k6-proofs` directory is not enough, and neither is one catalog
+// directory: a proof harness always has both a manifest catalog and a scenario
+// catalog. Requiring both stops an unrelated ancestor that merely happens to
+// contain a similarly named path from capturing discovery.
+const CATALOG_SENTINELS = ['manifests', 'scenarios'];
 
 function isDirectory(candidate) {
   try {
@@ -48,13 +49,13 @@ function canonical(candidate) {
 
 /**
  * A directory is a repository root when it directly contains `tools/k6-proofs`
- * and that directory holds a `manifests` proof catalog.
+ * and that directory holds both proof catalogs (`manifests` and `scenarios`).
  */
 export function isRepositoryRoot(candidate) {
   if (!candidate) return false;
   const toolDir = path.join(candidate, PROOFS_TOOL_DIR);
   if (!isDirectory(toolDir)) return false;
-  return isDirectory(path.join(toolDir, CATALOG_SENTINEL));
+  return CATALOG_SENTINELS.every((sentinel) => isDirectory(path.join(toolDir, sentinel)));
 }
 
 /**

--- a/tools/k6-proofs/lib/repo-root.mjs
+++ b/tools/k6-proofs/lib/repo-root.mjs
@@ -1,0 +1,113 @@
+/**
+ * repo-root.mjs — the single repository-root contract for k6-proofs catalog tooling.
+ *
+ * Every catalog/manifest validator resolves exactly one repository root and then
+ * joins `tools/k6-proofs` exactly once. Before this contract each validator used
+ * `process.cwd()` directly, so invoking them from `tools/k6-proofs` resolved
+ * `tools/k6-proofs/tools/k6-proofs/...` and reported an infrastructure ENOENT as
+ * an empty catalog (#495).
+ *
+ * Resolution order:
+ *   1. an explicit `--repo-root <dir>` argument;
+ *   2. the `OPENCLAW_PROOFS_REPO_ROOT` environment variable;
+ *   3. the nearest ancestor-or-self of the working directory that contains a
+ *      `tools/k6-proofs` directory.
+ *
+ * Rule 3 makes the repository root, `tools/k6-proofs`, and `tools/k6-proofs/scripts`
+ * all resolve to the same root, so the tool prefix can never be applied twice.
+ * Resolution never silently falls back to the checkout that happens to contain
+ * this module: a caller standing outside any proof harness fails closed with an
+ * explicit contract error instead of validating an unrelated catalog.
+ */
+import { statSync } from 'node:fs';
+import path from 'node:path';
+
+export const PROOFS_TOOL_DIR = path.join('tools', 'k6-proofs');
+export const REPO_ROOT_ENV_VAR = 'OPENCLAW_PROOFS_REPO_ROOT';
+export const REPO_ROOT_FLAG = '--repo-root';
+
+function isDirectory(candidate) {
+  try {
+    return statSync(candidate).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** A directory is a repository root when it directly contains `tools/k6-proofs`. */
+export function isRepositoryRoot(candidate) {
+  return Boolean(candidate) && isDirectory(path.join(candidate, PROOFS_TOOL_DIR));
+}
+
+/**
+ * Split `--repo-root <dir>` out of an argument list so callers can keep their own
+ * flags. Returns the raw (unvalidated) value plus the remaining arguments.
+ */
+export function parseRepoRootArg(argv = []) {
+  const rest = [];
+  let repoRoot = null;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === REPO_ROOT_FLAG) {
+      const value = argv[index + 1];
+      if (!value || value.startsWith('--')) throw new Error(`${REPO_ROOT_FLAG} requires a directory value`);
+      repoRoot = value;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith(`${REPO_ROOT_FLAG}=`)) {
+      const value = arg.slice(REPO_ROOT_FLAG.length + 1);
+      if (!value) throw new Error(`${REPO_ROOT_FLAG} requires a directory value`);
+      repoRoot = value;
+      continue;
+    }
+    rest.push(arg);
+  }
+  return { repoRoot, rest };
+}
+
+function explicitRoot(value, source) {
+  const resolved = path.resolve(value);
+  if (!isRepositoryRoot(resolved)) {
+    throw new Error(`${source} is not a repository root: no ${PROOFS_TOOL_DIR} directory under ${resolved}`);
+  }
+  return resolved;
+}
+
+function walkUpFrom(cwd) {
+  let current = path.resolve(cwd);
+  for (;;) {
+    if (isRepositoryRoot(current)) return current;
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+/**
+ * Resolve the one repository root for a catalog validator.
+ *
+ * @param {{argv?: string[], cwd?: string, env?: NodeJS.ProcessEnv}} [options]
+ * @returns {{root: string, source: string, rest: string[]}}
+ */
+export function resolveRepositoryRoot({ argv = [], cwd = process.cwd(), env = process.env } = {}) {
+  const { repoRoot, rest } = parseRepoRootArg(argv);
+  if (repoRoot) return { root: explicitRoot(repoRoot, REPO_ROOT_FLAG), source: REPO_ROOT_FLAG, rest };
+
+  const fromEnv = env?.[REPO_ROOT_ENV_VAR];
+  if (fromEnv) return { root: explicitRoot(fromEnv, REPO_ROOT_ENV_VAR), source: REPO_ROOT_ENV_VAR, rest };
+
+  const discovered = walkUpFrom(cwd);
+  if (!discovered) {
+    throw new Error(
+      `unable to resolve a repository root from ${path.resolve(cwd)}: ` +
+      `no ancestor contains ${PROOFS_TOOL_DIR}. Pass ${REPO_ROOT_FLAG} <dir> or set ${REPO_ROOT_ENV_VAR}.`,
+    );
+  }
+  return { root: discovered, source: 'cwd-ancestor', rest };
+}
+
+/** Join a path underneath the resolved `tools/k6-proofs` directory. */
+export function proofsToolPath(root, ...segments) {
+  return path.join(root, PROOFS_TOOL_DIR, ...segments);
+}

--- a/tools/k6-proofs/scripts/__tests__/candidate-run-result.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/candidate-run-result.test.mjs
@@ -14,7 +14,13 @@ const script = path.resolve('tools/k6-proofs/scripts/validate-candidate-run-resu
 const corpusValidator = path.resolve('tools/k6-proofs/scripts/validate-corpus.mjs');
 const sha = 'a'.repeat(40);
 const docsRef = 'b'.repeat(40);
+const repository = 'karmaterminal/karmaterminal-openclaw-docs';
+const scenarioSource = 'export default function scenario() { return true; }\n';
 const gatewayKey = 'candidate-test-gateway-key';
+
+function digest(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
 
 function manifest() {
   return {
@@ -41,17 +47,45 @@ function runResult(overrides = {}) {
   };
 }
 
+/**
+ * The runner copies the exact manifest and scenario bytes it fired into the
+ * candidate directory and records their digests plus the frozen docs ref, so a
+ * faithful fixture must carry the same immutable harness identity (#496).
+ */
+async function writeHarnessSources(candidateDir, manifestBody, scenario = scenarioSource) {
+  await writeFile(path.join(candidateDir, 'row-manifest.json'), manifestBody);
+  await writeFile(path.join(candidateDir, 'row-scenario.js'), scenario);
+}
+
+function harnessMetadata({ manifestBody, scenario = scenarioSource, rowFile = 'r-cw-test' } = {}) {
+  return {
+    docsRef,
+    repository,
+    manifestPath: `tools/k6-proofs/manifests/${rowFile}.json`,
+    manifestSha256: digest(manifestBody),
+    scenarioPath: `tools/k6-proofs/scenarios/${rowFile}.js`,
+    scenarioSha256: digest(scenario),
+  };
+}
+
 async function fixture({ result = runResult(), metadata = null, manifestValue = manifest() } = {}) {
   const root = await mkdtemp(path.join(tmpdir(), 'candidate-run-result-'));
   const candidateDir = path.join(root, 'candidate');
   await mkdir(candidateDir);
   const manifestPath = path.join(root, 'manifest.json');
-  await writeFile(manifestPath, `${JSON.stringify(manifestValue, null, 2)}\n`);
-  await writeFile(path.join(candidateDir, 'runner-metadata.json'), `${JSON.stringify(metadata || {
-    row: 'R-CW-TEST', candidateSha: sha, seat: 'cael', scenario: 'r-cw-test.js',
+  const manifestBody = `${JSON.stringify(manifestValue, null, 2)}\n`;
+  await writeFile(manifestPath, manifestBody);
+  await writeHarnessSources(candidateDir, manifestBody);
+  await writeFile(path.join(candidateDir, 'runner-metadata.json'), `${JSON.stringify({
+    row: 'R-CW-TEST',
+    candidateSha: sha,
+    seat: 'cael',
+    scenario: 'r-cw-test.js',
+    ...harnessMetadata({ manifestBody }),
+    ...(metadata || {}),
   }, null, 2)}\n`);
   await writeFile(path.join(candidateDir, 'run-result.json'), `${JSON.stringify(result, null, 2)}\n`);
-  return { root, candidateDir, manifestPath };
+  return { root, candidateDir, manifestPath, manifestBody };
 }
 
 async function invoke({ manifestPath, candidateDir, out = null }) {
@@ -69,6 +103,13 @@ test('emits a public-safe, candidate-only routing envelope for a complete candid
     assert.equal(result.schema, 'openclaw.k6.candidate-run-result.v1');
     assert.equal(result.candidate.sha, sha);
     assert.equal(result.candidate.docsRef, docsRef);
+    assert.equal(result.harness.docsRef, docsRef);
+    assert.equal(result.harness.repository, repository);
+    assert.equal(result.harness.manifestSha256, digest(setup.manifestBody));
+    assert.equal(result.harness.scenarioSha256, digest(scenarioSource));
+    assert.equal(result.harness.manifestArtifact, 'row-manifest.json');
+    assert.equal(result.harness.scenarioArtifact, 'row-scenario.js');
+    assert.ok(result.artifacts.files.includes('row-scenario.js'));
     assert.equal(result.run.rowId, 'R-CW-TEST');
     assert.equal(result.result.outcome, 'PASS-candidate');
     assert.equal(result.result.behaviorProof, false);
@@ -110,6 +151,108 @@ test('rejects malformed, identity-mismatched, and review-incomplete candidates',
   });
 });
 
+test('candidate envelope binds the approved docs ref and both harness source digests', async (t) => {
+  await t.test('omitted docs ref', async () => {
+    const setup = await fixture({ metadata: { docsRef: undefined } });
+    try {
+      await assert.rejects(invoke(setup), /runner metadata docsRef must be a 40-character lowercase SHA/);
+    } finally { await rm(setup.root, { recursive: true, force: true }); }
+  });
+
+  await t.test('mismatched docs ref', async () => {
+    const setup = await fixture({ metadata: { docsRef: 'c'.repeat(40) } });
+    try {
+      await assert.rejects(invoke(setup), /docs ref mismatch/);
+    } finally { await rm(setup.root, { recursive: true, force: true }); }
+  });
+
+  await t.test('omitted repository identity', async () => {
+    const setup = await fixture({ metadata: { repository: undefined } });
+    try {
+      await assert.rejects(invoke(setup), /runner metadata repository must be a non-empty string/);
+    } finally { await rm(setup.root, { recursive: true, force: true }); }
+  });
+
+  await t.test('private path smuggled as repository identity', async () => {
+    const setup = await fixture({ metadata: { repository: '/home/someone/private/checkout' } });
+    try {
+      await assert.rejects(invoke(setup), /safe <owner>\/<repo> identity/);
+    } finally { await rm(setup.root, { recursive: true, force: true }); }
+  });
+
+  await t.test('omitted manifest digest', async () => {
+    const setup = await fixture({ metadata: { manifestSha256: undefined } });
+    try {
+      await assert.rejects(invoke(setup), /runner metadata manifestSha256 must be a 64-character lowercase sha256 digest/);
+    } finally { await rm(setup.root, { recursive: true, force: true }); }
+  });
+
+  await t.test('omitted scenario digest', async () => {
+    const setup = await fixture({ metadata: { scenarioSha256: undefined } });
+    try {
+      await assert.rejects(invoke(setup), /runner metadata scenarioSha256 must be a 64-character lowercase sha256 digest/);
+    } finally { await rm(setup.root, { recursive: true, force: true }); }
+  });
+
+  await t.test('manifest source mutated after capture', async () => {
+    const setup = await fixture();
+    try {
+      await writeFile(path.join(setup.candidateDir, 'row-manifest.json'), '{"rowId":"R-CW-TEST"}\n');
+      await assert.rejects(invoke(setup), /copied row manifest digest mismatch/);
+    } finally { await rm(setup.root, { recursive: true, force: true }); }
+  });
+
+  await t.test('scenario source mutated after capture', async () => {
+    const setup = await fixture();
+    try {
+      await writeFile(path.join(setup.candidateDir, 'row-scenario.js'), '// swapped\n');
+      await assert.rejects(invoke(setup), /copied row scenario digest mismatch/);
+    } finally { await rm(setup.root, { recursive: true, force: true }); }
+  });
+
+  await t.test('scenario source missing entirely', async () => {
+    const setup = await fixture();
+    try {
+      await rm(path.join(setup.candidateDir, 'row-scenario.js'));
+      await assert.rejects(invoke(setup), /copied row scenario missing or unreadable/);
+    } finally { await rm(setup.root, { recursive: true, force: true }); }
+  });
+
+  await t.test('sibling contract rejects a sidecar whose harness identity is unrecorded or mutated', async () => {
+    const setup = await fixture();
+    try {
+      const envelope = JSON.parse((await invoke(setup)).stdout);
+      const metadata = JSON.parse(await readFile(path.join(setup.candidateDir, 'runner-metadata.json'), 'utf8'));
+      const siblings = (overrides = {}) => ({
+        envelope,
+        manifest: manifest(),
+        metadata,
+        runResult: runResult(),
+        runDir: setup.candidateDir,
+        ...overrides,
+      });
+      assert.equal(candidateEnvelopeMatchesSiblings(siblings()), true);
+
+      for (const omitted of ['docsRef', 'repository', 'manifestSha256', 'scenarioSha256']) {
+        const stripped = { ...metadata };
+        delete stripped[omitted];
+        assert.equal(
+          candidateEnvelopeMatchesSiblings(siblings({ metadata: stripped })),
+          false,
+          `metadata omitting ${omitted} must not satisfy the sibling contract`,
+        );
+      }
+
+      assert.equal(candidateEnvelopeMatchesSiblings(siblings({
+        envelope: { ...envelope, harness: { ...envelope.harness, docsRef: 'c'.repeat(40) } },
+      })), false);
+
+      await writeFile(path.join(setup.candidateDir, 'row-scenario.js'), '// swapped after the envelope was written\n');
+      assert.equal(candidateEnvelopeMatchesSiblings(siblings()), false);
+    } finally { await rm(setup.root, { recursive: true, force: true }); }
+  });
+});
+
 test('R-RC-2 honest limit requires the nonce-bound structured threshold receipt in both validation layers', async () => {
   const manifestValue = {
     schema: 'openclaw.k6.proof-row-manifest.v1',
@@ -120,11 +263,13 @@ test('R-RC-2 honest limit requires the nonce-bound structured threshold receipt 
     review: { candidateOnly: true, foldRequiresReview: true },
     liveRunSafety: { expectedArtifactClass: 'HONEST-LIMIT-candidate' },
   };
+  const rrc2ManifestBody = `${JSON.stringify(manifestValue, null, 2)}\n`;
   const metadata = {
     row: 'R-RC-2',
     candidateSha: sha,
     seat: 'cael',
     scenario: 'r-rc-2-delegate-request-compaction.js',
+    ...harnessMetadata({ manifestBody: rrc2ManifestBody, rowFile: 'r-rc-2-delegate-request-compaction' }),
   };
   const verifiedEvidence = {
     row: 'R-RC-2',
@@ -261,9 +406,16 @@ test('R-CD-TOKEN requires the signed authoritative receipt and rejects tampering
   await mkdir(candidateDir);
   const manifestPath = path.join(root, 'manifest.json');
   const h = (character) => character.repeat(16);
+  const tokenManifestBody = `${JSON.stringify({
+    schema: 'openclaw.k6.proof-row-manifest.v1', rowId: 'R-CD-TOKEN', candidateSha: sha,
+    scenario: { name: 'r-cd-token-bracket-delegate' },
+    review: { candidateOnly: true, foldRequiresReview: true },
+    liveRunSafety: { expectedArtifactClass: 'PASS-candidate' },
+  }, null, 2)}\n`;
   const metadata = {
     row: 'R-CD-TOKEN', candidateSha: sha, runtimeBuildSha: sha,
     seat: 'elliott', scenario: 'r-cd-token-bracket-delegate.js',
+    ...harnessMetadata({ manifestBody: tokenManifestBody, rowFile: 'r-cd-token-bracket-delegate' }),
   };
   const evidence = {
     surface_class: 'raw-final-text', session_created: true, disposable_origin_ready: true,
@@ -299,13 +451,9 @@ test('R-CD-TOKEN requires the signed authoritative receipt and rejects tampering
     evidence, correlation, attemptState, metadata, signingKey: gatewayKey,
   });
   const raw = `${JSON.stringify(receipt, null, 2)}\n`;
-  const digest = createHash('sha256').update(raw).digest('hex');
-  await writeFile(manifestPath, `${JSON.stringify({
-    schema: 'openclaw.k6.proof-row-manifest.v1', rowId: 'R-CD-TOKEN', candidateSha: sha,
-    scenario: { name: 'r-cd-token-bracket-delegate' },
-    review: { candidateOnly: true, foldRequiresReview: true },
-    liveRunSafety: { expectedArtifactClass: 'PASS-candidate' },
-  }, null, 2)}\n`);
+  const receiptDigest = createHash('sha256').update(raw).digest('hex');
+  await writeFile(manifestPath, tokenManifestBody);
+  await writeHarnessSources(candidateDir, tokenManifestBody);
   await writeFile(path.join(candidateDir, 'runner-metadata.json'), `${JSON.stringify(metadata)}\n`);
   await writeFile(path.join(candidateDir, 'r-cd-token-authoritative-receipt.json'), raw);
   await writeFile(path.join(candidateDir, 'run-result.json'), `${JSON.stringify({
@@ -313,7 +461,7 @@ test('R-CD-TOKEN requires the signed authoritative receipt and rejects tampering
     verdictSource: 'r-cd-token-authoritative-receipt', candidateOnly: true,
     foldRequiresReview: true,
     authoritativeReceipt: {
-      file: 'r-cd-token-authoritative-receipt.json', sha256: digest,
+      file: 'r-cd-token-authoritative-receipt.json', sha256: receiptDigest,
       validated: true, source: 'r-cd-token-row-scoped-resolver',
     },
     observability: {
@@ -324,7 +472,8 @@ test('R-CD-TOKEN requires the signed authoritative receipt and rejects tampering
   }, null, 2)}\n`);
   try {
     const good = JSON.parse((await invoke({ manifestPath, candidateDir })).stdout);
-    assert.equal(good.authoritativeReceipt.sha256, digest);
+    assert.equal(good.authoritativeReceipt.sha256, receiptDigest);
+    assert.equal(good.harness.docsRef, docsRef);
     await writeFile(
       path.join(candidateDir, 'runner-metadata.json'),
       `${JSON.stringify({ ...metadata, runtimeBuildSha: 'f'.repeat(40) })}\n`,

--- a/tools/k6-proofs/scripts/__tests__/candidate-run-result.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/candidate-run-result.test.mjs
@@ -306,6 +306,26 @@ test('candidate envelope binds the approved docs ref and both harness source dig
         ...envelope,
         artifacts: { ...envelope.artifacts, files: [...envelope.artifacts.files, 'gateway.token'] },
       }), false);
+      // An allowed field is not automatically a safe value.
+      assert.equal(siblings({
+        ...envelope,
+        artifacts: { ...envelope.artifacts, files: [...envelope.artifacts.files, '../../private-summary.json'] },
+      }), false);
+      assert.equal(siblings({
+        ...envelope,
+        artifacts: { ...envelope.artifacts, tempoTraceJson: '../../../etc/passwd' },
+      }), false);
+      // Observability artifact names must still agree with the raw sibling.
+      assert.equal(siblings({
+        ...envelope,
+        artifacts: { ...envelope.artifacts, correlationReceipt: 'invented-correlation.json' },
+      }), false);
+      assert.equal(siblings({ ...envelope, run: { ...envelope.run, executionKind: 'hand-written' } }), false);
+      // R-CW-TEST has no row-scoped resolver, so it may not carry one.
+      assert.equal(siblings({
+        ...envelope,
+        authoritativeReceipt: { file: 'r-cd-2-authoritative-receipt.json', sha256: 'a'.repeat(64) },
+      }), false);
       const { harness, ...withoutHarness } = envelope;
       assert.equal(siblings(withoutHarness), false);
     } finally { await rm(setup.root, { recursive: true, force: true }); }

--- a/tools/k6-proofs/scripts/__tests__/candidate-run-result.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/candidate-run-result.test.mjs
@@ -330,6 +330,33 @@ test('candidate envelope binds the approved docs ref and both harness source dig
       assert.equal(siblings(withoutHarness), false);
     } finally { await rm(setup.root, { recursive: true, force: true }); }
   });
+
+  await t.test('isolated observability mismatches cannot suppress the raw sibling', async () => {
+    const setup = await fixture();
+    try {
+      const envelope = JSON.parse((await invoke(setup)).stdout);
+      const metadata = JSON.parse(await readFile(path.join(setup.candidateDir, 'runner-metadata.json'), 'utf8'));
+      const siblings = (value) => candidateEnvelopeMatchesSiblings({
+        envelope: value,
+        manifest: manifest(),
+        metadata,
+        runResult: runResult(),
+        runDir: setup.candidateDir,
+      });
+      assert.equal(siblings(envelope), true);
+
+      for (const [field, value] of [
+        ['traceStatus', 'missing'],
+        ['traceCaptured', false],
+        ['correlationReceiptPresent', false],
+      ]) {
+        assert.equal(siblings({
+          ...envelope,
+          observability: { ...envelope.observability, [field]: value },
+        }), false, `${field} mismatch must not suppress the raw sibling`);
+      }
+    } finally { await rm(setup.root, { recursive: true, force: true }); }
+  });
 });
 
 test('R-RC-2 honest limit requires the nonce-bound structured threshold receipt in both validation layers', async () => {

--- a/tools/k6-proofs/scripts/__tests__/candidate-run-result.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/candidate-run-result.test.mjs
@@ -233,7 +233,7 @@ test('candidate envelope binds the approved docs ref and both harness source dig
       });
       assert.equal(candidateEnvelopeMatchesSiblings(siblings()), true);
 
-      for (const omitted of ['docsRef', 'repository', 'manifestSha256', 'scenarioSha256']) {
+      for (const omitted of ['docsRef', 'repository', 'manifestPath', 'scenarioPath', 'manifestSha256', 'scenarioSha256']) {
         const stripped = { ...metadata };
         delete stripped[omitted];
         assert.equal(
@@ -246,9 +246,68 @@ test('candidate envelope binds the approved docs ref and both harness source dig
       assert.equal(candidateEnvelopeMatchesSiblings(siblings({
         envelope: { ...envelope, harness: { ...envelope.harness, docsRef: 'c'.repeat(40) } },
       })), false);
+      assert.equal(candidateEnvelopeMatchesSiblings(siblings({
+        envelope: { ...envelope, harness: { ...envelope.harness, manifestPath: 'tools/k6-proofs/manifests/other.json' } },
+      })), false);
 
       await writeFile(path.join(setup.candidateDir, 'row-scenario.js'), '// swapped after the envelope was written\n');
       assert.equal(candidateEnvelopeMatchesSiblings(siblings()), false);
+    } finally { await rm(setup.root, { recursive: true, force: true }); }
+  });
+
+  await t.test('a supplied manifest that is not the captured manifest is refused', async () => {
+    const setup = await fixture();
+    const otherManifest = path.join(setup.root, 'other-manifest.json');
+    try {
+      await writeFile(otherManifest, `${JSON.stringify({ ...manifest(), seat: 'elliott' }, null, 2)}\n`);
+      await assert.rejects(
+        invoke({ ...setup, manifestPath: otherManifest }),
+        /supplied manifest is not the manifest captured for this run/,
+      );
+    } finally { await rm(setup.root, { recursive: true, force: true }); }
+  });
+
+  await t.test('unsafe or unrecorded harness paths are refused', async (sub) => {
+    for (const [label, override, expected] of [
+      ['omitted manifest path', { manifestPath: undefined }, /runner metadata manifestPath must be a non-empty string/],
+      ['escaping manifest path', { manifestPath: '../../etc/passwd' }, /manifestPath must be a tools\/k6-proofs\/manifests/],
+      ['omitted scenario path', { scenarioPath: undefined }, /runner metadata scenarioPath must be a non-empty string/],
+      ['absolute scenario path', { scenarioPath: '/home/someone/scenarios/r-cw-test.js' }, /scenarioPath must be a tools\/k6-proofs\/scenarios/],
+    ]) {
+      await sub.test(label, async () => {
+        const setup = await fixture({ metadata: override });
+        try {
+          await assert.rejects(invoke(setup), expected);
+        } finally { await rm(setup.root, { recursive: true, force: true }); }
+      });
+    }
+  });
+
+  await t.test('a sidecar carrying fields the emitter never writes is refused', async () => {
+    const setup = await fixture();
+    try {
+      const envelope = JSON.parse((await invoke(setup)).stdout);
+      const metadata = JSON.parse(await readFile(path.join(setup.candidateDir, 'runner-metadata.json'), 'utf8'));
+      const siblings = (value) => candidateEnvelopeMatchesSiblings({
+        envelope: value,
+        manifest: manifest(),
+        metadata,
+        runResult: runResult(),
+        runDir: setup.candidateDir,
+      });
+      assert.equal(siblings(envelope), true);
+
+      // Smuggling extra material past review must not be possible even when
+      // every checked identity field still agrees.
+      assert.equal(siblings({ ...envelope, gatewayToken: 'not-a-real-token' }), false);
+      assert.equal(siblings({ ...envelope, harness: { ...envelope.harness, operatorNote: '/home/someone/private' } }), false);
+      assert.equal(siblings({ ...envelope, candidate: { ...envelope.candidate, sessionKey: 'agent:main' } }), false);
+      assert.equal(siblings({
+        ...envelope,
+        artifacts: { ...envelope.artifacts, files: [...envelope.artifacts.files, 'gateway.token'] },
+      }), false);
+      const { harness, ...withoutHarness } = envelope;
+      assert.equal(siblings(withoutHarness), false);
     } finally { await rm(setup.root, { recursive: true, force: true }); }
   });
 });

--- a/tools/k6-proofs/scripts/__tests__/catalog-root-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/catalog-root-contract.test.mjs
@@ -1,0 +1,169 @@
+/**
+ * catalog-root-contract.test.mjs — #495.
+ *
+ * The Project 86 matrix ran its catalog checks from `tools/k6-proofs`, where the
+ * validators prepended `tools/k6-proofs` a second time and reported
+ * `ENOENT ... /tools/k6-proofs/tools/k6-proofs/scenarios` as an empty catalog.
+ * Those rows were then emitted as immediate product failures.
+ *
+ * These tests pin the repaired contract: every catalog validator resolves one
+ * repository root and produces byte-identical output and exit status from the
+ * repository root, from `tools/k6-proofs`, and from `tools/k6-proofs/scripts`.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+const CHECKS = ['check-manifest-scenarios.mjs', 'check-scenario-alignment.mjs', 'check-proof-row-manifests.mjs'];
+const scriptPath = (name) => path.join(repoRoot, 'tools/k6-proofs/scripts', name);
+const CORPUS_SHA = '0123456789abcdef0123456789abcdef01234567';
+
+const WORKFLOW = `name: k6-proof
+on:
+  workflow_dispatch:
+    inputs:
+      scenario:
+        description: "scenario basename"
+        required: true
+        type: choice
+        options:
+          - r-ok
+`;
+
+function manifest({ rowId = 'R-OK', file = 'r-ok.js' } = {}) {
+  return {
+    schema: 'openclaw.k6.proof-row-manifest.v1',
+    rowId,
+    scenario: { status: 'runnable', name: 'r-ok', file },
+  };
+}
+
+async function fixtureRepo({ scenarios = ['r-ok.js'], manifests = [manifest()] } = {}) {
+  const root = await mkdtemp(path.join(tmpdir(), 'p81-catalog-root-'));
+  const proofs = path.join(root, 'tools/k6-proofs');
+  await mkdir(path.join(proofs, 'manifests'), { recursive: true });
+  await mkdir(path.join(proofs, 'scenarios'), { recursive: true });
+  await mkdir(path.join(proofs, 'scripts'), { recursive: true });
+  await mkdir(path.join(root, '.github/workflows'), { recursive: true });
+  await mkdir(path.join(root, 'PROOFS', CORPUS_SHA, 'R-OK'), { recursive: true });
+  await writeFile(path.join(root, '.github/workflows/k6-proof.yml'), WORKFLOW);
+  await writeFile(path.join(root, 'PROOFS/INDEX.json'), `${JSON.stringify({ current_sha: CORPUS_SHA })}\n`);
+  for (const scenario of scenarios) {
+    await writeFile(path.join(proofs, 'scenarios', scenario), 'export default function () {}\n');
+  }
+  for (const entry of manifests) {
+    await writeFile(path.join(proofs, 'manifests', `${entry.rowId.toLowerCase()}.json`), `${JSON.stringify(entry, null, 2)}\n`);
+  }
+  return { root, proofs };
+}
+
+function invoke(check, cwd, extraArgs = [], env = {}) {
+  const result = spawnSync(process.execPath, [scriptPath(check), ...extraArgs], {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, OPENCLAW_PROOFS_REPO_ROOT: '', ...env },
+  });
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+}
+
+test('catalog validators produce identical results from every supported working directory', async () => {
+  const fixture = await fixtureRepo();
+  try {
+    for (const check of CHECKS) {
+      const fromRepoRoot = invoke(check, fixture.root);
+      const fromToolDir = invoke(check, fixture.proofs);
+      const fromScriptsDir = invoke(check, path.join(fixture.proofs, 'scripts'));
+
+      assert.equal(fromRepoRoot.status, 0, `${check} must pass from the repository root: ${fromRepoRoot.stderr}`);
+      assert.deepEqual(fromToolDir, fromRepoRoot, `${check} diverged when invoked from tools/k6-proofs`);
+      assert.deepEqual(fromScriptsDir, fromRepoRoot, `${check} diverged when invoked from tools/k6-proofs/scripts`);
+      assert.doesNotMatch(
+        fromToolDir.stdout + fromToolDir.stderr,
+        /tools\/k6-proofs\/tools\/k6-proofs/,
+        `${check} still double-resolves the tool root`,
+      );
+    }
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('a genuine catalog defect fails identically from every supported working directory', async () => {
+  // A runnable manifest whose scenario file does not exist is a real catalog
+  // error; the doubled-prefix defect used to produce the same symptom for a
+  // perfectly valid catalog.
+  const fixture = await fixtureRepo({ manifests: [manifest({ file: 'r-missing.js' })] });
+  try {
+    for (const check of ['check-manifest-scenarios.mjs', 'check-scenario-alignment.mjs']) {
+      const fromRepoRoot = invoke(check, fixture.root);
+      const fromToolDir = invoke(check, fixture.proofs);
+      assert.notEqual(fromRepoRoot.status, 0, `${check} must fail closed on a missing runnable scenario`);
+      assert.deepEqual(fromToolDir, fromRepoRoot, `${check} diverged when invoked from tools/k6-proofs`);
+      assert.match(fromRepoRoot.stdout + fromRepoRoot.stderr, /r-missing/);
+    }
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('catalog validators count the same rows from every supported working directory', async () => {
+  const fixture = await fixtureRepo();
+  try {
+    const alignment = JSON.parse(invoke('check-scenario-alignment.mjs', fixture.proofs).stdout);
+    assert.equal(alignment.ok, true);
+    assert.deepEqual(alignment.scenarioFiles, ['r-ok']);
+    assert.deepEqual(alignment.workflowChoices, ['r-ok']);
+    assert.equal(alignment.manifests.length, 1);
+
+    const coverage = invoke('check-proof-row-manifests.mjs', fixture.proofs);
+    assert.match(coverage.stdout, /Proof rows: 1/);
+    assert.match(coverage.stdout, /Manifest entries: 1/);
+    assert.match(coverage.stdout, /Missing manifests: 0/);
+
+    const registry = invoke('check-manifest-scenarios.mjs', fixture.proofs);
+    assert.match(registry.stdout, /1 manifests; 1 scenario files/);
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+  }
+});
+
+test('an explicit repository root overrides the working directory for every validator', async () => {
+  const fixture = await fixtureRepo();
+  const elsewhere = await mkdtemp(path.join(tmpdir(), 'p81-catalog-root-elsewhere-'));
+  try {
+    for (const check of CHECKS) {
+      const expected = invoke(check, fixture.root);
+      assert.deepEqual(invoke(check, elsewhere, ['--repo-root', fixture.root]), expected, `${check} ignored --repo-root`);
+      assert.deepEqual(
+        invoke(check, elsewhere, [], { OPENCLAW_PROOFS_REPO_ROOT: fixture.root }),
+        expected,
+        `${check} ignored OPENCLAW_PROOFS_REPO_ROOT`,
+      );
+    }
+  } finally {
+    await rm(fixture.root, { recursive: true, force: true });
+    await rm(elsewhere, { recursive: true, force: true });
+  }
+});
+
+test('validators fail closed with an explicit contract error outside any harness', async () => {
+  const elsewhere = await mkdtemp(path.join(tmpdir(), 'p81-catalog-root-none-'));
+  try {
+    for (const check of CHECKS) {
+      const result = invoke(check, elsewhere);
+      assert.notEqual(result.status, 0, `${check} must not silently validate an unrelated catalog`);
+      assert.match(result.stderr, /unable to resolve a repository root/);
+      assert.match(result.stderr, /OPENCLAW_PROOFS_REPO_ROOT/);
+    }
+    const bogus = invoke('check-manifest-scenarios.mjs', elsewhere, ['--repo-root', elsewhere]);
+    assert.notEqual(bogus.status, 0);
+    assert.match(bogus.stderr, /--repo-root is not a repository root/);
+  } finally {
+    await rm(elsewhere, { recursive: true, force: true });
+  }
+});

--- a/tools/k6-proofs/scripts/__tests__/catalog-root-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/catalog-root-contract.test.mjs
@@ -175,6 +175,7 @@ test('an incidental tools/k6-proofs directory is not mistaken for a harness root
   for (const [label, contents] of [
     ['no catalog directory at all', 'notes'],
     ['scenarios but no manifest catalog', 'scenarios'],
+    ['manifests but no scenario catalog', 'manifests'],
   ]) {
     await t.test(label, async () => {
       const decoy = await mkdtemp(path.join(tmpdir(), 'p81-catalog-root-decoy-'));

--- a/tools/k6-proofs/scripts/__tests__/catalog-root-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/catalog-root-contract.test.mjs
@@ -20,6 +20,7 @@ import { fileURLToPath } from 'node:url';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
 const CHECKS = ['check-manifest-scenarios.mjs', 'check-scenario-alignment.mjs', 'check-proof-row-manifests.mjs'];
+const CATALOG_READERS = [...CHECKS, 'list-runnable-rows.mjs'];
 const scriptPath = (name) => path.join(repoRoot, 'tools/k6-proofs/scripts', name);
 const CORPUS_SHA = '0123456789abcdef0123456789abcdef01234567';
 
@@ -71,10 +72,10 @@ function invoke(check, cwd, extraArgs = [], env = {}) {
   return { status: result.status, stdout: result.stdout, stderr: result.stderr };
 }
 
-test('catalog validators produce identical results from every supported working directory', async () => {
+test('catalog readers produce identical results from every supported working directory', async () => {
   const fixture = await fixtureRepo();
   try {
-    for (const check of CHECKS) {
+    for (const check of CATALOG_READERS) {
       const fromRepoRoot = invoke(check, fixture.root);
       const fromToolDir = invoke(check, fixture.proofs);
       const fromScriptsDir = invoke(check, path.join(fixture.proofs, 'scripts'));
@@ -136,7 +137,7 @@ test('an explicit repository root overrides the working directory for every vali
   const fixture = await fixtureRepo();
   const elsewhere = await mkdtemp(path.join(tmpdir(), 'p81-catalog-root-elsewhere-'));
   try {
-    for (const check of CHECKS) {
+    for (const check of CATALOG_READERS) {
       const expected = invoke(check, fixture.root);
       assert.deepEqual(invoke(check, elsewhere, ['--repo-root', fixture.root]), expected, `${check} ignored --repo-root`);
       assert.deepEqual(
@@ -154,7 +155,7 @@ test('an explicit repository root overrides the working directory for every vali
 test('validators fail closed with an explicit contract error outside any harness', async () => {
   const elsewhere = await mkdtemp(path.join(tmpdir(), 'p81-catalog-root-none-'));
   try {
-    for (const check of CHECKS) {
+    for (const check of CATALOG_READERS) {
       const result = invoke(check, elsewhere);
       assert.notEqual(result.status, 0, `${check} must not silently validate an unrelated catalog`);
       assert.match(result.stderr, /unable to resolve a repository root/);

--- a/tools/k6-proofs/scripts/__tests__/catalog-root-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/catalog-root-contract.test.mjs
@@ -169,19 +169,26 @@ test('validators fail closed with an explicit contract error outside any harness
   }
 });
 
-test('an incidental tools/k6-proofs directory is not mistaken for a harness root', async () => {
-  // A bare directory of the right name is not a proof catalog. Without a
-  // sentinel the walk-up would bind to it and validate nothing.
-  const decoy = await mkdtemp(path.join(tmpdir(), 'p81-catalog-root-decoy-'));
-  try {
-    await mkdir(path.join(decoy, 'tools/k6-proofs/notes'), { recursive: true });
-    await mkdir(path.join(decoy, 'work'), { recursive: true });
-    for (const check of CATALOG_READERS) {
-      const result = invoke(check, path.join(decoy, 'work'));
-      assert.notEqual(result.status, 0, `${check} bound to a directory with no proof catalog`);
-      assert.match(result.stderr, /unable to resolve a repository root/);
-    }
-  } finally {
-    await rm(decoy, { recursive: true, force: true });
+test('an incidental tools/k6-proofs directory is not mistaken for a harness root', async (t) => {
+  // A directory of the right name is not a proof catalog. Without a sentinel the
+  // walk-up would bind to it and validate nothing.
+  for (const [label, contents] of [
+    ['no catalog directory at all', 'notes'],
+    ['scenarios but no manifest catalog', 'scenarios'],
+  ]) {
+    await t.test(label, async () => {
+      const decoy = await mkdtemp(path.join(tmpdir(), 'p81-catalog-root-decoy-'));
+      try {
+        await mkdir(path.join(decoy, 'tools/k6-proofs', contents), { recursive: true });
+        await mkdir(path.join(decoy, 'work'), { recursive: true });
+        for (const check of CATALOG_READERS) {
+          const result = invoke(check, path.join(decoy, 'work'));
+          assert.notEqual(result.status, 0, `${check} bound to a directory with no proof catalog`);
+          assert.match(result.stderr, /unable to resolve a repository root/);
+        }
+      } finally {
+        await rm(decoy, { recursive: true, force: true });
+      }
+    });
   }
 });

--- a/tools/k6-proofs/scripts/__tests__/catalog-root-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/catalog-root-contract.test.mjs
@@ -168,3 +168,20 @@ test('validators fail closed with an explicit contract error outside any harness
     await rm(elsewhere, { recursive: true, force: true });
   }
 });
+
+test('an incidental tools/k6-proofs directory is not mistaken for a harness root', async () => {
+  // A bare directory of the right name is not a proof catalog. Without a
+  // sentinel the walk-up would bind to it and validate nothing.
+  const decoy = await mkdtemp(path.join(tmpdir(), 'p81-catalog-root-decoy-'));
+  try {
+    await mkdir(path.join(decoy, 'tools/k6-proofs/notes'), { recursive: true });
+    await mkdir(path.join(decoy, 'work'), { recursive: true });
+    for (const check of CATALOG_READERS) {
+      const result = invoke(check, path.join(decoy, 'work'));
+      assert.notEqual(result.status, 0, `${check} bound to a directory with no proof catalog`);
+      assert.match(result.stderr, /unable to resolve a repository root/);
+    }
+  } finally {
+    await rm(decoy, { recursive: true, force: true });
+  }
+});

--- a/tools/k6-proofs/scripts/__tests__/check-proof-row-manifests.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/check-proof-row-manifests.test.mjs
@@ -17,6 +17,8 @@ async function withFixture({ rows = ['R-OK'], manifests = [{ file: 'r-ok.json', 
     const manifestsDir = join(root, 'tools/k6-proofs/manifests');
     await mkdir(corpus, { recursive: true });
     await mkdir(manifestsDir, { recursive: true });
+    // Both catalog directories define a harness root (see lib/repo-root.mjs).
+    await mkdir(join(root, 'tools/k6-proofs/scenarios'), { recursive: true });
     await writeFile(join(root, 'PROOFS/INDEX.json'), `${JSON.stringify({ current_sha: SHA })}\n`);
     for (const row of rows) await mkdir(join(corpus, row), { recursive: true });
     for (const manifest of manifests) {

--- a/tools/k6-proofs/scripts/__tests__/continuation-row-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/continuation-row-contract.test.mjs
@@ -8,6 +8,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
+import { buildHarnessCheckout } from './helpers/harness-checkout.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
 const manifestsDir = path.join(repoRoot, 'tools/k6-proofs/manifests');
@@ -56,11 +57,16 @@ async function writeExecutable(file, source) {
   await chmod(file, 0o755);
 }
 
+/**
+ * Build a throwaway git checkout that contains exactly the harness bytes under
+ * test, commit them, and return the immutable ref the runner must be bound to.
+ */
 async function runRcd2RunnerFixture({ tamper = false } = {}) {
   const root = await mkdtemp(path.join(tmpdir(), 'r-cd-2-runner-contract-'));
   const bin = path.join(root, 'bin');
   const out = path.join(root, 'out');
   await Promise.all([mkdir(bin, { recursive: true }), mkdir(out, { recursive: true })]);
+  const harness = await buildHarnessCheckout(repoRoot, path.join(root, 'harness'));
 
   const manifest = JSON.parse(await readFile(path.join(manifestsDir, 'r-cd-2.json'), 'utf8'));
   const nonce = 'RCD2-RUNNER-CONTRACT-NONCE';
@@ -113,13 +119,13 @@ async function runRcd2RunnerFixture({ tamper = false } = {}) {
       OPENCLAW_SESSION_KEY: 'main',
       OPENCLAW_SEAT_NAME: 'cael-dgx',
     };
-    const result = await run('bash', ['scripts/run-proofs.sh', '--live', '--out-dir', out, 'R-CD-2', candidateSha], {
-      cwd: path.join(repoRoot, 'tools/k6-proofs'), env, timeout: 30_000,
+    const result = await run('bash', ['scripts/run-proofs.sh', '--live', '--docs-ref', harness.docsRef, '--out-dir', out, 'R-CD-2', candidateSha], {
+      cwd: path.join(harness.checkout, 'tools/k6-proofs'), env, timeout: 60_000,
     });
     const runBase = path.join(out, candidateSha, 'R-CD-2', 'cael-dgx');
     const [runId] = await readdir(runBase);
     const runDir = path.join(runBase, runId);
-    return { root, out, runDir, result };
+    return { root, out, runDir, result, docsRef: harness.docsRef, checkout: harness.checkout };
   } catch (error) {
     await rm(root, { recursive: true, force: true });
     throw error;
@@ -268,6 +274,36 @@ test('R-CD-2 live runner emits an envelope only for an untampered authoritative 
       assert.equal(envelope.result.outcome, 'PASS-candidate');
       assert.equal(envelope.authoritativeReceipt.sha256, result.authoritativeReceipt.sha256);
       assert.match(fixture.result.stdout, /CANDIDATE REVIEW ENVELOPE/);
+
+      // The live receipt carries the immutable harness identity it was fired
+      // from, recomputable from the copied source bytes (#496).
+      const metadata = JSON.parse(await readFile(path.join(fixture.runDir, 'runner-metadata.json'), 'utf8'));
+      const sha256 = async (file) => createHash('sha256').update(await readFile(path.join(fixture.runDir, file))).digest('hex');
+      assert.equal(metadata.docsRef, fixture.docsRef);
+      assert.equal(metadata.repository, 'karmaterminal/karmaterminal-openclaw-docs');
+      assert.equal(metadata.manifestPath, 'tools/k6-proofs/manifests/r-cd-2.json');
+      assert.equal(metadata.scenarioPath, 'tools/k6-proofs/scenarios/r-cd-2-silent-wake.js');
+      assert.equal(metadata.manifestSha256, await sha256('row-manifest.json'));
+      assert.equal(metadata.scenarioSha256, await sha256('row-scenario.js'));
+      assert.equal(envelope.candidate.docsRef, fixture.docsRef);
+      assert.equal(envelope.harness.docsRef, fixture.docsRef);
+      assert.equal(envelope.harness.manifestSha256, metadata.manifestSha256);
+      assert.equal(envelope.harness.scenarioSha256, metadata.scenarioSha256);
+
+      const provenance = JSON.parse(await readFile(path.join(fixture.out, 'harness-provenance.json'), 'utf8'));
+      assert.equal(provenance.schema, 'openclaw.k6.harness-provenance.v1');
+      assert.equal(provenance.docsRef, fixture.docsRef);
+      assert.equal(provenance.harnessIdentityVerified, true);
+      assert.equal(provenance.candidateSha, candidateSha);
+      assert.match(provenance.runnerScriptSha256, /^[a-f0-9]{64}$/);
+      assert.deepEqual(provenance.rowSelection, ['R-CD-2']);
+      assert.deepEqual(provenance.rows, [{
+        rowId: 'R-CD-2',
+        manifestPath: 'tools/k6-proofs/manifests/r-cd-2.json',
+        manifestSha256: metadata.manifestSha256,
+        scenarioPath: 'tools/k6-proofs/scenarios/r-cd-2-silent-wake.js',
+        scenarioSha256: metadata.scenarioSha256,
+      }]);
     } finally {
       await rm(fixture.root, { recursive: true, force: true });
     }

--- a/tools/k6-proofs/scripts/__tests__/harness-provenance-runner.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/harness-provenance-runner.test.mjs
@@ -174,10 +174,16 @@ test('a spoofed snapshot handoff is refused', async (t) => {
         env: {
           OPENCLAW_PROOFS_HARNESS_SNAPSHOT: harness.checkout,
           OPENCLAW_PROOFS_ORIGIN_ROOT: harness.checkout,
+          OPENCLAW_PROOFS_HARNESS_SNAPSHOT_TOKEN: 'forged-token',
         },
       });
       await assertInfrastructureFailure(harness, result, { stage: 'harness-identity', check: 'snapshot-handoff-authentic' });
       assert.match(result.stderr, /spoofed or aliased handoff/);
+      // A rejected claim must never become cleanup-owned.
+      assert.ok(
+        (await readdir(harness.checkout)).includes('tools'),
+        'a rejected handoff must not delete the directory it claimed',
+      );
     });
   });
 
@@ -192,9 +198,37 @@ test('a spoofed snapshot handoff is refused', async (t) => {
         env: {
           OPENCLAW_PROOFS_HARNESS_SNAPSHOT: snapshot,
           OPENCLAW_PROOFS_ORIGIN_ROOT: harness.checkout,
+          OPENCLAW_PROOFS_HARNESS_SNAPSHOT_TOKEN: 'forged-token',
         },
       });
       await assertInfrastructureFailure(harness, result, { stage: 'harness-identity', check: 'snapshot-handoff-authentic' });
+      assert.ok(
+        (await readdir(snapshot)).includes('tools'),
+        'a rejected handoff must not delete the directory it claimed',
+      );
+      assert.ok((await readdir(harness.checkout)).includes('tools'));
+    });
+  });
+
+  await t.test('an arbitrary writable directory claimed as a snapshot survives', async () => {
+    await withRunner(async (harness) => {
+      const bystander = path.join(harness.root, 'unrelated-directory');
+      await mkdir(bystander, { recursive: true });
+      await writeFile(path.join(bystander, 'important.txt'), 'must survive\n');
+      const result = await invokeRunner(harness, {
+        args: ['--docs-ref', harness.docsRef],
+        env: {
+          OPENCLAW_PROOFS_HARNESS_SNAPSHOT: bystander,
+          OPENCLAW_PROOFS_ORIGIN_ROOT: harness.checkout,
+          OPENCLAW_PROOFS_HARNESS_SNAPSHOT_TOKEN: 'forged-token',
+        },
+      });
+      await assertInfrastructureFailure(harness, result, { stage: 'harness-identity', check: 'snapshot-handoff-authentic' });
+      assert.deepEqual(
+        await readdir(bystander),
+        ['important.txt'],
+        'a rejected handoff must never recursively delete an arbitrary claimed path',
+      );
     });
   });
 });

--- a/tools/k6-proofs/scripts/__tests__/harness-provenance-runner.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/harness-provenance-runner.test.mjs
@@ -198,18 +198,46 @@ test('a catalog preflight failure stops the matrix as harness infrastructure', a
     async (harness) => {
       const result = await invokeRunner(harness, { args: ['--docs-ref', harness.docsRef] });
       const receipt = await assertInfrastructureFailure(harness, result, { stage: 'catalog-preflight' });
-      assert.equal(receipt.detail.failedCheck, 'check-manifest-scenarios.mjs');
+      assert.equal(receipt.detail.failedCheck, 'check-scenario-alignment.mjs');
       assert.equal(receipt.detail.log, 'catalog-preflight.log');
       const log = await readFile(path.join(harness.out, 'catalog-preflight.log'), 'utf8');
-      assert.match(log, /r-cd-2-silent-wake\.js' is missing/);
+      assert.match(log, /k6-proof\.yml/);
       assert.match(result.stderr, /catalog validator .* failed/);
       assert.doesNotMatch(log, /tools\/k6-proofs\/tools\/k6-proofs/);
     },
     {
+      // Break the catalog outside tools/k6-proofs so the harness identity gate,
+      // which now runs first, still passes and the preflight is what fails.
       mutate: async (harness) => {
-        await rm(path.join(harness.proofsDir, 'scenarios/r-cd-2-silent-wake.js'));
+        await rm(path.join(harness.checkout, '.github/workflows/k6-proof.yml'));
       },
     },
+  );
+});
+
+test('catalog validators run with no inherited environment at all', async () => {
+  // A validator is executed by the runner, so it must be unable to observe any
+  // ambient credential even if it tries.
+  const probe = [
+    '#!/bin/sh',
+    'case "$*" in',
+    '  *check-manifest-scenarios.mjs*)',
+    '    printf \'PROBE TOKEN_SEEN=%s HOME_SEEN=%s\\n\' "${OPENCLAW_GATEWAY_TOKEN:-<absent>}" "${HOME:-<absent>}"',
+    '    ;;',
+    'esac',
+    `exec ${process.execPath} "$@"`,
+    '',
+  ].join('\n');
+
+  await withApprovedMatrix(
+    async (harness) => {
+      const result = await harness.invoke();
+      assert.equal(result.code, 0, result.stderr);
+      const log = await readFile(path.join(harness.out, 'catalog-preflight.log'), 'utf8');
+      assert.match(log, /PROBE TOKEN_SEEN=<absent> HOME_SEEN=<absent>/);
+      assert.doesNotMatch(log, new RegExp(APPROVED_TOKEN));
+    },
+    { nodeShim: probe },
   );
 });
 
@@ -258,7 +286,7 @@ const APPROVED_TOKEN = 'harness-provenance-test-token-do-not-log';
  * provenance emission with stubbed tooling. R-CW-5A is runnable but
  * static-preflight-only, so no live k6 row is dispatched.
  */
-async function withApprovedMatrix(fn, { afterCommit = null, rows = 'R-CW-5A', nodeShim = null, envFor = null } = {}) {
+async function withApprovedMatrix(fn, { afterCommit = null, rows = 'R-CW-5A', nodeShim = null, nodeShimFor = null, journalShimFor = null, envFor = null } = {}) {
   const root = await mkdtemp(path.join(tmpdir(), 'p86-harness-provenance-ok-'));
   const bin = path.join(root, 'bin');
   const out = path.join(root, 'out');
@@ -280,7 +308,9 @@ async function withApprovedMatrix(fn, { afterCommit = null, rows = 'R-CW-5A', no
     await executable('k6', "#!/bin/sh\nif [ \"${1:-}\" = version ]; then printf '%s\\n' 'k6 v2.0.0'; exit 0; fi\nexit 0\n");
     await executable('openclaw', '#!/bin/sh\nprintf \'%s\\n\' \'{"enabled":true,"maxChainLength":3,"maxDelegatesPerTurn":3,"costCapTokens":3}\'\n');
     await executable('hostname', "#!/bin/sh\nprintf '%s\\n' contract-seat\n");
-    if (nodeShim) await executable('node', nodeShim);
+    const shimSource = nodeShimFor ? nodeShimFor(harness) : nodeShim;
+    if (shimSource) await executable('node', shimSource);
+    if (journalShimFor) await executable('journalctl', journalShimFor(harness));
 
     const invoke = async () => {
       try {
@@ -345,14 +375,14 @@ test('the catalog preflight log is public-safe: no credentials, no local paths',
 test('harness bytes mutated after the gate froze them fail closed before capture', async () => {
   // The shim mutates a selected scenario while seat readiness runs, i.e. after
   // the identity gate froze its digest but before the row is captured.
-  const shim = [
+  const shimFor = (harness) => [
     '#!/bin/sh',
     'case "$*" in',
     '  *seat-readiness-preflight.mjs*)',
-    '    printf \'\\n// mutated after the approved ref was frozen\\n\' >> "$MUTATE_TARGET"',
+    `    printf '\\n// mutated after the approved ref was frozen\\n' >> ${path.join(harness.proofsDir, 'scenarios/r-cd-2-silent-wake.js')}`,
     '    ;;',
     'esac',
-    'exec "$REAL_NODE" "$@"',
+    `exec ${process.execPath} "$@"`,
     '',
   ].join('\n');
 
@@ -370,14 +400,44 @@ test('harness bytes mutated after the gate froze them fail closed before capture
       assert.match(result.stderr, /refusing to execute unapproved source/);
       await assert.rejects(readFile(path.join(harness.out, candidateSha, 'R-CD-2'), 'utf8'), /ENOENT/);
     },
-    {
-      rows: 'R-CD-2',
-      nodeShim: shim,
-      envFor: (harness) => ({
-        REAL_NODE: process.execPath,
-        MUTATE_TARGET: path.join(harness.proofsDir, 'scenarios/r-cd-2-silent-wake.js'),
-      }),
+    { rows: 'R-CD-2', nodeShimFor: shimFor },
+  );
+});
+
+test('a mutation caught after capture removes the provisional run directory', async () => {
+  // journalctl is invoked after the run directory exists but before k6 starts,
+  // so mutating there exercises the pre-k6-execution assertion with a partially
+  // written row on disk. That directory holds no candidate evidence and must not
+  // survive as one.
+  const journalFor = (harness) => [
+    '#!/bin/sh',
+    'case " $* " in',
+    '  *" --show-cursor "*)',
+    `    printf '\\n// mutated between capture and execution\\n' >> ${path.join(harness.proofsDir, 'scenarios/r-cd-2-silent-wake.js')}`,
+    "    printf '%s\\n' '-- cursor: provisional-purge'",
+    '    ;;',
+    'esac',
+    '',
+  ].join('\n');
+
+  await withApprovedMatrix(
+    async (harness) => {
+      const result = await harness.invoke();
+      assert.equal(result.code, HARNESS_INFRA_EXIT, result.stderr);
+      const receipt = JSON.parse(await readFile(path.join(harness.out, 'harness-control-receipt.json'), 'utf8'));
+      assert.equal(receipt.stage, 'harness-identity');
+      assert.equal(receipt.detail.check, 'frozen-bytes-still-current');
+      assert.equal(receipt.detail.phase, 'pre-k6-execution');
+      assert.equal(receipt.rowsExecuted, 0);
+      assert.equal(receipt.rowVerdictsSynthesized, false);
+      const seatDir = path.join(harness.out, candidateSha, 'R-CD-2', 'contract-seat');
+      assert.deepEqual(
+        await readdir(seatDir),
+        [],
+        'a provisional run directory must not survive a pre-execution infrastructure failure',
+      );
     },
+    { rows: 'R-CD-2', journalShimFor: journalFor },
   );
 });
 

--- a/tools/k6-proofs/scripts/__tests__/harness-provenance-runner.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/harness-provenance-runner.test.mjs
@@ -43,11 +43,11 @@ async function withRunner(fn, { mutate = null } = {}) {
   }
 }
 
-async function invokeRunner(harness, { rows = 'R-CD-2', args = [], env = {} } = {}) {
+async function invokeRunner(harness, { rows = 'R-CD-2', args = [], env = {}, candidate = candidateSha } = {}) {
   try {
     const result = await run(
       'bash',
-      ['scripts/run-proofs.sh', '--live', '--out-dir', harness.out, ...args, rows, candidateSha],
+      ['scripts/run-proofs.sh', '--live', '--out-dir', harness.out, ...args, rows, candidate],
       {
         cwd: harness.proofsDir,
         encoding: 'utf8',
@@ -201,10 +201,10 @@ test('a row whose contract is untracked at the approved ref fails closed', async
   await withRunner(
     async (harness) => {
       const result = await invokeRunner(harness, { rows: 'R-UNRECORDED', args: ['--docs-ref', harness.docsRef] });
-      const receipt = await assertInfrastructureFailure(harness, result, { stage: 'harness-identity', check: 'tracked-at-docs-ref' });
+      const receipt = await assertInfrastructureFailure(harness, result, { stage: 'harness-identity', check: 'row-recorded-at-docs-ref' });
       assert.equal(receipt.detail.row, 'R-UNRECORDED');
-      assert.match(receipt.detail.path, /^tools\/k6-proofs\//);
-      assert.match(result.stderr, /not tracked at the approved docs ref/);
+      assert.equal(receipt.detail.approved, harness.docsRef);
+      assert.match(result.stderr, /unrecorded rows cannot be fired or counted/);
     },
     {
       // Untracked-but-present bytes: `git status` on tracked files stays clean,
@@ -321,12 +321,13 @@ const APPROVED_TOKEN = 'harness-provenance-test-token-do-not-log';
  * provenance emission with stubbed tooling. R-CW-5A is runnable but
  * static-preflight-only, so no live k6 row is dispatched.
  */
-async function withApprovedMatrix(fn, { afterCommit = null, rows = 'R-CW-5A', nodeShim = null, nodeShimFor = null, journalShimFor = null, envFor = null } = {}) {
+async function withApprovedMatrix(fn, { afterCommit = null, rows = 'R-CW-5A', nodeShim = null, nodeShimFor = null, journalShimFor = null, k6ShimFor = null, envFor = null } = {}) {
   const root = await mkdtemp(path.join(tmpdir(), 'p86-harness-provenance-ok-'));
   const bin = path.join(root, 'bin');
   const out = path.join(root, 'out');
   await Promise.all([mkdir(bin, { recursive: true }), mkdir(out, { recursive: true })]);
-  const harness = await buildHarnessCheckout(repoRoot, path.join(root, 'harness'));
+  const built = await buildHarnessCheckout(repoRoot, path.join(root, 'harness'));
+  const harness = { ...built, root, out };
   if (afterCommit) await afterCommit(harness);
 
   const gateway = createServer((req, res) => res.writeHead(req.url.startsWith('/health') || req.url.startsWith('/status') ? 200 : 404).end('{}'));
@@ -340,7 +341,7 @@ async function withApprovedMatrix(fn, { afterCommit = null, rows = 'R-CW-5A', no
   };
 
   try {
-    await executable('k6', "#!/bin/sh\nif [ \"${1:-}\" = version ]; then printf '%s\\n' 'k6 v2.0.0'; exit 0; fi\nexit 0\n");
+    await executable('k6', k6ShimFor ? k6ShimFor(harness) : "#!/bin/sh\nif [ \"${1:-}\" = version ]; then printf '%s\\n' 'k6 v2.0.0'; exit 0; fi\nexit 0\n");
     await executable('openclaw', '#!/bin/sh\nprintf \'%s\\n\' \'{"enabled":true,"maxChainLength":3,"maxDelegatesPerTurn":3,"costCapTokens":3}\'\n');
     await executable('hostname', "#!/bin/sh\nprintf '%s\\n' contract-seat\n");
     const shimSource = nodeShimFor ? nodeShimFor(harness) : nodeShim;
@@ -376,7 +377,7 @@ async function withApprovedMatrix(fn, { afterCommit = null, rows = 'R-CW-5A', no
       }
     };
 
-    return await fn({ ...harness, out, root, invoke });
+    return await fn({ ...harness, invoke });
   } finally {
     await new Promise((resolve) => gateway.close(resolve));
     await rm(root, { recursive: true, force: true });
@@ -399,7 +400,7 @@ test('the catalog preflight log is public-safe: no credentials, no local paths',
       const result = await harness.invoke();
       assert.equal(result.code, HARNESS_INFRA_EXIT);
       const log = await readFile(path.join(harness.out, 'catalog-preflight.log'), 'utf8');
-      assert.match(log, /<repo-root>\/PROOFS\/INDEX\.json/);
+      assert.match(log, /<(?:repo-root|harness)>\/PROOFS\/INDEX\.json/);
       assert.ok(!log.includes(harness.checkout), 'the checkout path must not reach a public log');
       assert.doesNotMatch(log, new RegExp(APPROVED_TOKEN));
     },
@@ -408,8 +409,10 @@ test('the catalog preflight log is public-safe: no credentials, no local paths',
 });
 
 test('harness bytes mutated after the gate froze them fail closed before capture', async () => {
-  // The shim mutates a selected scenario while seat readiness runs, i.e. after
-  // the identity gate froze its digest but before the row is captured.
+  // The shim mutates the operator's copy of a selected scenario while seat
+  // readiness runs. The executed bytes live in the immutable snapshot, so this
+  // cannot change what runs — but run-proofs.sh itself is read incrementally
+  // from that same checkout, so a mid-matrix mutation must still fail closed.
   const shimFor = (harness) => [
     '#!/bin/sh',
     'case "$*" in',
@@ -427,12 +430,12 @@ test('harness bytes mutated after the gate froze them fail closed before capture
       assert.equal(result.code, HARNESS_INFRA_EXIT, result.stderr);
       const receipt = JSON.parse(await readFile(path.join(harness.out, 'harness-control-receipt.json'), 'utf8'));
       assert.equal(receipt.stage, 'harness-identity');
-      assert.equal(receipt.detail.check, 'frozen-bytes-still-current');
+      assert.equal(receipt.detail.check, 'harness-tree-still-current');
       assert.equal(receipt.detail.phase, 'pre-capture');
-      assert.equal(receipt.detail.scenarioChanged, true);
+      assert.ok(receipt.detail.trackedFiles > 1);
       assert.equal(receipt.rowsExecuted, 0);
       assert.equal(receipt.rowVerdictsSynthesized, false);
-      assert.match(result.stderr, /refusing to execute unapproved source/);
+      assert.match(result.stderr, /do not match the approved docs ref/);
       await assert.rejects(readFile(path.join(harness.out, candidateSha, 'R-CD-2'), 'utf8'), /ENOENT/);
     },
     { rows: 'R-CD-2', nodeShimFor: shimFor },
@@ -461,7 +464,7 @@ test('a mutation caught after capture removes the provisional run directory', as
       assert.equal(result.code, HARNESS_INFRA_EXIT, result.stderr);
       const receipt = JSON.parse(await readFile(path.join(harness.out, 'harness-control-receipt.json'), 'utf8'));
       assert.equal(receipt.stage, 'harness-identity');
-      assert.equal(receipt.detail.check, 'frozen-bytes-still-current');
+      assert.equal(receipt.detail.check, 'harness-tree-still-current');
       assert.equal(receipt.detail.phase, 'pre-k6-execution');
       assert.equal(receipt.rowsExecuted, 0);
       assert.equal(receipt.rowVerdictsSynthesized, false);
@@ -473,6 +476,60 @@ test('a mutation caught after capture removes the provisional run directory', as
       );
     },
     { rows: 'R-CD-2', journalShimFor: journalFor },
+  );
+});
+
+test('a live matrix refuses an unvalidated candidate SHA before creating artifacts', async () => {
+  await withRunner(async (harness) => {
+    const result = await invokeRunner(harness, {
+      args: ['--docs-ref', harness.docsRef],
+      candidate: '../../etc/passwd',
+      env: { OPENCLAW_CANDIDATE_SHA: '' },
+    });
+    await assertInfrastructureFailure(harness, result, { stage: 'harness-identity', check: 'candidate-sha-shape' });
+    const receipt = await controlReceipt(harness);
+    // Rejected input must not survive anywhere in the public receipt.
+    assert.equal(receipt.candidateSha, 'malformed');
+    assert.ok(!JSON.stringify(receipt).includes('passwd'));
+  });
+});
+
+test('rows execute from an immutable snapshot, not from the operator checkout', async () => {
+  // Direct observation: the k6 process records where it was actually run from
+  // and the bytes of the scenario it was handed.
+  await withApprovedMatrix(
+    async (harness) => {
+      // The row's own verdict is irrelevant here; only where it executed is.
+      await harness.invoke();
+      const [cwd, scenarioDigest] = (await readFile(path.join(harness.root, 'k6-observed.txt'), 'utf8')).trim().split('\n');
+
+      assert.ok(cwd, 'k6 must have run');
+      assert.ok(
+        !cwd.startsWith(harness.checkout),
+        `k6 must not execute from the operator checkout, ran in ${cwd.startsWith(harness.checkout) ? '<checkout>' : '<snapshot>'}`,
+      );
+      const approved = (await run(
+        'git',
+        ['-C', harness.checkout, 'show', `${harness.docsRef}:tools/k6-proofs/scenarios/r-cd-2-silent-wake.js`],
+        { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 },
+      )).stdout;
+      assert.equal(
+        scenarioDigest,
+        createHash('sha256').update(approved).digest('hex'),
+        'the executed scenario bytes must be the approved committed bytes',
+      );
+    },
+    {
+      rows: 'R-CD-2',
+      k6ShimFor: (harness) => [
+        '#!/bin/sh',
+        'if [ "${1:-}" = version ]; then printf \'%s\\n\' \'k6 v2.0.0\'; exit 0; fi',
+        `{ pwd; sha256sum "$2" | cut -d' ' -f1; } > ${path.join(harness.root, 'k6-observed.txt')}`,
+        "printf '%s %s\\n' '=== K6-PROOF-EVIDENCE ===' '{\"row\":\"R-CD-2\"}'",
+        'exit 0',
+        '',
+      ].join('\n'),
+    },
   );
 });
 
@@ -506,93 +563,49 @@ test('an approved live run tolerates a git replacement object without trusting i
 });
 
 test('an approved live run freezes the docs ref and records the exact harness digests', async () => {
-  const root = await mkdtemp(path.join(tmpdir(), 'p86-harness-provenance-ok-'));
-  const bin = path.join(root, 'bin');
-  const out = path.join(root, 'out');
-  await Promise.all([mkdir(bin, { recursive: true }), mkdir(out, { recursive: true })]);
-  const harness = await buildHarnessCheckout(repoRoot, path.join(root, 'harness'));
+  await withApprovedMatrix(async (harness) => {
+    const result = await harness.invoke();
+    assert.equal(result.code, 0, result.stderr);
+    await assert.rejects(readFile(path.join(harness.out, 'harness-control-receipt.json'), 'utf8'), /ENOENT/);
+      const provenance = JSON.parse(await readFile(path.join(harness.out, 'harness-provenance.json'), 'utf8'));
+      assert.equal(provenance.schema, 'openclaw.k6.harness-provenance.v1');
+      assert.equal(provenance.mode, 'live');
+      assert.equal(provenance.docsRef, harness.docsRef);
+      assert.equal(provenance.docsRefSource, 'approved-input');
+      assert.equal(provenance.harnessIdentityVerified, true);
+      assert.equal(provenance.repository, HARNESS_REPOSITORY);
+      assert.equal(provenance.candidateSha, candidateSha);
+      assert.equal(provenance.runtimeIdentity.runtimeBuildSha, candidateSha);
+      assert.equal(provenance.runtimeIdentity.candidateMatchesRuntime, true);
+      assert.equal(provenance.runtimeIdentity.seatReadinessReceipt, 'seat-readiness.json');
+      assert.match(provenance.runtimeIdentity.seatReadinessSha256, /^[a-f0-9]{64}$/);
+      assert.equal(provenance.runnerScript, 'tools/k6-proofs/scripts/run-proofs.sh');
+      assert.match(provenance.runnerScriptSha256, /^[a-f0-9]{64}$/);
+      assert.equal(provenance.candidateOnly, true);
+      assert.equal(provenance.foldRequiresReview, true);
+      assert.match(provenance.startedAt, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+      assert.deepEqual(provenance.rowSelection, ['R-CW-5A']);
 
-  const gateway = createServer((req, res) => res.writeHead(req.url.startsWith('/health') || req.url.startsWith('/status') ? 200 : 404).end('{}'));
-  await new Promise((resolve) => gateway.listen(0, '127.0.0.1', resolve));
-  const gatewayPort = gateway.address().port;
+      const sha256 = async (relative) => createHash('sha256')
+        .update(await readFile(path.join(harness.checkout, relative)))
+        .digest('hex');
+      assert.deepEqual(provenance.rows, [{
+        rowId: 'R-CW-5A',
+        manifestPath: 'tools/k6-proofs/manifests/r-cw-5a-static.json',
+        manifestSha256: await sha256('tools/k6-proofs/manifests/r-cw-5a-static.json'),
+        scenarioPath: 'tools/k6-proofs/scenarios/static-corpus-row-validator.js',
+        scenarioSha256: await sha256('tools/k6-proofs/scenarios/static-corpus-row-validator.js'),
+      }]);
 
-  const executable = async (name, source) => {
-    const file = path.join(bin, name);
-    await writeFile(file, source, { mode: 0o755 });
-    await chmod(file, 0o755);
-  };
+      // The runner script digest is a real digest of the script it just ran.
+      assert.equal(provenance.runnerScriptSha256, await sha256('tools/k6-proofs/scripts/run-proofs.sh'));
+      assert.match(result.stdout, /Approved docs ref: [0-9a-f]{40}/);
+      assert.match(result.stdout, /Harness identity: every tracked byte under tools\/k6-proofs matches the approved docs ref/);
+      assert.match(result.stdout, /Harness contract binding: frozen manifest\/scenario digests/);
+      assert.match(result.stdout, /\[R-CW-5A\] SKIPPED: liveRunSafety classification/);
 
-  try {
-    await executable('k6', "#!/bin/sh\nif [ \"${1:-}\" = version ]; then printf '%s\\n' 'k6 v2.0.0'; exit 0; fi\nexit 0\n");
-    await executable('openclaw', '#!/bin/sh\nprintf \'%s\\n\' \'{"enabled":true,"maxChainLength":3,"maxDelegatesPerTurn":3,"costCapTokens":3}\'\n');
-    await executable('hostname', "#!/bin/sh\nprintf '%s\\n' contract-seat\n");
-
-    // R-CW-5A is runnable but static-preflight-only, so the identity gate and
-    // provenance receipt are exercised without dispatching a live k6 row.
-    const result = await run(
-      'bash',
-      ['scripts/run-proofs.sh', '--live', '--out-dir', out, '--docs-ref', harness.docsRef, 'R-CW-5A', candidateSha],
-      {
-        cwd: harness.proofsDir,
-        encoding: 'utf8',
-        timeout: 60_000,
-        env: {
-          ...process.env,
-          PATH: `${bin}:${process.env.PATH}`,
-          K6_BIN: path.join(bin, 'k6'),
-          OPENCLAW_GATEWAY_TOKEN: 'harness-provenance-test-token',
-          OPENCLAW_GATEWAY_WS: `ws://127.0.0.1:${gatewayPort}`,
-          OPENCLAW_SESSION_KEY: 'main',
-          OPENCLAW_SEAT_NAME: 'contract-seat',
-          OPENCLAW_CANDIDATE_SHA: candidateSha,
-          OPENCLAW_RUNTIME_BUILD_SHA: candidateSha,
-        },
-      },
-    );
-
-    await assert.rejects(readFile(path.join(out, 'harness-control-receipt.json'), 'utf8'), /ENOENT/);
-    const provenance = JSON.parse(await readFile(path.join(out, 'harness-provenance.json'), 'utf8'));
-    assert.equal(provenance.schema, 'openclaw.k6.harness-provenance.v1');
-    assert.equal(provenance.mode, 'live');
-    assert.equal(provenance.docsRef, harness.docsRef);
-    assert.equal(provenance.docsRefSource, 'approved-input');
-    assert.equal(provenance.harnessIdentityVerified, true);
-    assert.equal(provenance.repository, HARNESS_REPOSITORY);
-    assert.equal(provenance.candidateSha, candidateSha);
-    assert.equal(provenance.runtimeIdentity.runtimeBuildSha, candidateSha);
-    assert.equal(provenance.runtimeIdentity.candidateMatchesRuntime, true);
-    assert.equal(provenance.runtimeIdentity.seatReadinessReceipt, 'seat-readiness.json');
-    assert.match(provenance.runtimeIdentity.seatReadinessSha256, /^[a-f0-9]{64}$/);
-    assert.equal(provenance.runnerScript, 'tools/k6-proofs/scripts/run-proofs.sh');
-    assert.match(provenance.runnerScriptSha256, /^[a-f0-9]{64}$/);
-    assert.equal(provenance.candidateOnly, true);
-    assert.equal(provenance.foldRequiresReview, true);
-    assert.match(provenance.startedAt, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
-    assert.deepEqual(provenance.rowSelection, ['R-CW-5A']);
-
-    const sha256 = async (relative) => createHash('sha256')
-      .update(await readFile(path.join(harness.checkout, relative)))
-      .digest('hex');
-    assert.deepEqual(provenance.rows, [{
-      rowId: 'R-CW-5A',
-      manifestPath: 'tools/k6-proofs/manifests/r-cw-5a-static.json',
-      manifestSha256: await sha256('tools/k6-proofs/manifests/r-cw-5a-static.json'),
-      scenarioPath: 'tools/k6-proofs/scenarios/static-corpus-row-validator.js',
-      scenarioSha256: await sha256('tools/k6-proofs/scenarios/static-corpus-row-validator.js'),
-    }]);
-
-    // The runner script digest is a real digest of the script it just ran.
-    assert.equal(provenance.runnerScriptSha256, await sha256('tools/k6-proofs/scripts/run-proofs.sh'));
-    assert.match(result.stdout, /Approved docs ref: [0-9a-f]{40}/);
-    assert.match(result.stdout, /Harness identity: every tracked byte under tools\/k6-proofs matches the approved docs ref/);
-    assert.match(result.stdout, /Harness contract binding: frozen manifest\/scenario digests/);
-    assert.match(result.stdout, /\[R-CW-5A\] SKIPPED: liveRunSafety classification/);
-
-    const receipt = JSON.stringify(provenance);
-    assert.doesNotMatch(receipt, /harness-provenance-test-token/);
-    assert.doesNotMatch(receipt, new RegExp(root.replaceAll('/', '\\/')));
-  } finally {
-    await new Promise((resolve) => gateway.close(resolve));
-    await rm(root, { recursive: true, force: true });
-  }
+      const receipt = JSON.stringify(provenance);
+      assert.doesNotMatch(receipt, /harness-provenance-test-token/);
+      assert.doesNotMatch(receipt, new RegExp(harness.root.replaceAll('/', '\\/')));
+  });
 });

--- a/tools/k6-proofs/scripts/__tests__/harness-provenance-runner.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/harness-provenance-runner.test.mjs
@@ -1,0 +1,305 @@
+/**
+ * harness-provenance-runner.test.mjs — #495 / #496.
+ *
+ * The 2026-08-01 Project 86 matrix fired from a detached July harness commit
+ * while docs `main` had moved on, recorded no docs ref in any
+ * `runner-metadata.json`, and turned a catalog root-resolution error into
+ * per-row product failures.
+ *
+ * These tests pin the repaired runner contract:
+ *   - catalog preflight and harness identity are checked before any row runs;
+ *   - a missing, malformed, mismatched, dirty, or unrecorded harness fails once
+ *     as infrastructure and leaves exactly one control receipt;
+ *   - an approved run freezes the docs ref and records the exact manifest and
+ *     scenario digests it fired.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { execFile } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { buildHarnessCheckout, HARNESS_REPOSITORY } from './helpers/harness-checkout.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+const run = promisify(execFile);
+const candidateSha = 'a'.repeat(40);
+const HARNESS_INFRA_EXIT = 78;
+
+async function withRunner(fn, { mutate = null } = {}) {
+  const root = await mkdtemp(path.join(tmpdir(), 'p86-harness-provenance-'));
+  const out = path.join(root, 'out');
+  await mkdir(out, { recursive: true });
+  const harness = await buildHarnessCheckout(repoRoot, path.join(root, 'harness'));
+  if (mutate) await mutate(harness);
+  try {
+    return await fn({ ...harness, out, root });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function invokeRunner(harness, { rows = 'R-CD-2', args = [], env = {} } = {}) {
+  try {
+    const result = await run(
+      'bash',
+      ['scripts/run-proofs.sh', '--live', '--out-dir', harness.out, ...args, rows, candidateSha],
+      {
+        cwd: harness.proofsDir,
+        encoding: 'utf8',
+        timeout: 60_000,
+        env: {
+          ...process.env,
+          OPENCLAW_PROOFS_DOCS_REF: '',
+          OPENCLAW_GATEWAY_TOKEN: 'harness-provenance-test-token',
+          OPENCLAW_SESSION_KEY: 'main',
+          OPENCLAW_SEAT_NAME: 'contract-seat',
+          OPENCLAW_CANDIDATE_SHA: candidateSha,
+          OPENCLAW_RUNTIME_BUILD_SHA: candidateSha,
+          ...env,
+        },
+      },
+    );
+    return { code: 0, stdout: result.stdout, stderr: result.stderr };
+  } catch (error) {
+    return { code: error.code, stdout: error.stdout || '', stderr: error.stderr || '' };
+  }
+}
+
+async function controlReceipt(harness) {
+  return JSON.parse(await readFile(path.join(harness.out, 'harness-control-receipt.json'), 'utf8'));
+}
+
+/** No candidate run directory may exist when the harness failed closed. */
+async function assertNoRowsExecuted(harness) {
+  const entries = await readdir(harness.out, { withFileTypes: true });
+  const rowDirs = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
+  assert.deepEqual(rowDirs, [], `harness failure must not create candidate run directories: ${rowDirs.join(', ')}`);
+  await assert.rejects(readFile(path.join(harness.out, 'harness-provenance.json'), 'utf8'), /ENOENT/);
+}
+
+async function assertInfrastructureFailure(harness, result, { stage, check }) {
+  assert.equal(result.code, HARNESS_INFRA_EXIT, `expected harness infrastructure exit ${HARNESS_INFRA_EXIT}: ${result.stderr}`);
+  const receipt = await controlReceipt(harness);
+  assert.equal(receipt.schema, 'openclaw.k6.harness-control-receipt.v1');
+  assert.equal(receipt.classification, 'harness-infrastructure');
+  assert.equal(receipt.ok, false);
+  assert.equal(receipt.stage, stage);
+  assert.equal(receipt.rowsExecuted, 0);
+  assert.equal(receipt.rowVerdictsSynthesized, false);
+  assert.equal(receipt.productVerdict, null);
+  assert.equal(receipt.exitCode, HARNESS_INFRA_EXIT);
+  if (check) assert.equal(receipt.detail.check, check);
+  await assertNoRowsExecuted(harness);
+  return receipt;
+}
+
+test('a live matrix refuses to fire without an approved docs ref', async () => {
+  await withRunner(async (harness) => {
+    const result = await invokeRunner(harness);
+    const receipt = await assertInfrastructureFailure(harness, result, { stage: 'harness-identity', check: 'docs-ref-shape' });
+    assert.equal(receipt.docsRef, null);
+    assert.equal(receipt.docsRefRequested, null);
+    assert.match(result.stderr, /requires an approved docs\/harness ref/);
+    assert.deepEqual(receipt.rowSelection, ['R-CD-2']);
+  });
+});
+
+test('a malformed docs ref is rejected before any row runs', async (t) => {
+  for (const malformed of ['not-a-sha', 'A'.repeat(40), 'abc123', `${'a'.repeat(39)}`]) {
+    await t.test(`rejects ${malformed.slice(0, 12)}`, async () => {
+      await withRunner(async (harness) => {
+        const result = await invokeRunner(harness, { args: ['--docs-ref', malformed] });
+        const receipt = await assertInfrastructureFailure(harness, result, { stage: 'harness-identity', check: 'docs-ref-shape' });
+        // A public receipt records only that the input was malformed; it never
+        // echoes an arbitrary operator-supplied string.
+        assert.equal(receipt.docsRefRequested, 'malformed');
+        assert.equal(receipt.detail.provided, 'malformed');
+        assert.equal(receipt.docsRef, null);
+      });
+    });
+  }
+});
+
+test('a docs ref that is not the current checkout fails closed as stale or mixed', async () => {
+  await withRunner(async (harness) => {
+    const stale = 'f'.repeat(40);
+    const result = await invokeRunner(harness, { args: ['--docs-ref', stale] });
+    const receipt = await assertInfrastructureFailure(harness, result, { stage: 'harness-identity', check: 'head-equals-docs-ref' });
+    assert.equal(receipt.detail.approved, stale);
+    assert.equal(receipt.detail.head, harness.docsRef);
+    assert.match(result.stderr, /stale or mixed harness/);
+  });
+});
+
+test('the docs ref may be supplied through the named environment variable', async () => {
+  await withRunner(async (harness) => {
+    const stale = 'f'.repeat(40);
+    const result = await invokeRunner(harness, { env: { OPENCLAW_PROOFS_DOCS_REF: stale } });
+    const receipt = await assertInfrastructureFailure(harness, result, { stage: 'harness-identity', check: 'head-equals-docs-ref' });
+    assert.equal(receipt.detail.approved, stale);
+  });
+});
+
+test('mutated tracked harness bytes fail closed before any row runs', async () => {
+  await withRunner(
+    async (harness) => {
+      const result = await invokeRunner(harness, { args: ['--docs-ref', harness.docsRef] });
+      const receipt = await assertInfrastructureFailure(harness, result, { stage: 'harness-identity', check: 'harness-tree-clean' });
+      assert.ok(receipt.detail.dirtyEntries >= 1);
+      assert.match(result.stderr, /dirty harness cannot certify/);
+    },
+    {
+      mutate: async (harness) => {
+        const scenario = path.join(harness.proofsDir, 'scenarios/r-cd-2-silent-wake.js');
+        await writeFile(scenario, `${await readFile(scenario, 'utf8')}\n// local edit after the approved commit\n`);
+      },
+    },
+  );
+});
+
+test('a row whose contract is untracked at the approved ref fails closed', async () => {
+  await withRunner(
+    async (harness) => {
+      const result = await invokeRunner(harness, { rows: 'R-UNRECORDED', args: ['--docs-ref', harness.docsRef] });
+      const receipt = await assertInfrastructureFailure(harness, result, { stage: 'harness-identity', check: 'tracked-at-docs-ref' });
+      assert.equal(receipt.detail.row, 'R-UNRECORDED');
+      assert.match(receipt.detail.path, /^tools\/k6-proofs\//);
+      assert.match(result.stderr, /not tracked at the approved docs ref/);
+    },
+    {
+      // Untracked-but-present bytes: `git status` on tracked files stays clean,
+      // so only the tracked-at-commit check can catch this.
+      mutate: async (harness) => {
+        await writeFile(path.join(harness.proofsDir, 'scenarios/r-unrecorded.js'), 'export default function () {}\n');
+        await writeFile(path.join(harness.proofsDir, 'manifests/r-unrecorded.json'), `${JSON.stringify({
+          schema: 'openclaw.k6.proof-row-manifest.v1',
+          rowId: 'R-UNRECORDED',
+          scenario: { status: 'runnable', name: 'r-unrecorded', file: 'r-unrecorded.js' },
+          liveRunSafety: {
+            classification: 'k6-runnable',
+            expectedArtifactClass: 'PASS-candidate',
+            foldRequiresReview: true,
+            requiresCandidateSha: true,
+            requiredReceipts: ['seat-readiness'],
+          },
+        }, null, 2)}\n`);
+      },
+    },
+  );
+});
+
+test('a catalog preflight failure stops the matrix as harness infrastructure', async () => {
+  await withRunner(
+    async (harness) => {
+      const result = await invokeRunner(harness, { args: ['--docs-ref', harness.docsRef] });
+      const receipt = await assertInfrastructureFailure(harness, result, { stage: 'catalog-preflight' });
+      assert.equal(receipt.detail.failedCheck, 'check-manifest-scenarios.mjs');
+      assert.equal(receipt.detail.log, 'catalog-preflight.log');
+      const log = await readFile(path.join(harness.out, 'catalog-preflight.log'), 'utf8');
+      assert.match(log, /r-cd-2-silent-wake\.js' is missing/);
+      assert.match(result.stderr, /catalog validator .* failed/);
+      assert.doesNotMatch(log, /tools\/k6-proofs\/tools\/k6-proofs/);
+    },
+    {
+      mutate: async (harness) => {
+        await rm(path.join(harness.proofsDir, 'scenarios/r-cd-2-silent-wake.js'));
+      },
+    },
+  );
+});
+
+test('an approved live run freezes the docs ref and records the exact harness digests', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'p86-harness-provenance-ok-'));
+  const bin = path.join(root, 'bin');
+  const out = path.join(root, 'out');
+  await Promise.all([mkdir(bin, { recursive: true }), mkdir(out, { recursive: true })]);
+  const harness = await buildHarnessCheckout(repoRoot, path.join(root, 'harness'));
+
+  const gateway = createServer((req, res) => res.writeHead(req.url.startsWith('/health') || req.url.startsWith('/status') ? 200 : 404).end('{}'));
+  await new Promise((resolve) => gateway.listen(0, '127.0.0.1', resolve));
+  const gatewayPort = gateway.address().port;
+
+  const executable = async (name, source) => {
+    const file = path.join(bin, name);
+    await writeFile(file, source, { mode: 0o755 });
+    await chmod(file, 0o755);
+  };
+
+  try {
+    await executable('k6', "#!/bin/sh\nif [ \"${1:-}\" = version ]; then printf '%s\\n' 'k6 v2.0.0'; exit 0; fi\nexit 0\n");
+    await executable('openclaw', '#!/bin/sh\nprintf \'%s\\n\' \'{"enabled":true,"maxChainLength":3,"maxDelegatesPerTurn":3,"costCapTokens":3}\'\n');
+    await executable('hostname', "#!/bin/sh\nprintf '%s\\n' contract-seat\n");
+
+    // R-CW-5A is runnable but static-preflight-only, so the identity gate and
+    // provenance receipt are exercised without dispatching a live k6 row.
+    const result = await run(
+      'bash',
+      ['scripts/run-proofs.sh', '--live', '--out-dir', out, '--docs-ref', harness.docsRef, 'R-CW-5A', candidateSha],
+      {
+        cwd: harness.proofsDir,
+        encoding: 'utf8',
+        timeout: 60_000,
+        env: {
+          ...process.env,
+          PATH: `${bin}:${process.env.PATH}`,
+          K6_BIN: path.join(bin, 'k6'),
+          OPENCLAW_GATEWAY_TOKEN: 'harness-provenance-test-token',
+          OPENCLAW_GATEWAY_WS: `ws://127.0.0.1:${gatewayPort}`,
+          OPENCLAW_SESSION_KEY: 'main',
+          OPENCLAW_SEAT_NAME: 'contract-seat',
+          OPENCLAW_CANDIDATE_SHA: candidateSha,
+          OPENCLAW_RUNTIME_BUILD_SHA: candidateSha,
+        },
+      },
+    );
+
+    await assert.rejects(readFile(path.join(out, 'harness-control-receipt.json'), 'utf8'), /ENOENT/);
+    const provenance = JSON.parse(await readFile(path.join(out, 'harness-provenance.json'), 'utf8'));
+    assert.equal(provenance.schema, 'openclaw.k6.harness-provenance.v1');
+    assert.equal(provenance.mode, 'live');
+    assert.equal(provenance.docsRef, harness.docsRef);
+    assert.equal(provenance.docsRefSource, 'approved-input');
+    assert.equal(provenance.harnessIdentityVerified, true);
+    assert.equal(provenance.repository, HARNESS_REPOSITORY);
+    assert.equal(provenance.candidateSha, candidateSha);
+    assert.equal(provenance.runtimeIdentity.runtimeBuildSha, candidateSha);
+    assert.equal(provenance.runtimeIdentity.candidateMatchesRuntime, true);
+    assert.equal(provenance.runtimeIdentity.seatReadinessReceipt, 'seat-readiness.json');
+    assert.match(provenance.runtimeIdentity.seatReadinessSha256, /^[a-f0-9]{64}$/);
+    assert.equal(provenance.runnerScript, 'tools/k6-proofs/scripts/run-proofs.sh');
+    assert.match(provenance.runnerScriptSha256, /^[a-f0-9]{64}$/);
+    assert.equal(provenance.candidateOnly, true);
+    assert.equal(provenance.foldRequiresReview, true);
+    assert.match(provenance.startedAt, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+    assert.deepEqual(provenance.rowSelection, ['R-CW-5A']);
+
+    const sha256 = async (relative) => createHash('sha256')
+      .update(await readFile(path.join(harness.checkout, relative)))
+      .digest('hex');
+    assert.deepEqual(provenance.rows, [{
+      rowId: 'R-CW-5A',
+      manifestPath: 'tools/k6-proofs/manifests/r-cw-5a-static.json',
+      manifestSha256: await sha256('tools/k6-proofs/manifests/r-cw-5a-static.json'),
+      scenarioPath: 'tools/k6-proofs/scenarios/static-corpus-row-validator.js',
+      scenarioSha256: await sha256('tools/k6-proofs/scenarios/static-corpus-row-validator.js'),
+    }]);
+
+    // The runner script digest is a real digest of the script it just ran.
+    assert.equal(provenance.runnerScriptSha256, await sha256('tools/k6-proofs/scripts/run-proofs.sh'));
+    assert.match(result.stdout, /Approved docs ref: [0-9a-f]{40}/);
+    assert.match(result.stdout, /Harness identity: verified clean and tracked/);
+    assert.match(result.stdout, /\[R-CW-5A\] SKIPPED: liveRunSafety classification/);
+
+    const receipt = JSON.stringify(provenance);
+    assert.doesNotMatch(receipt, /harness-provenance-test-token/);
+    assert.doesNotMatch(receipt, new RegExp(root.replaceAll('/', '\\/')));
+  } finally {
+    await new Promise((resolve) => gateway.close(resolve));
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/tools/k6-proofs/scripts/__tests__/harness-provenance-runner.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/harness-provenance-runner.test.mjs
@@ -150,8 +150,9 @@ test('mutated tracked harness bytes fail closed before any row runs', async () =
     async (harness) => {
       const result = await invokeRunner(harness, { args: ['--docs-ref', harness.docsRef] });
       const receipt = await assertInfrastructureFailure(harness, result, { stage: 'harness-identity', check: 'harness-tree-clean' });
-      assert.ok(receipt.detail.dirtyEntries >= 1);
-      assert.match(result.stderr, /dirty harness cannot certify/);
+      assert.equal(receipt.detail.phase, 'startup');
+      assert.ok(receipt.detail.trackedFiles > 1, 'the whole tracked tree must be verified, not one file');
+      assert.match(result.stderr, /do not match the approved docs ref/);
     },
     {
       mutate: async (harness) => {
@@ -160,6 +161,40 @@ test('mutated tracked harness bytes fail closed before any row runs', async () =
       },
     },
   );
+});
+
+test('an index-hidden mutation cannot pass as a clean harness', async (t) => {
+  // `git status` consults the index, so assume-unchanged / skip-worktree hide a
+  // modified file from it. The gate hashes working-tree bytes instead, which
+  // cannot be suppressed that way.
+  for (const flag of ['--assume-unchanged', '--skip-worktree']) {
+    await t.test(`hidden with ${flag}`, async () => {
+      await withRunner(
+        async (harness) => {
+          const status = await run(
+            'git',
+            ['-C', harness.checkout, 'status', '--porcelain', '--untracked-files=no', '--', 'tools/k6-proofs'],
+            { encoding: 'utf8' },
+          );
+          assert.equal(status.stdout, '', 'the mutation must be invisible to git status for this test to mean anything');
+
+          const result = await invokeRunner(harness, { args: ['--docs-ref', harness.docsRef] });
+          const receipt = await assertInfrastructureFailure(harness, result, { stage: 'harness-identity', check: 'harness-tree-clean' });
+          assert.ok(receipt.detail.trackedFiles > 1);
+          assert.match(result.stderr, /do not match the approved docs ref/);
+        },
+        {
+          mutate: async (harness) => {
+            // A shared library a scenario imports, not the scenario itself.
+            const library = 'tools/k6-proofs/lib/gateway-ws.js';
+            await run('git', ['-C', harness.checkout, 'update-index', flag, '--', library], { encoding: 'utf8' });
+            const file = path.join(harness.checkout, library);
+            await writeFile(file, `${await readFile(file, 'utf8')}\n// hidden from the index\n`);
+          },
+        },
+      );
+    });
+  }
 });
 
 test('a row whose contract is untracked at the approved ref fails closed', async () => {
@@ -549,7 +584,8 @@ test('an approved live run freezes the docs ref and records the exact harness di
     // The runner script digest is a real digest of the script it just ran.
     assert.equal(provenance.runnerScriptSha256, await sha256('tools/k6-proofs/scripts/run-proofs.sh'));
     assert.match(result.stdout, /Approved docs ref: [0-9a-f]{40}/);
-    assert.match(result.stdout, /Harness identity: verified clean and tracked/);
+    assert.match(result.stdout, /Harness identity: every tracked byte under tools\/k6-proofs matches the approved docs ref/);
+    assert.match(result.stdout, /Harness contract binding: frozen manifest\/scenario digests/);
     assert.match(result.stdout, /\[R-CW-5A\] SKIPPED: liveRunSafety classification/);
 
     const receipt = JSON.stringify(provenance);

--- a/tools/k6-proofs/scripts/__tests__/harness-provenance-runner.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/harness-provenance-runner.test.mjs
@@ -213,6 +213,44 @@ test('a catalog preflight failure stops the matrix as harness infrastructure', a
   );
 });
 
+test('the runner resolves its own harness root regardless of the caller working directory', async () => {
+  await withRunner(async (harness) => {
+    const dryRun = async (cwd, script) => {
+      const out = await mkdtemp(path.join(harness.root, 'dry-'));
+      const result = await run('bash', [script, '--dry-run', '--out-dir', out, 'R-CD-2,R-CW-1', candidateSha], {
+        cwd,
+        encoding: 'utf8',
+        timeout: 60_000,
+        env: {
+          ...process.env,
+          OPENCLAW_PROOFS_DOCS_REF: '',
+          OPENCLAW_SESSION_KEY: 'main',
+          OPENCLAW_SEAT_NAME: 'contract-seat',
+          OPENCLAW_CANDIDATE_SHA: candidateSha,
+        },
+      });
+      const provenance = JSON.parse(await readFile(path.join(out, 'harness-provenance.json'), 'utf8'));
+      return { provenance, stdout: result.stdout };
+    };
+
+    const fromToolDir = await dryRun(harness.proofsDir, 'scripts/run-proofs.sh');
+    const fromRepoRoot = await dryRun(harness.checkout, './tools/k6-proofs/scripts/run-proofs.sh');
+
+    const expectedRunnerDigest = createHash('sha256')
+      .update(await readFile(path.join(harness.proofsDir, 'scripts/run-proofs.sh')))
+      .digest('hex');
+    for (const invocation of [fromToolDir, fromRepoRoot]) {
+      assert.deepEqual(invocation.provenance.rowSelection, ['R-CD-2', 'R-CW-1']);
+      assert.equal(invocation.provenance.mode, 'dry-run');
+      assert.equal(invocation.provenance.harnessIdentityVerified, false);
+      assert.equal(invocation.provenance.runnerScriptSha256, expectedRunnerDigest);
+      assert.match(invocation.stdout, /\[R-CD-2\] DRY RUN/);
+      assert.match(invocation.stdout, /CATALOG PREFLIGHT/);
+    }
+    assert.deepEqual(fromRepoRoot.provenance.rows, fromToolDir.provenance.rows);
+  });
+});
+
 test('an approved live run freezes the docs ref and records the exact harness digests', async () => {
   const root = await mkdtemp(path.join(tmpdir(), 'p86-harness-provenance-ok-'));
   const bin = path.join(root, 'bin');

--- a/tools/k6-proofs/scripts/__tests__/harness-provenance-runner.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/harness-provenance-runner.test.mjs
@@ -233,18 +233,21 @@ test('a catalog preflight failure stops the matrix as harness infrastructure', a
     async (harness) => {
       const result = await invokeRunner(harness, { args: ['--docs-ref', harness.docsRef] });
       const receipt = await assertInfrastructureFailure(harness, result, { stage: 'catalog-preflight' });
-      assert.equal(receipt.detail.failedCheck, 'check-scenario-alignment.mjs');
+      assert.equal(receipt.detail.failedCheck, 'check-proof-row-manifests.mjs');
       assert.equal(receipt.detail.log, 'catalog-preflight.log');
       const log = await readFile(path.join(harness.out, 'catalog-preflight.log'), 'utf8');
-      assert.match(log, /k6-proof\.yml/);
+      assert.match(log, /proof rows missing manifest entries: R-PHANTOM/);
       assert.match(result.stderr, /catalog validator .* failed/);
       assert.doesNotMatch(log, /tools\/k6-proofs\/tools\/k6-proofs/);
     },
     {
-      // Break the catalog outside tools/k6-proofs so the harness identity gate,
-      // which now runs first, still passes and the preflight is what fails.
+      // Every tracked tree is byte-verified before the preflight runs, so the
+      // catalog is broken with an untracked stray corpus directory instead:
+      // a real, tracked-byte-preserving way to reach a preflight failure.
       mutate: async (harness) => {
-        await rm(path.join(harness.checkout, '.github/workflows/k6-proof.yml'));
+        const indexRaw = await readFile(path.join(harness.checkout, 'PROOFS/INDEX.json'), 'utf8');
+        const currentSha = JSON.parse(indexRaw).current_sha;
+        await mkdir(path.join(harness.checkout, 'PROOFS', currentSha, 'R-PHANTOM'), { recursive: true });
       },
     },
   );
@@ -257,7 +260,7 @@ test('catalog validators run with no inherited environment at all', async () => 
     '#!/bin/sh',
     'case "$*" in',
     '  *check-manifest-scenarios.mjs*)',
-    '    printf \'PROBE TOKEN_SEEN=%s HOME_SEEN=%s\\n\' "${OPENCLAW_GATEWAY_TOKEN:-<absent>}" "${HOME:-<absent>}"',
+    '    printf \'PROBE TOKEN_SEEN=%s HOME_SEEN=%s CWD=%s\\n\' "${OPENCLAW_GATEWAY_TOKEN:-<absent>}" "${HOME:-<absent>}" "$(pwd)"',
     '    ;;',
     'esac',
     `exec ${process.execPath} "$@"`,
@@ -271,6 +274,9 @@ test('catalog validators run with no inherited environment at all', async () => 
       const log = await readFile(path.join(harness.out, 'catalog-preflight.log'), 'utf8');
       assert.match(log, /PROBE TOKEN_SEEN=<absent> HOME_SEEN=<absent>/);
       assert.doesNotMatch(log, new RegExp(APPROVED_TOKEN));
+      // The validator ran from the snapshot, and that private path is scrubbed
+      // out of the published log.
+      assert.match(log, /CWD=<harness>\/tools\/k6-proofs/);
     },
     { nodeShim: probe },
   );
@@ -394,17 +400,25 @@ test('the catalog preflight log is public-safe: no credentials, no local paths',
     assert.ok(!log.includes(harness.out), 'the artifact root path must not reach a public log');
   });
 
-  // Force a validator to print an absolute path and require it to be scrubbed.
+  // The failure path publishes validator output too, and must be just as safe.
   await withApprovedMatrix(
     async (harness) => {
       const result = await harness.invoke();
       assert.equal(result.code, HARNESS_INFRA_EXIT);
       const log = await readFile(path.join(harness.out, 'catalog-preflight.log'), 'utf8');
-      assert.match(log, /<(?:repo-root|harness)>\/PROOFS\/INDEX\.json/);
+      assert.match(log, /proof rows missing manifest entries: R-PHANTOM/);
       assert.ok(!log.includes(harness.checkout), 'the checkout path must not reach a public log');
+      assert.ok(!log.includes(harness.out), 'the artifact root path must not reach a public log');
       assert.doesNotMatch(log, new RegExp(APPROVED_TOKEN));
+      assert.doesNotMatch(log, /\/tmp\/openclaw-k6-harness\./, 'the snapshot path must not reach a public log');
     },
-    { afterCommit: async (harness) => rm(path.join(harness.checkout, 'PROOFS/INDEX.json')) },
+    {
+      afterCommit: async (harness) => {
+        const indexRaw = await readFile(path.join(harness.checkout, 'PROOFS/INDEX.json'), 'utf8');
+        const currentSha = JSON.parse(indexRaw).current_sha;
+        await mkdir(path.join(harness.checkout, 'PROOFS', currentSha, 'R-PHANTOM'), { recursive: true });
+      },
+    },
   );
 });
 

--- a/tools/k6-proofs/scripts/__tests__/harness-provenance-runner.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/harness-provenance-runner.test.mjs
@@ -251,6 +251,165 @@ test('the runner resolves its own harness root regardless of the caller working 
   });
 });
 
+const APPROVED_TOKEN = 'harness-provenance-test-token-do-not-log';
+
+/**
+ * Drive the runner all the way through the identity gate, seat readiness, and
+ * provenance emission with stubbed tooling. R-CW-5A is runnable but
+ * static-preflight-only, so no live k6 row is dispatched.
+ */
+async function withApprovedMatrix(fn, { afterCommit = null, rows = 'R-CW-5A', nodeShim = null, envFor = null } = {}) {
+  const root = await mkdtemp(path.join(tmpdir(), 'p86-harness-provenance-ok-'));
+  const bin = path.join(root, 'bin');
+  const out = path.join(root, 'out');
+  await Promise.all([mkdir(bin, { recursive: true }), mkdir(out, { recursive: true })]);
+  const harness = await buildHarnessCheckout(repoRoot, path.join(root, 'harness'));
+  if (afterCommit) await afterCommit(harness);
+
+  const gateway = createServer((req, res) => res.writeHead(req.url.startsWith('/health') || req.url.startsWith('/status') ? 200 : 404).end('{}'));
+  await new Promise((resolve) => gateway.listen(0, '127.0.0.1', resolve));
+  const gatewayPort = gateway.address().port;
+
+  const executable = async (name, source) => {
+    const file = path.join(bin, name);
+    await writeFile(file, source, { mode: 0o755 });
+    await chmod(file, 0o755);
+  };
+
+  try {
+    await executable('k6', "#!/bin/sh\nif [ \"${1:-}\" = version ]; then printf '%s\\n' 'k6 v2.0.0'; exit 0; fi\nexit 0\n");
+    await executable('openclaw', '#!/bin/sh\nprintf \'%s\\n\' \'{"enabled":true,"maxChainLength":3,"maxDelegatesPerTurn":3,"costCapTokens":3}\'\n');
+    await executable('hostname', "#!/bin/sh\nprintf '%s\\n' contract-seat\n");
+    if (nodeShim) await executable('node', nodeShim);
+
+    const invoke = async () => {
+      try {
+        const ok = await run(
+          'bash',
+          ['scripts/run-proofs.sh', '--live', '--out-dir', out, '--docs-ref', harness.docsRef, rows, candidateSha],
+          {
+            cwd: harness.proofsDir,
+            encoding: 'utf8',
+            timeout: 60_000,
+            env: {
+              ...process.env,
+              PATH: `${bin}:${process.env.PATH}`,
+              K6_BIN: path.join(bin, 'k6'),
+              OPENCLAW_GATEWAY_TOKEN: APPROVED_TOKEN,
+              OPENCLAW_GATEWAY_WS: `ws://127.0.0.1:${gatewayPort}`,
+              OPENCLAW_SESSION_KEY: 'main',
+              OPENCLAW_SEAT_NAME: 'contract-seat',
+              OPENCLAW_CANDIDATE_SHA: candidateSha,
+              OPENCLAW_RUNTIME_BUILD_SHA: candidateSha,
+              ...(envFor ? envFor(harness) : {}),
+            },
+          },
+        );
+        return { code: 0, stdout: ok.stdout, stderr: ok.stderr };
+      } catch (error) {
+        return { code: error.code, stdout: error.stdout || '', stderr: error.stderr || '' };
+      }
+    };
+
+    return await fn({ ...harness, out, root, invoke });
+  } finally {
+    await new Promise((resolve) => gateway.close(resolve));
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+test('the catalog preflight log is public-safe: no credentials, no local paths', async () => {
+  await withApprovedMatrix(async (harness) => {
+    const result = await harness.invoke();
+    assert.equal(result.code, 0, result.stderr);
+    const log = await readFile(path.join(harness.out, 'catalog-preflight.log'), 'utf8');
+    assert.doesNotMatch(log, new RegExp(APPROVED_TOKEN));
+    assert.ok(!log.includes(harness.checkout), 'the checkout path must not reach a public log');
+    assert.ok(!log.includes(harness.out), 'the artifact root path must not reach a public log');
+  });
+
+  // Force a validator to print an absolute path and require it to be scrubbed.
+  await withApprovedMatrix(
+    async (harness) => {
+      const result = await harness.invoke();
+      assert.equal(result.code, HARNESS_INFRA_EXIT);
+      const log = await readFile(path.join(harness.out, 'catalog-preflight.log'), 'utf8');
+      assert.match(log, /<repo-root>\/PROOFS\/INDEX\.json/);
+      assert.ok(!log.includes(harness.checkout), 'the checkout path must not reach a public log');
+      assert.doesNotMatch(log, new RegExp(APPROVED_TOKEN));
+    },
+    { afterCommit: async (harness) => rm(path.join(harness.checkout, 'PROOFS/INDEX.json')) },
+  );
+});
+
+test('harness bytes mutated after the gate froze them fail closed before capture', async () => {
+  // The shim mutates a selected scenario while seat readiness runs, i.e. after
+  // the identity gate froze its digest but before the row is captured.
+  const shim = [
+    '#!/bin/sh',
+    'case "$*" in',
+    '  *seat-readiness-preflight.mjs*)',
+    '    printf \'\\n// mutated after the approved ref was frozen\\n\' >> "$MUTATE_TARGET"',
+    '    ;;',
+    'esac',
+    'exec "$REAL_NODE" "$@"',
+    '',
+  ].join('\n');
+
+  await withApprovedMatrix(
+    async (harness) => {
+      const result = await harness.invoke();
+      assert.equal(result.code, HARNESS_INFRA_EXIT, result.stderr);
+      const receipt = JSON.parse(await readFile(path.join(harness.out, 'harness-control-receipt.json'), 'utf8'));
+      assert.equal(receipt.stage, 'harness-identity');
+      assert.equal(receipt.detail.check, 'frozen-bytes-still-current');
+      assert.equal(receipt.detail.phase, 'pre-capture');
+      assert.equal(receipt.detail.scenarioChanged, true);
+      assert.equal(receipt.rowsExecuted, 0);
+      assert.equal(receipt.rowVerdictsSynthesized, false);
+      assert.match(result.stderr, /refusing to execute unapproved source/);
+      await assert.rejects(readFile(path.join(harness.out, candidateSha, 'R-CD-2'), 'utf8'), /ENOENT/);
+    },
+    {
+      rows: 'R-CD-2',
+      nodeShim: shim,
+      envFor: (harness) => ({
+        REAL_NODE: process.execPath,
+        MUTATE_TARGET: path.join(harness.proofsDir, 'scenarios/r-cd-2-silent-wake.js'),
+      }),
+    },
+  );
+});
+
+test('an approved live run tolerates a git replacement object without trusting it', async () => {
+  // `git replace` rewrites what plain `git show`/`cat-file` return. The identity
+  // gate must read the true object store, so the run still verifies clean.
+  await withApprovedMatrix(
+    async (harness) => {
+      const result = await harness.invoke();
+      assert.equal(result.code, 0, result.stderr);
+      const provenance = JSON.parse(await readFile(path.join(harness.out, 'harness-provenance.json'), 'utf8'));
+      assert.equal(provenance.harnessIdentityVerified, true);
+      assert.equal(provenance.docsRef, harness.docsRef);
+      await assert.rejects(readFile(path.join(harness.out, 'harness-control-receipt.json'), 'utf8'), /ENOENT/);
+    },
+    {
+      afterCommit: async (harness) => {
+        const git = (...args) => run('git', ['-C', harness.checkout, ...args], { encoding: 'utf8' });
+        const scenario = path.join(harness.proofsDir, 'scenarios/static-corpus-row-validator.js');
+        const original = await readFile(scenario, 'utf8');
+        await writeFile(scenario, `${original}\n// decoy commit content\n`);
+        await git('add', '--all');
+        await git('commit', '--quiet', '--message', 'decoy');
+        const { stdout } = await git('rev-parse', 'HEAD');
+        const decoy = stdout.trim();
+        await git('checkout', '--quiet', harness.docsRef);
+        await git('replace', harness.docsRef, decoy);
+      },
+    },
+  );
+});
+
 test('an approved live run freezes the docs ref and records the exact harness digests', async () => {
   const root = await mkdtemp(path.join(tmpdir(), 'p86-harness-provenance-ok-'));
   const bin = path.join(root, 'bin');

--- a/tools/k6-proofs/scripts/__tests__/harness-provenance-runner.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/harness-provenance-runner.test.mjs
@@ -30,11 +30,11 @@ const run = promisify(execFile);
 const candidateSha = 'a'.repeat(40);
 const HARNESS_INFRA_EXIT = 78;
 
-async function withRunner(fn, { mutate = null } = {}) {
+async function withRunner(fn, { mutate = null, beforeCommit = null } = {}) {
   const root = await mkdtemp(path.join(tmpdir(), 'p86-harness-provenance-'));
   const out = path.join(root, 'out');
   await mkdir(out, { recursive: true });
-  const harness = await buildHarnessCheckout(repoRoot, path.join(root, 'harness'));
+  const harness = await buildHarnessCheckout(repoRoot, path.join(root, 'harness'), { beforeCommit });
   if (mutate) await mutate(harness);
   try {
     return await fn({ ...harness, out, root });
@@ -163,6 +163,61 @@ test('mutated tracked harness bytes fail closed before any row runs', async () =
   );
 });
 
+test('a spoofed snapshot handoff is refused', async (t) => {
+  // The handoff variables are ambient input. A modified external copy of the
+  // runner could otherwise set them, point them at clean trees, skip the exec,
+  // and keep executing its own bytes.
+  await t.test('snapshot aliased to the checkout', async () => {
+    await withRunner(async (harness) => {
+      const result = await invokeRunner(harness, {
+        args: ['--docs-ref', harness.docsRef],
+        env: {
+          OPENCLAW_PROOFS_HARNESS_SNAPSHOT: harness.checkout,
+          OPENCLAW_PROOFS_ORIGIN_ROOT: harness.checkout,
+        },
+      });
+      await assertInfrastructureFailure(harness, result, { stage: 'harness-identity', check: 'snapshot-handoff-authentic' });
+      assert.match(result.stderr, /spoofed or aliased handoff/);
+    });
+  });
+
+  await t.test('checkout runner claiming a real snapshot', async () => {
+    await withRunner(async (harness) => {
+      // A genuine, byte-correct snapshot — but this process is not its runner.
+      const snapshot = path.join(harness.root, 'external-snapshot');
+      await mkdir(snapshot, { recursive: true });
+      await run('bash', ['-c', `git -C ${harness.checkout} archive ${harness.docsRef} -- tools/k6-proofs PROOFS .github | tar -x -C ${snapshot}`], { encoding: 'utf8' });
+      const result = await invokeRunner(harness, {
+        args: ['--docs-ref', harness.docsRef],
+        env: {
+          OPENCLAW_PROOFS_HARNESS_SNAPSHOT: snapshot,
+          OPENCLAW_PROOFS_ORIGIN_ROOT: harness.checkout,
+        },
+      });
+      await assertInfrastructureFailure(harness, result, { stage: 'harness-identity', check: 'snapshot-handoff-authentic' });
+    });
+  });
+});
+
+test('a mutated proof corpus cannot produce a candidate verdict', async () => {
+  // Static rows read committed corpus evidence during k6 execution, so the
+  // corpus is part of the verified, materialized input set.
+  await withRunner(
+    async (harness) => {
+      const result = await invokeRunner(harness, { args: ['--docs-ref', harness.docsRef] });
+      const receipt = await assertInfrastructureFailure(harness, result, { stage: 'harness-identity', check: 'harness-tree-clean' });
+      assert.ok(receipt.detail.trackedFiles > 1);
+      assert.match(result.stderr, /do not match the approved docs ref/);
+    },
+    {
+      mutate: async (harness) => {
+        const evidence = path.join(harness.checkout, 'PROOFS', harness.corpusSha, 'R-CD-2', 'corpus-evidence.txt');
+        await writeFile(evidence, 'locally edited corpus evidence\n');
+      },
+    },
+  );
+});
+
 test('an index-hidden mutation cannot pass as a clean harness', async (t) => {
   // `git status` consults the index, so assume-unchanged / skip-worktree hide a
   // modified file from it. The gate hashes working-tree bytes instead, which
@@ -241,13 +296,13 @@ test('a catalog preflight failure stops the matrix as harness infrastructure', a
       assert.doesNotMatch(log, /tools\/k6-proofs\/tools\/k6-proofs/);
     },
     {
-      // Every tracked tree is byte-verified before the preflight runs, so the
-      // catalog is broken with an untracked stray corpus directory instead:
-      // a real, tracked-byte-preserving way to reach a preflight failure.
-      mutate: async (harness) => {
-        const indexRaw = await readFile(path.join(harness.checkout, 'PROOFS/INDEX.json'), 'utf8');
-        const currentSha = JSON.parse(indexRaw).current_sha;
-        await mkdir(path.join(harness.checkout, 'PROOFS', currentSha, 'R-PHANTOM'), { recursive: true });
+      // Every consumed tree is materialized from the approved ref, so a local
+      // stray cannot reach the validators. The catalog defect must therefore be
+      // committed: a corpus row the manifest catalog does not describe.
+      beforeCommit: async ({ checkout, corpusSha }) => {
+        const phantom = path.join(checkout, 'PROOFS', corpusSha, 'R-PHANTOM');
+        await mkdir(phantom, { recursive: true });
+        await writeFile(path.join(phantom, 'corpus-evidence.txt'), 'phantom row\n');
       },
     },
   );
@@ -327,12 +382,12 @@ const APPROVED_TOKEN = 'harness-provenance-test-token-do-not-log';
  * provenance emission with stubbed tooling. R-CW-5A is runnable but
  * static-preflight-only, so no live k6 row is dispatched.
  */
-async function withApprovedMatrix(fn, { afterCommit = null, rows = 'R-CW-5A', nodeShim = null, nodeShimFor = null, journalShimFor = null, k6ShimFor = null, envFor = null } = {}) {
+async function withApprovedMatrix(fn, { afterCommit = null, beforeCommit = null, rows = 'R-CW-5A', nodeShim = null, nodeShimFor = null, journalShimFor = null, k6ShimFor = null, envFor = null } = {}) {
   const root = await mkdtemp(path.join(tmpdir(), 'p86-harness-provenance-ok-'));
   const bin = path.join(root, 'bin');
   const out = path.join(root, 'out');
   await Promise.all([mkdir(bin, { recursive: true }), mkdir(out, { recursive: true })]);
-  const built = await buildHarnessCheckout(repoRoot, path.join(root, 'harness'));
+  const built = await buildHarnessCheckout(repoRoot, path.join(root, 'harness'), { beforeCommit });
   const harness = { ...built, root, out };
   if (afterCommit) await afterCommit(harness);
 
@@ -413,10 +468,10 @@ test('the catalog preflight log is public-safe: no credentials, no local paths',
       assert.doesNotMatch(log, /\/tmp\/openclaw-k6-harness\./, 'the snapshot path must not reach a public log');
     },
     {
-      afterCommit: async (harness) => {
-        const indexRaw = await readFile(path.join(harness.checkout, 'PROOFS/INDEX.json'), 'utf8');
-        const currentSha = JSON.parse(indexRaw).current_sha;
-        await mkdir(path.join(harness.checkout, 'PROOFS', currentSha, 'R-PHANTOM'), { recursive: true });
+      beforeCommit: async ({ checkout, corpusSha }) => {
+        const phantom = path.join(checkout, 'PROOFS', corpusSha, 'R-PHANTOM');
+        await mkdir(phantom, { recursive: true });
+        await writeFile(path.join(phantom, 'corpus-evidence.txt'), 'phantom row\n');
       },
     },
   );

--- a/tools/k6-proofs/scripts/__tests__/helpers/harness-checkout.mjs
+++ b/tools/k6-proofs/scripts/__tests__/helpers/harness-checkout.mjs
@@ -15,9 +15,10 @@ import { promisify } from 'node:util';
 const run = promisify(execFile);
 
 export const HARNESS_REPOSITORY = 'karmaterminal/karmaterminal-openclaw-docs';
+export const CORPUS_EVIDENCE_FILE = 'corpus-evidence.txt';
 export const HARNESS_REMOTE = `https://github.com/${HARNESS_REPOSITORY}.git`;
 
-export async function buildHarnessCheckout(repoRoot, checkout) {
+export async function buildHarnessCheckout(repoRoot, checkout, { beforeCommit = null } = {}) {
   await mkdir(path.join(checkout, 'tools'), { recursive: true });
   await mkdir(path.join(checkout, '.github/workflows'), { recursive: true });
   await mkdir(path.join(checkout, 'PROOFS'), { recursive: true });
@@ -34,7 +35,13 @@ export async function buildHarnessCheckout(repoRoot, checkout) {
   await writeFile(path.join(checkout, 'PROOFS/INDEX.json'), indexRaw);
   const currentSha = JSON.parse(indexRaw).current_sha;
   for (const entry of await readdir(path.join(repoRoot, 'PROOFS', currentSha), { withFileTypes: true })) {
-    if (entry.isDirectory()) await mkdir(path.join(checkout, 'PROOFS', currentSha, entry.name), { recursive: true });
+    if (!entry.isDirectory()) continue;
+    const rowDir = path.join(checkout, 'PROOFS', currentSha, entry.name);
+    await mkdir(rowDir, { recursive: true });
+    // Static rows read committed corpus evidence during k6 execution, so the
+    // fixture carries a real tracked file per row: the corpus is part of the
+    // verified, materialized input set, not just a set of directory names.
+    await writeFile(path.join(rowDir, CORPUS_EVIDENCE_FILE), `${entry.name} corpus evidence fixture\n`);
   }
 
   const git = (...args) => run('git', ['-C', checkout, ...args], { encoding: 'utf8' });
@@ -43,8 +50,16 @@ export async function buildHarnessCheckout(repoRoot, checkout) {
   await git('config', 'user.email', 'p81-harness-contract@example.invalid');
   await git('config', 'commit.gpgsign', 'false');
   await git('remote', 'add', 'origin', HARNESS_REMOTE);
+  // Lets a test commit a genuine catalog defect, so the defect survives the
+  // runner materializing every consumed tree from the approved ref.
+  if (beforeCommit) await beforeCommit({ checkout, proofsDir: path.join(checkout, 'tools/k6-proofs'), corpusSha: currentSha });
   await git('add', '--all');
   await git('commit', '--quiet', '--message', 'harness under contract test');
   const { stdout } = await git('rev-parse', 'HEAD');
-  return { checkout, proofsDir: path.join(checkout, 'tools/k6-proofs'), docsRef: stdout.trim() };
+  return {
+    checkout,
+    proofsDir: path.join(checkout, 'tools/k6-proofs'),
+    corpusSha: currentSha,
+    docsRef: stdout.trim(),
+  };
 }

--- a/tools/k6-proofs/scripts/__tests__/helpers/harness-checkout.mjs
+++ b/tools/k6-proofs/scripts/__tests__/helpers/harness-checkout.mjs
@@ -1,0 +1,50 @@
+/**
+ * harness-checkout.mjs — build a throwaway immutable harness checkout for tests.
+ *
+ * The live runner refuses to fire unless repository HEAD equals the approved
+ * docs ref and the tracked bytes under tools/k6-proofs are clean (#496), so a
+ * runner test cannot borrow the developer's working tree. This helper copies the
+ * harness under test into a fresh git repository, commits it, and returns the
+ * resulting immutable ref.
+ */
+import { cp, mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+const run = promisify(execFile);
+
+export const HARNESS_REPOSITORY = 'karmaterminal/karmaterminal-openclaw-docs';
+export const HARNESS_REMOTE = `https://github.com/${HARNESS_REPOSITORY}.git`;
+
+export async function buildHarnessCheckout(repoRoot, checkout) {
+  await mkdir(path.join(checkout, 'tools'), { recursive: true });
+  await mkdir(path.join(checkout, '.github/workflows'), { recursive: true });
+  await mkdir(path.join(checkout, 'PROOFS'), { recursive: true });
+  await cp(path.join(repoRoot, 'tools/k6-proofs'), path.join(checkout, 'tools/k6-proofs'), { recursive: true });
+  await cp(
+    path.join(repoRoot, '.github/workflows/k6-proof.yml'),
+    path.join(checkout, '.github/workflows/k6-proof.yml'),
+  );
+
+  // The catalog preflight reads PROOFS/INDEX.json and the current corpus row
+  // directories. Only the row directory names matter, so the (large) corpus
+  // contents are deliberately not copied.
+  const indexRaw = await readFile(path.join(repoRoot, 'PROOFS/INDEX.json'), 'utf8');
+  await writeFile(path.join(checkout, 'PROOFS/INDEX.json'), indexRaw);
+  const currentSha = JSON.parse(indexRaw).current_sha;
+  for (const entry of await readdir(path.join(repoRoot, 'PROOFS', currentSha), { withFileTypes: true })) {
+    if (entry.isDirectory()) await mkdir(path.join(checkout, 'PROOFS', currentSha, entry.name), { recursive: true });
+  }
+
+  const git = (...args) => run('git', ['-C', checkout, ...args], { encoding: 'utf8' });
+  await git('init', '--quiet', '--initial-branch=main');
+  await git('config', 'user.name', 'p81-harness-contract');
+  await git('config', 'user.email', 'p81-harness-contract@example.invalid');
+  await git('config', 'commit.gpgsign', 'false');
+  await git('remote', 'add', 'origin', HARNESS_REMOTE);
+  await git('add', '--all');
+  await git('commit', '--quiet', '--message', 'harness under contract test');
+  const { stdout } = await git('rev-parse', 'HEAD');
+  return { checkout, proofsDir: path.join(checkout, 'tools/k6-proofs'), docsRef: stdout.trim() };
+}

--- a/tools/k6-proofs/scripts/__tests__/report-render.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/report-render.test.mjs
@@ -34,6 +34,18 @@ function envelopeHarness(identity) {
   return { ...identity, manifestArtifact: 'row-manifest.json', scenarioArtifact: 'row-scenario.js' };
 }
 
+function envelopeArtifacts({ files = [], tempoTraceJson = null, correlationReceipt = null } = {}) {
+  return {
+    manifest: 'row-manifest.json',
+    scenario: 'row-scenario.js',
+    runnerMetadata: 'runner-metadata.json',
+    runResult: 'run-result.json',
+    files,
+    tempoTraceJson,
+    correlationReceipt,
+  };
+}
+
 test('renders public-safe HTML report from row-list runner artifacts', async () => {
   const root = await mkdtemp(path.join(tmpdir(), 'k6-proof-report-'));
   try {
@@ -100,15 +112,22 @@ test('uses candidate-run-result.v1 as the unambiguous review input when present'
       observability: { traceStatus: 'present', traceId: 'safe-trace-id', correlationReceipt: 'continuation-correlation.json' },
       review: { status: 'ready-for-human-review', pendingReceipts: [] },
     })}\n`);
+    await writeFile(path.join(runDir, 'r-cw-1-summary.json'), `${JSON.stringify({
+      metrics: { duration_ms: { avg: 4321 } },
+    })}\n`);
     await writeFile(path.join(runDir, 'candidate-run-result.json'), `${JSON.stringify({
       schema: 'openclaw.k6.candidate-run-result.v1',
       candidateOnly: true, foldRequiresReview: true, canonicalFoldForbidden: true,
       candidate: { sha, docsRef },
       harness: envelopeHarness(identity),
-      run: { id: 'k6-run-1', rowId: 'R-CW-1', seat: 'cael', scenario: 'r-cw-1' },
+      run: { id: 'k6-run-1', rowId: 'R-CW-1', seat: 'cael', scenario: 'r-cw-1', executionKind: 'row-list-runner' },
       result: { outcome: 'PASS-candidate', outcomeSource: 'k6-summary', effectiveExitCode: 0, behaviorProof: false },
       observability: { traceStatus: 'present', traceCaptured: true, correlationReceiptPresent: true },
       review: { status: 'ready-for-human-review', pendingReceipts: [], complete: true },
+      artifacts: envelopeArtifacts({
+        files: ['row-manifest.json', 'row-scenario.js', 'runner-metadata.json', 'run-result.json', 'candidate-run-result.json', 'r-cw-1-summary.json'],
+        correlationReceipt: 'continuation-correlation.json',
+      }),
     }, null, 2)}\n`);
     const out = path.join(root, 'report.html');
     const run = spawnSync(process.execPath, [script, '--root', root, '--out', out], { encoding: 'utf8' });
@@ -117,6 +136,8 @@ test('uses candidate-run-result.v1 as the unambiguous review input when present'
     assert.match(html, /R-CW-1/);
     assert.match(html, /ready-for-human-review/);
     assert.doesNotMatch(html, /<td>review-pending<\/td>/);
+    assert.match(html, /<td>n\/a ms<\/td>/);
+    assert.doesNotMatch(html, /4321 ms/);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -147,18 +168,18 @@ test('falls back to the sibling raw result when a sidecar is malformed or unsafe
   }
 });
 
-test('falls back to raw trace debt when an identity-valid sidecar forges observability', async () => {
+test('falls back to raw trace debt while the raw sibling remains review-pending', async () => {
   const root = await mkdtemp(path.join(tmpdir(), 'k6-proof-envelope-observability-forgery-'));
   try {
-    const runDir = path.join(root, 'candidate', 'R-CD-2', 'cael', 'k6-run-2');
+    const runDir = path.join(root, 'candidate', 'R-CW-2', 'cael', 'k6-run-2');
     const sha = 'b40e59f08c7a8997e50a5c8a24b00bc68f653882';
     await mkdir(runDir, { recursive: true });
     const manifestBody = `${JSON.stringify({
-      schema: 'openclaw.k6.proof-row-manifest.v1', rowId: 'R-CD-2', candidateSha: sha,
-      scenario: { name: 'r-cd-2' }, review: { candidateOnly: true, foldRequiresReview: true },
+      schema: 'openclaw.k6.proof-row-manifest.v1', rowId: 'R-CW-2', candidateSha: sha,
+      scenario: { name: 'r-cw-2' }, review: { candidateOnly: true, foldRequiresReview: true },
     })}\n`;
-    const identity = await writeHarnessIdentity(runDir, { manifestBody, rowFile: 'r-cd-2' });
-    await writeFile(path.join(runDir, 'runner-metadata.json'), `${JSON.stringify({ row: 'R-CD-2', candidateSha: sha, seat: 'cael', scenario: 'r-cd-2', ...identity })}\n`);
+    const identity = await writeHarnessIdentity(runDir, { manifestBody, rowFile: 'r-cw-2' });
+    await writeFile(path.join(runDir, 'runner-metadata.json'), `${JSON.stringify({ row: 'R-CW-2', candidateSha: sha, seat: 'cael', scenario: 'r-cw-2', ...identity })}\n`);
     await writeFile(path.join(runDir, 'run-result.json'), `${JSON.stringify({
       candidateOnly: true, foldRequiresReview: true, effectiveExitCode: 0, verdict: 'PASS-candidate', verdictSource: 'k6-summary',
       observability: { traceStatus: 'missing', traceId: null, correlationReceipt: null },
@@ -168,10 +189,11 @@ test('falls back to raw trace debt when an identity-valid sidecar forges observa
       schema: 'openclaw.k6.candidate-run-result.v1', candidateOnly: true, foldRequiresReview: true, canonicalFoldForbidden: true,
       candidate: { sha, docsRef },
       harness: envelopeHarness(identity),
-      run: { id: 'k6-run-2', rowId: 'R-CD-2', seat: 'cael', scenario: 'r-cd-2' },
+      run: { id: 'k6-run-2', rowId: 'R-CW-2', seat: 'cael', scenario: 'r-cw-2', executionKind: 'row-list-runner' },
       result: { outcome: 'PASS-candidate', outcomeSource: 'k6-summary', effectiveExitCode: 0, behaviorProof: false },
-      observability: { traceStatus: 'present', traceCaptured: true, correlationReceiptPresent: true },
+      observability: { traceStatus: 'missing', traceCaptured: false, correlationReceiptPresent: false },
       review: { status: 'ready-for-human-review', pendingReceipts: [], complete: true },
+      artifacts: envelopeArtifacts(),
     })}\n`);
     const out = path.join(root, 'report.html');
     const run = spawnSync(process.execPath, [script, '--root', root, '--out', out], { encoding: 'utf8' });

--- a/tools/k6-proofs/scripts/__tests__/report-render.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/report-render.test.mjs
@@ -1,11 +1,38 @@
 import { mkdtemp, mkdir, writeFile, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { createHash } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
 const script = path.resolve('tools/k6-proofs/scripts/render-run-report.mjs');
+const docsRef = 'a'.repeat(40);
+const repository = 'karmaterminal/karmaterminal-openclaw-docs';
+const scenarioSource = 'export default function scenario() { return true; }\n';
+const digest = (value) => createHash('sha256').update(value).digest('hex');
+
+/**
+ * Write the copied manifest/scenario sources the runner captures alongside a
+ * live row and return the matching immutable harness identity (#496). Without
+ * it a sidecar envelope can never suppress its raw sibling.
+ */
+async function writeHarnessIdentity(runDir, { manifestBody, rowFile }) {
+  await writeFile(path.join(runDir, 'row-manifest.json'), manifestBody);
+  await writeFile(path.join(runDir, 'row-scenario.js'), scenarioSource);
+  return {
+    docsRef,
+    repository,
+    manifestPath: `tools/k6-proofs/manifests/${rowFile}.json`,
+    manifestSha256: digest(manifestBody),
+    scenarioPath: `tools/k6-proofs/scenarios/${rowFile}.js`,
+    scenarioSha256: digest(scenarioSource),
+  };
+}
+
+function envelopeHarness(identity) {
+  return { ...identity, manifestArtifact: 'row-manifest.json', scenarioArtifact: 'row-scenario.js' };
+}
 
 test('renders public-safe HTML report from row-list runner artifacts', async () => {
   const root = await mkdtemp(path.join(tmpdir(), 'k6-proof-report-'));
@@ -62,11 +89,12 @@ test('uses candidate-run-result.v1 as the unambiguous review input when present'
     const runDir = path.join(root, 'candidate', 'R-CW-1', 'cael', 'k6-run-1');
     await mkdir(runDir, { recursive: true });
     const sha = 'b40e59f08c7a8997e50a5c8a24b00bc68f653882';
-    await writeFile(path.join(runDir, 'row-manifest.json'), `${JSON.stringify({
+    const manifestBody = `${JSON.stringify({
       schema: 'openclaw.k6.proof-row-manifest.v1', rowId: 'R-CW-1', candidateSha: sha,
       scenario: { name: 'r-cw-1' }, review: { candidateOnly: true, foldRequiresReview: true },
-    })}\n`);
-    await writeFile(path.join(runDir, 'runner-metadata.json'), `${JSON.stringify({ row: 'R-CW-1', candidateSha: sha, seat: 'cael', scenario: 'r-cw-1' })}\n`);
+    })}\n`;
+    const identity = await writeHarnessIdentity(runDir, { manifestBody, rowFile: 'r-cw-1' });
+    await writeFile(path.join(runDir, 'runner-metadata.json'), `${JSON.stringify({ row: 'R-CW-1', candidateSha: sha, seat: 'cael', scenario: 'r-cw-1', ...identity })}\n`);
     await writeFile(path.join(runDir, 'run-result.json'), `${JSON.stringify({
       candidateOnly: true, foldRequiresReview: true, effectiveExitCode: 0, verdict: 'PASS-candidate', verdictSource: 'k6-summary',
       observability: { traceStatus: 'present', traceId: 'safe-trace-id', correlationReceipt: 'continuation-correlation.json' },
@@ -75,7 +103,8 @@ test('uses candidate-run-result.v1 as the unambiguous review input when present'
     await writeFile(path.join(runDir, 'candidate-run-result.json'), `${JSON.stringify({
       schema: 'openclaw.k6.candidate-run-result.v1',
       candidateOnly: true, foldRequiresReview: true, canonicalFoldForbidden: true,
-      candidate: { sha, docsRef: 'a'.repeat(40) },
+      candidate: { sha, docsRef },
+      harness: envelopeHarness(identity),
       run: { id: 'k6-run-1', rowId: 'R-CW-1', seat: 'cael', scenario: 'r-cw-1' },
       result: { outcome: 'PASS-candidate', outcomeSource: 'k6-summary', effectiveExitCode: 0, behaviorProof: false },
       observability: { traceStatus: 'present', traceCaptured: true, correlationReceiptPresent: true },
@@ -124,11 +153,12 @@ test('falls back to raw trace debt when an identity-valid sidecar forges observa
     const runDir = path.join(root, 'candidate', 'R-CD-2', 'cael', 'k6-run-2');
     const sha = 'b40e59f08c7a8997e50a5c8a24b00bc68f653882';
     await mkdir(runDir, { recursive: true });
-    await writeFile(path.join(runDir, 'row-manifest.json'), `${JSON.stringify({
+    const manifestBody = `${JSON.stringify({
       schema: 'openclaw.k6.proof-row-manifest.v1', rowId: 'R-CD-2', candidateSha: sha,
       scenario: { name: 'r-cd-2' }, review: { candidateOnly: true, foldRequiresReview: true },
-    })}\n`);
-    await writeFile(path.join(runDir, 'runner-metadata.json'), `${JSON.stringify({ row: 'R-CD-2', candidateSha: sha, seat: 'cael', scenario: 'r-cd-2' })}\n`);
+    })}\n`;
+    const identity = await writeHarnessIdentity(runDir, { manifestBody, rowFile: 'r-cd-2' });
+    await writeFile(path.join(runDir, 'runner-metadata.json'), `${JSON.stringify({ row: 'R-CD-2', candidateSha: sha, seat: 'cael', scenario: 'r-cd-2', ...identity })}\n`);
     await writeFile(path.join(runDir, 'run-result.json'), `${JSON.stringify({
       candidateOnly: true, foldRequiresReview: true, effectiveExitCode: 0, verdict: 'PASS-candidate', verdictSource: 'k6-summary',
       observability: { traceStatus: 'missing', traceId: null, correlationReceipt: null },
@@ -136,7 +166,9 @@ test('falls back to raw trace debt when an identity-valid sidecar forges observa
     })}\n`);
     await writeFile(path.join(runDir, 'candidate-run-result.json'), `${JSON.stringify({
       schema: 'openclaw.k6.candidate-run-result.v1', candidateOnly: true, foldRequiresReview: true, canonicalFoldForbidden: true,
-      candidate: { sha, docsRef: 'a'.repeat(40) }, run: { id: 'k6-run-2', rowId: 'R-CD-2', seat: 'cael', scenario: 'r-cd-2' },
+      candidate: { sha, docsRef },
+      harness: envelopeHarness(identity),
+      run: { id: 'k6-run-2', rowId: 'R-CD-2', seat: 'cael', scenario: 'r-cd-2' },
       result: { outcome: 'PASS-candidate', outcomeSource: 'k6-summary', effectiveExitCode: 0, behaviorProof: false },
       observability: { traceStatus: 'present', traceCaptured: true, correlationReceiptPresent: true },
       review: { status: 'ready-for-human-review', pendingReceipts: [], complete: true },

--- a/tools/k6-proofs/scripts/__tests__/review-debt.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/review-debt.test.mjs
@@ -1,6 +1,7 @@
 import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { createHash } from 'node:crypto';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import test from 'node:test';
@@ -8,6 +9,10 @@ import assert from 'node:assert/strict';
 
 const script = path.resolve('tools/k6-proofs/scripts/summarize-review-debt.mjs');
 const runNode = promisify(execFile);
+const docsRef = 'b'.repeat(40);
+const repository = 'karmaterminal/karmaterminal-openclaw-docs';
+const scenarioSource = 'export default function scenario() { return true; }\n';
+const digest = (value) => createHash('sha256').update(value).digest('hex');
 
 async function writeResult(root, row, body) {
   const dir = path.join(root, 'candidate-sha', row, 'seat', `run-${row}`);
@@ -25,11 +30,24 @@ async function writeValidatedEnvelopeFixture(root, row) {
   const dir = path.join(root, 'candidate-sha', row, 'seat', `run-${row}`);
   const sha = 'a'.repeat(40);
   await mkdir(dir, { recursive: true });
-  await writeFile(path.join(dir, 'row-manifest.json'), `${JSON.stringify({
+  const manifestBody = `${JSON.stringify({
     schema: 'openclaw.k6.proof-row-manifest.v1', rowId: row, candidateSha: sha,
     scenario: { name: 'r-cw-1' }, review: { candidateOnly: true, foldRequiresReview: true },
-  })}\n`);
-  await writeFile(path.join(dir, 'runner-metadata.json'), `${JSON.stringify({ row, candidateSha: sha, seat: 'seat', scenario: 'r-cw-1' })}\n`);
+  })}\n`;
+  // The runner copies the fired manifest/scenario bytes next to the receipt and
+  // records their digests; a sidecar without that identity cannot suppress its
+  // raw sibling (#496).
+  await writeFile(path.join(dir, 'row-manifest.json'), manifestBody);
+  await writeFile(path.join(dir, 'row-scenario.js'), scenarioSource);
+  const identity = {
+    docsRef,
+    repository,
+    manifestPath: 'tools/k6-proofs/manifests/r-cw-1.json',
+    manifestSha256: digest(manifestBody),
+    scenarioPath: 'tools/k6-proofs/scenarios/r-cw-1.js',
+    scenarioSha256: digest(scenarioSource),
+  };
+  await writeFile(path.join(dir, 'runner-metadata.json'), `${JSON.stringify({ row, candidateSha: sha, seat: 'seat', scenario: 'r-cw-1', ...identity })}\n`);
   await writeResult(root, row, {
     candidateOnly: true, foldRequiresReview: true, effectiveExitCode: 0, verdict: 'PASS-candidate', verdictSource: 'k6-summary',
     observability: { traceStatus: 'present', traceId: 'safe-trace-id', correlationReceipt: 'continuation-correlation.json' },
@@ -37,11 +55,14 @@ async function writeValidatedEnvelopeFixture(root, row) {
   });
   await writeCandidateResult(root, row, {
     schema: 'openclaw.k6.candidate-run-result.v1', candidateOnly: true, foldRequiresReview: true, canonicalFoldForbidden: true,
-    candidate: { sha, docsRef: 'b'.repeat(40) }, run: { id: `run-${row}`, rowId: row, seat: 'seat', scenario: 'r-cw-1' },
+    candidate: { sha, docsRef },
+    harness: { ...identity, manifestArtifact: 'row-manifest.json', scenarioArtifact: 'row-scenario.js' },
+    run: { id: `run-${row}`, rowId: row, seat: 'seat', scenario: 'r-cw-1' },
     result: { outcome: 'PASS-candidate', outcomeSource: 'k6-summary', effectiveExitCode: 0, behaviorProof: false },
     observability: { traceStatus: 'present', traceCaptured: true, correlationReceiptPresent: true },
     review: { status: 'ready-for-human-review', pendingReceipts: [], complete: true },
   });
+  return identity;
 }
 
 test('summarizes trace-missing debt as unfetchable when no trace id exists', async () => {
@@ -134,7 +155,7 @@ test('falls back to raw review debt when an identity-valid sidecar forges trace 
   const root = await mkdtemp(path.join(tmpdir(), 'review-debt-envelope-observability-forgery-'));
   try {
     const row = 'R-CD-2';
-    await writeValidatedEnvelopeFixture(root, row);
+    const identity = await writeValidatedEnvelopeFixture(root, row);
     const dir = path.join(root, 'candidate-sha', row, 'seat', `run-${row}`);
     await writeResult(root, row, {
       candidateOnly: true, foldRequiresReview: true, effectiveExitCode: 0, verdict: 'PASS-candidate', verdictSource: 'k6-summary',
@@ -143,7 +164,9 @@ test('falls back to raw review debt when an identity-valid sidecar forges trace 
     });
     await writeFile(path.join(dir, 'candidate-run-result.json'), `${JSON.stringify({
       schema: 'openclaw.k6.candidate-run-result.v1', candidateOnly: true, foldRequiresReview: true, canonicalFoldForbidden: true,
-      candidate: { sha: 'a'.repeat(40), docsRef: 'b'.repeat(40) }, run: { id: `run-${row}`, rowId: row, seat: 'seat', scenario: 'r-cw-1' },
+      candidate: { sha: 'a'.repeat(40), docsRef },
+      harness: { ...identity, manifestArtifact: 'row-manifest.json', scenarioArtifact: 'row-scenario.js' },
+      run: { id: `run-${row}`, rowId: row, seat: 'seat', scenario: 'r-cw-1' },
       result: { outcome: 'PASS-candidate', outcomeSource: 'k6-summary', effectiveExitCode: 0, behaviorProof: false },
       observability: { traceStatus: 'present', traceCaptured: true, correlationReceiptPresent: true },
       review: { status: 'ready-for-human-review', pendingReceipts: [], complete: true },

--- a/tools/k6-proofs/scripts/__tests__/review-debt.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/review-debt.test.mjs
@@ -6,6 +6,7 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { candidateEnvelopeMatchesSiblings } from '../candidate-run-result-contract.mjs';
 
 const script = path.resolve('tools/k6-proofs/scripts/summarize-review-debt.mjs');
 const runNode = promisify(execFile);
@@ -13,6 +14,18 @@ const docsRef = 'b'.repeat(40);
 const repository = 'karmaterminal/karmaterminal-openclaw-docs';
 const scenarioSource = 'export default function scenario() { return true; }\n';
 const digest = (value) => createHash('sha256').update(value).digest('hex');
+
+function envelopeArtifacts({ files = [], tempoTraceJson = null, correlationReceipt = null } = {}) {
+  return {
+    manifest: 'row-manifest.json',
+    scenario: 'row-scenario.js',
+    runnerMetadata: 'runner-metadata.json',
+    runResult: 'run-result.json',
+    files,
+    tempoTraceJson,
+    correlationReceipt,
+  };
+}
 
 async function writeResult(root, row, body) {
   const dir = path.join(root, 'candidate-sha', row, 'seat', `run-${row}`);
@@ -47,22 +60,26 @@ async function writeValidatedEnvelopeFixture(root, row) {
     scenarioPath: 'tools/k6-proofs/scenarios/r-cw-1.js',
     scenarioSha256: digest(scenarioSource),
   };
-  await writeFile(path.join(dir, 'runner-metadata.json'), `${JSON.stringify({ row, candidateSha: sha, seat: 'seat', scenario: 'r-cw-1', ...identity })}\n`);
-  await writeResult(root, row, {
+  const metadata = { row, candidateSha: sha, seat: 'seat', scenario: 'r-cw-1', ...identity };
+  const runResult = {
     candidateOnly: true, foldRequiresReview: true, effectiveExitCode: 0, verdict: 'PASS-candidate', verdictSource: 'k6-summary',
     observability: { traceStatus: 'present', traceId: 'safe-trace-id', correlationReceipt: 'continuation-correlation.json' },
     review: { status: 'ready-for-human-review', pendingReceipts: [] },
-  });
-  await writeCandidateResult(root, row, {
+  };
+  const envelope = {
     schema: 'openclaw.k6.candidate-run-result.v1', candidateOnly: true, foldRequiresReview: true, canonicalFoldForbidden: true,
     candidate: { sha, docsRef },
     harness: { ...identity, manifestArtifact: 'row-manifest.json', scenarioArtifact: 'row-scenario.js' },
-    run: { id: `run-${row}`, rowId: row, seat: 'seat', scenario: 'r-cw-1' },
+    run: { id: `run-${row}`, rowId: row, seat: 'seat', scenario: 'r-cw-1', executionKind: 'row-list-runner' },
     result: { outcome: 'PASS-candidate', outcomeSource: 'k6-summary', effectiveExitCode: 0, behaviorProof: false },
     observability: { traceStatus: 'present', traceCaptured: true, correlationReceiptPresent: true },
     review: { status: 'ready-for-human-review', pendingReceipts: [], complete: true },
-  });
-  return identity;
+    artifacts: envelopeArtifacts({ correlationReceipt: 'continuation-correlation.json' }),
+  };
+  await writeFile(path.join(dir, 'runner-metadata.json'), `${JSON.stringify(metadata)}\n`);
+  await writeResult(root, row, runResult);
+  await writeCandidateResult(root, row, envelope);
+  return { dir, identity, manifest: JSON.parse(manifestBody), metadata, runResult, envelope };
 }
 
 test('summarizes trace-missing debt as unfetchable when no trace id exists', async () => {
@@ -117,7 +134,14 @@ test('renders human-readable review debt table', async () => {
 test('consumes the versioned candidate envelope without double-counting its legacy run result', async () => {
   const root = await mkdtemp(path.join(tmpdir(), 'review-debt-envelope-'));
   try {
-    await writeValidatedEnvelopeFixture(root, 'R-CW-1');
+    const fixture = await writeValidatedEnvelopeFixture(root, 'R-CW-1');
+    assert.equal(candidateEnvelopeMatchesSiblings({
+      envelope: fixture.envelope,
+      manifest: fixture.manifest,
+      metadata: fixture.metadata,
+      runResult: fixture.runResult,
+      runDir: fixture.dir,
+    }), true);
     const run = await runNode(process.execPath, [script, '--run-root', root, '--json'], { encoding: 'utf8' });
     const summary = JSON.parse(run.stdout);
     assert.equal(summary.totalRows, 1);
@@ -151,11 +175,12 @@ test('never lets malformed, mismatched, incomplete, or hand-written envelopes su
   }
 });
 
-test('falls back to raw review debt when an identity-valid sidecar forges trace observability', async () => {
+test('falls back to raw review debt while the raw sibling remains review-pending', async () => {
   const root = await mkdtemp(path.join(tmpdir(), 'review-debt-envelope-observability-forgery-'));
   try {
-    const row = 'R-CD-2';
-    const identity = await writeValidatedEnvelopeFixture(root, row);
+    const row = 'R-CW-2';
+    const fixture = await writeValidatedEnvelopeFixture(root, row);
+    const { identity } = fixture;
     const dir = path.join(root, 'candidate-sha', row, 'seat', `run-${row}`);
     await writeResult(root, row, {
       candidateOnly: true, foldRequiresReview: true, effectiveExitCode: 0, verdict: 'PASS-candidate', verdictSource: 'k6-summary',
@@ -166,10 +191,11 @@ test('falls back to raw review debt when an identity-valid sidecar forges trace 
       schema: 'openclaw.k6.candidate-run-result.v1', candidateOnly: true, foldRequiresReview: true, canonicalFoldForbidden: true,
       candidate: { sha: 'a'.repeat(40), docsRef },
       harness: { ...identity, manifestArtifact: 'row-manifest.json', scenarioArtifact: 'row-scenario.js' },
-      run: { id: `run-${row}`, rowId: row, seat: 'seat', scenario: 'r-cw-1' },
+      run: { id: `run-${row}`, rowId: row, seat: 'seat', scenario: 'r-cw-1', executionKind: 'row-list-runner' },
       result: { outcome: 'PASS-candidate', outcomeSource: 'k6-summary', effectiveExitCode: 0, behaviorProof: false },
-      observability: { traceStatus: 'present', traceCaptured: true, correlationReceiptPresent: true },
+      observability: { traceStatus: 'missing', traceCaptured: false, correlationReceiptPresent: false },
       review: { status: 'ready-for-human-review', pendingReceipts: [], complete: true },
+      artifacts: envelopeArtifacts(),
     }, null, 2)}\n`);
     const run = await runNode(process.execPath, [script, '--run-root', root, '--json'], { encoding: 'utf8' });
     const summary = JSON.parse(run.stdout);

--- a/tools/k6-proofs/scripts/candidate-run-result-contract.mjs
+++ b/tools/k6-proofs/scripts/candidate-run-result-contract.mjs
@@ -29,6 +29,9 @@ export const SAFE_CANDIDATE_ARTIFACTS = new Set([
 ]);
 
 export function isSafeCandidateArtifact(name) {
+  // Basename only. `../../private-summary.json` must never satisfy the summary
+  // pattern, and no artifact entry may traverse out of the candidate directory.
+  if (typeof name !== 'string' || !name || name.includes('/') || name.includes('\\') || name === '.' || name === '..') return false;
   return SAFE_CANDIDATE_ARTIFACTS.has(name) || /(?:^|-)summary\.json$/i.test(name);
 }
 
@@ -71,11 +74,31 @@ function envelopeShapeIsCanonical(envelope) {
   }
   if (Object.prototype.hasOwnProperty.call(envelope, 'authoritativeReceipt') &&
       !hasExactKeys(envelope.authoritativeReceipt, ENVELOPE_KEYS.authoritativeReceipt)) return false;
+  if (envelope.run.executionKind !== 'row-list-runner') return false;
   const artifacts = envelope.artifacts;
   if (artifacts.manifest !== COPIED_MANIFEST || artifacts.scenario !== COPIED_SCENARIO) return false;
   if (artifacts.runnerMetadata !== 'runner-metadata.json' || artifacts.runResult !== 'run-result.json') return false;
-  if (!Array.isArray(artifacts.files) || !artifacts.files.every((name) => typeof name === 'string' && isSafeCandidateArtifact(name))) return false;
+  if (!Array.isArray(artifacts.files) || !artifacts.files.every(isSafeCandidateArtifact)) return false;
+  for (const optional of ['tempoTraceJson', 'correlationReceipt']) {
+    const value = artifacts[optional];
+    if (value !== null && !isSafeArtifactReference(value)) return false;
+  }
   return true;
+}
+
+// Observability artifact names are emitted straight from the raw run result, so
+// they must be basename-only and must still agree with that sibling.
+export function isSafeArtifactReference(value) {
+  return typeof value === 'string' && /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(value);
+}
+
+function artifactReferencesMatchRunResult(envelope, runResult) {
+  const observability = runResult?.observability || {};
+  const pairs = [
+    [envelope.artifacts.tempoTraceJson, observability.tempoTraceJson],
+    [envelope.artifacts.correlationReceipt, observability.correlationReceipt],
+  ];
+  return pairs.every(([declared, raw]) => (declared ?? null) === (raw ?? null));
 }
 
 function nonEmptyString(value) {
@@ -200,6 +223,11 @@ export function candidateEnvelopeMatchesSiblings({ envelope, manifest, metadata,
   if (!rowId || !candidateSha || !seat || !scenario || !SHA.test(candidateSha)) return false;
   if (!hasVerifiedRrc2Outcome(rowId, envelope.result.outcome, runResult.evidence)) return false;
   const authoritative = authoritativeReceiptContract(rowId);
+  // A row with no row-scoped resolver must not carry an authoritative receipt
+  // declaration at all: that block is the sole verdict authority where it
+  // applies, and it may not be introduced anywhere else.
+  if (!authoritative && Object.prototype.hasOwnProperty.call(envelope, 'authoritativeReceipt')) return false;
+  if (authoritative && !Object.prototype.hasOwnProperty.call(envelope, 'authoritativeReceipt')) return false;
   if (authoritative && (
     runResult.verdictSource !== authoritative.verdictSource ||
     runResult.authoritativeReceipt?.validated !== true ||
@@ -207,6 +235,7 @@ export function candidateEnvelopeMatchesSiblings({ envelope, manifest, metadata,
     runResult.authoritativeReceipt?.file !== authoritative.file ||
     !existsSync(path.join(runDir, authoritative.file))
   )) return false;
+  if (!artifactReferencesMatchRunResult(envelope, runResult)) return false;
   if (manifest.rowId !== rowId || scenarioName(manifest) !== scenario) return false;
   if (manifest.candidateSha && manifest.candidateSha !== candidateSha) return false;
   if (envelope.candidate?.sha !== candidateSha || !SHA.test(envelope.candidate?.docsRef || '')) return false;

--- a/tools/k6-proofs/scripts/candidate-run-result-contract.mjs
+++ b/tools/k6-proofs/scripts/candidate-run-result-contract.mjs
@@ -8,10 +8,47 @@ export const CANDIDATE_RUN_RESULT_SCHEMA = 'openclaw.k6.candidate-run-result.v1'
 export const PROOF_ROW_MANIFEST_SCHEMA = 'openclaw.k6.proof-row-manifest.v1';
 
 const SHA = /^[0-9a-f]{40}$/;
+const DIGEST = /^[0-9a-f]{64}$/;
+const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const COPIED_MANIFEST = 'row-manifest.json';
+const COPIED_SCENARIO = 'row-scenario.js';
 const OUTCOMES = new Set(['PASS-candidate', 'HONEST-LIMIT-candidate', 'PARTIAL-candidate', 'FAIL-candidate', 'construct-only']);
 
 function nonEmptyString(value) {
   return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function fileDigest(file) {
+  try {
+    return createHash('sha256').update(readFileSync(file)).digest('hex');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Re-verify the immutable harness identity a sidecar envelope claims (#496).
+ *
+ * A sidecar may only suppress its raw sibling when the run metadata records the
+ * approved docs ref plus both source digests, the envelope repeats them exactly,
+ * and the copied manifest/scenario bytes still hash to those digests.
+ */
+function harnessIdentityMatches({ envelope, metadata, runDir }) {
+  const harness = envelope?.harness;
+  if (!harness) return false;
+  const docsRef = nonEmptyString(metadata.docsRef);
+  const repository = nonEmptyString(metadata.repository);
+  const manifestSha256 = nonEmptyString(metadata.manifestSha256);
+  const scenarioSha256 = nonEmptyString(metadata.scenarioSha256);
+  if (!SHA.test(docsRef || '') || !REPOSITORY.test(repository || '')) return false;
+  if (!DIGEST.test(manifestSha256 || '') || !DIGEST.test(scenarioSha256 || '')) return false;
+  if (envelope.candidate?.docsRef !== docsRef) return false;
+  if (harness.docsRef !== docsRef || harness.repository !== repository) return false;
+  if (harness.manifestSha256 !== manifestSha256 || harness.scenarioSha256 !== scenarioSha256) return false;
+  if (harness.manifestArtifact !== COPIED_MANIFEST || harness.scenarioArtifact !== COPIED_SCENARIO) return false;
+  if (fileDigest(path.join(runDir, COPIED_MANIFEST)) !== manifestSha256) return false;
+  if (fileDigest(path.join(runDir, COPIED_SCENARIO)) !== scenarioSha256) return false;
+  return true;
 }
 
 function scenarioName(manifest) {
@@ -103,6 +140,7 @@ export function candidateEnvelopeMatchesSiblings({ envelope, manifest, metadata,
   if (manifest.rowId !== rowId || scenarioName(manifest) !== scenario) return false;
   if (manifest.candidateSha && manifest.candidateSha !== candidateSha) return false;
   if (envelope.candidate?.sha !== candidateSha || !SHA.test(envelope.candidate?.docsRef || '')) return false;
+  if (!harnessIdentityMatches({ envelope, metadata, runDir })) return false;
   if (envelope.run?.id !== path.basename(runDir) || envelope.run?.rowId !== rowId || envelope.run?.seat !== seat || envelope.run?.scenario !== scenario) return false;
   if (envelope.result?.outcome !== runResult.verdict || envelope.result?.outcomeSource !== runResult.verdictSource) return false;
   if (authoritative) {

--- a/tools/k6-proofs/scripts/candidate-run-result-contract.mjs
+++ b/tools/k6-proofs/scripts/candidate-run-result-contract.mjs
@@ -10,9 +10,73 @@ export const PROOF_ROW_MANIFEST_SCHEMA = 'openclaw.k6.proof-row-manifest.v1';
 const SHA = /^[0-9a-f]{40}$/;
 const DIGEST = /^[0-9a-f]{64}$/;
 const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
-const COPIED_MANIFEST = 'row-manifest.json';
-const COPIED_SCENARIO = 'row-scenario.js';
+const HARNESS_MANIFEST_PATH = /^tools\/k6-proofs\/manifests\/[A-Za-z0-9._-]+\.json$/;
+const HARNESS_SCENARIO_PATH = /^tools\/k6-proofs\/scenarios\/[A-Za-z0-9._-]+\.js$/;
+export const COPIED_MANIFEST = 'row-manifest.json';
+export const COPIED_SCENARIO = 'row-scenario.js';
 const OUTCOMES = new Set(['PASS-candidate', 'HONEST-LIMIT-candidate', 'PARTIAL-candidate', 'FAIL-candidate', 'construct-only']);
+
+// The exact public-safe artifact names a candidate directory may publish. Both
+// the emitter and this consumer contract use this one list.
+export const SAFE_CANDIDATE_ARTIFACTS = new Set([
+  COPIED_MANIFEST, COPIED_SCENARIO, 'runner-metadata.json', 'run-result.json',
+  'candidate-run-result.json', 'seat-readiness.json', 'evidence.jsonl',
+  'r-cd-2-authoritative-receipt.json',
+  'attempt-state.json', 'build-identity-gate.json', 'interruption-receipt.json',
+  'r-cd-token-authoritative-receipt.json',
+  'evidence-lines.log', 'evidence-redaction.json', 'gateway-journal.log',
+  'gateway-journal-capture.json', 'gateway-journal-redaction.json',
+]);
+
+export function isSafeCandidateArtifact(name) {
+  return SAFE_CANDIDATE_ARTIFACTS.has(name) || /(?:^|-)summary\.json$/i.test(name);
+}
+
+// The envelope is machine-generated with a fixed shape. Refusing unknown keys
+// stops a hand-edited sidecar from smuggling extra material (a token, a private
+// path, raw process output) past review while every checked field still agrees.
+const ENVELOPE_KEYS = {
+  root: {
+    required: ['schema', 'candidateOnly', 'foldRequiresReview', 'canonicalFoldForbidden', 'candidate', 'harness', 'run', 'result', 'observability', 'review', 'artifacts'],
+    optional: ['authoritativeReceipt'],
+  },
+  candidate: { required: ['sha', 'docsRef'], optional: [] },
+  harness: {
+    required: ['docsRef', 'repository', 'manifestPath', 'manifestSha256', 'scenarioPath', 'scenarioSha256', 'manifestArtifact', 'scenarioArtifact'],
+    optional: [],
+  },
+  run: { required: ['id', 'rowId', 'seat', 'scenario', 'executionKind'], optional: [] },
+  result: { required: ['outcome', 'outcomeSource', 'effectiveExitCode', 'behaviorProof'], optional: [] },
+  observability: { required: ['traceStatus', 'traceCaptured', 'correlationReceiptPresent'], optional: [] },
+  review: { required: ['status', 'pendingReceipts', 'complete'], optional: [] },
+  artifacts: {
+    required: ['manifest', 'scenario', 'runnerMetadata', 'runResult', 'files', 'tempoTraceJson', 'correlationReceipt'],
+    optional: [],
+  },
+  authoritativeReceipt: { required: ['file', 'sha256'], optional: [] },
+};
+
+function hasExactKeys(value, spec) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const keys = Object.keys(value);
+  const allowed = new Set([...spec.required, ...spec.optional]);
+  if (keys.some((key) => !allowed.has(key))) return false;
+  return spec.required.every((key) => Object.prototype.hasOwnProperty.call(value, key));
+}
+
+function envelopeShapeIsCanonical(envelope) {
+  if (!hasExactKeys(envelope, ENVELOPE_KEYS.root)) return false;
+  for (const section of ['candidate', 'harness', 'run', 'result', 'observability', 'review', 'artifacts']) {
+    if (!hasExactKeys(envelope[section], ENVELOPE_KEYS[section])) return false;
+  }
+  if (Object.prototype.hasOwnProperty.call(envelope, 'authoritativeReceipt') &&
+      !hasExactKeys(envelope.authoritativeReceipt, ENVELOPE_KEYS.authoritativeReceipt)) return false;
+  const artifacts = envelope.artifacts;
+  if (artifacts.manifest !== COPIED_MANIFEST || artifacts.scenario !== COPIED_SCENARIO) return false;
+  if (artifacts.runnerMetadata !== 'runner-metadata.json' || artifacts.runResult !== 'run-result.json') return false;
+  if (!Array.isArray(artifacts.files) || !artifacts.files.every((name) => typeof name === 'string' && isSafeCandidateArtifact(name))) return false;
+  return true;
+}
 
 function nonEmptyString(value) {
   return typeof value === 'string' && value.trim() ? value : null;
@@ -30,20 +94,25 @@ function fileDigest(file) {
  * Re-verify the immutable harness identity a sidecar envelope claims (#496).
  *
  * A sidecar may only suppress its raw sibling when the run metadata records the
- * approved docs ref plus both source digests, the envelope repeats them exactly,
- * and the copied manifest/scenario bytes still hash to those digests.
+ * approved docs ref, the repository identity, both harness source paths, and
+ * both source digests; when the envelope repeats every one of them exactly; and
+ * when the copied manifest/scenario bytes still hash to those digests.
  */
 function harnessIdentityMatches({ envelope, metadata, runDir }) {
   const harness = envelope?.harness;
   if (!harness) return false;
   const docsRef = nonEmptyString(metadata.docsRef);
   const repository = nonEmptyString(metadata.repository);
+  const manifestPath = nonEmptyString(metadata.manifestPath);
+  const scenarioPath = nonEmptyString(metadata.scenarioPath);
   const manifestSha256 = nonEmptyString(metadata.manifestSha256);
   const scenarioSha256 = nonEmptyString(metadata.scenarioSha256);
   if (!SHA.test(docsRef || '') || !REPOSITORY.test(repository || '')) return false;
+  if (!HARNESS_MANIFEST_PATH.test(manifestPath || '') || !HARNESS_SCENARIO_PATH.test(scenarioPath || '')) return false;
   if (!DIGEST.test(manifestSha256 || '') || !DIGEST.test(scenarioSha256 || '')) return false;
   if (envelope.candidate?.docsRef !== docsRef) return false;
   if (harness.docsRef !== docsRef || harness.repository !== repository) return false;
+  if (harness.manifestPath !== manifestPath || harness.scenarioPath !== scenarioPath) return false;
   if (harness.manifestSha256 !== manifestSha256 || harness.scenarioSha256 !== scenarioSha256) return false;
   if (harness.manifestArtifact !== COPIED_MANIFEST || harness.scenarioArtifact !== COPIED_SCENARIO) return false;
   if (fileDigest(path.join(runDir, COPIED_MANIFEST)) !== manifestSha256) return false;
@@ -114,6 +183,7 @@ function authoritativeReceiptContract(rowId) {
 // canonical fold or behavioral PASS.
 export function candidateEnvelopeMatchesSiblings({ envelope, manifest, metadata, runResult, runDir }) {
   if (!envelope || envelope.schema !== CANDIDATE_RUN_RESULT_SCHEMA) return false;
+  if (!envelopeShapeIsCanonical(envelope)) return false;
   if (envelope.candidateOnly !== true || envelope.foldRequiresReview !== true || envelope.canonicalFoldForbidden !== true) return false;
   if (envelope.result?.behaviorProof !== false || !OUTCOMES.has(envelope.result?.outcome)) return false;
   if (envelope.result?.effectiveExitCode !== 0) return false;

--- a/tools/k6-proofs/scripts/check-manifest-scenarios.mjs
+++ b/tools/k6-proofs/scripts/check-manifest-scenarios.mjs
@@ -7,14 +7,17 @@
  *     tools/k6-proofs/scenarios/*.js file via scenario.file (or scenario.name), or
  *   - declares scenario.status="scaffold" / "construct-only" to make a missing
  *     scenario intentionally non-runnable instead of accidental.
+ *
+ * The repository root comes from the shared repo-root contract, so running this
+ * from the repository root and from tools/k6-proofs inspects the same files.
  */
 import { readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
+import { proofsToolPath, resolveRepositoryRoot } from '../lib/repo-root.mjs';
 
-const root = process.cwd();
-const proofsDir = path.join(root, 'tools', 'k6-proofs');
-const manifestsDir = path.join(proofsDir, 'manifests');
-const scenariosDir = path.join(proofsDir, 'scenarios');
+const { root } = resolveRepositoryRoot({ argv: process.argv.slice(2) });
+const manifestsDir = proofsToolPath(root, 'manifests');
+const scenariosDir = proofsToolPath(root, 'scenarios');
 const validStatuses = new Set(['runnable', 'scaffold', 'construct-only']);
 const validSafetyClasses = new Set(['static-preflight-only', 'k6-runnable', 'orchestration-required', 'construct-only']);
 const validArtifactClasses = new Set(['PASS-candidate', 'HONEST-LIMIT-candidate', 'PARTIAL-candidate', 'FAIL-candidate', 'construct-only']);

--- a/tools/k6-proofs/scripts/check-proof-row-manifests.mjs
+++ b/tools/k6-proofs/scripts/check-proof-row-manifests.mjs
@@ -5,13 +5,17 @@
  * This does not require every proof row to be k6-runnable. Manual-only rows may be
  * construct-only or scaffold, but they should still be explicit in the catalog so
  * the public executable-suite surface can explain the full 29-row corpus.
+ *
+ * The repository root comes from the shared repo-root contract, so running this
+ * from the repository root and from tools/k6-proofs inspects the same files.
  */
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
+import { proofsToolPath, resolveRepositoryRoot } from '../lib/repo-root.mjs';
 
-const root = process.cwd();
+const { root } = resolveRepositoryRoot({ argv: process.argv.slice(2) });
 const indexPath = path.join(root, 'PROOFS', 'INDEX.json');
-const manifestsDir = path.join(root, 'tools', 'k6-proofs', 'manifests');
+const manifestsDir = proofsToolPath(root, 'manifests');
 const failures = [];
 const SUPPORT_DIRECTORIES = new Set(['artifacts', 'gates']);
 

--- a/tools/k6-proofs/scripts/check-scenario-alignment.mjs
+++ b/tools/k6-proofs/scripts/check-scenario-alignment.mjs
@@ -8,13 +8,17 @@
  * - every manifest uses the current scenario.status registry contract:
  *   - runnable manifests point at an existing scenario via scenario.file or name
  *   - scaffold / construct-only manifests explicitly mark intentional non-runnable rows
+ *
+ * The repository root comes from the shared repo-root contract, so running this
+ * from the repository root and from tools/k6-proofs inspects the same files.
  */
 import fs from 'node:fs';
 import path from 'node:path';
+import { proofsToolPath, resolveRepositoryRoot } from '../lib/repo-root.mjs';
 
-const ROOT = process.cwd();
-const SCENARIO_DIR = path.join(ROOT, 'tools/k6-proofs/scenarios');
-const MANIFEST_DIR = path.join(ROOT, 'tools/k6-proofs/manifests');
+const { root: ROOT } = resolveRepositoryRoot({ argv: process.argv.slice(2) });
+const SCENARIO_DIR = proofsToolPath(ROOT, 'scenarios');
+const MANIFEST_DIR = proofsToolPath(ROOT, 'manifests');
 const WORKFLOW_PATH = path.join(ROOT, '.github/workflows/k6-proof.yml');
 const VALID_STATUSES = new Set(['runnable', 'scaffold', 'construct-only']);
 const VALID_SAFETY_CLASSES = new Set(['static-preflight-only', 'k6-runnable', 'orchestration-required', 'construct-only']);

--- a/tools/k6-proofs/scripts/list-runnable-rows.mjs
+++ b/tools/k6-proofs/scripts/list-runnable-rows.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { proofsToolPath, resolveRepositoryRoot } from '../lib/repo-root.mjs';
 
-const args = new Set(process.argv.slice(2));
-const root = process.cwd().endsWith('/tools/k6-proofs') ? process.cwd() : join(process.cwd(), 'tools/k6-proofs');
-const manifestsDir = join(root, 'manifests');
+const { root, rest } = resolveRepositoryRoot({ argv: process.argv.slice(2) });
+const args = new Set(rest);
+const manifestsDir = proofsToolPath(root, 'manifests');
 const rows = [];
 for (const file of readdirSync(manifestsDir).filter((name) => name.endsWith('.json')).sort()) {
   const manifest = JSON.parse(readFileSync(join(manifestsDir, file), 'utf8'));

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -14,23 +14,36 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-RUNNER_SCRIPT_PATH="$SCRIPT_DIR/$(basename "${BASH_SOURCE[0]}")"
-PROOFS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-REPO_ROOT="$(cd "$PROOFS_DIR/../.." && pwd)"
+RUNNER_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER_SCRIPT_PATH="$RUNNER_SCRIPT_DIR/$(basename "${BASH_SOURCE[0]}")"
+# The operator's checkout. Identity is always verified against this tree.
+REPO_ROOT="$(cd "$RUNNER_SCRIPT_DIR/../../.." && pwd)"
 PROOFS_TOOL_RELPATH="tools/k6-proofs"
+# The tree harness components are executed from. For a live run this is replaced
+# by an immutable snapshot of the approved docs ref (see bind_execution_roots).
+EXEC_ROOT="$REPO_ROOT"
+SCRIPT_DIR="$RUNNER_SCRIPT_DIR"
+PROOFS_DIR="$(cd "$RUNNER_SCRIPT_DIR/.." && pwd)"
+HARNESS_SNAPSHOT_ROOT=""
 # Infrastructure exit code (EX_CONFIG). It is deliberately distinct from a row's
 # effective exit code so a harness setup failure can never be read as a product
 # verdict.
 HARNESS_INFRA_EXIT=78
 CATALOG_CHECKS=(check-manifest-scenarios.mjs check-scenario-alignment.mjs check-proof-row-manifests.mjs)
-EVIDENCE_EXTRACTOR="$SCRIPT_DIR/extract-k6-evidence.mjs"
-CONTINUATION_TRACE_COLLECTOR="$SCRIPT_DIR/collect-continuation-trace.mjs"
-R_CD_2_RECEIPT_RESOLVER="$SCRIPT_DIR/resolve-r-cd-2-authoritative-receipt.mjs"
-ARTIFACT_SANITIZER="$SCRIPT_DIR/sanitize-k6-artifacts.mjs"
-CANDIDATE_RESULT_VALIDATOR="$SCRIPT_DIR/validate-candidate-run-result.mjs"
-INTERRUPTED_RESULT_WRITER="$SCRIPT_DIR/write-interrupted-run-result.mjs"
-R_CD_TOKEN_RECEIPT_RESOLVER="$SCRIPT_DIR/resolve-r-cd-token-authoritative-receipt.mjs"
+
+# Point every executed harness component at the current execution root.
+bind_execution_roots() {
+  PROOFS_DIR="$EXEC_ROOT/$PROOFS_TOOL_RELPATH"
+  SCRIPT_DIR="$PROOFS_DIR/scripts"
+  EVIDENCE_EXTRACTOR="$SCRIPT_DIR/extract-k6-evidence.mjs"
+  CONTINUATION_TRACE_COLLECTOR="$SCRIPT_DIR/collect-continuation-trace.mjs"
+  R_CD_2_RECEIPT_RESOLVER="$SCRIPT_DIR/resolve-r-cd-2-authoritative-receipt.mjs"
+  ARTIFACT_SANITIZER="$SCRIPT_DIR/sanitize-k6-artifacts.mjs"
+  CANDIDATE_RESULT_VALIDATOR="$SCRIPT_DIR/validate-candidate-run-result.mjs"
+  INTERRUPTED_RESULT_WRITER="$SCRIPT_DIR/write-interrupted-run-result.mjs"
+  R_CD_TOKEN_RECEIPT_RESOLVER="$SCRIPT_DIR/resolve-r-cd-token-authoritative-receipt.mjs"
+}
+bind_execution_roots
 PRIVATE_K6_LOG=""
 PRIVATE_EVIDENCE_FILE=""
 PRIVATE_GATEWAY_LOG=""
@@ -48,6 +61,7 @@ cleanup_private_artifacts() {
     "${PRIVATE_GATEWAY_LOG:-}" \
     "${CATALOG_PREFLIGHT_RAW_FILE:-}" \
     "${SOURCE_CONTRACT_FILE:-}"
+  if [[ -n "${HARNESS_SNAPSHOT_ROOT:-}" ]]; then rm -rf "$HARNESS_SNAPSHOT_ROOT"; fi
 }
 
 finalize_interrupted_token_run() {
@@ -86,6 +100,7 @@ HARNESS_IDENTITY_VERIFIED=false
 ROW_SELECTION_JSON='[]'
 PROVISIONAL_RUN_DIR=""
 ROWS_DISPATCHED=0
+ROWS_TERMINAL_PRE_DISPATCH=0
 MATRIX_NONCE=""
 declare -A ROW_MANIFEST_RELPATH=()
 declare -A ROW_MANIFEST_SHA256=()
@@ -170,6 +185,7 @@ scrub_public_text() {
     process.stdin.on("data", (chunk) => { data += chunk; });
     process.stdin.on("end", () => {
       const replacements = [
+        [process.argv[4], "<harness>"],
         [process.argv[1], "<repo-root>"],
         [process.argv[2], "<out-root>"],
         [process.argv[3], "<home>"],
@@ -180,7 +196,7 @@ scrub_public_text() {
       }
       process.stdout.write(out);
     });
-  ' "$REPO_ROOT" "$OUT_ROOT" "${HOME:-}"
+  ' "$REPO_ROOT" "$OUT_ROOT" "${HOME:-}" "${HARNESS_SNAPSHOT_ROOT:-}"
 }
 
 # One harness infrastructure receipt, written instead of any per-row product
@@ -205,6 +221,7 @@ write_harness_control_receipt() {
     --arg recordedAt "$recorded_at" \
     --argjson exitCode "$HARNESS_INFRA_EXIT" \
     --argjson rowsExecuted "${ROWS_DISPATCHED:-0}" \
+    --argjson rowsTerminatedPreDispatch "${ROWS_TERMINAL_PRE_DISPATCH:-0}" \
     --argjson rowSelection "$(safe_row_selection_json)" \
     --argjson detail "$detail_json" \
     '{
@@ -220,6 +237,7 @@ write_harness_control_receipt() {
       repository: (if $repository == "" then null else $repository end),
       rowSelection: $rowSelection,
       rowsExecuted: $rowsExecuted,
+      rowsTerminatedPreDispatch: $rowsTerminatedPreDispatch,
       rowVerdictsSynthesized: false,
       productVerdict: null,
       exitCode: $exitCode,
@@ -228,7 +246,7 @@ write_harness_control_receipt() {
     }' > "$OUT_ROOT/harness-control-receipt.json"
   echo "HARNESS INFRASTRUCTURE FAILURE [$stage]: $reason" >&2
   echo "CONTROL RECEIPT: $OUT_ROOT/harness-control-receipt.json" >&2
-  echo "Rows dispatched before this failure: ${ROWS_DISPATCHED:-0}. No per-row candidate verdict was synthesized." >&2
+  echo "k6 dispatches before this failure: ${ROWS_DISPATCHED:-0}; pre-dispatch terminal results: ${ROWS_TERMINAL_PRE_DISPATCH:-0}. No per-row candidate verdict was synthesized." >&2
 }
 
 safe_sha_or_marker() {
@@ -398,7 +416,9 @@ assert_harness_tree_matches_docs_ref() {
   fi
   expected_objects="$(printf '%s\n' "$listing" | cut -f1 | awk '{print $3}')"
   paths="$(printf '%s\n' "$listing" | cut -f2-)"
-  actual_objects="$(printf '%s\n' "$paths" | harness_git hash-object --stdin-paths 2>/dev/null || true)"
+  # --no-filters: a configured clean filter would otherwise be able to transform
+  # dirty bytes into the approved blob hash, and would itself execute here.
+  actual_objects="$(printf '%s\n' "$paths" | harness_git hash-object --no-filters --stdin-paths 2>/dev/null || true)"
   if [[ "$expected_objects" != "$actual_objects" ]]; then
     local expected_count actual_count
     expected_count="$(printf '%s\n' "$expected_objects" | grep -c . || true)"
@@ -417,8 +437,9 @@ assert_harness_tree_matches_docs_ref() {
   fi
 }
 
-worktree_sha256() {
-  sha256sum "$REPO_ROOT/$1" 2>/dev/null | cut -d' ' -f1
+# Hash the bytes that will actually execute (the snapshot for a live run).
+exec_sha256() {
+  sha256sum "$EXEC_ROOT/$1" 2>/dev/null | cut -d' ' -f1
 }
 
 # The digests are frozen once at startup, but k6 and the scenario read the
@@ -441,8 +462,8 @@ assert_row_bytes_frozen() {
       "$(jq -n --arg row "$row" --arg phase "$phase" '{check:"row-bound-to-docs-ref", row:$row, phase:$phase}')"
   fi
   local actual_manifest actual_scenario
-  actual_manifest="$(worktree_sha256 "$manifest_rel" || true)"
-  actual_scenario="$(worktree_sha256 "$scenario_rel" || true)"
+  actual_manifest="$(exec_sha256 "$manifest_rel" || true)"
+  actual_scenario="$(exec_sha256 "$scenario_rel" || true)"
   if [[ -z "$actual_manifest" || -z "$actual_scenario" ||
         "$actual_manifest" != "$expected_manifest" || "$actual_scenario" != "$expected_scenario" ]]; then
     fail_harness \
@@ -455,9 +476,10 @@ assert_row_bytes_frozen() {
         --argjson scenarioChanged "$(if [[ "$actual_scenario" != "$expected_scenario" ]]; then printf 'true'; else printf 'false'; fi)" \
         '{check:"frozen-bytes-still-current", row:$row, phase:$phase, manifestChanged:$manifestChanged, scenarioChanged:$scenarioChanged}')"
   fi
-  # A scenario is not self-contained: it imports the shared harness library.
-  # Re-verifying the whole tracked tree covers lib/, scripts/, and every other
-  # file a row can reach.
+  # The executed bytes live in an immutable snapshot, so this re-verification of
+  # the operator's checkout exists for a different reason: bash reads this very
+  # script incrementally, so run-proofs.sh itself must still match the approved
+  # ref while it is running.
   assert_harness_tree_matches_docs_ref "harness-tree-still-current" "$phase" "$row"
 }
 
@@ -498,6 +520,13 @@ if [[ "$DRY_RUN" == "false" ]]; then
 
   assert_harness_tree_matches_docs_ref "harness-tree-clean" "startup" ""
 
+  if [[ ! "${OPENCLAW_CANDIDATE_SHA:-}" =~ ^[0-9a-f]{40}$ ]]; then
+    fail_harness \
+      "harness-identity" \
+      "a live matrix requires an exact 40-character lowercase candidate SHA; unvalidated input must not reach artifact paths or metadata" \
+      "$(jq -n '{check:"candidate-sha-shape"}')"
+  fi
+
   if [[ ! "$DOCS_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
     fail_harness \
       "harness-identity" \
@@ -505,9 +534,30 @@ if [[ "$DRY_RUN" == "false" ]]; then
       "$(jq -n '{check:"repository-identity"}')"
   fi
 
+  # Everything executed from here on comes out of an immutable extract of the
+  # approved commit, not the operator's mutable working tree. This closes the
+  # check-then-use window for the catalog validators, seat readiness, k6, and
+  # every scenario import: those bytes cannot change while the matrix runs.
+  HARNESS_SNAPSHOT_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-k6-harness.XXXXXX")"
+  chmod 700 "$HARNESS_SNAPSHOT_ROOT"
+  if ! harness_git archive "$DOCS_REF" -- "$PROOFS_TOOL_RELPATH" | tar -x -C "$HARNESS_SNAPSHOT_ROOT"; then
+    fail_harness \
+      "harness-identity" \
+      "the approved $PROOFS_TOOL_RELPATH tree could not be extracted for immutable execution" \
+      "$(jq -n '{check:"harness-snapshot-extractable"}')"
+  fi
+  # Read-only corpus/workflow inputs the catalog validators need. They are never
+  # executed, so they are referenced rather than copied.
+  ln -s "$REPO_ROOT/PROOFS" "$HARNESS_SNAPSHOT_ROOT/PROOFS"
+  ln -s "$REPO_ROOT/.github" "$HARNESS_SNAPSHOT_ROOT/.github"
+  EXEC_ROOT="$HARNESS_SNAPSHOT_ROOT"
+  bind_execution_roots
+  cd "$PROOFS_DIR"
+
   HARNESS_IDENTITY_VERIFIED=true
   echo "Approved docs ref: $DOCS_REF ($DOCS_REPOSITORY)"
   echo "Harness identity: every tracked byte under $PROOFS_TOOL_RELPATH matches the approved docs ref."
+  echo "Harness execution: immutable snapshot of the approved tree."
 elif [[ "$DOCS_REF_INPUT" =~ ^[0-9a-f]{40}$ ]]; then
   DOCS_REF="$DOCS_REF_INPUT"
   DOCS_REF_SOURCE="approved-input"
@@ -527,7 +577,7 @@ publish_catalog_preflight_log() {
 }
 for CATALOG_CHECK in "${CATALOG_CHECKS[@]}"; do
   printf '### %s\n' "$CATALOG_CHECK" >> "$CATALOG_PREFLIGHT_RAW"
-  if ! run_with_minimal_env node "$SCRIPT_DIR/$CATALOG_CHECK" --repo-root "$REPO_ROOT" >> "$CATALOG_PREFLIGHT_RAW" 2>&1; then
+  if ! run_with_minimal_env node "$SCRIPT_DIR/$CATALOG_CHECK" --repo-root "$EXEC_ROOT" >> "$CATALOG_PREFLIGHT_RAW" 2>&1; then
     publish_catalog_preflight_log
     fail_harness \
       "catalog-preflight" \
@@ -576,9 +626,16 @@ if [[ "$DRY_RUN" == "false" ]]; then
     BIND_ROW="$(printf '%s' "$BIND_ROW" | tr '[:lower:]' '[:upper:]')"
     BIND_MANIFEST=""
     BIND_MANIFEST="$(find_manifest_relpath "$BIND_ROW" || true)"
-    # A row with no manifest is reported as SKIPPED by the row loop; it never
-    # fires, so it has no harness contract to bind.
-    [[ -n "$BIND_MANIFEST" ]] || continue
+    # The approved harness defines every row it can prove. A selected row with no
+    # manifest at the approved ref must fail once as infrastructure rather than
+    # be silently skipped, which is exactly how a matrix acquires a phantom
+    # denominator.
+    if [[ -z "$BIND_MANIFEST" ]]; then
+      fail_harness \
+        "harness-identity" \
+        "row $BIND_ROW has no manifest at the approved docs ref; unrecorded rows cannot be fired or counted" \
+        "$(jq -n --arg row "$BIND_ROW" --arg approved "$DOCS_REF" '{check:"row-recorded-at-docs-ref", row:$row, approved:$approved}')"
+    fi
     BIND_STATUS=""
     if ! BIND_STATUS="$(jq -r '.scenario.status // empty' "$BIND_MANIFEST" 2>/dev/null)"; then
       fail_harness \
@@ -611,8 +668,8 @@ if [[ "$DRY_RUN" == "false" ]]; then
           "$BIND_PATH is not tracked at the approved docs ref; unrecorded harness bytes cannot produce a receipt" \
           "$(jq -n --arg row "$BIND_ROW" --arg path "$BIND_PATH" --arg approved "$DOCS_REF" '{check:"tracked-at-docs-ref", row:$row, path:$path, approved:$approved}')"
       fi
-      BIND_WORKTREE="$(worktree_sha256 "$BIND_PATH")"
-      if [[ "$BIND_TRACKED" != "$BIND_WORKTREE" ]]; then
+      BIND_EXEC="$(exec_sha256 "$BIND_PATH")"
+      if [[ -z "$BIND_EXEC" || "$BIND_TRACKED" != "$BIND_EXEC" ]]; then
         fail_harness \
           "harness-identity" \
           "$BIND_PATH differs from the approved docs ref; refusing to fire mutated harness bytes" \
@@ -620,10 +677,10 @@ if [[ "$DRY_RUN" == "false" ]]; then
       fi
       if [[ "$BIND_PATH" == "$BIND_MANIFEST_REL" ]]; then
         ROW_MANIFEST_RELPATH["$BIND_ROW"]="$BIND_MANIFEST_REL"
-        ROW_MANIFEST_SHA256["$BIND_ROW"]="$BIND_WORKTREE"
+        ROW_MANIFEST_SHA256["$BIND_ROW"]="$BIND_EXEC"
       else
         ROW_SCENARIO_RELPATH["$BIND_ROW"]="$BIND_SCENARIO_REL"
-        ROW_SCENARIO_SHA256["$BIND_ROW"]="$BIND_WORKTREE"
+        ROW_SCENARIO_SHA256["$BIND_ROW"]="$BIND_EXEC"
       fi
     done
   done
@@ -808,13 +865,15 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
     # earlier run for the same candidate/row/seat within the same second.
     RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%s' "$ROW_ID" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-')-${MATRIX_NONCE}"
     RUN_DIR="$OUT_ROOT/$OPENCLAW_CANDIDATE_SHA/$ROW_ID/$OPENCLAW_SEAT_NAME/$RUN_ID"
-    if [[ -e "$RUN_DIR" ]]; then
+    # Atomic: the leaf mkdir fails if anything already owns this path, so this
+    # process can only ever purge a directory it created itself.
+    mkdir -p "$(dirname "$RUN_DIR")"
+    if ! mkdir "$RUN_DIR" 2>/dev/null; then
       fail_harness \
         "harness-identity" \
         "row $ROW_ID run directory already exists; refusing to write into another invocation's artifacts" \
         "$(jq -n --arg row "$ROW_ID" '{check:"run-directory-exclusive", row:$row}')"
     fi
-    mkdir -p "$RUN_DIR"
     PROVISIONAL_RUN_DIR="$RUN_DIR"
     touch "$RUN_DIR/.started"
     cp "$MANIFEST_FILE" "$RUN_DIR/row-manifest.json"
@@ -862,7 +921,7 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
           > "$RUN_DIR/run-result.json"
         rm -f "$RUN_DIR/.started"
         PROVISIONAL_RUN_DIR=""
-        ROWS_DISPATCHED=$((ROWS_DISPATCHED + 1))
+        ROWS_TERMINAL_PRE_DISPATCH=$((ROWS_TERMINAL_PRE_DISPATCH + 1))
         echo "[$ROW_ID] PARTIAL-candidate: exact equal candidate/runtime SHAs are required; no dispatch occurred."
         continue
       fi
@@ -904,7 +963,7 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
         ACTIVE_TOKEN_PHASE="pre-dispatch-surface-gate"
         ACTIVE_TOKEN_RUN_DIR=""
         PROVISIONAL_RUN_DIR=""
-        ROWS_DISPATCHED=$((ROWS_DISPATCHED + 1))
+        ROWS_TERMINAL_PRE_DISPATCH=$((ROWS_TERMINAL_PRE_DISPATCH + 1))
         echo "[$ROW_ID] PARTIAL-candidate: seat readiness class '$OPENCLAW_SEAT_CLASS' is not scanner-supported raw-final-text; no dispatch occurred."
         continue
       fi

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -34,7 +34,11 @@ HARNESS_VERIFIED_PATHS=("tools/k6-proofs" "PROOFS" ".github")
 EXEC_ROOT="$REPO_ROOT"
 SCRIPT_DIR="$RUNNER_SCRIPT_DIR"
 PROOFS_DIR="$(cd "$RUNNER_SCRIPT_DIR/.." && pwd)"
+# Only ever set for a snapshot THIS process created, or one whose handoff has
+# been fully authenticated. The EXIT trap removes it recursively, so an
+# unauthenticated claimed path must never reach this variable.
 HARNESS_SNAPSHOT_ROOT=""
+HARNESS_SNAPSHOT_SENTINEL=".openclaw-harness-snapshot"
 # Infrastructure exit code (EX_CONFIG). It is deliberately distinct from a row's
 # effective exit code so a harness setup failure can never be read as a product
 # verdict.
@@ -206,7 +210,7 @@ scrub_public_text() {
       }
       process.stdout.write(out);
     });
-  ' "$REPO_ROOT" "$OUT_ROOT" "${HOME:-}" "${HARNESS_SNAPSHOT_ROOT:-}"
+  ' "$REPO_ROOT" "$OUT_ROOT" "${HOME:-}" "${EXEC_ROOT:-}"
 }
 
 # One harness infrastructure receipt, written instead of any per-row product
@@ -532,6 +536,7 @@ if [[ "$DRY_RUN" == "false" ]]; then
   # way the remaining commands are guaranteed to be approved bytes is to hand
   # execution to the snapshot's own copy before any credential is loaded.
   if [[ -z "${OPENCLAW_PROOFS_HARNESS_SNAPSHOT:-}" ]]; then
+    # Created here, so this process owns its cleanup from the moment it exists.
     HARNESS_SNAPSHOT_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-k6-harness.XXXXXX")"
     chmod 700 "$HARNESS_SNAPSHOT_ROOT"
     # Every consumed tree is materialized, not referenced: static rows read the
@@ -544,7 +549,12 @@ if [[ "$DRY_RUN" == "false" ]]; then
         "the approved ${HARNESS_VERIFIED_PATHS[*]} trees could not be extracted for immutable execution" \
         "$(jq -n '{check:"harness-snapshot-extractable"}')"
     fi
+    # An unguessable ownership sentinel. Only a process that was handed this
+    # value may adopt (and therefore later delete) the snapshot.
+    HARNESS_SNAPSHOT_TOKEN="$(tr -d '-' < /proc/sys/kernel/random/uuid 2>/dev/null || printf '%04x%04x%04x%04x' "$RANDOM" "$RANDOM" "$RANDOM" "$RANDOM")"
+    (umask 077; printf '%s' "$HARNESS_SNAPSHOT_TOKEN" > "$HARNESS_SNAPSHOT_ROOT/$HARNESS_SNAPSHOT_SENTINEL")
     export OPENCLAW_PROOFS_HARNESS_SNAPSHOT="$HARNESS_SNAPSHOT_ROOT"
+    export OPENCLAW_PROOFS_HARNESS_SNAPSHOT_TOKEN="$HARNESS_SNAPSHOT_TOKEN"
     export OPENCLAW_PROOFS_ORIGIN_ROOT="$REPO_ROOT"
     echo "Harness execution: handing off to the approved runner in an immutable snapshot."
     # `exec` replaces this process, so no EXIT trap fires here and the snapshot
@@ -558,23 +568,31 @@ if [[ "$DRY_RUN" == "false" ]]; then
   # runner and that the snapshot is a distinct tree from the checkout. Otherwise
   # a modified external copy could set both variables, point them at clean
   # trees, skip the exec, and keep running.
-  HARNESS_SNAPSHOT_ROOT="$OPENCLAW_PROOFS_HARNESS_SNAPSHOT"
-  SNAPSHOT_RUNNER="$(readlink -f "$HARNESS_SNAPSHOT_ROOT/$PROOFS_TOOL_RELPATH/scripts/run-proofs.sh" 2>/dev/null || true)"
+  # The claimed path stays untrusted — and therefore NOT cleanup-owned — until
+  # every check below passes. Assigning it to HARNESS_SNAPSHOT_ROOT early would
+  # let a rejected handoff hand an arbitrary directory to the EXIT trap's rm -rf.
+  CLAIMED_SNAPSHOT_ROOT="$OPENCLAW_PROOFS_HARNESS_SNAPSHOT"
+  CLAIMED_SNAPSHOT_TOKEN="${OPENCLAW_PROOFS_HARNESS_SNAPSHOT_TOKEN:-}"
+  SNAPSHOT_RUNNER="$(readlink -f "$CLAIMED_SNAPSHOT_ROOT/$PROOFS_TOOL_RELPATH/scripts/run-proofs.sh" 2>/dev/null || true)"
   EXECUTING_RUNNER="$(readlink -f "$RUNNER_SCRIPT_PATH" 2>/dev/null || true)"
-  CANONICAL_SNAPSHOT="$(readlink -f "$HARNESS_SNAPSHOT_ROOT" 2>/dev/null || true)"
+  CANONICAL_SNAPSHOT="$(readlink -f "$CLAIMED_SNAPSHOT_ROOT" 2>/dev/null || true)"
   CANONICAL_ORIGIN="$(readlink -f "$REPO_ROOT" 2>/dev/null || true)"
+  SENTINEL_VALUE="$(cat "$CLAIMED_SNAPSHOT_ROOT/$HARNESS_SNAPSHOT_SENTINEL" 2>/dev/null || true)"
   if [[ -z "$SNAPSHOT_RUNNER" || -z "$EXECUTING_RUNNER" || "$EXECUTING_RUNNER" != "$SNAPSHOT_RUNNER" ||
         -z "$CANONICAL_SNAPSHOT" || -z "$CANONICAL_ORIGIN" ||
-        "$CANONICAL_SNAPSHOT" == "$CANONICAL_ORIGIN" || "$CANONICAL_SNAPSHOT" == "$CANONICAL_ORIGIN"/* ]]; then
+        "$CANONICAL_SNAPSHOT" == "$CANONICAL_ORIGIN" || "$CANONICAL_SNAPSHOT" == "$CANONICAL_ORIGIN"/* ||
+        -z "$CLAIMED_SNAPSHOT_TOKEN" || "$SENTINEL_VALUE" != "$CLAIMED_SNAPSHOT_TOKEN" ]]; then
     fail_harness \
       "harness-identity" \
       "the executing runner is not the approved snapshot's own runner; refusing a spoofed or aliased handoff" \
       "$(jq -n '{check:"snapshot-handoff-authentic"}')"
   fi
-  EXEC_ROOT="$HARNESS_SNAPSHOT_ROOT"
+  EXEC_ROOT="$CLAIMED_SNAPSHOT_ROOT"
   bind_execution_roots
   cd "$PROOFS_DIR"
   assert_harness_tree_matches_docs_ref "harness-snapshot-matches-docs-ref" "startup" "" "$EXEC_ROOT"
+  # Authenticated and verified: this process may now own its removal.
+  HARNESS_SNAPSHOT_ROOT="$CLAIMED_SNAPSHOT_ROOT"
 
   HARNESS_IDENTITY_VERIFIED=true
   echo "Approved docs ref: $DOCS_REF ($DOCS_REPOSITORY)"

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -15,6 +15,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER_SCRIPT_PATH="$SCRIPT_DIR/$(basename "${BASH_SOURCE[0]}")"
 PROOFS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="$(cd "$PROOFS_DIR/../.." && pwd)"
 PROOFS_TOOL_RELPATH="tools/k6-proofs"
@@ -427,7 +428,7 @@ fi
 # fires so the bundle always states which harness bytes and which product
 # candidate produced everything beneath it.
 HARNESS_PROVENANCE_JSON="$OUT_ROOT/harness-provenance.json"
-RUNNER_SCRIPT_SHA256="$(sha256sum "${BASH_SOURCE[0]}" | cut -d' ' -f1)"
+RUNNER_SCRIPT_SHA256="$(sha256sum "$RUNNER_SCRIPT_PATH" | cut -d' ' -f1)"
 RUN_MATRIX_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 PROVENANCE_ROWS_JSON='[]'
 for PROV_ROW in "${ROW_ARRAY[@]}"; do

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -1,15 +1,28 @@
 #!/usr/bin/env bash
 #
 # Seat-aware row-list runner for Project 81 / k6-proofs
-# References: #178 / #106 / #119 / #179 / #403
+# References: #178 / #106 / #119 / #179 / #403 / #495 / #496
 #
 # Usage:
 #   cd tools/k6-proofs
-#   ./scripts/run-proofs.sh [--dry-run] [--out-dir /tmp/k6-proof-runs] [R-CD-2,R-CD-4] [candidate_sha]
+#   ./scripts/run-proofs.sh [--dry-run] [--out-dir /tmp/k6-proof-runs] \
+#     [--docs-ref <40-hex>] [R-CD-2,R-CD-4] [candidate_sha]
+#
+# A live run binds itself to one immutable docs/harness commit before any row
+# fires. --docs-ref (or OPENCLAW_PROOFS_DOCS_REF) is resolved and frozen once at
+# startup; ambient HEAD is never re-read after rows have run.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROOFS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$PROOFS_DIR/../.." && pwd)"
+PROOFS_TOOL_RELPATH="tools/k6-proofs"
+# Infrastructure exit code (EX_CONFIG). It is deliberately distinct from a row's
+# effective exit code so a harness setup failure can never be read as a product
+# verdict.
+HARNESS_INFRA_EXIT=78
+CATALOG_CHECKS=(check-manifest-scenarios.mjs check-scenario-alignment.mjs check-proof-row-manifests.mjs)
 EVIDENCE_EXTRACTOR="$SCRIPT_DIR/extract-k6-evidence.mjs"
 CONTINUATION_TRACE_COLLECTOR="$SCRIPT_DIR/collect-continuation-trace.mjs"
 R_CD_2_RECEIPT_RESOLVER="$SCRIPT_DIR/resolve-r-cd-2-authoritative-receipt.mjs"
@@ -63,6 +76,16 @@ trap 'ACTIVE_TOKEN_CAUSE=signal-term; exit 143' TERM
 DRY_RUN=true
 ROWS=""
 CANDIDATE_SHA=""
+DOCS_REF_INPUT="${OPENCLAW_PROOFS_DOCS_REF:-}"
+DOCS_REF=""
+DOCS_REF_SOURCE="none"
+DOCS_REPOSITORY=""
+HARNESS_IDENTITY_VERIFIED=false
+ROW_SELECTION_JSON='[]'
+declare -A ROW_MANIFEST_RELPATH=()
+declare -A ROW_MANIFEST_SHA256=()
+declare -A ROW_SCENARIO_RELPATH=()
+declare -A ROW_SCENARIO_SHA256=()
 SESSION_SELECTOR="discord-channel:1466192485440164011"
 OUT_ROOT="${K6_PROOF_OUT_DIR:-/tmp/k6-proof-runs}"
 
@@ -72,6 +95,7 @@ while [[ "$#" -gt 0 ]]; do
     --live) DRY_RUN=false; shift ;;
     --session) SESSION_SELECTOR="$2"; shift 2 ;;
     --out-dir) OUT_ROOT="$2"; shift 2 ;;
+    --docs-ref) DOCS_REF_INPUT="$2"; shift 2 ;;
     *)
       if [[ -z "$ROWS" ]]; then
         ROWS="$1"
@@ -91,8 +115,69 @@ if [[ -z "$ROWS" ]]; then
   exit 1
 fi
 
+RUN_MODE="live"
+if [[ "$DRY_RUN" == "true" ]]; then RUN_MODE="dry-run"; fi
+ROW_SELECTION_JSON="$(printf '%s' "$ROWS" | jq -R 'split(",") | map(ascii_upcase)')"
+
+mkdir -p "$OUT_ROOT"
+OUT_ROOT="$(cd "$OUT_ROOT" && pwd)"
+# The runner owns its own harness root. Row/scenario/manifest lookups are always
+# relative to tools/k6-proofs, never to an ambient caller working directory.
+cd "$PROOFS_DIR"
+
+# One harness infrastructure receipt, written instead of any per-row product
+# verdict. A catalog/identity failure is a setup fault: no row may execute, and
+# nothing here may be read as candidate behavior.
+write_harness_control_receipt() {
+  local stage="$1"
+  local reason="$2"
+  local detail_json="${3:-null}"
+  local recorded_at
+  recorded_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  mkdir -p "$OUT_ROOT"
+  jq -n \
+    --arg stage "$stage" \
+    --arg reason "$reason" \
+    --arg mode "$RUN_MODE" \
+    --arg docsRef "$DOCS_REF" \
+    --arg docsRefInput "$DOCS_REF_INPUT" \
+    --arg candidate "${OPENCLAW_CANDIDATE_SHA:-}" \
+    --arg repository "$DOCS_REPOSITORY" \
+    --arg recordedAt "$recorded_at" \
+    --argjson exitCode "$HARNESS_INFRA_EXIT" \
+    --argjson rowSelection "$ROW_SELECTION_JSON" \
+    --argjson detail "$detail_json" \
+    '{
+      schema: "openclaw.k6.harness-control-receipt.v1",
+      classification: "harness-infrastructure",
+      ok: false,
+      stage: $stage,
+      reason: $reason,
+      mode: $mode,
+      docsRef: (if $docsRef == "" then null else $docsRef end),
+      docsRefRequested: (if $docsRefInput == "" then null else $docsRefInput end),
+      candidateSha: (if $candidate == "" then null else $candidate end),
+      repository: (if $repository == "" then null else $repository end),
+      rowSelection: $rowSelection,
+      rowsExecuted: 0,
+      rowVerdictsSynthesized: false,
+      productVerdict: null,
+      exitCode: $exitCode,
+      detail: $detail,
+      recordedAt: $recordedAt
+    }' > "$OUT_ROOT/harness-control-receipt.json"
+  echo "HARNESS INFRASTRUCTURE FAILURE [$stage]: $reason" >&2
+  echo "CONTROL RECEIPT: $OUT_ROOT/harness-control-receipt.json" >&2
+  echo "No rows executed; no per-row candidate verdict was synthesized." >&2
+}
+
+fail_harness() {
+  write_harness_control_receipt "$1" "$2" "${3:-null}"
+  exit "$HARNESS_INFRA_EXIT"
+}
+
 if [[ -z "$CANDIDATE_SHA" && -z "${OPENCLAW_CANDIDATE_SHA:-}" ]]; then
-  CANDIDATE_SHA="$(git rev-parse HEAD 2>/dev/null || echo 'unknown')"
+  CANDIDATE_SHA="$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo 'unknown')"
 fi
 
 if [[ -n "$CANDIDATE_SHA" ]]; then export OPENCLAW_CANDIDATE_SHA="${CANDIDATE_SHA}"; fi
@@ -149,6 +234,24 @@ echo "Target Candidate SHA: $OPENCLAW_CANDIDATE_SHA"
 echo "Deployed Runtime SHA: $OPENCLAW_RUNTIME_BUILD_SHA"
 echo "Session configured: true"
 echo "Artifact root: $OUT_ROOT"
+
+# Catalog preflight (#495). The validators receive one explicit repository root,
+# so they inspect the same files whatever directory the caller started in. A
+# failure here stops the matrix before any row executes.
+CATALOG_PREFLIGHT_LOG="$OUT_ROOT/catalog-preflight.log"
+: > "$CATALOG_PREFLIGHT_LOG"
+echo "Running catalog preflight (repository root: $PROOFS_TOOL_RELPATH resolved once)..."
+for CATALOG_CHECK in "${CATALOG_CHECKS[@]}"; do
+  printf '### %s\n' "$CATALOG_CHECK" >> "$CATALOG_PREFLIGHT_LOG"
+  if ! node "$SCRIPT_DIR/$CATALOG_CHECK" --repo-root "$REPO_ROOT" >> "$CATALOG_PREFLIGHT_LOG" 2>&1; then
+    fail_harness \
+      "catalog-preflight" \
+      "catalog validator '$CATALOG_CHECK' failed; the row catalog could not be resolved" \
+      "$(jq -n --arg check "$CATALOG_CHECK" '{failedCheck:$check, log:"catalog-preflight.log"}')"
+  fi
+done
+echo "CATALOG PREFLIGHT: $CATALOG_PREFLIGHT_LOG"
+
 if [[ "$ROWS" == "all" ]]; then
   ROWS="$(for f in manifests/*.json; do jq -r 'select(.scenario.status == "runnable") | .rowId' "$f"; done | paste -sd, -)"
 fi
@@ -158,9 +261,149 @@ if [[ -z "$ROWS" ]]; then
   exit 1
 fi
 
+ROW_SELECTION_JSON="$(printf '%s' "$ROWS" | jq -R 'split(",") | map(ascii_upcase)')"
+IFS=',' read -ra ROW_ARRAY <<< "$ROWS"
+
 echo "Rows: $ROWS"
 echo "Dry Run: $DRY_RUN"
 echo "=========================================================="
+
+# ---------------------------------------------------------------------------
+# Immutable harness identity (#496)
+# ---------------------------------------------------------------------------
+# Locate the manifest for a row id, echoing its tools/k6-proofs-relative path.
+find_manifest_relpath() {
+  local row="$1" candidate
+  for candidate in manifests/*.json; do
+    if jq -e --arg row "$row" '(.rowId | ascii_upcase) == $row' "$candidate" >/dev/null; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Public-safe repository identity. Only a real remote (scheme or scp form) is
+# accepted so a local clone path can never leak into a public receipt.
+resolve_docs_repository() {
+  local override url
+  override="${OPENCLAW_PROOFS_DOCS_REPOSITORY:-}"
+  if [[ -n "$override" ]]; then
+    printf '%s' "$override"
+    return 0
+  fi
+  url="$(git -C "$REPO_ROOT" config --get remote.origin.url 2>/dev/null || true)"
+  case "$url" in
+    *://*|*@*:*) ;;
+    *) return 0 ;;
+  esac
+  url="${url%.git}"
+  url="${url%/}"
+  local slug
+  slug="$(printf '%s' "$url" | sed -nE 's#^.*[:/]([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)$#\1/\2#p')"
+  printf '%s' "$slug"
+}
+
+# sha256 of the bytes tracked at the frozen docs ref, or failure when the path is
+# untracked at that commit.
+tracked_blob_sha256() {
+  local relpath="$1"
+  git -C "$REPO_ROOT" cat-file -e "$DOCS_REF:$relpath" 2>/dev/null || return 1
+  git -C "$REPO_ROOT" show "$DOCS_REF:$relpath" 2>/dev/null | sha256sum | cut -d' ' -f1
+}
+
+worktree_sha256() {
+  sha256sum "$REPO_ROOT/$1" | cut -d' ' -f1
+}
+
+DOCS_REPOSITORY="$(resolve_docs_repository)"
+
+if [[ "$DRY_RUN" == "false" ]]; then
+  if [[ ! "$DOCS_REF_INPUT" =~ ^[0-9a-f]{40}$ ]]; then
+    fail_harness \
+      "harness-identity" \
+      "a live matrix requires an approved docs/harness ref: pass --docs-ref <40-char-lowercase-sha> or set OPENCLAW_PROOFS_DOCS_REF" \
+      "$(jq -n --arg provided "$DOCS_REF_INPUT" '{check:"docs-ref-shape", provided:(if $provided == "" then null else "malformed" end)}')"
+  fi
+  # Frozen for the whole run. Ambient HEAD is never consulted again.
+  DOCS_REF="$DOCS_REF_INPUT"
+  DOCS_REF_SOURCE="approved-input"
+  readonly DOCS_REF
+
+  HEAD_SHA="$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || true)"
+  if [[ "$HEAD_SHA" != "$DOCS_REF" ]]; then
+    fail_harness \
+      "harness-identity" \
+      "harness checkout does not match the approved docs ref; refusing to fire a stale or mixed harness" \
+      "$(jq -n --arg head "$HEAD_SHA" --arg approved "$DOCS_REF" '{check:"head-equals-docs-ref", head:(if $head == "" then null else $head end), approved:$approved}')"
+  fi
+
+  HARNESS_DIRTY="$(git -C "$REPO_ROOT" status --porcelain --untracked-files=no -- "$PROOFS_TOOL_RELPATH" 2>/dev/null || printf 'git-unavailable')"
+  if [[ -n "$HARNESS_DIRTY" ]]; then
+    fail_harness \
+      "harness-identity" \
+      "tracked bytes under $PROOFS_TOOL_RELPATH are modified; a dirty harness cannot certify which contract produced a receipt" \
+      "$(jq -n --arg count "$(printf '%s\n' "$HARNESS_DIRTY" | grep -c . || true)" '{check:"harness-tree-clean", dirtyEntries:($count|tonumber)}')"
+  fi
+
+  if [[ ! "$DOCS_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+    fail_harness \
+      "harness-identity" \
+      "no public-safe repository identity for the harness; set OPENCLAW_PROOFS_DOCS_REPOSITORY=<owner>/<repo>" \
+      "$(jq -n '{check:"repository-identity"}')"
+  fi
+
+  for BIND_ROW in "${ROW_ARRAY[@]}"; do
+    BIND_ROW="$(printf '%s' "$BIND_ROW" | tr '[:lower:]' '[:upper:]')"
+    BIND_MANIFEST=""
+    BIND_MANIFEST="$(find_manifest_relpath "$BIND_ROW" || true)"
+    # A row with no manifest is reported as SKIPPED by the row loop; it never
+    # fires, so it has no harness contract to bind.
+    [[ -n "$BIND_MANIFEST" ]] || continue
+    BIND_STATUS="$(jq -r '.scenario.status // empty' "$BIND_MANIFEST")"
+    [[ "$BIND_STATUS" == "runnable" ]] || continue
+    BIND_SCENARIO="$(jq -r '.scenario.file // .scenario.name // empty' "$BIND_MANIFEST")"
+    if [[ -z "$BIND_SCENARIO" || ! -f "scenarios/$BIND_SCENARIO" ]]; then
+      fail_harness \
+        "harness-identity" \
+        "row $BIND_ROW is runnable but its scenario file is missing from the harness tree" \
+        "$(jq -n --arg row "$BIND_ROW" --arg scenario "$BIND_SCENARIO" '{check:"scenario-present", row:$row, scenario:(if $scenario == "" then null else $scenario end)}')"
+    fi
+    BIND_MANIFEST_REL="$PROOFS_TOOL_RELPATH/$BIND_MANIFEST"
+    BIND_SCENARIO_REL="$PROOFS_TOOL_RELPATH/scenarios/$BIND_SCENARIO"
+    for BIND_PATH in "$BIND_MANIFEST_REL" "$BIND_SCENARIO_REL"; do
+      BIND_TRACKED=""
+      BIND_TRACKED="$(tracked_blob_sha256 "$BIND_PATH" || true)"
+      if [[ -z "$BIND_TRACKED" ]]; then
+        fail_harness \
+          "harness-identity" \
+          "$BIND_PATH is not tracked at the approved docs ref; unrecorded harness bytes cannot produce a receipt" \
+          "$(jq -n --arg row "$BIND_ROW" --arg path "$BIND_PATH" --arg approved "$DOCS_REF" '{check:"tracked-at-docs-ref", row:$row, path:$path, approved:$approved}')"
+      fi
+      BIND_WORKTREE="$(worktree_sha256 "$BIND_PATH")"
+      if [[ "$BIND_TRACKED" != "$BIND_WORKTREE" ]]; then
+        fail_harness \
+          "harness-identity" \
+          "$BIND_PATH differs from the approved docs ref; refusing to fire mutated harness bytes" \
+          "$(jq -n --arg row "$BIND_ROW" --arg path "$BIND_PATH" '{check:"bytes-match-docs-ref", row:$row, path:$path}')"
+      fi
+      if [[ "$BIND_PATH" == "$BIND_MANIFEST_REL" ]]; then
+        ROW_MANIFEST_RELPATH["$BIND_ROW"]="$BIND_MANIFEST_REL"
+        ROW_MANIFEST_SHA256["$BIND_ROW"]="$BIND_WORKTREE"
+      else
+        ROW_SCENARIO_RELPATH["$BIND_ROW"]="$BIND_SCENARIO_REL"
+        ROW_SCENARIO_SHA256["$BIND_ROW"]="$BIND_WORKTREE"
+      fi
+    done
+  done
+  HARNESS_IDENTITY_VERIFIED=true
+  echo "Approved docs ref: $DOCS_REF ($DOCS_REPOSITORY)"
+  echo "Harness identity: verified clean and tracked for every selected runnable row."
+elif [[ "$DOCS_REF_INPUT" =~ ^[0-9a-f]{40}$ ]]; then
+  DOCS_REF="$DOCS_REF_INPUT"
+  DOCS_REF_SOURCE="approved-input"
+  echo "Docs ref (recorded, unenforced in dry run): $DOCS_REF"
+fi
 
 # Check for Live Bridge alignment (candidate vs deployed runtime)
 if [[ "$DRY_RUN" == "false" && "$OPENCLAW_CANDIDATE_SHA" != "$OPENCLAW_RUNTIME_BUILD_SHA" && "$OPENCLAW_RUNTIME_BUILD_SHA" != *"(${OPENCLAW_CANDIDATE_SHA:0:7})"* ]]; then
@@ -168,8 +411,8 @@ if [[ "$DRY_RUN" == "false" && "$OPENCLAW_CANDIDATE_SHA" != "$OPENCLAW_RUNTIME_B
   echo "Unless this is a known stale-stamp or you have proven a rebuild bridge, live proofs will be marked PARTIAL."
 fi
 
-mkdir -p "$OUT_ROOT"
 SEAT_READINESS_JSON="$OUT_ROOT/seat-readiness.json"
+SEAT_READINESS_SHA256=""
 if [[ "$DRY_RUN" == "false" ]]; then
   echo "Running seat-readiness preflight (k6/tooling/gateway/continuation config)..."
   if ! node scripts/seat-readiness-preflight.mjs --json > "$SEAT_READINESS_JSON"; then
@@ -177,10 +420,77 @@ if [[ "$DRY_RUN" == "false" ]]; then
     jq -r '.outcome as $out | "outcome=\($out) continuation=\(.continuation.enabled) defaults=\(.continuation.defaultsPresent) notes=\(.notes|join("; "))"' "$SEAT_READINESS_JSON" >&2 || true
     exit 1
   fi
+  SEAT_READINESS_SHA256="$(sha256sum "$SEAT_READINESS_JSON" | cut -d' ' -f1)"
   echo "SEAT READINESS: $SEAT_READINESS_JSON"
 fi
 
-IFS=',' read -ra ROW_ARRAY <<< "$ROWS"
+# Public-safe top-level provenance receipt. It is written before the first row
+# fires so the bundle always states which harness bytes and which product
+# candidate produced everything beneath it.
+HARNESS_PROVENANCE_JSON="$OUT_ROOT/harness-provenance.json"
+RUNNER_SCRIPT_SHA256="$(sha256sum "${BASH_SOURCE[0]}" | cut -d' ' -f1)"
+RUN_MATRIX_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+PROVENANCE_ROWS_JSON='[]'
+for PROV_ROW in "${ROW_ARRAY[@]}"; do
+  PROV_ROW="$(printf '%s' "$PROV_ROW" | tr '[:lower:]' '[:upper:]')"
+  PROVENANCE_ROWS_JSON="$(
+    jq -cn \
+      --argjson rows "$PROVENANCE_ROWS_JSON" \
+      --arg row "$PROV_ROW" \
+      --arg manifest "${ROW_MANIFEST_RELPATH[$PROV_ROW]:-}" \
+      --arg manifestSha256 "${ROW_MANIFEST_SHA256[$PROV_ROW]:-}" \
+      --arg scenario "${ROW_SCENARIO_RELPATH[$PROV_ROW]:-}" \
+      --arg scenarioSha256 "${ROW_SCENARIO_SHA256[$PROV_ROW]:-}" \
+      '$rows + [{
+        rowId: $row,
+        manifestPath: (if $manifest == "" then null else $manifest end),
+        manifestSha256: (if $manifestSha256 == "" then null else $manifestSha256 end),
+        scenarioPath: (if $scenario == "" then null else $scenario end),
+        scenarioSha256: (if $scenarioSha256 == "" then null else $scenarioSha256 end)
+      }]'
+  )"
+done
+jq -n \
+  --arg docsRef "$DOCS_REF" \
+  --arg docsRefSource "$DOCS_REF_SOURCE" \
+  --arg repository "$DOCS_REPOSITORY" \
+  --arg candidate "$OPENCLAW_CANDIDATE_SHA" \
+  --arg runtimeBuildSha "$OPENCLAW_RUNTIME_BUILD_SHA" \
+  --arg seat "$OPENCLAW_SEAT_NAME" \
+  --arg seatReadinessSha256 "$SEAT_READINESS_SHA256" \
+  --arg runnerScript "$PROOFS_TOOL_RELPATH/scripts/run-proofs.sh" \
+  --arg runnerScriptSha256 "$RUNNER_SCRIPT_SHA256" \
+  --arg mode "$RUN_MODE" \
+  --arg startedAt "$RUN_MATRIX_STARTED_AT" \
+  --argjson identityVerified "$HARNESS_IDENTITY_VERIFIED" \
+  --argjson rowSelection "$ROW_SELECTION_JSON" \
+  --argjson rows "$PROVENANCE_ROWS_JSON" \
+  '{
+    schema: "openclaw.k6.harness-provenance.v1",
+    classification: "harness-provenance",
+    mode: $mode,
+    docsRef: (if $docsRef == "" then null else $docsRef end),
+    docsRefSource: $docsRefSource,
+    repository: (if $repository == "" then null else $repository end),
+    harnessIdentityVerified: $identityVerified,
+    candidateSha: (if $candidate == "" or $candidate == "unknown" then null else $candidate end),
+    runtimeIdentity: {
+      seat: $seat,
+      runtimeBuildSha: (if $runtimeBuildSha == "" or $runtimeBuildSha == "unknown" then null else $runtimeBuildSha end),
+      candidateMatchesRuntime: ($candidate == $runtimeBuildSha),
+      seatReadinessReceipt: (if $seatReadinessSha256 == "" then null else "seat-readiness.json" end),
+      seatReadinessSha256: (if $seatReadinessSha256 == "" then null else $seatReadinessSha256 end)
+    },
+    runnerScript: $runnerScript,
+    runnerScriptSha256: $runnerScriptSha256,
+    rowSelection: $rowSelection,
+    rows: $rows,
+    candidateOnly: true,
+    foldRequiresReview: true,
+    startedAt: $startedAt
+  }' > "$HARNESS_PROVENANCE_JSON"
+echo "HARNESS PROVENANCE: $HARNESS_PROVENANCE_JSON"
+rm -f "$OUT_ROOT/harness-control-receipt.json"
 
 for ROW_ID in "${ROW_ARRAY[@]}"; do
   # Normalize row ID
@@ -230,6 +540,19 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
   if [[ "$DRY_RUN" == "true" ]]; then
     echo "[$ROW_ID] DRY RUN: Would execute k6 run scenarios/$SCENARIO_FILE"
   else
+    ROW_MANIFEST_REL="${ROW_MANIFEST_RELPATH[$ROW_ID]:-}"
+    ROW_MANIFEST_DIGEST="${ROW_MANIFEST_SHA256[$ROW_ID]:-}"
+    ROW_SCENARIO_REL="${ROW_SCENARIO_RELPATH[$ROW_ID]:-}"
+    ROW_SCENARIO_DIGEST="${ROW_SCENARIO_SHA256[$ROW_ID]:-}"
+    # Frozen at startup by the harness identity gate. An unbound row means the
+    # gate never saw it, so it must not fire and must not produce a verdict.
+    if [[ -z "$ROW_MANIFEST_DIGEST" || -z "$ROW_SCENARIO_DIGEST" ]]; then
+      fail_harness \
+        "harness-identity" \
+        "row $ROW_ID has no frozen manifest/scenario digest bound to the approved docs ref" \
+        "$(jq -n --arg row "$ROW_ID" '{check:"row-bound-to-docs-ref", row:$row}')"
+    fi
+
     echo "[$ROW_ID] RUNNING..."
     export OPENCLAW_ROW_MANIFEST="$MANIFEST_FILE"
 
@@ -238,6 +561,9 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
     mkdir -p "$RUN_DIR"
     touch "$RUN_DIR/.started"
     cp "$MANIFEST_FILE" "$RUN_DIR/row-manifest.json"
+    # The exact scenario source travels with the receipt so a reviewer can prove
+    # which contract bytes produced it without trusting the run directory name.
+    cp "scenarios/$SCENARIO_FILE" "$RUN_DIR/row-scenario.js"
     RUN_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     jq -n \
       --arg row "$ROW_ID" \
@@ -246,7 +572,13 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
       --arg runtime "$OPENCLAW_RUNTIME_BUILD_SHA" \
       --arg seat "$OPENCLAW_SEAT_NAME" \
       --arg started "$RUN_STARTED_AT" \
-      '{row:$row, scenario:$scenario, candidateSha:$candidate, runtimeBuildSha:$runtime, seat:$seat, sessionConfigured:true, startedAt:$started}' \
+      --arg docsRef "$DOCS_REF" \
+      --arg repository "$DOCS_REPOSITORY" \
+      --arg manifestPath "$ROW_MANIFEST_REL" \
+      --arg manifestSha256 "$ROW_MANIFEST_DIGEST" \
+      --arg scenarioPath "$ROW_SCENARIO_REL" \
+      --arg scenarioSha256 "$ROW_SCENARIO_DIGEST" \
+      '{row:$row, scenario:$scenario, candidateSha:$candidate, runtimeBuildSha:$runtime, seat:$seat, sessionConfigured:true, startedAt:$started, docsRef:$docsRef, repository:$repository, manifestPath:$manifestPath, manifestSha256:$manifestSha256, scenarioPath:$scenarioPath, scenarioSha256:$scenarioSha256}' \
       > "$RUN_DIR/runner-metadata.json"
     if [[ "$ROW_ID" == "R-CD-TOKEN" ]]; then
       if [[ ! "$OPENCLAW_CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ||
@@ -761,8 +1093,11 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
     # envelope. Review-pending runs intentionally remain represented only by
     # run-result.json so review-debt can route their missing receipts; neither
     # form is canonical proof or an automatic fold input.
-    DOCS_REF="$(git rev-parse HEAD 2>/dev/null || true)"
-    if [[ "$DOCS_REF" =~ ^[0-9a-f]{40}$ ]] && node "$CANDIDATE_RESULT_VALIDATOR" \
+    #
+    # DOCS_REF was frozen before the first row fired. Ambient HEAD is never
+    # re-read here: a mid-matrix checkout change must not silently relabel the
+    # harness that produced this receipt.
+    if node "$CANDIDATE_RESULT_VALIDATOR" \
       --manifest "$MANIFEST_FILE" \
       --candidate-dir "$RUN_DIR" \
       --docs-ref "$DOCS_REF" \

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -313,45 +313,16 @@ fi
 if [[ -n "$CANDIDATE_SHA" ]]; then export OPENCLAW_CANDIDATE_SHA="${CANDIDATE_SHA}"; fi
 export OPENCLAW_SEAT_NAME="$(hostname)"
 
-# Fetch deployed runtime build stamp explicitly (do not collapse into CANDIDATE_SHA).
-# Operators may provide OPENCLAW_RUNTIME_BUILD_SHA when they have an external deploy
-# receipt for the exact SHA. Otherwise prefer a structured CLI receipt when available
-# and fall back to the human version string (for example, "OpenClaw ... (1cc8f4e)").
-DEPLOYED_BUILD_STAMP="${OPENCLAW_RUNTIME_BUILD_SHA:-unknown}"
-if [[ "$DEPLOYED_BUILD_STAMP" == "unknown" && -f ~/.openclaw/openclaw.json ]]; then
-  if openclaw version --json >/dev/null 2>&1; then
-    DEPLOYED_BUILD_STAMP="$(openclaw version --json | jq -r '.build.sha // empty')"
-  elif openclaw --version >/dev/null 2>&1; then
-    DEPLOYED_BUILD_STAMP="$(openclaw --version | head -n 1)"
-  fi
-fi
-export OPENCLAW_RUNTIME_BUILD_SHA="$DEPLOYED_BUILD_STAMP"
-
 # Portable observability endpoints. Defaults preserve the dandelion fleet, but
 # reviewers can override without editing scripts or docs-local config.
 export OPENCLAW_PROOFS_TEMPO_BASE_URL="${OPENCLAW_PROOFS_TEMPO_BASE_URL:-${TEMPO_BASE_URL:-http://tempo.dandelion.cult}}"
 export OPENCLAW_PROOFS_LOKI_BASE_URL="${OPENCLAW_PROOFS_LOKI_BASE_URL:-${LOKI_BASE_URL:-http://loki.dandelion.cult}}"
 export OPENCLAW_PROOFS_PROMETHEUS_BASE_URL="${OPENCLAW_PROOFS_PROMETHEUS_BASE_URL:-${PROMETHEUS_BASE_URL:-http://prometheus.dandelion.cult}}"
 
-# Resolve Session Key
-if [[ -z "${OPENCLAW_SESSION_KEY:-}" ]]; then
-  echo "Resolving session key for selector: $SESSION_SELECTOR"
-  case "$SESSION_SELECTOR" in
-    main|agent:*)
-      export OPENCLAW_SESSION_KEY="$SESSION_SELECTOR"
-      ;;
-    *)
-      export OPENCLAW_SESSION_KEY="main" # Fallback/stub. In a full implementation this shells out to `openclaw sessions --json`
-      ;;
-  esac
-fi
-
 echo "=========================================================="
 echo "Project 81: Seat-Aware k6 Proof Runner"
 echo "Seat: $OPENCLAW_SEAT_NAME"
 echo "Target Candidate SHA: $OPENCLAW_CANDIDATE_SHA"
-echo "Deployed Runtime SHA: $OPENCLAW_RUNTIME_BUILD_SHA"
-echo "Session configured: true"
 echo "Artifact root: $OUT_ROOT"
 
 
@@ -563,17 +534,16 @@ if [[ "$DRY_RUN" == "false" ]]; then
   if [[ -z "${OPENCLAW_PROOFS_HARNESS_SNAPSHOT:-}" ]]; then
     HARNESS_SNAPSHOT_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-k6-harness.XXXXXX")"
     chmod 700 "$HARNESS_SNAPSHOT_ROOT"
-    if ! harness_git archive "$DOCS_REF" -- "$PROOFS_TOOL_RELPATH" | tar -x -C "$HARNESS_SNAPSHOT_ROOT"; then
+    # Every consumed tree is materialized, not referenced: static rows read the
+    # proof corpus during k6 execution, so a symlink back to the operator's
+    # checkout would leave exactly the check-then-use hole the snapshot exists
+    # to close. The full corpus extracts in about a second.
+    if ! harness_git archive "$DOCS_REF" -- "${HARNESS_VERIFIED_PATHS[@]}" | tar -x -C "$HARNESS_SNAPSHOT_ROOT"; then
       fail_harness \
         "harness-identity" \
-        "the approved $PROOFS_TOOL_RELPATH tree could not be extracted for immutable execution" \
+        "the approved ${HARNESS_VERIFIED_PATHS[*]} trees could not be extracted for immutable execution" \
         "$(jq -n '{check:"harness-snapshot-extractable"}')"
     fi
-    # The corpus and workflow trees are byte-verified against the approved ref
-    # above, so they are referenced rather than copied; PROOFS alone is hundreds
-    # of megabytes and every one of its bytes is checked before and between rows.
-    ln -s "$REPO_ROOT/PROOFS" "$HARNESS_SNAPSHOT_ROOT/PROOFS"
-    ln -s "$REPO_ROOT/.github" "$HARNESS_SNAPSHOT_ROOT/.github"
     export OPENCLAW_PROOFS_HARNESS_SNAPSHOT="$HARNESS_SNAPSHOT_ROOT"
     export OPENCLAW_PROOFS_ORIGIN_ROOT="$REPO_ROOT"
     echo "Harness execution: handing off to the approved runner in an immutable snapshot."
@@ -583,9 +553,24 @@ if [[ "$DRY_RUN" == "false" ]]; then
       "${ORIGINAL_ARGS[@]}" --out-dir "$OUT_ROOT"
   fi
 
-  # Re-executed copy: adopt the snapshot and prove it is the approved tree before
-  # trusting anything in it.
+  # Re-executed copy. The handoff variables are ambient input, so before any of
+  # it is trusted this process must prove that it really is the snapshot's own
+  # runner and that the snapshot is a distinct tree from the checkout. Otherwise
+  # a modified external copy could set both variables, point them at clean
+  # trees, skip the exec, and keep running.
   HARNESS_SNAPSHOT_ROOT="$OPENCLAW_PROOFS_HARNESS_SNAPSHOT"
+  SNAPSHOT_RUNNER="$(readlink -f "$HARNESS_SNAPSHOT_ROOT/$PROOFS_TOOL_RELPATH/scripts/run-proofs.sh" 2>/dev/null || true)"
+  EXECUTING_RUNNER="$(readlink -f "$RUNNER_SCRIPT_PATH" 2>/dev/null || true)"
+  CANONICAL_SNAPSHOT="$(readlink -f "$HARNESS_SNAPSHOT_ROOT" 2>/dev/null || true)"
+  CANONICAL_ORIGIN="$(readlink -f "$REPO_ROOT" 2>/dev/null || true)"
+  if [[ -z "$SNAPSHOT_RUNNER" || -z "$EXECUTING_RUNNER" || "$EXECUTING_RUNNER" != "$SNAPSHOT_RUNNER" ||
+        -z "$CANONICAL_SNAPSHOT" || -z "$CANONICAL_ORIGIN" ||
+        "$CANONICAL_SNAPSHOT" == "$CANONICAL_ORIGIN" || "$CANONICAL_SNAPSHOT" == "$CANONICAL_ORIGIN"/* ]]; then
+    fail_harness \
+      "harness-identity" \
+      "the executing runner is not the approved snapshot's own runner; refusing a spoofed or aliased handoff" \
+      "$(jq -n '{check:"snapshot-handoff-authentic"}')"
+  fi
   EXEC_ROOT="$HARNESS_SNAPSHOT_ROOT"
   bind_execution_roots
   cd "$PROOFS_DIR"
@@ -723,6 +708,39 @@ if [[ "$DRY_RUN" == "false" ]]; then
   done
   echo "Harness contract binding: frozen manifest/scenario digests for every selected runnable row."
 fi
+
+# Runtime and session resolution run only in the verified snapshot runner: the
+# bootstrap must not invoke external tooling or resolve session state while it is
+# still executing unproven bytes.
+# Fetch deployed runtime build stamp explicitly (do not collapse into CANDIDATE_SHA).
+# Operators may provide OPENCLAW_RUNTIME_BUILD_SHA when they have an external deploy
+# receipt for the exact SHA. Otherwise prefer a structured CLI receipt when available
+# and fall back to the human version string (for example, "OpenClaw ... (1cc8f4e)").
+DEPLOYED_BUILD_STAMP="${OPENCLAW_RUNTIME_BUILD_SHA:-unknown}"
+if [[ "$DEPLOYED_BUILD_STAMP" == "unknown" && -f ~/.openclaw/openclaw.json ]]; then
+  if openclaw version --json >/dev/null 2>&1; then
+    DEPLOYED_BUILD_STAMP="$(openclaw version --json | jq -r '.build.sha // empty')"
+  elif openclaw --version >/dev/null 2>&1; then
+    DEPLOYED_BUILD_STAMP="$(openclaw --version | head -n 1)"
+  fi
+fi
+export OPENCLAW_RUNTIME_BUILD_SHA="$DEPLOYED_BUILD_STAMP"
+
+# Resolve Session Key
+if [[ -z "${OPENCLAW_SESSION_KEY:-}" ]]; then
+  echo "Resolving session key for selector: $SESSION_SELECTOR"
+  case "$SESSION_SELECTOR" in
+    main|agent:*)
+      export OPENCLAW_SESSION_KEY="$SESSION_SELECTOR"
+      ;;
+    *)
+      export OPENCLAW_SESSION_KEY="main" # Fallback/stub. In a full implementation this shells out to `openclaw sessions --json`
+      ;;
+  esac
+fi
+
+echo "Deployed Runtime SHA: $OPENCLAW_RUNTIME_BUILD_SHA"
+echo "Session configured: true"
 
 # Check for Live Bridge alignment (candidate vs deployed runtime)
 if [[ "$DRY_RUN" == "false" && "$OPENCLAW_CANDIDATE_SHA" != "$OPENCLAW_RUNTIME_BUILD_SHA" && "$OPENCLAW_RUNTIME_BUILD_SHA" != *"(${OPENCLAW_CANDIDATE_SHA:0:7})"* ]]; then

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -84,6 +84,7 @@ DOCS_REF_SOURCE="none"
 DOCS_REPOSITORY=""
 HARNESS_IDENTITY_VERIFIED=false
 ROW_SELECTION_JSON='[]'
+PROVISIONAL_RUN_DIR=""
 declare -A ROW_MANIFEST_RELPATH=()
 declare -A ROW_MANIFEST_SHA256=()
 declare -A ROW_SCENARIO_RELPATH=()
@@ -144,15 +145,17 @@ harness_git() {
     git --no-replace-objects -C "$REPO_ROOT" "$@"
 }
 
-# Harness code runs before its identity is proven, so it must never see live
-# credentials or session material.
-run_without_secrets() {
-  env \
-    -u OPENCLAW_GATEWAY_TOKEN \
-    -u OPENCLAW_SESSION_KEY \
-    -u OPENCLAW_ROW_NONCE \
-    -u OPENCLAW_PROOF_ATTEMPT_ID \
-    -u OPENCLAW_ROW_MANIFEST \
+# Catalog code is executed by this runner, so it is run with an explicit minimal
+# environment rather than an inherited one: no credential of any kind (gateway,
+# provider, cloud, registry) can reach it, whatever it does. For a live run the
+# harness identity gate has already proven these validators are the approved
+# committed bytes.
+run_with_minimal_env() {
+  env -i \
+    PATH="$PATH" \
+    LANG="${LANG:-C}" \
+    LC_ALL="${LC_ALL:-C}" \
+    TMPDIR="${TMPDIR:-/tmp}" \
     "$@"
 }
 
@@ -237,6 +240,13 @@ safe_repository_or_marker() {
   fi
 }
 
+safe_row_id_or_marker() {
+  local row_pattern='^[A-Z0-9][A-Z0-9._-]*$'
+  if [[ "$1" =~ $row_pattern ]]; then printf '%s' "$1"
+  elif [[ -n "$1" ]]; then printf 'malformed'
+  fi
+}
+
 safe_row_selection_json() {
   jq -c 'map(if test("^[A-Z0-9][A-Z0-9._-]*$") then . else "malformed" end)' <<< "$ROW_SELECTION_JSON"
 }
@@ -252,6 +262,15 @@ safe_runtime_stamp() {
 }
 
 fail_harness() {
+  # A pre-execution infrastructure failure can happen after a run directory was
+  # created but before the row dispatched. That directory holds no candidate
+  # evidence, so it is removed and the interruption writer is disarmed: the
+  # control receipt's rowsExecuted:0 must stay literally true.
+  if [[ -n "${PROVISIONAL_RUN_DIR:-}" ]]; then
+    rm -rf "$PROVISIONAL_RUN_DIR"
+    PROVISIONAL_RUN_DIR=""
+  fi
+  ACTIVE_TOKEN_RUN_DIR=""
   write_harness_control_receipt "$1" "$2" "${3:-null}"
   exit "$HARNESS_INFRA_EXIT"
 }
@@ -262,17 +281,6 @@ fi
 
 if [[ -n "$CANDIDATE_SHA" ]]; then export OPENCLAW_CANDIDATE_SHA="${CANDIDATE_SHA}"; fi
 export OPENCLAW_SEAT_NAME="$(hostname)"
-
-# Local Gateway Auth extraction (never logged/committed)
-if [[ -z "${OPENCLAW_GATEWAY_TOKEN:-}" && -f ~/.openclaw/openclaw.json ]]; then
-  export OPENCLAW_GATEWAY_TOKEN="$(jq -r '.gateway.auth.token // .auth.operatorToken // empty' ~/.openclaw/openclaw.json)"
-fi
-if [[ -z "${OPENCLAW_GATEWAY_TOKEN:-}" ]]; then
-  echo "Warning: OPENCLAW_GATEWAY_TOKEN not found in local config."
-  if [[ "$DRY_RUN" == "false" ]]; then
-    exit 1
-  fi
-fi
 
 # Fetch deployed runtime build stamp explicitly (do not collapse into CANDIDATE_SHA).
 # Operators may provide OPENCLAW_RUNTIME_BUILD_SHA when they have an external deploy
@@ -315,36 +323,16 @@ echo "Deployed Runtime SHA: $OPENCLAW_RUNTIME_BUILD_SHA"
 echo "Session configured: true"
 echo "Artifact root: $OUT_ROOT"
 
-# Catalog preflight (#495). The validators receive one explicit repository root,
-# so they inspect the same files whatever directory the caller started in. A
-# failure here stops the matrix before any row executes.
-CATALOG_PREFLIGHT_LOG="$OUT_ROOT/catalog-preflight.log"
-CATALOG_PREFLIGHT_RAW="$(mktemp "${TMPDIR:-/tmp}/openclaw-k6-catalog.XXXXXX")"
-CATALOG_PREFLIGHT_RAW_FILE="$CATALOG_PREFLIGHT_RAW"
-: > "$CATALOG_PREFLIGHT_RAW"
-echo "Running catalog preflight (repository root: $PROOFS_TOOL_RELPATH resolved once)..."
-publish_catalog_preflight_log() {
-  scrub_public_text < "$CATALOG_PREFLIGHT_RAW" > "$CATALOG_PREFLIGHT_LOG"
-}
-for CATALOG_CHECK in "${CATALOG_CHECKS[@]}"; do
-  printf '### %s\n' "$CATALOG_CHECK" >> "$CATALOG_PREFLIGHT_RAW"
-  # Catalog code executes before its own identity is proven, so it runs without
-  # the gateway token or session material in its environment.
-  if ! run_without_secrets node "$SCRIPT_DIR/$CATALOG_CHECK" --repo-root "$REPO_ROOT" >> "$CATALOG_PREFLIGHT_RAW" 2>&1; then
-    publish_catalog_preflight_log
-    fail_harness \
-      "catalog-preflight" \
-      "catalog validator '$CATALOG_CHECK' failed; the row catalog could not be resolved" \
-      "$(jq -n --arg check "$CATALOG_CHECK" '{failedCheck:$check, log:"catalog-preflight.log"}')"
-  fi
-done
-publish_catalog_preflight_log
-rm -f "$CATALOG_PREFLIGHT_RAW"
-CATALOG_PREFLIGHT_RAW_FILE=""
-echo "CATALOG PREFLIGHT: $CATALOG_PREFLIGHT_LOG"
 
 if [[ "$ROWS" == "all" ]]; then
-  ROWS="$(for f in manifests/*.json; do jq -r 'select(.scenario.status == "runnable") | .rowId' "$f"; done | paste -sd, -)"
+  # Data-only read of the manifest catalog. A malformed catalog is an
+  # infrastructure fault, not an empty row list.
+  if ! ROWS="$(for f in manifests/*.json; do jq -r 'select(.scenario.status == "runnable") | .rowId' "$f"; done | paste -sd, -)"; then
+    fail_harness \
+      "catalog-preflight" \
+      "the manifest catalog could not be read to resolve the 'all' row selection" \
+      "$(jq -n '{check:"row-selection-resolvable"}')"
+  fi
 fi
 
 if [[ -z "$ROWS" ]]; then
@@ -404,13 +392,15 @@ tracked_blob_sha256() {
 }
 
 worktree_sha256() {
-  sha256sum "$REPO_ROOT/$1" | cut -d' ' -f1
+  sha256sum "$REPO_ROOT/$1" 2>/dev/null | cut -d' ' -f1
 }
 
 # The digests are frozen once at startup, but k6 and the scenario read the
-# working tree at row time. Re-assert the frozen bytes at every step that can
-# still change what actually executes, so a mid-matrix mutation fails closed as
-# infrastructure instead of producing a receipt for unapproved source.
+# working tree at row time, and a scenario also imports tools/k6-proofs/lib/*.
+# Re-assert both the row's own bytes and the cleanliness of every tracked byte
+# under tools/k6-proofs at each step that can still change what executes, so a
+# mid-matrix mutation fails closed as infrastructure instead of producing a
+# receipt for unapproved source.
 assert_row_bytes_frozen() {
   local row="$1"
   local phase="$2"
@@ -425,9 +415,10 @@ assert_row_bytes_frozen() {
       "$(jq -n --arg row "$row" --arg phase "$phase" '{check:"row-bound-to-docs-ref", row:$row, phase:$phase}')"
   fi
   local actual_manifest actual_scenario
-  actual_manifest="$(worktree_sha256 "$manifest_rel")"
-  actual_scenario="$(worktree_sha256 "$scenario_rel")"
-  if [[ "$actual_manifest" != "$expected_manifest" || "$actual_scenario" != "$expected_scenario" ]]; then
+  actual_manifest="$(worktree_sha256 "$manifest_rel" || true)"
+  actual_scenario="$(worktree_sha256 "$scenario_rel" || true)"
+  if [[ -z "$actual_manifest" || -z "$actual_scenario" ||
+        "$actual_manifest" != "$expected_manifest" || "$actual_scenario" != "$expected_scenario" ]]; then
     fail_harness \
       "harness-identity" \
       "row $row harness bytes changed after the approved docs ref was frozen; refusing to execute unapproved source" \
@@ -438,6 +429,18 @@ assert_row_bytes_frozen() {
         --argjson scenarioChanged "$(if [[ "$actual_scenario" != "$expected_scenario" ]]; then printf 'true'; else printf 'false'; fi)" \
         '{check:"frozen-bytes-still-current", row:$row, phase:$phase, manifestChanged:$manifestChanged, scenarioChanged:$scenarioChanged}')"
   fi
+  # A scenario is not self-contained: it imports the shared harness library.
+  # Re-checking the whole tracked tree covers lib/, scripts/, and every other
+  # file a row can reach.
+  local dirty
+  dirty="$(harness_git status --porcelain --untracked-files=no -- "$PROOFS_TOOL_RELPATH" 2>/dev/null || printf 'git-unavailable')"
+  if [[ -n "$dirty" ]]; then
+    fail_harness \
+      "harness-identity" \
+      "tracked bytes under $PROOFS_TOOL_RELPATH changed after the approved docs ref was frozen; refusing to execute unapproved source" \
+      "$(jq -n --arg row "$row" --arg phase "$phase" --arg count "$(printf '%s\n' "$dirty" | grep -c . || true)" \
+        '{check:"harness-tree-still-clean", row:$row, phase:$phase, dirtyEntries:($count|tonumber)}')"
+  fi
 }
 
 assert_copied_artifact_frozen() {
@@ -445,8 +448,8 @@ assert_copied_artifact_frozen() {
   local artifact="$2"
   local expected="$3"
   local actual
-  actual="$(sha256sum "$artifact" | cut -d' ' -f1)"
-  if [[ "$actual" != "$expected" ]]; then
+  actual="$(sha256sum "$artifact" 2>/dev/null | cut -d' ' -f1 || true)"
+  if [[ -z "$actual" || "$actual" != "$expected" ]]; then
     fail_harness \
       "harness-identity" \
       "row $row captured artifact $(basename "$artifact") does not match its frozen digest" \
@@ -542,10 +545,50 @@ elif [[ "$DOCS_REF_INPUT" =~ ^[0-9a-f]{40}$ ]]; then
   echo "Docs ref (recorded, unenforced in dry run): $DOCS_REF"
 fi
 
+# Catalog preflight (#495). The validators receive one explicit repository root,
+# so they inspect the same files whatever directory the caller started in. A
+# failure here stops the matrix before any row executes.
+CATALOG_PREFLIGHT_LOG="$OUT_ROOT/catalog-preflight.log"
+CATALOG_PREFLIGHT_RAW="$(mktemp "${TMPDIR:-/tmp}/openclaw-k6-catalog.XXXXXX")"
+CATALOG_PREFLIGHT_RAW_FILE="$CATALOG_PREFLIGHT_RAW"
+: > "$CATALOG_PREFLIGHT_RAW"
+echo "Running catalog preflight (repository root: $PROOFS_TOOL_RELPATH resolved once)..."
+publish_catalog_preflight_log() {
+  scrub_public_text < "$CATALOG_PREFLIGHT_RAW" > "$CATALOG_PREFLIGHT_LOG"
+}
+for CATALOG_CHECK in "${CATALOG_CHECKS[@]}"; do
+  printf '### %s\n' "$CATALOG_CHECK" >> "$CATALOG_PREFLIGHT_RAW"
+  if ! run_with_minimal_env node "$SCRIPT_DIR/$CATALOG_CHECK" --repo-root "$REPO_ROOT" >> "$CATALOG_PREFLIGHT_RAW" 2>&1; then
+    publish_catalog_preflight_log
+    fail_harness \
+      "catalog-preflight" \
+      "catalog validator '$CATALOG_CHECK' failed; the row catalog could not be resolved" \
+      "$(jq -n --arg check "$CATALOG_CHECK" '{failedCheck:$check, log:"catalog-preflight.log"}')"
+  fi
+done
+publish_catalog_preflight_log
+rm -f "$CATALOG_PREFLIGHT_RAW"
+CATALOG_PREFLIGHT_RAW_FILE=""
+echo "CATALOG PREFLIGHT: $CATALOG_PREFLIGHT_LOG"
+
 # Check for Live Bridge alignment (candidate vs deployed runtime)
 if [[ "$DRY_RUN" == "false" && "$OPENCLAW_CANDIDATE_SHA" != "$OPENCLAW_RUNTIME_BUILD_SHA" && "$OPENCLAW_RUNTIME_BUILD_SHA" != *"(${OPENCLAW_CANDIDATE_SHA:0:7})"* ]]; then
   echo "WARNING: Candidate SHA ($OPENCLAW_CANDIDATE_SHA) does not match Deployed Runtime SHA ($OPENCLAW_RUNTIME_BUILD_SHA)."
   echo "Unless this is a known stale-stamp or you have proven a rebuild bridge, live proofs will be marked PARTIAL."
+fi
+
+# Local Gateway Auth extraction (never logged/committed).
+# Deliberately last: neither the harness identity gate nor the catalog
+# validators run with this credential in their environment.
+if [[ -z "${OPENCLAW_GATEWAY_TOKEN:-}" && -f ~/.openclaw/openclaw.json ]]; then
+  OPENCLAW_GATEWAY_TOKEN="$(jq -r '.gateway.auth.token // .auth.operatorToken // empty' ~/.openclaw/openclaw.json)"
+  export OPENCLAW_GATEWAY_TOKEN
+fi
+if [[ -z "${OPENCLAW_GATEWAY_TOKEN:-}" ]]; then
+  echo "Warning: OPENCLAW_GATEWAY_TOKEN not found in local config."
+  if [[ "$DRY_RUN" == "false" ]]; then
+    exit 1
+  fi
 fi
 
 SEAT_READINESS_JSON="$OUT_ROOT/seat-readiness.json"
@@ -572,6 +615,8 @@ RUN_MATRIX_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 # and stamps its id into every row's runner-metadata.json.
 MATRIX_ID="$(date -u +%Y%m%dT%H%M%SZ)-${DOCS_REF:0:12}"
 if [[ -z "$DOCS_REF" ]]; then MATRIX_ID="${MATRIX_ID}unbound"; fi
+# Two matrices for the same docs ref can start within the same second.
+MATRIX_ID="${MATRIX_ID}-$(cat /proc/sys/kernel/random/uuid 2>/dev/null | tr -d '-' | cut -c1-8 || printf '%08x' "$RANDOM")"
 HARNESS_PROVENANCE_ARCHIVE="$OUT_ROOT/harness-provenance/$MATRIX_ID.json"
 mkdir -p "$OUT_ROOT/harness-provenance"
 PROVENANCE_ROWS_JSON='[]'
@@ -580,7 +625,7 @@ for PROV_ROW in "${ROW_ARRAY[@]}"; do
   PROVENANCE_ROWS_JSON="$(
     jq -cn \
       --argjson rows "$PROVENANCE_ROWS_JSON" \
-      --arg row "$PROV_ROW" \
+      --arg row "$(safe_row_id_or_marker "$PROV_ROW")" \
       --arg manifest "${ROW_MANIFEST_RELPATH[$PROV_ROW]:-}" \
       --arg manifestSha256 "${ROW_MANIFEST_SHA256[$PROV_ROW]:-}" \
       --arg scenario "${ROW_SCENARIO_RELPATH[$PROV_ROW]:-}" \
@@ -699,6 +744,7 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
     RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%s' "$ROW_ID" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-')"
     RUN_DIR="$OUT_ROOT/$OPENCLAW_CANDIDATE_SHA/$ROW_ID/$OPENCLAW_SEAT_NAME/$RUN_ID"
     mkdir -p "$RUN_DIR"
+    PROVISIONAL_RUN_DIR="$RUN_DIR"
     touch "$RUN_DIR/.started"
     cp "$MANIFEST_FILE" "$RUN_DIR/row-manifest.json"
     # The exact scenario source travels with the receipt so a reviewer can prove
@@ -716,7 +762,7 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
       --arg row "$ROW_ID" \
       --arg scenario "$SCENARIO_FILE" \
       --arg candidate "$OPENCLAW_CANDIDATE_SHA" \
-      --arg runtime "$OPENCLAW_RUNTIME_BUILD_SHA" \
+      --arg runtime "$(safe_runtime_stamp "$OPENCLAW_RUNTIME_BUILD_SHA")" \
       --arg seat "$OPENCLAW_SEAT_NAME" \
       --arg started "$RUN_STARTED_AT" \
       --arg docsRef "$DOCS_REF" \
@@ -744,6 +790,7 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
           '{k6ExitCode:0,postprocessExitCode:0,effectiveExitCode:0,endedAt:$endedAt,verdict:"PARTIAL-candidate",verdictSource:"pre-dispatch-build-identity-gate",summaryFileVerdict:null,vuLogVerdict:null,summaryFiles:[],evidence:{row:"R-CD-TOKEN",dispatched:false},candidateOnly:true,foldRequiresReview:true,terminal:true,observability:{traceStatus:"not-applicable",traceId:null,tempoTraceJson:null,correlationReceipt:null,serviceLogStatus:"not-started",serviceLog:null,serviceLogCapture:null,serviceLogRedaction:null},review:{status:"review-pending",pendingReceipts:["exact-candidate-runtime-identity","attempt-state","raw-final-text-origin","parser-detected","queue-identity","child-spawned","child-completed","parent-return-event","tempo-trace-json","continuation-trace-correlation"]}}' \
           > "$RUN_DIR/run-result.json"
         rm -f "$RUN_DIR/.started"
+        PROVISIONAL_RUN_DIR=""
         echo "[$ROW_ID] PARTIAL-candidate: exact equal candidate/runtime SHAs are required; no dispatch occurred."
         continue
       fi
@@ -784,6 +831,7 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
         rm -f "$RUN_DIR/.started"
         ACTIVE_TOKEN_PHASE="pre-dispatch-surface-gate"
         ACTIVE_TOKEN_RUN_DIR=""
+        PROVISIONAL_RUN_DIR=""
         echo "[$ROW_ID] PARTIAL-candidate: seat readiness class '$OPENCLAW_SEAT_CLASS' is not scanner-supported raw-final-text; no dispatch occurred."
         continue
       fi
@@ -833,6 +881,8 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
     if [[ "$ROW_ID" == "R-CD-TOKEN" ]]; then ACTIVE_TOKEN_PHASE="k6-running"; fi
     # Last assertion before unapproved bytes could be executed.
     assert_row_bytes_frozen "$ROW_ID" "pre-k6-execution"
+    # From here the directory holds real candidate evidence and must survive.
+    PROVISIONAL_RUN_DIR=""
     set +e
     k6 run "scenarios/$SCENARIO_FILE" > "$PRIVATE_K6_LOG" 2>&1
     k6_rc=$?

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -46,6 +46,7 @@ cleanup_private_artifacts() {
     "${PRIVATE_K6_LOG:-}" \
     "${PRIVATE_EVIDENCE_FILE:-}" \
     "${PRIVATE_GATEWAY_LOG:-}" \
+    "${CATALOG_PREFLIGHT_RAW_FILE:-}" \
     "${SOURCE_CONTRACT_FILE:-}"
 }
 
@@ -126,9 +127,61 @@ OUT_ROOT="$(cd "$OUT_ROOT" && pwd)"
 # relative to tools/k6-proofs, never to an ambient caller working directory.
 cd "$PROOFS_DIR"
 
+# Identity git calls must describe the real object store. refs/replace/* is
+# honoured by default, so an ambient replacement object could let `rev-parse
+# HEAD` report the approved SHA while `show`/`cat-file` served different bytes.
+# Ambient GIT_DIR/GIT_WORK_TREE style overrides are cleared for the same reason.
+harness_git() {
+  env \
+    -u GIT_DIR \
+    -u GIT_WORK_TREE \
+    -u GIT_INDEX_FILE \
+    -u GIT_OBJECT_DIRECTORY \
+    -u GIT_ALTERNATE_OBJECT_DIRECTORIES \
+    -u GIT_COMMON_DIR \
+    -u GIT_CEILING_DIRECTORIES \
+    GIT_NO_REPLACE_OBJECTS=1 \
+    git --no-replace-objects -C "$REPO_ROOT" "$@"
+}
+
+# Harness code runs before its identity is proven, so it must never see live
+# credentials or session material.
+run_without_secrets() {
+  env \
+    -u OPENCLAW_GATEWAY_TOKEN \
+    -u OPENCLAW_SESSION_KEY \
+    -u OPENCLAW_ROW_NONCE \
+    -u OPENCLAW_PROOF_ATTEMPT_ID \
+    -u OPENCLAW_ROW_MANIFEST \
+    "$@"
+}
+
+# Replace local filesystem locations with stable placeholders before any
+# captured text becomes a public artifact.
+scrub_public_text() {
+  node -e '
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => { data += chunk; });
+    process.stdin.on("end", () => {
+      const replacements = [
+        [process.argv[1], "<repo-root>"],
+        [process.argv[2], "<out-root>"],
+        [process.argv[3], "<home>"],
+      ];
+      let out = data;
+      for (const [value, placeholder] of replacements) {
+        if (value && value.length > 4) out = out.split(value).join(placeholder);
+      }
+      process.stdout.write(out);
+    });
+  ' "$REPO_ROOT" "$OUT_ROOT" "${HOME:-}"
+}
+
 # One harness infrastructure receipt, written instead of any per-row product
 # verdict. A catalog/identity failure is a setup fault: no row may execute, and
-# nothing here may be read as candidate behavior.
+# nothing here may be read as candidate behavior. Only validated values reach
+# this receipt: rejected operator input is recorded as "malformed", never echoed.
 write_harness_control_receipt() {
   local stage="$1"
   local reason="$2"
@@ -141,12 +194,12 @@ write_harness_control_receipt() {
     --arg reason "$reason" \
     --arg mode "$RUN_MODE" \
     --arg docsRef "$DOCS_REF" \
-    --arg docsRefInput "$(if [[ "$DOCS_REF_INPUT" =~ ^[0-9a-f]{40}$ ]]; then printf '%s' "$DOCS_REF_INPUT"; elif [[ -n "$DOCS_REF_INPUT" ]]; then printf 'malformed'; fi)" \
-    --arg candidate "${OPENCLAW_CANDIDATE_SHA:-}" \
-    --arg repository "$DOCS_REPOSITORY" \
+    --arg docsRefInput "$(safe_sha_or_marker "$DOCS_REF_INPUT")" \
+    --arg candidate "$(safe_sha_or_marker "${OPENCLAW_CANDIDATE_SHA:-}")" \
+    --arg repository "$(safe_repository_or_marker "$DOCS_REPOSITORY")" \
     --arg recordedAt "$recorded_at" \
     --argjson exitCode "$HARNESS_INFRA_EXIT" \
-    --argjson rowSelection "$ROW_SELECTION_JSON" \
+    --argjson rowSelection "$(safe_row_selection_json)" \
     --argjson detail "$detail_json" \
     '{
       schema: "openclaw.k6.harness-control-receipt.v1",
@@ -172,13 +225,39 @@ write_harness_control_receipt() {
   echo "No rows executed; no per-row candidate verdict was synthesized." >&2
 }
 
+safe_sha_or_marker() {
+  if [[ "$1" =~ ^[0-9a-f]{40}$ ]]; then printf '%s' "$1"
+  elif [[ -n "$1" ]]; then printf 'malformed'
+  fi
+}
+
+safe_repository_or_marker() {
+  if [[ "$1" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then printf '%s' "$1"
+  elif [[ -n "$1" ]]; then printf 'malformed'
+  fi
+}
+
+safe_row_selection_json() {
+  jq -c 'map(if test("^[A-Z0-9][A-Z0-9._-]*$") then . else "malformed" end)' <<< "$ROW_SELECTION_JSON"
+}
+
+# Product version stamps are public, but they come from external process output.
+# Anything that is not an exact SHA or a conservative version string is withheld.
+safe_runtime_stamp() {
+  local sha_pattern='^[0-9a-f]{40}$'
+  local version_pattern='^[A-Za-z0-9][A-Za-z0-9 ()._-]*$'
+  if [[ "$1" =~ $sha_pattern || "$1" =~ $version_pattern ]]; then printf '%s' "$1"
+  elif [[ -n "$1" ]]; then printf 'unverified'
+  fi
+}
+
 fail_harness() {
   write_harness_control_receipt "$1" "$2" "${3:-null}"
   exit "$HARNESS_INFRA_EXIT"
 }
 
 if [[ -z "$CANDIDATE_SHA" && -z "${OPENCLAW_CANDIDATE_SHA:-}" ]]; then
-  CANDIDATE_SHA="$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo 'unknown')"
+  CANDIDATE_SHA="$(harness_git rev-parse HEAD 2>/dev/null || echo 'unknown')"
 fi
 
 if [[ -n "$CANDIDATE_SHA" ]]; then export OPENCLAW_CANDIDATE_SHA="${CANDIDATE_SHA}"; fi
@@ -240,17 +319,28 @@ echo "Artifact root: $OUT_ROOT"
 # so they inspect the same files whatever directory the caller started in. A
 # failure here stops the matrix before any row executes.
 CATALOG_PREFLIGHT_LOG="$OUT_ROOT/catalog-preflight.log"
-: > "$CATALOG_PREFLIGHT_LOG"
+CATALOG_PREFLIGHT_RAW="$(mktemp "${TMPDIR:-/tmp}/openclaw-k6-catalog.XXXXXX")"
+CATALOG_PREFLIGHT_RAW_FILE="$CATALOG_PREFLIGHT_RAW"
+: > "$CATALOG_PREFLIGHT_RAW"
 echo "Running catalog preflight (repository root: $PROOFS_TOOL_RELPATH resolved once)..."
+publish_catalog_preflight_log() {
+  scrub_public_text < "$CATALOG_PREFLIGHT_RAW" > "$CATALOG_PREFLIGHT_LOG"
+}
 for CATALOG_CHECK in "${CATALOG_CHECKS[@]}"; do
-  printf '### %s\n' "$CATALOG_CHECK" >> "$CATALOG_PREFLIGHT_LOG"
-  if ! node "$SCRIPT_DIR/$CATALOG_CHECK" --repo-root "$REPO_ROOT" >> "$CATALOG_PREFLIGHT_LOG" 2>&1; then
+  printf '### %s\n' "$CATALOG_CHECK" >> "$CATALOG_PREFLIGHT_RAW"
+  # Catalog code executes before its own identity is proven, so it runs without
+  # the gateway token or session material in its environment.
+  if ! run_without_secrets node "$SCRIPT_DIR/$CATALOG_CHECK" --repo-root "$REPO_ROOT" >> "$CATALOG_PREFLIGHT_RAW" 2>&1; then
+    publish_catalog_preflight_log
     fail_harness \
       "catalog-preflight" \
       "catalog validator '$CATALOG_CHECK' failed; the row catalog could not be resolved" \
       "$(jq -n --arg check "$CATALOG_CHECK" '{failedCheck:$check, log:"catalog-preflight.log"}')"
   fi
 done
+publish_catalog_preflight_log
+rm -f "$CATALOG_PREFLIGHT_RAW"
+CATALOG_PREFLIGHT_RAW_FILE=""
 echo "CATALOG PREFLIGHT: $CATALOG_PREFLIGHT_LOG"
 
 if [[ "$ROWS" == "all" ]]; then
@@ -293,7 +383,7 @@ resolve_docs_repository() {
     printf '%s' "$override"
     return 0
   fi
-  url="$(git -C "$REPO_ROOT" config --get remote.origin.url 2>/dev/null || true)"
+  url="$(harness_git config --get remote.origin.url 2>/dev/null || true)"
   case "$url" in
     *://*|*@*:*) ;;
     *) return 0 ;;
@@ -309,12 +399,59 @@ resolve_docs_repository() {
 # untracked at that commit.
 tracked_blob_sha256() {
   local relpath="$1"
-  git -C "$REPO_ROOT" cat-file -e "$DOCS_REF:$relpath" 2>/dev/null || return 1
-  git -C "$REPO_ROOT" show "$DOCS_REF:$relpath" 2>/dev/null | sha256sum | cut -d' ' -f1
+  harness_git cat-file -e "$DOCS_REF:$relpath" 2>/dev/null || return 1
+  harness_git show "$DOCS_REF:$relpath" 2>/dev/null | sha256sum | cut -d' ' -f1
 }
 
 worktree_sha256() {
   sha256sum "$REPO_ROOT/$1" | cut -d' ' -f1
+}
+
+# The digests are frozen once at startup, but k6 and the scenario read the
+# working tree at row time. Re-assert the frozen bytes at every step that can
+# still change what actually executes, so a mid-matrix mutation fails closed as
+# infrastructure instead of producing a receipt for unapproved source.
+assert_row_bytes_frozen() {
+  local row="$1"
+  local phase="$2"
+  local manifest_rel="${ROW_MANIFEST_RELPATH[$row]:-}"
+  local scenario_rel="${ROW_SCENARIO_RELPATH[$row]:-}"
+  local expected_manifest="${ROW_MANIFEST_SHA256[$row]:-}"
+  local expected_scenario="${ROW_SCENARIO_SHA256[$row]:-}"
+  if [[ -z "$manifest_rel" || -z "$scenario_rel" || -z "$expected_manifest" || -z "$expected_scenario" ]]; then
+    fail_harness \
+      "harness-identity" \
+      "row $row has no frozen manifest/scenario digest bound to the approved docs ref" \
+      "$(jq -n --arg row "$row" --arg phase "$phase" '{check:"row-bound-to-docs-ref", row:$row, phase:$phase}')"
+  fi
+  local actual_manifest actual_scenario
+  actual_manifest="$(worktree_sha256 "$manifest_rel")"
+  actual_scenario="$(worktree_sha256 "$scenario_rel")"
+  if [[ "$actual_manifest" != "$expected_manifest" || "$actual_scenario" != "$expected_scenario" ]]; then
+    fail_harness \
+      "harness-identity" \
+      "row $row harness bytes changed after the approved docs ref was frozen; refusing to execute unapproved source" \
+      "$(jq -n \
+        --arg row "$row" \
+        --arg phase "$phase" \
+        --argjson manifestChanged "$(if [[ "$actual_manifest" != "$expected_manifest" ]]; then printf 'true'; else printf 'false'; fi)" \
+        --argjson scenarioChanged "$(if [[ "$actual_scenario" != "$expected_scenario" ]]; then printf 'true'; else printf 'false'; fi)" \
+        '{check:"frozen-bytes-still-current", row:$row, phase:$phase, manifestChanged:$manifestChanged, scenarioChanged:$scenarioChanged}')"
+  fi
+}
+
+assert_copied_artifact_frozen() {
+  local row="$1"
+  local artifact="$2"
+  local expected="$3"
+  local actual
+  actual="$(sha256sum "$artifact" | cut -d' ' -f1)"
+  if [[ "$actual" != "$expected" ]]; then
+    fail_harness \
+      "harness-identity" \
+      "row $row captured artifact $(basename "$artifact") does not match its frozen digest" \
+      "$(jq -n --arg row "$row" --arg artifact "$(basename "$artifact")" '{check:"captured-artifact-matches-frozen-digest", row:$row, artifact:$artifact}')"
+  fi
 }
 
 DOCS_REPOSITORY="$(resolve_docs_repository)"
@@ -330,7 +467,7 @@ if [[ "$DRY_RUN" == "false" ]]; then
   DOCS_REF_SOURCE="approved-input"
   readonly DOCS_REF
 
-  HEAD_SHA="$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || true)"
+  HEAD_SHA="$(harness_git rev-parse HEAD 2>/dev/null || true)"
   if [[ "$HEAD_SHA" != "$DOCS_REF" ]]; then
     fail_harness \
       "harness-identity" \
@@ -338,7 +475,7 @@ if [[ "$DRY_RUN" == "false" ]]; then
       "$(jq -n --arg head "$HEAD_SHA" --arg approved "$DOCS_REF" '{check:"head-equals-docs-ref", head:(if $head == "" then null else $head end), approved:$approved}')"
   fi
 
-  HARNESS_DIRTY="$(git -C "$REPO_ROOT" status --porcelain --untracked-files=no -- "$PROOFS_TOOL_RELPATH" 2>/dev/null || printf 'git-unavailable')"
+  HARNESS_DIRTY="$(harness_git status --porcelain --untracked-files=no -- "$PROOFS_TOOL_RELPATH" 2>/dev/null || printf 'git-unavailable')"
   if [[ -n "$HARNESS_DIRTY" ]]; then
     fail_harness \
       "harness-identity" \
@@ -430,6 +567,13 @@ fi
 HARNESS_PROVENANCE_JSON="$OUT_ROOT/harness-provenance.json"
 RUNNER_SCRIPT_SHA256="$(sha256sum "$RUNNER_SCRIPT_PATH" | cut -d' ' -f1)"
 RUN_MATRIX_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+# A reused artifact root must not let a later matrix overwrite the provenance of
+# rows an earlier one already wrote, so each matrix also keeps an immutable copy
+# and stamps its id into every row's runner-metadata.json.
+MATRIX_ID="$(date -u +%Y%m%dT%H%M%SZ)-${DOCS_REF:0:12}"
+if [[ -z "$DOCS_REF" ]]; then MATRIX_ID="${MATRIX_ID}unbound"; fi
+HARNESS_PROVENANCE_ARCHIVE="$OUT_ROOT/harness-provenance/$MATRIX_ID.json"
+mkdir -p "$OUT_ROOT/harness-provenance"
 PROVENANCE_ROWS_JSON='[]'
 for PROV_ROW in "${ROW_ARRAY[@]}"; do
   PROV_ROW="$(printf '%s' "$PROV_ROW" | tr '[:lower:]' '[:upper:]')"
@@ -453,31 +597,33 @@ done
 jq -n \
   --arg docsRef "$DOCS_REF" \
   --arg docsRefSource "$DOCS_REF_SOURCE" \
-  --arg repository "$DOCS_REPOSITORY" \
-  --arg candidate "$OPENCLAW_CANDIDATE_SHA" \
-  --arg runtimeBuildSha "$OPENCLAW_RUNTIME_BUILD_SHA" \
+  --arg repository "$(safe_repository_or_marker "$DOCS_REPOSITORY")" \
+  --arg candidate "$(safe_sha_or_marker "$OPENCLAW_CANDIDATE_SHA")" \
+  --arg runtimeBuildSha "$(safe_runtime_stamp "$OPENCLAW_RUNTIME_BUILD_SHA")" \
   --arg seat "$OPENCLAW_SEAT_NAME" \
   --arg seatReadinessSha256 "$SEAT_READINESS_SHA256" \
   --arg runnerScript "$PROOFS_TOOL_RELPATH/scripts/run-proofs.sh" \
   --arg runnerScriptSha256 "$RUNNER_SCRIPT_SHA256" \
   --arg mode "$RUN_MODE" \
+  --arg matrixId "$MATRIX_ID" \
   --arg startedAt "$RUN_MATRIX_STARTED_AT" \
   --argjson identityVerified "$HARNESS_IDENTITY_VERIFIED" \
-  --argjson rowSelection "$ROW_SELECTION_JSON" \
+  --argjson rowSelection "$(safe_row_selection_json)" \
   --argjson rows "$PROVENANCE_ROWS_JSON" \
   '{
     schema: "openclaw.k6.harness-provenance.v1",
     classification: "harness-provenance",
+    matrixId: $matrixId,
     mode: $mode,
     docsRef: (if $docsRef == "" then null else $docsRef end),
     docsRefSource: $docsRefSource,
     repository: (if $repository == "" then null else $repository end),
     harnessIdentityVerified: $identityVerified,
-    candidateSha: (if $candidate == "" or $candidate == "unknown" then null else $candidate end),
+    candidateSha: (if $candidate == "" then null else $candidate end),
     runtimeIdentity: {
       seat: $seat,
       runtimeBuildSha: (if $runtimeBuildSha == "" or $runtimeBuildSha == "unknown" then null else $runtimeBuildSha end),
-      candidateMatchesRuntime: ($candidate == $runtimeBuildSha),
+      candidateMatchesRuntime: ($candidate != "" and $candidate == $runtimeBuildSha),
       seatReadinessReceipt: (if $seatReadinessSha256 == "" then null else "seat-readiness.json" end),
       seatReadinessSha256: (if $seatReadinessSha256 == "" then null else $seatReadinessSha256 end)
     },
@@ -489,7 +635,9 @@ jq -n \
     foldRequiresReview: true,
     startedAt: $startedAt
   }' > "$HARNESS_PROVENANCE_JSON"
+cp "$HARNESS_PROVENANCE_JSON" "$HARNESS_PROVENANCE_ARCHIVE"
 echo "HARNESS PROVENANCE: $HARNESS_PROVENANCE_JSON"
+echo "HARNESS PROVENANCE (matrix $MATRIX_ID): $HARNESS_PROVENANCE_ARCHIVE"
 rm -f "$OUT_ROOT/harness-control-receipt.json"
 
 for ROW_ID in "${ROW_ARRAY[@]}"; do
@@ -544,17 +692,9 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
     ROW_MANIFEST_DIGEST="${ROW_MANIFEST_SHA256[$ROW_ID]:-}"
     ROW_SCENARIO_REL="${ROW_SCENARIO_RELPATH[$ROW_ID]:-}"
     ROW_SCENARIO_DIGEST="${ROW_SCENARIO_SHA256[$ROW_ID]:-}"
-    # Frozen at startup by the harness identity gate. An unbound row means the
-    # gate never saw it, so it must not fire and must not produce a verdict.
-    if [[ -z "$ROW_MANIFEST_DIGEST" || -z "$ROW_SCENARIO_DIGEST" ]]; then
-      fail_harness \
-        "harness-identity" \
-        "row $ROW_ID has no frozen manifest/scenario digest bound to the approved docs ref" \
-        "$(jq -n --arg row "$ROW_ID" '{check:"row-bound-to-docs-ref", row:$row}')"
-    fi
+    assert_row_bytes_frozen "$ROW_ID" "pre-capture"
 
     echo "[$ROW_ID] RUNNING..."
-    export OPENCLAW_ROW_MANIFEST="$MANIFEST_FILE"
 
     RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%s' "$ROW_ID" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-')"
     RUN_DIR="$OUT_ROOT/$OPENCLAW_CANDIDATE_SHA/$ROW_ID/$OPENCLAW_SEAT_NAME/$RUN_ID"
@@ -564,6 +704,13 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
     # The exact scenario source travels with the receipt so a reviewer can prove
     # which contract bytes produced it without trusting the run directory name.
     cp "scenarios/$SCENARIO_FILE" "$RUN_DIR/row-scenario.js"
+    assert_copied_artifact_frozen "$ROW_ID" "$RUN_DIR/row-manifest.json" "$ROW_MANIFEST_DIGEST"
+    assert_copied_artifact_frozen "$ROW_ID" "$RUN_DIR/row-scenario.js" "$ROW_SCENARIO_DIGEST"
+    # Everything downstream reads the verified copy, never the mutable worktree
+    # manifest, so the contract the scenario loads is the contract that was
+    # digest-bound to the approved docs ref.
+    MANIFEST_FILE="$RUN_DIR/row-manifest.json"
+    export OPENCLAW_ROW_MANIFEST="$MANIFEST_FILE"
     RUN_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     jq -n \
       --arg row "$ROW_ID" \
@@ -574,11 +721,12 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
       --arg started "$RUN_STARTED_AT" \
       --arg docsRef "$DOCS_REF" \
       --arg repository "$DOCS_REPOSITORY" \
+      --arg matrixId "$MATRIX_ID" \
       --arg manifestPath "$ROW_MANIFEST_REL" \
       --arg manifestSha256 "$ROW_MANIFEST_DIGEST" \
       --arg scenarioPath "$ROW_SCENARIO_REL" \
       --arg scenarioSha256 "$ROW_SCENARIO_DIGEST" \
-      '{row:$row, scenario:$scenario, candidateSha:$candidate, runtimeBuildSha:$runtime, seat:$seat, sessionConfigured:true, startedAt:$started, docsRef:$docsRef, repository:$repository, manifestPath:$manifestPath, manifestSha256:$manifestSha256, scenarioPath:$scenarioPath, scenarioSha256:$scenarioSha256}' \
+      '{row:$row, scenario:$scenario, candidateSha:$candidate, runtimeBuildSha:$runtime, seat:$seat, sessionConfigured:true, startedAt:$started, docsRef:$docsRef, repository:$repository, matrixId:$matrixId, manifestPath:$manifestPath, manifestSha256:$manifestSha256, scenarioPath:$scenarioPath, scenarioSha256:$scenarioSha256}' \
       > "$RUN_DIR/runner-metadata.json"
     if [[ "$ROW_ID" == "R-CD-TOKEN" ]]; then
       if [[ ! "$OPENCLAW_CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ||
@@ -683,6 +831,8 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
     fi
     POSTPROCESS_RC=0
     if [[ "$ROW_ID" == "R-CD-TOKEN" ]]; then ACTIVE_TOKEN_PHASE="k6-running"; fi
+    # Last assertion before unapproved bytes could be executed.
+    assert_row_bytes_frozen "$ROW_ID" "pre-k6-execution"
     set +e
     k6 run "scenarios/$SCENARIO_FILE" > "$PRIVATE_K6_LOG" 2>&1
     k6_rc=$?

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -85,6 +85,8 @@ DOCS_REPOSITORY=""
 HARNESS_IDENTITY_VERIFIED=false
 ROW_SELECTION_JSON='[]'
 PROVISIONAL_RUN_DIR=""
+ROWS_DISPATCHED=0
+MATRIX_NONCE=""
 declare -A ROW_MANIFEST_RELPATH=()
 declare -A ROW_MANIFEST_SHA256=()
 declare -A ROW_SCENARIO_RELPATH=()
@@ -202,6 +204,7 @@ write_harness_control_receipt() {
     --arg repository "$(safe_repository_or_marker "$DOCS_REPOSITORY")" \
     --arg recordedAt "$recorded_at" \
     --argjson exitCode "$HARNESS_INFRA_EXIT" \
+    --argjson rowsExecuted "${ROWS_DISPATCHED:-0}" \
     --argjson rowSelection "$(safe_row_selection_json)" \
     --argjson detail "$detail_json" \
     '{
@@ -216,7 +219,7 @@ write_harness_control_receipt() {
       candidateSha: (if $candidate == "" then null else $candidate end),
       repository: (if $repository == "" then null else $repository end),
       rowSelection: $rowSelection,
-      rowsExecuted: 0,
+      rowsExecuted: $rowsExecuted,
       rowVerdictsSynthesized: false,
       productVerdict: null,
       exitCode: $exitCode,
@@ -225,7 +228,7 @@ write_harness_control_receipt() {
     }' > "$OUT_ROOT/harness-control-receipt.json"
   echo "HARNESS INFRASTRUCTURE FAILURE [$stage]: $reason" >&2
   echo "CONTROL RECEIPT: $OUT_ROOT/harness-control-receipt.json" >&2
-  echo "No rows executed; no per-row candidate verdict was synthesized." >&2
+  echo "Rows dispatched before this failure: ${ROWS_DISPATCHED:-0}. No per-row candidate verdict was synthesized." >&2
 }
 
 safe_sha_or_marker() {
@@ -324,26 +327,7 @@ echo "Session configured: true"
 echo "Artifact root: $OUT_ROOT"
 
 
-if [[ "$ROWS" == "all" ]]; then
-  # Data-only read of the manifest catalog. A malformed catalog is an
-  # infrastructure fault, not an empty row list.
-  if ! ROWS="$(for f in manifests/*.json; do jq -r 'select(.scenario.status == "runnable") | .rowId' "$f"; done | paste -sd, -)"; then
-    fail_harness \
-      "catalog-preflight" \
-      "the manifest catalog could not be read to resolve the 'all' row selection" \
-      "$(jq -n '{check:"row-selection-resolvable"}')"
-  fi
-fi
-
-if [[ -z "$ROWS" ]]; then
-  echo "No runnable rows found."
-  exit 1
-fi
-
-ROW_SELECTION_JSON="$(printf '%s' "$ROWS" | jq -R 'split(",") | map(ascii_upcase)')"
-IFS=',' read -ra ROW_ARRAY <<< "$ROWS"
-
-echo "Rows: $ROWS"
+echo "Row selection: $ROWS"
 echo "Dry Run: $DRY_RUN"
 echo "=========================================================="
 
@@ -391,6 +375,48 @@ tracked_blob_sha256() {
   harness_git show "$DOCS_REF:$relpath" 2>/dev/null | sha256sum | cut -d' ' -f1
 }
 
+# Byte-integrity verification of every tracked file under tools/k6-proofs.
+#
+# `git status` is deliberately NOT used: it consults the index, so
+# assume-unchanged / skip-worktree entries or preserved stat metadata can hide a
+# modified file. Hashing the working-tree bytes with `git hash-object` and
+# comparing against the blob names recorded in the approved commit cannot be
+# suppressed that way. `--stdin-paths` keeps this to one process for the whole
+# tree, so it is cheap enough to re-assert before every row.
+assert_harness_tree_matches_docs_ref() {
+  local check="$1"
+  local phase="$2"
+  local row="$3"
+  local listing expected_objects paths actual_objects
+  listing="$(harness_git ls-tree -r "$DOCS_REF" -- "$PROOFS_TOOL_RELPATH" 2>/dev/null || true)"
+  if [[ -z "$listing" ]]; then
+    fail_harness \
+      "harness-identity" \
+      "the approved docs ref records no $PROOFS_TOOL_RELPATH tree; refusing to fire an unrecorded harness" \
+      "$(jq -n --arg check "$check" --arg phase "$phase" --arg row "$row" \
+        '{check:$check, phase:$phase, row:(if $row == "" then null else $row end), reason:"empty-tree-listing"}')"
+  fi
+  expected_objects="$(printf '%s\n' "$listing" | cut -f1 | awk '{print $3}')"
+  paths="$(printf '%s\n' "$listing" | cut -f2-)"
+  actual_objects="$(printf '%s\n' "$paths" | harness_git hash-object --stdin-paths 2>/dev/null || true)"
+  if [[ "$expected_objects" != "$actual_objects" ]]; then
+    local expected_count actual_count
+    expected_count="$(printf '%s\n' "$expected_objects" | grep -c . || true)"
+    actual_count="$(printf '%s\n' "$actual_objects" | grep -c . || true)"
+    fail_harness \
+      "harness-identity" \
+      "tracked bytes under $PROOFS_TOOL_RELPATH do not match the approved docs ref; refusing to fire a mutated or mixed harness" \
+      "$(jq -n \
+        --arg check "$check" \
+        --arg phase "$phase" \
+        --arg row "$row" \
+        --arg expectedFiles "$expected_count" \
+        --arg hashedFiles "$actual_count" \
+        '{check:$check, phase:$phase, row:(if $row == "" then null else $row end),
+          trackedFiles:($expectedFiles|tonumber), hashedFiles:($hashedFiles|tonumber)}')"
+  fi
+}
+
 worktree_sha256() {
   sha256sum "$REPO_ROOT/$1" 2>/dev/null | cut -d' ' -f1
 }
@@ -430,17 +456,9 @@ assert_row_bytes_frozen() {
         '{check:"frozen-bytes-still-current", row:$row, phase:$phase, manifestChanged:$manifestChanged, scenarioChanged:$scenarioChanged}')"
   fi
   # A scenario is not self-contained: it imports the shared harness library.
-  # Re-checking the whole tracked tree covers lib/, scripts/, and every other
+  # Re-verifying the whole tracked tree covers lib/, scripts/, and every other
   # file a row can reach.
-  local dirty
-  dirty="$(harness_git status --porcelain --untracked-files=no -- "$PROOFS_TOOL_RELPATH" 2>/dev/null || printf 'git-unavailable')"
-  if [[ -n "$dirty" ]]; then
-    fail_harness \
-      "harness-identity" \
-      "tracked bytes under $PROOFS_TOOL_RELPATH changed after the approved docs ref was frozen; refusing to execute unapproved source" \
-      "$(jq -n --arg row "$row" --arg phase "$phase" --arg count "$(printf '%s\n' "$dirty" | grep -c . || true)" \
-        '{check:"harness-tree-still-clean", row:$row, phase:$phase, dirtyEntries:($count|tonumber)}')"
-  fi
+  assert_harness_tree_matches_docs_ref "harness-tree-still-current" "$phase" "$row"
 }
 
 assert_copied_artifact_frozen() {
@@ -478,13 +496,7 @@ if [[ "$DRY_RUN" == "false" ]]; then
       "$(jq -n --arg head "$HEAD_SHA" --arg approved "$DOCS_REF" '{check:"head-equals-docs-ref", head:(if $head == "" then null else $head end), approved:$approved}')"
   fi
 
-  HARNESS_DIRTY="$(harness_git status --porcelain --untracked-files=no -- "$PROOFS_TOOL_RELPATH" 2>/dev/null || printf 'git-unavailable')"
-  if [[ -n "$HARNESS_DIRTY" ]]; then
-    fail_harness \
-      "harness-identity" \
-      "tracked bytes under $PROOFS_TOOL_RELPATH are modified; a dirty harness cannot certify which contract produced a receipt" \
-      "$(jq -n --arg count "$(printf '%s\n' "$HARNESS_DIRTY" | grep -c . || true)" '{check:"harness-tree-clean", dirtyEntries:($count|tonumber)}')"
-  fi
+  assert_harness_tree_matches_docs_ref "harness-tree-clean" "startup" ""
 
   if [[ ! "$DOCS_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
     fail_harness \
@@ -493,6 +505,73 @@ if [[ "$DRY_RUN" == "false" ]]; then
       "$(jq -n '{check:"repository-identity"}')"
   fi
 
+  HARNESS_IDENTITY_VERIFIED=true
+  echo "Approved docs ref: $DOCS_REF ($DOCS_REPOSITORY)"
+  echo "Harness identity: every tracked byte under $PROOFS_TOOL_RELPATH matches the approved docs ref."
+elif [[ "$DOCS_REF_INPUT" =~ ^[0-9a-f]{40}$ ]]; then
+  DOCS_REF="$DOCS_REF_INPUT"
+  DOCS_REF_SOURCE="approved-input"
+  echo "Docs ref (recorded, unenforced in dry run): $DOCS_REF"
+fi
+
+# Catalog preflight (#495). The validators receive one explicit repository root,
+# so they inspect the same files whatever directory the caller started in. A
+# failure here stops the matrix before any row executes.
+CATALOG_PREFLIGHT_LOG="$OUT_ROOT/catalog-preflight.log"
+CATALOG_PREFLIGHT_RAW="$(mktemp "${TMPDIR:-/tmp}/openclaw-k6-catalog.XXXXXX")"
+CATALOG_PREFLIGHT_RAW_FILE="$CATALOG_PREFLIGHT_RAW"
+: > "$CATALOG_PREFLIGHT_RAW"
+echo "Running catalog preflight (repository root: $PROOFS_TOOL_RELPATH resolved once)..."
+publish_catalog_preflight_log() {
+  scrub_public_text < "$CATALOG_PREFLIGHT_RAW" > "$CATALOG_PREFLIGHT_LOG"
+}
+for CATALOG_CHECK in "${CATALOG_CHECKS[@]}"; do
+  printf '### %s\n' "$CATALOG_CHECK" >> "$CATALOG_PREFLIGHT_RAW"
+  if ! run_with_minimal_env node "$SCRIPT_DIR/$CATALOG_CHECK" --repo-root "$REPO_ROOT" >> "$CATALOG_PREFLIGHT_RAW" 2>&1; then
+    publish_catalog_preflight_log
+    fail_harness \
+      "catalog-preflight" \
+      "catalog validator '$CATALOG_CHECK' failed; the row catalog could not be resolved" \
+      "$(jq -n --arg check "$CATALOG_CHECK" '{failedCheck:$check, log:"catalog-preflight.log"}')"
+  fi
+done
+publish_catalog_preflight_log
+rm -f "$CATALOG_PREFLIGHT_RAW"
+CATALOG_PREFLIGHT_RAW_FILE=""
+echo "CATALOG PREFLIGHT: $CATALOG_PREFLIGHT_LOG"
+
+# ---------------------------------------------------------------------------
+# Row selection and per-row contract binding
+# ---------------------------------------------------------------------------
+# Everything below parses the manifest catalog, so it runs only after the
+# validators have approved that catalog and after the harness bytes have been
+# proven to match the approved docs ref. Every catalog read is classified as
+# infrastructure rather than allowed to abort the shell.
+if [[ "$ROWS" == "all" ]]; then
+  ROWS=""
+  for f in manifests/*.json; do
+    ROW_FROM_MANIFEST=""
+    if ! ROW_FROM_MANIFEST="$(jq -r 'select(.scenario.status == "runnable") | .rowId' "$f" 2>/dev/null)"; then
+      fail_harness \
+        "catalog-preflight" \
+        "manifest '$f' could not be read to resolve the 'all' row selection" \
+        "$(jq -n --arg manifest "$f" '{check:"row-selection-resolvable", manifest:$manifest}')"
+    fi
+    [[ -n "$ROW_FROM_MANIFEST" ]] || continue
+    ROWS="${ROWS:+$ROWS,}$ROW_FROM_MANIFEST"
+  done
+fi
+
+if [[ -z "$ROWS" ]]; then
+  echo "No runnable rows found."
+  exit 1
+fi
+
+ROW_SELECTION_JSON="$(printf '%s' "$ROWS" | jq -R 'split(",") | map(ascii_upcase)')"
+IFS=',' read -ra ROW_ARRAY <<< "$ROWS"
+echo "Rows: $ROWS"
+
+if [[ "$DRY_RUN" == "false" ]]; then
   for BIND_ROW in "${ROW_ARRAY[@]}"; do
     BIND_ROW="$(printf '%s' "$BIND_ROW" | tr '[:lower:]' '[:upper:]')"
     BIND_MANIFEST=""
@@ -500,9 +579,21 @@ if [[ "$DRY_RUN" == "false" ]]; then
     # A row with no manifest is reported as SKIPPED by the row loop; it never
     # fires, so it has no harness contract to bind.
     [[ -n "$BIND_MANIFEST" ]] || continue
-    BIND_STATUS="$(jq -r '.scenario.status // empty' "$BIND_MANIFEST")"
+    BIND_STATUS=""
+    if ! BIND_STATUS="$(jq -r '.scenario.status // empty' "$BIND_MANIFEST" 2>/dev/null)"; then
+      fail_harness \
+        "catalog-preflight" \
+        "manifest '$BIND_MANIFEST' could not be read while binding row $BIND_ROW" \
+        "$(jq -n --arg row "$BIND_ROW" --arg manifest "$BIND_MANIFEST" '{check:"manifest-readable", row:$row, manifest:$manifest}')"
+    fi
     [[ "$BIND_STATUS" == "runnable" ]] || continue
-    BIND_SCENARIO="$(jq -r '.scenario.file // .scenario.name // empty' "$BIND_MANIFEST")"
+    BIND_SCENARIO=""
+    if ! BIND_SCENARIO="$(jq -r '.scenario.file // .scenario.name // empty' "$BIND_MANIFEST" 2>/dev/null)"; then
+      fail_harness \
+        "catalog-preflight" \
+        "manifest '$BIND_MANIFEST' could not be read while binding row $BIND_ROW" \
+        "$(jq -n --arg row "$BIND_ROW" --arg manifest "$BIND_MANIFEST" '{check:"manifest-readable", row:$row, manifest:$manifest}')"
+    fi
     if [[ -z "$BIND_SCENARIO" || ! -f "scenarios/$BIND_SCENARIO" ]]; then
       fail_harness \
         "harness-identity" \
@@ -536,40 +627,8 @@ if [[ "$DRY_RUN" == "false" ]]; then
       fi
     done
   done
-  HARNESS_IDENTITY_VERIFIED=true
-  echo "Approved docs ref: $DOCS_REF ($DOCS_REPOSITORY)"
-  echo "Harness identity: verified clean and tracked for every selected runnable row."
-elif [[ "$DOCS_REF_INPUT" =~ ^[0-9a-f]{40}$ ]]; then
-  DOCS_REF="$DOCS_REF_INPUT"
-  DOCS_REF_SOURCE="approved-input"
-  echo "Docs ref (recorded, unenforced in dry run): $DOCS_REF"
+  echo "Harness contract binding: frozen manifest/scenario digests for every selected runnable row."
 fi
-
-# Catalog preflight (#495). The validators receive one explicit repository root,
-# so they inspect the same files whatever directory the caller started in. A
-# failure here stops the matrix before any row executes.
-CATALOG_PREFLIGHT_LOG="$OUT_ROOT/catalog-preflight.log"
-CATALOG_PREFLIGHT_RAW="$(mktemp "${TMPDIR:-/tmp}/openclaw-k6-catalog.XXXXXX")"
-CATALOG_PREFLIGHT_RAW_FILE="$CATALOG_PREFLIGHT_RAW"
-: > "$CATALOG_PREFLIGHT_RAW"
-echo "Running catalog preflight (repository root: $PROOFS_TOOL_RELPATH resolved once)..."
-publish_catalog_preflight_log() {
-  scrub_public_text < "$CATALOG_PREFLIGHT_RAW" > "$CATALOG_PREFLIGHT_LOG"
-}
-for CATALOG_CHECK in "${CATALOG_CHECKS[@]}"; do
-  printf '### %s\n' "$CATALOG_CHECK" >> "$CATALOG_PREFLIGHT_RAW"
-  if ! run_with_minimal_env node "$SCRIPT_DIR/$CATALOG_CHECK" --repo-root "$REPO_ROOT" >> "$CATALOG_PREFLIGHT_RAW" 2>&1; then
-    publish_catalog_preflight_log
-    fail_harness \
-      "catalog-preflight" \
-      "catalog validator '$CATALOG_CHECK' failed; the row catalog could not be resolved" \
-      "$(jq -n --arg check "$CATALOG_CHECK" '{failedCheck:$check, log:"catalog-preflight.log"}')"
-  fi
-done
-publish_catalog_preflight_log
-rm -f "$CATALOG_PREFLIGHT_RAW"
-CATALOG_PREFLIGHT_RAW_FILE=""
-echo "CATALOG PREFLIGHT: $CATALOG_PREFLIGHT_LOG"
 
 # Check for Live Bridge alignment (candidate vs deployed runtime)
 if [[ "$DRY_RUN" == "false" && "$OPENCLAW_CANDIDATE_SHA" != "$OPENCLAW_RUNTIME_BUILD_SHA" && "$OPENCLAW_RUNTIME_BUILD_SHA" != *"(${OPENCLAW_CANDIDATE_SHA:0:7})"* ]]; then
@@ -613,10 +672,13 @@ RUN_MATRIX_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 # A reused artifact root must not let a later matrix overwrite the provenance of
 # rows an earlier one already wrote, so each matrix also keeps an immutable copy
 # and stamps its id into every row's runner-metadata.json.
+# Two matrices for the same docs ref can start within the same second, so every
+# matrix carries a random nonce that also makes its run directories exclusive.
+MATRIX_NONCE="$(tr -d '-' < /proc/sys/kernel/random/uuid 2>/dev/null | cut -c1-8)"
+if [[ -z "$MATRIX_NONCE" ]]; then MATRIX_NONCE="$(printf '%04x%04x' "$RANDOM" "$RANDOM")"; fi
 MATRIX_ID="$(date -u +%Y%m%dT%H%M%SZ)-${DOCS_REF:0:12}"
 if [[ -z "$DOCS_REF" ]]; then MATRIX_ID="${MATRIX_ID}unbound"; fi
-# Two matrices for the same docs ref can start within the same second.
-MATRIX_ID="${MATRIX_ID}-$(cat /proc/sys/kernel/random/uuid 2>/dev/null | tr -d '-' | cut -c1-8 || printf '%08x' "$RANDOM")"
+MATRIX_ID="${MATRIX_ID}-${MATRIX_NONCE}"
 HARNESS_PROVENANCE_ARCHIVE="$OUT_ROOT/harness-provenance/$MATRIX_ID.json"
 mkdir -p "$OUT_ROOT/harness-provenance"
 PROVENANCE_ROWS_JSON='[]'
@@ -741,8 +803,17 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
 
     echo "[$ROW_ID] RUNNING..."
 
-    RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%s' "$ROW_ID" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-')"
+    # The suffix makes the directory unique to this invocation: a pre-execution
+    # purge must never be able to delete evidence written by a concurrent or
+    # earlier run for the same candidate/row/seat within the same second.
+    RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$(printf '%s' "$ROW_ID" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-')-${MATRIX_NONCE}"
     RUN_DIR="$OUT_ROOT/$OPENCLAW_CANDIDATE_SHA/$ROW_ID/$OPENCLAW_SEAT_NAME/$RUN_ID"
+    if [[ -e "$RUN_DIR" ]]; then
+      fail_harness \
+        "harness-identity" \
+        "row $ROW_ID run directory already exists; refusing to write into another invocation's artifacts" \
+        "$(jq -n --arg row "$ROW_ID" '{check:"run-directory-exclusive", row:$row}')"
+    fi
     mkdir -p "$RUN_DIR"
     PROVISIONAL_RUN_DIR="$RUN_DIR"
     touch "$RUN_DIR/.started"
@@ -780,8 +851,8 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
             "$OPENCLAW_CANDIDATE_SHA" != "$OPENCLAW_RUNTIME_BUILD_SHA" ]]; then
         RUN_ENDED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
         jq -n \
-          --arg candidateSha "$OPENCLAW_CANDIDATE_SHA" \
-          --arg runtimeBuildSha "$OPENCLAW_RUNTIME_BUILD_SHA" \
+          --arg candidateSha "$(safe_sha_or_marker "$OPENCLAW_CANDIDATE_SHA")" \
+          --arg runtimeBuildSha "$(safe_sha_or_marker "$OPENCLAW_RUNTIME_BUILD_SHA")" \
           --arg endedAt "$RUN_ENDED_AT" \
           '{schema:"openclaw.k6.r-cd-token.build-identity-gate.v1",row:"R-CD-TOKEN",candidateSha:$candidateSha,runtimeBuildSha:$runtimeBuildSha,equalExactSha:false,dispatched:false,verdict:"PARTIAL-candidate",endedAt:$endedAt}' \
           > "$RUN_DIR/build-identity-gate.json"
@@ -791,6 +862,7 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
           > "$RUN_DIR/run-result.json"
         rm -f "$RUN_DIR/.started"
         PROVISIONAL_RUN_DIR=""
+        ROWS_DISPATCHED=$((ROWS_DISPATCHED + 1))
         echo "[$ROW_ID] PARTIAL-candidate: exact equal candidate/runtime SHAs are required; no dispatch occurred."
         continue
       fi
@@ -832,6 +904,7 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
         ACTIVE_TOKEN_PHASE="pre-dispatch-surface-gate"
         ACTIVE_TOKEN_RUN_DIR=""
         PROVISIONAL_RUN_DIR=""
+        ROWS_DISPATCHED=$((ROWS_DISPATCHED + 1))
         echo "[$ROW_ID] PARTIAL-candidate: seat readiness class '$OPENCLAW_SEAT_CLASS' is not scanner-supported raw-final-text; no dispatch occurred."
         continue
       fi
@@ -883,6 +956,7 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
     assert_row_bytes_frozen "$ROW_ID" "pre-k6-execution"
     # From here the directory holds real candidate evidence and must survive.
     PROVISIONAL_RUN_DIR=""
+    ROWS_DISPATCHED=$((ROWS_DISPATCHED + 1))
     set +e
     k6 run "scenarios/$SCENARIO_FILE" > "$PRIVATE_K6_LOG" 2>&1
     k6_rc=$?

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -140,7 +140,7 @@ write_harness_control_receipt() {
     --arg reason "$reason" \
     --arg mode "$RUN_MODE" \
     --arg docsRef "$DOCS_REF" \
-    --arg docsRefInput "$DOCS_REF_INPUT" \
+    --arg docsRefInput "$(if [[ "$DOCS_REF_INPUT" =~ ^[0-9a-f]{40}$ ]]; then printf '%s' "$DOCS_REF_INPUT"; elif [[ -n "$DOCS_REF_INPUT" ]]; then printf 'malformed'; fi)" \
     --arg candidate "${OPENCLAW_CANDIDATE_SHA:-}" \
     --arg repository "$DOCS_REPOSITORY" \
     --arg recordedAt "$recorded_at" \
@@ -324,8 +324,7 @@ if [[ "$DRY_RUN" == "false" ]]; then
       "harness-identity" \
       "a live matrix requires an approved docs/harness ref: pass --docs-ref <40-char-lowercase-sha> or set OPENCLAW_PROOFS_DOCS_REF" \
       "$(jq -n --arg provided "$DOCS_REF_INPUT" '{check:"docs-ref-shape", provided:(if $provided == "" then null else "malformed" end)}')"
-  fi
-  # Frozen for the whole run. Ambient HEAD is never consulted again.
+  fi  # Frozen for the whole run. Ambient HEAD is never consulted again.
   DOCS_REF="$DOCS_REF_INPUT"
   DOCS_REF_SOURCE="approved-input"
   readonly DOCS_REF

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -14,11 +14,21 @@
 
 set -euo pipefail
 
+ORIGINAL_ARGS=("$@")
+
 RUNNER_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RUNNER_SCRIPT_PATH="$RUNNER_SCRIPT_DIR/$(basename "${BASH_SOURCE[0]}")"
-# The operator's checkout. Identity is always verified against this tree.
-REPO_ROOT="$(cd "$RUNNER_SCRIPT_DIR/../../.." && pwd)"
+# The operator's checkout. Identity is always verified against this tree, even
+# when this process is the re-executed snapshot copy of the runner.
+if [[ -n "${OPENCLAW_PROOFS_ORIGIN_ROOT:-}" ]]; then
+  REPO_ROOT="$OPENCLAW_PROOFS_ORIGIN_ROOT"
+else
+  REPO_ROOT="$(cd "$RUNNER_SCRIPT_DIR/../../.." && pwd)"
+fi
 PROOFS_TOOL_RELPATH="tools/k6-proofs"
+# Every tree whose bytes a row can consume: the harness itself, the proof corpus
+# that static rows read, and the workflow the catalog validators parse.
+HARNESS_VERIFIED_PATHS=("tools/k6-proofs" "PROOFS" ".github")
 # The tree harness components are executed from. For a live run this is replaced
 # by an immutable snapshot of the approved docs ref (see bind_execution_roots).
 EXEC_ROOT="$REPO_ROOT"
@@ -401,21 +411,26 @@ tracked_blob_sha256() {
 # comparing against the blob names recorded in the approved commit cannot be
 # suppressed that way. `--stdin-paths` keeps this to one process for the whole
 # tree, so it is cheap enough to re-assert before every row.
+harness_tree_listing() {
+  harness_git ls-tree -r "$DOCS_REF" -- "${HARNESS_VERIFIED_PATHS[@]}" 2>/dev/null || true
+}
+
 assert_harness_tree_matches_docs_ref() {
   local check="$1"
   local phase="$2"
   local row="$3"
+  local root="${4:-$REPO_ROOT}"
   local listing expected_objects paths actual_objects
-  listing="$(harness_git ls-tree -r "$DOCS_REF" -- "$PROOFS_TOOL_RELPATH" 2>/dev/null || true)"
+  listing="$(harness_tree_listing)"
   if [[ -z "$listing" ]]; then
     fail_harness \
       "harness-identity" \
-      "the approved docs ref records no $PROOFS_TOOL_RELPATH tree; refusing to fire an unrecorded harness" \
+      "the approved docs ref records no ${HARNESS_VERIFIED_PATHS[*]} trees; refusing to fire an unrecorded harness" \
       "$(jq -n --arg check "$check" --arg phase "$phase" --arg row "$row" \
         '{check:$check, phase:$phase, row:(if $row == "" then null else $row end), reason:"empty-tree-listing"}')"
   fi
   expected_objects="$(printf '%s\n' "$listing" | cut -f1 | awk '{print $3}')"
-  paths="$(printf '%s\n' "$listing" | cut -f2-)"
+  paths="$(printf '%s\n' "$listing" | cut -f2- | awk -v root="$root" '{print root "/" $0}')"
   # --no-filters: a configured clean filter would otherwise be able to transform
   # dirty bytes into the approved blob hash, and would itself execute here.
   actual_objects="$(printf '%s\n' "$paths" | harness_git hash-object --no-filters --stdin-paths 2>/dev/null || true)"
@@ -425,7 +440,7 @@ assert_harness_tree_matches_docs_ref() {
     actual_count="$(printf '%s\n' "$actual_objects" | grep -c . || true)"
     fail_harness \
       "harness-identity" \
-      "tracked bytes under $PROOFS_TOOL_RELPATH do not match the approved docs ref; refusing to fire a mutated or mixed harness" \
+      "bytes under ${HARNESS_VERIFIED_PATHS[*]} do not match the approved docs ref; refusing to fire a mutated or mixed harness" \
       "$(jq -n \
         --arg check "$check" \
         --arg phase "$phase" \
@@ -480,7 +495,10 @@ assert_row_bytes_frozen() {
   # the operator's checkout exists for a different reason: bash reads this very
   # script incrementally, so run-proofs.sh itself must still match the approved
   # ref while it is running.
-  assert_harness_tree_matches_docs_ref "harness-tree-still-current" "$phase" "$row"
+  assert_harness_tree_matches_docs_ref "harness-tree-still-current" "$phase" "$row" "$REPO_ROOT"
+  if [[ "$EXEC_ROOT" != "$REPO_ROOT" ]]; then
+    assert_harness_tree_matches_docs_ref "harness-snapshot-still-current" "$phase" "$row" "$EXEC_ROOT"
+  fi
 }
 
 assert_copied_artifact_frozen() {
@@ -518,7 +536,7 @@ if [[ "$DRY_RUN" == "false" ]]; then
       "$(jq -n --arg head "$HEAD_SHA" --arg approved "$DOCS_REF" '{check:"head-equals-docs-ref", head:(if $head == "" then null else $head end), approved:$approved}')"
   fi
 
-  assert_harness_tree_matches_docs_ref "harness-tree-clean" "startup" ""
+  assert_harness_tree_matches_docs_ref "harness-tree-clean" "startup" "" "$REPO_ROOT"
 
   if [[ ! "${OPENCLAW_CANDIDATE_SHA:-}" =~ ^[0-9a-f]{40}$ ]]; then
     fail_harness \
@@ -538,26 +556,45 @@ if [[ "$DRY_RUN" == "false" ]]; then
   # approved commit, not the operator's mutable working tree. This closes the
   # check-then-use window for the catalog validators, seat readiness, k6, and
   # every scenario import: those bytes cannot change while the matrix runs.
-  HARNESS_SNAPSHOT_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-k6-harness.XXXXXX")"
-  chmod 700 "$HARNESS_SNAPSHOT_ROOT"
-  if ! harness_git archive "$DOCS_REF" -- "$PROOFS_TOOL_RELPATH" | tar -x -C "$HARNESS_SNAPSHOT_ROOT"; then
-    fail_harness \
-      "harness-identity" \
-      "the approved $PROOFS_TOOL_RELPATH tree could not be extracted for immutable execution" \
-      "$(jq -n '{check:"harness-snapshot-extractable"}')"
+  #
+  # That includes this script. Bash reads its source incrementally, so the only
+  # way the remaining commands are guaranteed to be approved bytes is to hand
+  # execution to the snapshot's own copy before any credential is loaded.
+  if [[ -z "${OPENCLAW_PROOFS_HARNESS_SNAPSHOT:-}" ]]; then
+    HARNESS_SNAPSHOT_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-k6-harness.XXXXXX")"
+    chmod 700 "$HARNESS_SNAPSHOT_ROOT"
+    if ! harness_git archive "$DOCS_REF" -- "$PROOFS_TOOL_RELPATH" | tar -x -C "$HARNESS_SNAPSHOT_ROOT"; then
+      fail_harness \
+        "harness-identity" \
+        "the approved $PROOFS_TOOL_RELPATH tree could not be extracted for immutable execution" \
+        "$(jq -n '{check:"harness-snapshot-extractable"}')"
+    fi
+    # The corpus and workflow trees are byte-verified against the approved ref
+    # above, so they are referenced rather than copied; PROOFS alone is hundreds
+    # of megabytes and every one of its bytes is checked before and between rows.
+    ln -s "$REPO_ROOT/PROOFS" "$HARNESS_SNAPSHOT_ROOT/PROOFS"
+    ln -s "$REPO_ROOT/.github" "$HARNESS_SNAPSHOT_ROOT/.github"
+    export OPENCLAW_PROOFS_HARNESS_SNAPSHOT="$HARNESS_SNAPSHOT_ROOT"
+    export OPENCLAW_PROOFS_ORIGIN_ROOT="$REPO_ROOT"
+    echo "Harness execution: handing off to the approved runner in an immutable snapshot."
+    # `exec` replaces this process, so no EXIT trap fires here and the snapshot
+    # survives into the approved runner, which owns its cleanup.
+    exec bash "$HARNESS_SNAPSHOT_ROOT/$PROOFS_TOOL_RELPATH/scripts/run-proofs.sh" \
+      "${ORIGINAL_ARGS[@]}" --out-dir "$OUT_ROOT"
   fi
-  # Read-only corpus/workflow inputs the catalog validators need. They are never
-  # executed, so they are referenced rather than copied.
-  ln -s "$REPO_ROOT/PROOFS" "$HARNESS_SNAPSHOT_ROOT/PROOFS"
-  ln -s "$REPO_ROOT/.github" "$HARNESS_SNAPSHOT_ROOT/.github"
+
+  # Re-executed copy: adopt the snapshot and prove it is the approved tree before
+  # trusting anything in it.
+  HARNESS_SNAPSHOT_ROOT="$OPENCLAW_PROOFS_HARNESS_SNAPSHOT"
   EXEC_ROOT="$HARNESS_SNAPSHOT_ROOT"
   bind_execution_roots
   cd "$PROOFS_DIR"
+  assert_harness_tree_matches_docs_ref "harness-snapshot-matches-docs-ref" "startup" "" "$EXEC_ROOT"
 
   HARNESS_IDENTITY_VERIFIED=true
   echo "Approved docs ref: $DOCS_REF ($DOCS_REPOSITORY)"
   echo "Harness identity: every tracked byte under $PROOFS_TOOL_RELPATH matches the approved docs ref."
-  echo "Harness execution: immutable snapshot of the approved tree."
+  echo "Harness execution: immutable snapshot of the approved tree (runner included)."
 elif [[ "$DOCS_REF_INPUT" =~ ^[0-9a-f]{40}$ ]]; then
   DOCS_REF="$DOCS_REF_INPUT"
   DOCS_REF_SOURCE="approved-input"

--- a/tools/k6-proofs/scripts/validate-candidate-run-result.mjs
+++ b/tools/k6-proofs/scripts/validate-candidate-run-result.mjs
@@ -10,7 +10,7 @@ import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { validateRcd2AuthoritativeReceipt } from '../lib/r-cd-2-authoritative-receipt.mjs';
 import { validateRcdTokenAuthoritativeReceipt } from '../lib/r-cd-token-authoritative-receipt.mjs';
-import { COPIED_MANIFEST, COPIED_SCENARIO, isSafeCandidateArtifact } from './candidate-run-result-contract.mjs';
+import { COPIED_MANIFEST, COPIED_SCENARIO, isSafeArtifactReference, isSafeCandidateArtifact } from './candidate-run-result-contract.mjs';
 
 const SHA = /^[0-9a-f]{40}$/;
 const DIGEST = /^[0-9a-f]{64}$/;
@@ -117,10 +117,12 @@ async function harnessIdentity(metadata, candidateDir, docsRef, manifestPath) {
 
 function safeRelative(value, label) {
   if (value == null) return null;
-  if (typeof value !== 'string' || !value || path.isAbsolute(value) || value.split(/[\\/]+/).some((part) => part === '..')) {
-    throw new Error(`${label} must be a safe artifact-relative path`);
+  // Basename only: an artifact reference may never traverse out of the
+  // candidate directory it is published from.
+  if (!isSafeArtifactReference(value)) {
+    throw new Error(`${label} must be a safe artifact file name inside the candidate directory`);
   }
-  return value.replaceAll('\\', '/');
+  return value;
 }
 
 function same(value, expected, label) {

--- a/tools/k6-proofs/scripts/validate-candidate-run-result.mjs
+++ b/tools/k6-proofs/scripts/validate-candidate-run-result.mjs
@@ -12,6 +12,10 @@ import { validateRcd2AuthoritativeReceipt } from '../lib/r-cd-2-authoritative-re
 import { validateRcdTokenAuthoritativeReceipt } from '../lib/r-cd-token-authoritative-receipt.mjs';
 
 const SHA = /^[0-9a-f]{40}$/;
+const DIGEST = /^[0-9a-f]{64}$/;
+const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const COPIED_MANIFEST = 'row-manifest.json';
+const COPIED_SCENARIO = 'row-scenario.js';
 const OUTCOME = new Set(['PASS-candidate', 'HONEST-LIMIT-candidate', 'PARTIAL-candidate', 'FAIL-candidate', 'construct-only']);
 
 function usage() {
@@ -49,6 +53,55 @@ function requireString(value, label) {
 function requireSha(value, label) {
   if (!SHA.test(value || '')) throw new Error(`${label} must be a 40-character lowercase SHA`);
   return value;
+}
+
+function requireDigest(value, label) {
+  if (!DIGEST.test(value || '')) throw new Error(`${label} must be a 64-character lowercase sha256 digest`);
+  return value;
+}
+
+async function fileDigest(file, label) {
+  let raw;
+  try { raw = await readFile(file); }
+  catch (error) { throw new Error(`${label} missing or unreadable: ${error.message}`); }
+  return createHash('sha256').update(raw).digest('hex');
+}
+
+/**
+ * Bind the candidate directory to one immutable docs/harness commit (#496).
+ *
+ * The runner freezes the approved docs ref before the first row fires and copies
+ * the exact manifest and scenario bytes it used into the candidate directory.
+ * Metadata that omits the ref or either digest, or whose digests disagree with
+ * the copied source, cannot produce an envelope.
+ */
+async function harnessIdentity(metadata, candidateDir, docsRef) {
+  const metadataDocsRef = requireSha(metadata.docsRef, 'runner metadata docsRef');
+  same(metadataDocsRef, docsRef, 'docs ref');
+  const repository = requireString(metadata.repository, 'runner metadata repository');
+  if (!REPOSITORY.test(repository)) throw new Error('runner metadata repository must be a safe <owner>/<repo> identity');
+  const manifestSha256 = requireDigest(metadata.manifestSha256, 'runner metadata manifestSha256');
+  const scenarioSha256 = requireDigest(metadata.scenarioSha256, 'runner metadata scenarioSha256');
+
+  const copiedManifestDigest = await fileDigest(path.join(candidateDir, COPIED_MANIFEST), 'copied row manifest');
+  if (copiedManifestDigest !== manifestSha256) {
+    throw new Error(`copied row manifest digest mismatch: ${copiedManifestDigest} != ${manifestSha256}`);
+  }
+  const copiedScenarioDigest = await fileDigest(path.join(candidateDir, COPIED_SCENARIO), 'copied row scenario');
+  if (copiedScenarioDigest !== scenarioSha256) {
+    throw new Error(`copied row scenario digest mismatch: ${copiedScenarioDigest} != ${scenarioSha256}`);
+  }
+
+  return {
+    docsRef: metadataDocsRef,
+    repository,
+    manifestPath: safeRelative(metadata.manifestPath, 'manifest path'),
+    manifestSha256,
+    scenarioPath: safeRelative(metadata.scenarioPath, 'scenario path'),
+    scenarioSha256,
+    manifestArtifact: COPIED_MANIFEST,
+    scenarioArtifact: COPIED_SCENARIO,
+  };
 }
 
 function safeRelative(value, label) {
@@ -127,7 +180,7 @@ function authoritativeReceiptContract(rowId) {
 async function listSafeArtifacts(dir) {
   const entries = await readdir(dir, { withFileTypes: true });
   const allowed = new Set([
-    'row-manifest.json', 'runner-metadata.json', 'run-result.json',
+    'row-manifest.json', 'row-scenario.js', 'runner-metadata.json', 'run-result.json',
     'candidate-run-result.json', 'seat-readiness.json', 'evidence.jsonl',
     'r-cd-2-authoritative-receipt.json',
     'attempt-state.json', 'build-identity-gate.json', 'interruption-receipt.json',
@@ -159,6 +212,7 @@ async function main() {
   const candidateSha = requireSha(metadata.candidateSha, 'runner metadata candidateSha');
   const seat = requireString(metadata.seat, 'runner metadata seat');
   const scenario = requireString(metadata.scenario, 'runner metadata scenario').replace(/\.js$/, '');
+  const harness = await harnessIdentity(metadata, candidateDir, docsRef);
   same(rowId, manifest.rowId, 'row ID');
   same(scenario, scenarioName(manifest), 'scenario');
   const declaredSha = manifestCandidateSha(manifest);
@@ -197,7 +251,8 @@ async function main() {
     )) throw new Error('R-CD-TOKEN authoritative receipt build identity mismatch');
   }
   const artifacts = {
-    manifest: 'row-manifest.json',
+    manifest: COPIED_MANIFEST,
+    scenario: COPIED_SCENARIO,
     runnerMetadata: 'runner-metadata.json',
     runResult: 'run-result.json',
     files: await listSafeArtifacts(candidateDir),
@@ -210,6 +265,7 @@ async function main() {
     foldRequiresReview: true,
     canonicalFoldForbidden: true,
     candidate: { sha: candidateSha, docsRef },
+    harness,
     run: {
       id: path.basename(candidateDir),
       rowId,

--- a/tools/k6-proofs/scripts/validate-candidate-run-result.mjs
+++ b/tools/k6-proofs/scripts/validate-candidate-run-result.mjs
@@ -10,12 +10,13 @@ import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { validateRcd2AuthoritativeReceipt } from '../lib/r-cd-2-authoritative-receipt.mjs';
 import { validateRcdTokenAuthoritativeReceipt } from '../lib/r-cd-token-authoritative-receipt.mjs';
+import { COPIED_MANIFEST, COPIED_SCENARIO, isSafeCandidateArtifact } from './candidate-run-result-contract.mjs';
 
 const SHA = /^[0-9a-f]{40}$/;
 const DIGEST = /^[0-9a-f]{64}$/;
 const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
-const COPIED_MANIFEST = 'row-manifest.json';
-const COPIED_SCENARIO = 'row-scenario.js';
+const HARNESS_MANIFEST_PATH = /^tools\/k6-proofs\/manifests\/[A-Za-z0-9._-]+\.json$/;
+const HARNESS_SCENARIO_PATH = /^tools\/k6-proofs\/scenarios\/[A-Za-z0-9._-]+\.js$/;
 const OUTCOME = new Set(['PASS-candidate', 'HONEST-LIMIT-candidate', 'PARTIAL-candidate', 'FAIL-candidate', 'construct-only']);
 
 function usage() {
@@ -75,11 +76,15 @@ async function fileDigest(file, label) {
  * Metadata that omits the ref or either digest, or whose digests disagree with
  * the copied source, cannot produce an envelope.
  */
-async function harnessIdentity(metadata, candidateDir, docsRef) {
+async function harnessIdentity(metadata, candidateDir, docsRef, manifestPath) {
   const metadataDocsRef = requireSha(metadata.docsRef, 'runner metadata docsRef');
   same(metadataDocsRef, docsRef, 'docs ref');
   const repository = requireString(metadata.repository, 'runner metadata repository');
   if (!REPOSITORY.test(repository)) throw new Error('runner metadata repository must be a safe <owner>/<repo> identity');
+  const harnessManifestPath = requireString(metadata.manifestPath, 'runner metadata manifestPath');
+  if (!HARNESS_MANIFEST_PATH.test(harnessManifestPath)) throw new Error('runner metadata manifestPath must be a tools/k6-proofs/manifests/*.json harness path');
+  const harnessScenarioPath = requireString(metadata.scenarioPath, 'runner metadata scenarioPath');
+  if (!HARNESS_SCENARIO_PATH.test(harnessScenarioPath)) throw new Error('runner metadata scenarioPath must be a tools/k6-proofs/scenarios/*.js harness path');
   const manifestSha256 = requireDigest(metadata.manifestSha256, 'runner metadata manifestSha256');
   const scenarioSha256 = requireDigest(metadata.scenarioSha256, 'runner metadata scenarioSha256');
 
@@ -91,13 +96,19 @@ async function harnessIdentity(metadata, candidateDir, docsRef) {
   if (copiedScenarioDigest !== scenarioSha256) {
     throw new Error(`copied row scenario digest mismatch: ${copiedScenarioDigest} != ${scenarioSha256}`);
   }
+  // The semantic manifest checks below must describe the same bytes the run
+  // captured, not a different manifest handed in on the command line.
+  const suppliedManifestDigest = await fileDigest(manifestPath, 'supplied manifest');
+  if (suppliedManifestDigest !== manifestSha256) {
+    throw new Error('supplied manifest is not the manifest captured for this run: digest mismatch');
+  }
 
   return {
     docsRef: metadataDocsRef,
     repository,
-    manifestPath: safeRelative(metadata.manifestPath, 'manifest path'),
+    manifestPath: harnessManifestPath,
     manifestSha256,
-    scenarioPath: safeRelative(metadata.scenarioPath, 'scenario path'),
+    scenarioPath: harnessScenarioPath,
     scenarioSha256,
     manifestArtifact: COPIED_MANIFEST,
     scenarioArtifact: COPIED_SCENARIO,
@@ -179,17 +190,8 @@ function authoritativeReceiptContract(rowId) {
 
 async function listSafeArtifacts(dir) {
   const entries = await readdir(dir, { withFileTypes: true });
-  const allowed = new Set([
-    'row-manifest.json', 'row-scenario.js', 'runner-metadata.json', 'run-result.json',
-    'candidate-run-result.json', 'seat-readiness.json', 'evidence.jsonl',
-    'r-cd-2-authoritative-receipt.json',
-    'attempt-state.json', 'build-identity-gate.json', 'interruption-receipt.json',
-    'r-cd-token-authoritative-receipt.json',
-    'evidence-lines.log', 'evidence-redaction.json', 'gateway-journal.log',
-    'gateway-journal-capture.json', 'gateway-journal-redaction.json',
-  ]);
   return entries
-    .filter((entry) => entry.isFile() && (allowed.has(entry.name) || /(?:^|-)summary\.json$/i.test(entry.name)))
+    .filter((entry) => entry.isFile() && isSafeCandidateArtifact(entry.name))
     .map((entry) => entry.name)
     .sort();
 }
@@ -212,7 +214,7 @@ async function main() {
   const candidateSha = requireSha(metadata.candidateSha, 'runner metadata candidateSha');
   const seat = requireString(metadata.seat, 'runner metadata seat');
   const scenario = requireString(metadata.scenario, 'runner metadata scenario').replace(/\.js$/, '');
-  const harness = await harnessIdentity(metadata, candidateDir, docsRef);
+  const harness = await harnessIdentity(metadata, candidateDir, docsRef, manifestPath);
   same(rowId, manifest.rowId, 'row ID');
   same(scenario, scenarioName(manifest), 'scenario');
   const declaredSha = manifestCandidateSha(manifest);


### PR DESCRIPTION
Closes #495. Closes #496.

Base: `fb9d26b10a0fe90f24146015d3800efc60a3fa75`. Harness/docs only — no `PROOFS/**` corpus, `proofs-manifest.json` or `PROOFS/INDEX.json` bytes are touched (`git diff ... -- PROOFS` is empty), no product change, no live row fired.

## The proven failure this closes

The 2026-08-01 Project 86 matrix ran from detached docs commit `25d330ef` while docs `main` was `fb9d26b1`. All 35 captured row manifests were a July snapshot, 17 differed from current contracts, and no `runner-metadata.json` recorded any docs ref — so nothing could prove which harness contract produced which receipt. In the same run the catalog validators resolved `tools/k6-proofs/tools/k6-proofs/...`, crashed with ENOENT, and that infrastructure error was emitted as per-row `FAIL-candidate`/`BAD_PROOF` product verdicts.

## #495 — one repository-root contract

New `tools/k6-proofs/lib/repo-root.mjs`: `--repo-root` > `OPENCLAW_PROOFS_REPO_ROOT` > nearest ancestor-or-self of the working directory holding a `tools/k6-proofs` proof catalog (both `manifests/` and `scenarios/` required, canonicalised with `realpath`). Standing outside any harness is an explicit contract error, never a silently empty catalog.

`check-manifest-scenarios.mjs`, `check-scenario-alignment.mjs`, `check-proof-row-manifests.mjs` and `list-runnable-rows.mjs` all adopt it — the last of these carried the caller-specific path stripping the issue explicitly forbids. Invocation from the repository root, from `tools/k6-proofs`, and from `tools/k6-proofs/scripts` now produces byte-identical stdout, stderr and exit status.

`run-proofs.sh` runs all three validators as a preflight. A failure writes exactly one `harness-control-receipt.json` (`classification: "harness-infrastructure"`, `rowsExecuted: 0`, `rowVerdictsSynthesized: false`, `productVerdict: null`), executes no rows, and exits `78` — deliberately distinct from any row's exit code so a setup fault can never be read as a candidate outcome.

## #496 — immutable harness identity

`--docs-ref <40-hex>` (env `OPENCLAW_PROOFS_DOCS_REF`) is mandatory for a live run and frozen once at startup; the previous ambient `git rev-parse HEAD` — which ran *after* each row had executed — is gone.

Verification is ordered so nothing unproven ever executes and no catalog is parsed before it is validated:

1. **byte-only identity** — ref shape, `HEAD` equality, candidate SHA shape, repository identity, and a full byte comparison of `tools/k6-proofs`, `PROOFS` and `.github` against the approved commit. This hashes working-tree bytes with `git hash-object --no-filters`; `git status` is not used because the index makes `assume-unchanged`/`skip-worktree` able to hide a modified shared import.
2. **immutable snapshot** — all three trees are extracted with `git archive` into a private temp directory and the runner `exec`s that extract's own `run-proofs.sh`, before any credential is loaded. The handoff is authenticated, not trusted: the executing script must be the snapshot's own runner, the snapshot must be a distinct tree outside the checkout, and it must carry an unguessable ownership sentinel. Nothing is symlinked back to the checkout, because static rows read the proof corpus during k6 execution.
3. **catalog preflight** — validators run from the snapshot under `env -i` with a minimal allowlist.
4. **row selection and contract binding** — `all` expansion and the per-row manifest/scenario digest freeze. A selected row with no manifest at the approved ref fails closed rather than being silently skipped.

Credential, runtime-stamp and session resolution all happen only inside the verified runner.

### Receipts

- `harness-provenance.json` at the artifact root before the first row fires: matrix id, docs ref, repository identity, candidate SHA, runtime identity receipt, runner script digest, row selection with per-row manifest/scenario digests, start time. An immutable per-matrix copy is kept at `harness-provenance/<matrixId>.json`.
- every `runner-metadata.json` gains `docsRef`, `repository`, `matrixId`, `manifestPath`/`manifestSha256`, `scenarioPath`/`scenarioSha256`.
- every run directory gains `row-scenario.js` — the exact scenario source that fired, beside the copied `row-manifest.json`.
- both candidate-envelope validation layers bind those values fail-closed, with an exact key set, basename-only artifact references, and `authoritativeReceipt` permitted only on rows that have a row-scoped resolver.

Only validated values reach any public receipt; rejected operator input is recorded as `malformed`, and the snapshot/checkout/artifact-root/`$HOME` paths are scrubbed from any captured text.

Review boundaries are unchanged: `candidateOnly:true`, `foldRequiresReview:true`, `canonicalFoldForbidden:true`, `behaviorProof:false`.

## CI

`project81-k6-proof.yml` pins `actions/checkout` to `github.sha`, passes `--docs-ref "$DOCS_REF"` and `OPENCLAW_PROOFS_DOCS_REPOSITORY`, and gives the validators an explicit `--repo-root`.

## Validation

```
node --test tools/k6-proofs/scripts/__tests__/*.test.mjs   263 -> 318 pass / 0 fail
node --test tools/k6-proofs/tests/*.test.mjs                31 -> 31  pass / 0 fail
```

`bash -n` clean; `shellcheck -S warning` reports only two pre-existing SC2155 warnings; `git diff --check` clean.

Both defects were reproduced against the base commit rather than assumed: the pre-change validator still ENOENT-crashes from `tools/k6-proofs` where the new one matches the repository-root run exactly, and firing with the stale `25d330ef` ref now exits 78 with `{"check":"head-equals-docs-ref","rowsExecuted":0}` and no row executed.

The branch went through seven rounds of adversarial review; 22 real defects were found and fixed, each pinned by a regression test — including one dangerous bug introduced by this work itself (a rejected snapshot handoff recursively deleted the directory it claimed) which is now covered by a test asserting an unrelated bystander directory survives intact. The full table is in `output.md`.

## Agreed follow-ups (not blockers)

1. Committed symlink / gitlink / executable-mode comparison (content is compared; mode is not).
2. `analysis/project86-proof-issue-plan.corrected.json` still emits `--live` commands without `--docs-ref`; they now fail closed until `OPENCLAW_PROOFS_DOCS_REF` is exported. Left alone here because that file is guarded by its own idempotence and lock-serialization tests and touching it would collide with the separate R-CD-2 runtime-selection correction this branch excludes.
3. Inherited-token trust boundary: a token already exported by the caller is inherited by the bootstrap process by construction.

## Definition of done

A future Project 86 matrix cannot run from stale or ambiguous harness bytes, cannot double-resolve its catalog root, and carries enough immutable identity to prove which manifest/scenario contract produced every receipt.
