### PR TITLE
fix(k6-proofs): wait long enough for the originating tool span

### DIFF
--- a/tools/k6-proofs/scripts/collect-continuation-trace.mjs
+++ b/tools/k6-proofs/scripts/collect-continuation-trace.mjs
@@ -21,13 +21,19 @@ function usage() {
   console.error(`Usage: node collect-continuation-trace.mjs \\
   --run-dir <row-run-dir> --manifest <row-manifest.json> --seat <seat> \\
   [--evidence <private-evidence.jsonl>] \\
-  [--tempo-url <base-url>] [--timeout-ms 60000] [--poll-ms 2000]`);
+  [--tempo-url <base-url>] [--timeout-ms 180000] [--poll-ms 2000]`);
 }
 
 function parseArgs(argv, env = process.env) {
   const out = {
     tempoUrl: env.OPENCLAW_PROOFS_TEMPO_BASE_URL || env.TEMPO_BASE_URL || DEFAULT_TEMPO_BASE_URL,
-    timeoutMs: 60000,
+    // A row finishes when its own receipts land, but the spans it caused are
+    // still in flight: the batch span processor has not flushed and Tempo has
+    // not ingested. A continue_work tool span was observed starting ~77s after
+    // dispatch inside a ~107s root trace, so a 60s budget expired while the
+    // trace was still being assembled and reported an otherwise complete trace
+    // as missing its originating tool span.
+    timeoutMs: 180000,
     pollMs: 2000,
   };
   for (let i = 2; i < argv.length; i += 1) {


### PR DESCRIPTION
Continuation proof rows kept failing with `Tempo trace did not reach valid continuation topology before timeout: matched trace lacks the originating continue_work tool span` — while the trace in Tempo was **complete**.

## Cause

A row finishes when its own receipts land, but the spans it caused are still in flight: the batch span processor has not flushed and Tempo has not ingested. For R-CW-1 on cael the `continue_work` tool span starts ~**77s** after dispatch, inside a root trace lasting ~**107s**. The 60s budget expired mid-assembly, so the collector reported its last failed validation rather than the eventual success.

## Evidence (not argument)

Reran this collector **unchanged** over the same run directory and the same Tempo trace, raising only `--timeout-ms`:

```
{"traceId":"69138a9d9c6a7e1d05d5f9e1a4502a7b","reasonHash":"750346e3b1353653","chainId":"ad3264e7-6a9b-45d6-a5c7-e847d5474193"}
```

Same evidence, same trace, valid receipt. This also confirms continuation lineage is correct: that trace holds `continuation.work` x2, `continuation.work.fire` x2 and `openclaw.tool.execution` with `gen_ai.tool.name=continue_work`.

## Change

Default `timeoutMs` 60000 -> 180000. Polling interval unchanged, so a fast trace still returns as soon as it validates; only patience for a slow one changes.

Method note worth keeping: Tempo `/api/search` without explicit `start`/`end` silently applies a recent-only window. Absence from an unwindowed search is not evidence of absence — fetch by trace id or pass the window.