### PR TITLE
fix(k6-proofs): WO-1217 proof harness authority repair

### DIFF
--- a/RUNBOOKS/project-81/rows/R-CD-4.md
+++ b/RUNBOOKS/project-81/rows/R-CD-4.md
@@ -85,3 +85,15 @@ run=3 rc=0 verdict=PASS-candidate failures=0 duration_avg=14636ms evidence=paren
 ```
 
 This makes the positive targeted-return row mechanically repeatable as `PASS-candidate`. The older guard-side proof for invalid `fanoutMode + targetSessionKey` remains valid but is a different row shape; this scenario now covers the positive targeted-return path.
+
+## Authority note (WO-1217)
+
+Silent-wake delivery authority is the shared post-run collector over the
+payload-free gateway journal line:
+
+`[continuation:targeted-return] Delivered to <target> from <child>`
+
+Transcript `session.message` / `sessions.get` `TARGET-RECEIVED` text is
+diagnostic only and cannot promote PASS. The collector binds exact
+target/parent/child/window and publishes fingerprint fields only.
+

--- a/RUNBOOKS/project-81/rows/R-CD-CHAINED-DEPTH-2.md
+++ b/RUNBOOKS/project-81/rows/R-CD-CHAINED-DEPTH-2.md
@@ -54,3 +54,12 @@ OPENCLAW_CANDIDATE_SHA=<candidate-sha> \
 PASS requires parent→child→grandchild correlation and root/parent receipt of the final return. If the scenario observes only spawn but not final root receipt, fold as PARTIAL with exact missing surface.
 
 Before unattended runner use, add `liveRunSafety` with external tool invocation required and same-session concurrency unsafe.
+
+## Authority note (WO-1217)
+
+Nested child→grandchild call must request `fanoutMode="tree"` so grandchild
+completion routes to root. Outer parent→child is unchanged. Root routing
+authority is the shared targeted-return journal collector (grandchild→root),
+not transcript `GRANDCHILD-DONE` system text. Two distinct hop identities are
+required. The manifest no longer claims three separate subtests.
+

--- a/RUNBOOKS/project-81/rows/R-CD-MODEL-TOOL.md
+++ b/RUNBOOKS/project-81/rows/R-CD-MODEL-TOOL.md
@@ -64,7 +64,9 @@ If the child observes fallback/inherited/UNKNOWN model instead of the requested 
 Requires a disposable parent. Authoritative child identity is
 `sessions.list { spawnedBy: <parent>, limit: 100 }` pre/post set-diff with
 exactly one new child key; provider/model is read from that row. Parent
-`sessions.get` must show a nonce-bound normal-mode return. Child self-report
-is auxiliary and cannot establish model equality. Direct production DB queries
-are forbidden as PASS authority.
+`sessions.get` must show a nonce-bound normal-mode return via the exact
+`MODEL-TOOL-CHILD <nonce> MODEL <provider/model>` marker (paraphrased schedule
+acks or generic nonce text do not count). Child self-report is auxiliary and
+cannot establish model equality. Direct production DB queries are forbidden as
+PASS authority.
 

--- a/RUNBOOKS/project-81/rows/R-CD-MODEL-TOOL.md
+++ b/RUNBOOKS/project-81/rows/R-CD-MODEL-TOOL.md
@@ -58,3 +58,13 @@ A k6 `PASS-candidate` is review input, not a canonical proof fold. Fold only aft
 ## Nuance / caveat
 
 If the child observes fallback/inherited/UNKNOWN model instead of the requested model, package as HONEST-LIMIT-candidate with mismatch evidence, not pass. A child self-report is only useful when the requested model was not present in the child prompt; otherwise it proves echo, not runtime selection.
+
+## Authority note (WO-1217)
+
+Requires a disposable parent. Authoritative child identity is
+`sessions.list { spawnedBy: <parent>, limit: 100 }` pre/post set-diff with
+exactly one new child key; provider/model is read from that row. Parent
+`sessions.get` must show a nonce-bound normal-mode return. Child self-report
+is auxiliary and cannot establish model equality. Direct production DB queries
+are forbidden as PASS authority.
+

--- a/output.md
+++ b/output.md
@@ -2,7 +2,7 @@
 
 ## Branch / PR
 - Branch: `codeagent/wo1217-proof-harness-authority-fix`
-- Head SHA: `dffb1ceb8c78c789442c18135f00618b564da85d`
+- Head SHA: `cd40130b80fd8595c69fff9cf79ce029534be760`
 - Base: docs `origin/main` @ `513a74ad1db3cfbb5ac10cc45155ee1e1acb911a`
 - PR: https://github.com/karmaterminal/karmaterminal-openclaw-docs/pull/510 (not merged)
 

--- a/output.md
+++ b/output.md
@@ -2,61 +2,70 @@
 
 ## Branch / PR
 - Branch: `codeagent/wo1217-proof-harness-authority-fix`
-- Review-fix code commit: `dffb1ceb8c78c789442c18135f00618b564da85d`
-- Branch tip: use `git rev-parse HEAD` / origin branch tip after push
 - Base: docs `origin/main` @ `513a74ad1db3cfbb5ac10cc45155ee1e1acb911a`
 - PR: https://github.com/karmaterminal/karmaterminal-openclaw-docs/pull/510 (not merged)
+- Review-fix head before this turn: `5046874a38da47e074c61630b26c4e02f54853c3`
+- Branch tip: use `git rev-parse HEAD` / origin branch tip after push
 
-## Review fix (PR review 4920192489)
+## Review fix (PR review 4920347189)
 
-**Finding:** `parentReturnContainsNonce` accepted any assistant/system message containing the nonce, so a paraphrased schedule acknowledgement could falsely satisfy `parent_return_nonce_bound`.
-
-**Reproduction (now false):**
-`parentReturnContainsNonce([{role:'assistant', content:'Scheduled delegate for nonce-x; waiting for completion.'}], 'nonce-x')` => `false`
-
+### Finding 1 — targeted-return `authoritativeReceipt` unsigned / structuralOk false PASS
 **Fix:**
-- Require the exact `MODEL-TOOL-CHILD <nonce> MODEL <provider/model>` marker for parent return authority (shared via `childReturnMarkerRegex` with auxiliary self-report parse).
-- Adversarial schedule-paraphrase + loose MODEL-TOOL-CHILD mention cases added.
-- Exact marker still accepted on assistant/system history.
-- Metadata-only model equality unchanged (`resolveModelToolChildAuthority` / spawnedBy set-diff).
-- Runbook authority note updated.
+- HMAC-seal targeted-return receipts with `hmac-sha256-gateway-token-v1` over canonical closed fields (same createHmac/timingSafeEqual pattern as R-CD-2/R-CD-TOKEN).
+- Collector requires `OPENCLAW_GATEWAY_TOKEN`; self-validates seal before write.
+- `validateTargetedReturnReceipt(receipt, signingKey, expectedRow)` rejects missing token, forged unsigned PASS, tampered fields, wrong key.
+- PASS requires `structuralOk === true` (plus existing counts/fingerprints); hand-forged PASS with structuralOk:false is rejected even when HMAC is valid for that impossible body.
+- Candidate contract/validator wrappers pass the gateway token through.
+- `run-proofs.sh` fails closed if token missing on R-CD-4 / R-CD-CHAINED-DEPTH-2 collector path.
+- Public artifacts remain redacted (fingerprints only; token never serialized).
 
-**Files touched in this fix:**
+### Finding 2 — R-CD-MODEL-TOOL sole dispatch lost when pre baseline >500ms
+**Fix:**
+- Added `createModelToolDispatchGate()` state machine: dispatch exactly once from successful pre `sessions.list` baseline response.
+- Removed fixed +800ms sole dispatch timer.
+- 5s watchdog still fail-closes if baseline never arrives; late baseline after fail-closed cannot resurrect dispatch.
+- Delayed-baseline regression tests prove dispatchCount===1 and never-before-baseline.
+
+## Files touched this fix
+- `tools/k6-proofs/lib/targeted-return-receipt.mjs`
+- `tools/k6-proofs/scripts/collect-targeted-return-receipt.mjs`
+- `tools/k6-proofs/scripts/candidate-run-result-contract.mjs`
+- `tools/k6-proofs/scripts/validate-candidate-run-result.mjs`
+- `tools/k6-proofs/scripts/run-proofs.sh`
+- `tools/k6-proofs/lib/r-cd-4-authority.mjs`
+- `tools/k6-proofs/lib/r-cd-chained-depth-2-authority.mjs`
 - `tools/k6-proofs/lib/r-cd-model-tool-authority.mjs`
+- `tools/k6-proofs/scenarios/r-cd-model-tool.js`
+- `tools/k6-proofs/tests/targeted-return-receipt.test.mjs`
 - `tools/k6-proofs/tests/r-cd-model-tool-authority.test.mjs`
-- `RUNBOOKS/project-81/rows/R-CD-MODEL-TOOL.md`
+- `tools/k6-proofs/tests/r-cd-4-authority.test.mjs`
+- `tools/k6-proofs/tests/r-cd-chained-depth-2-authority.test.mjs`
 - `output.md`
-
-## Prior WO-1217 work (a26ca671)
-Shared targeted-return collector for R-CD-4 / R-CD-CHAINED-DEPTH-2; disposable-parent spawnedBy set-diff for R-CD-MODEL-TOOL; Tempo 31-hex pad. Historical PROOFS untouched; no product code.
 
 ## Validation
 
 ```bash
-node --test tools/k6-proofs/tests/r-cd-model-tool-authority.test.mjs
-# 5 pass / 0 fail
+node --test \
+  tools/k6-proofs/tests/targeted-return-receipt.test.mjs \
+  tools/k6-proofs/tests/r-cd-model-tool-authority.test.mjs \
+  tools/k6-proofs/tests/r-cd-chained-depth-2-authority.test.mjs \
+  tools/k6-proofs/tests/r-cd-4-authority.test.mjs
+# 36 pass / 0 fail
 
 node --test tools/k6-proofs/tests/**/*.test.mjs tools/k6-proofs/scripts/__tests__/**/*.test.mjs
-# full-suite: 363 pass / 1 fail (pre-existing INDEX schema drift on current_sha proofs-manifest)
+# full-suite: 367 pass / 1 fail (pre-existing INDEX schema drift on current_sha proofs-manifest)
 
 node tools/k6-proofs/scripts/check-manifest-scenarios.mjs --repo-root "$PWD"  # pass
 node tools/k6-proofs/scripts/check-scenario-alignment.mjs --repo-root "$PWD"  # pass
 node tools/k6-proofs/scripts/check-proof-row-manifests.mjs --repo-root "$PWD" # pass
 ```
 
-## Coupled fallout
-- No other k6-proofs lib helper used the loose assistant/system nonce-text return gate.
-- Targeted-return authority remains journal-line bound.
-- Model equality remains metadata-only.
-
-## GitNexus
-- Index present (70,515 nodes); impact/detect-changes blocked by LadybugDB v42 vs runtime v40.
-- Manual blast radius LOW: only r-cd-model-tool scenario + unit test.
-
-## Remaining live reruns
-R-CD-4, R-CD-CHAINED-DEPTH-2, R-CD-MODEL-TOOL need fresh disposable-session PASS-candidate fires under new authority.
-
 ## Product notes
 - R-CD-4 behavior did not regress.
 - Product trace bug remains karmaterminal/openclaw#1251.
-- Old artifacts unchanged. Do not merge.
+- Old PROOFS artifacts unchanged. Do not merge.
+- Remaining live reruns: R-CD-4, R-CD-CHAINED-DEPTH-2, R-CD-MODEL-TOOL under sealed authority.
+
+## GitNexus
+- Index present; prior LadybugDB version skew may block impact/detect-changes MCP.
+- Manual blast radius LOW: receipt seal + model-tool dispatch gate + collector/validator plumbing only.

--- a/output.md
+++ b/output.md
@@ -1,389 +1,74 @@
-# WO-P86-495/496 — Close Catalog Roots and Harness Provenance
+# WO-1217 — proof harness authority repair
 
-Branch: `codeagent/p86-495-496-harness-provenance`
-Base: `fb9d26b10a0fe90f24146015d3800efc60a3fa75` (docs `main`)
-Scope: harness/docs only. No `PROOFS/**` corpus, `proofs-manifest.json`, or
-`PROOFS/INDEX.json` bytes were touched. No product (`karmaterminal/openclaw`)
-change. No live row fired, no gateway restarted, no prince seat touched.
+## Branch / PR
+- Branch: `codeagent/wo1217-proof-harness-authority-fix`
+- Head SHA: (updated after review-fix commit)
+- Base: docs `origin/main` @ `513a74ad1db3cfbb5ac10cc45155ee1e1acb911a`
+- PR: https://github.com/karmaterminal/karmaterminal-openclaw-docs/pull/510 (not merged)
 
----
+## Review fix (PR review 4920192489)
 
-## 1. What changed
+**Finding:** `parentReturnContainsNonce` accepted any assistant/system message containing the nonce, so a paraphrased schedule acknowledgement could falsely satisfy `parent_return_nonce_bound`.
 
-### 1.1 One repository-root contract (#495)
+**Fix:**
+- Require the exact `MODEL-TOOL-CHILD <nonce> MODEL <provider/model>` marker for parent return authority (shared via `childReturnMarkerRegex` with auxiliary self-report parse).
+- Adversarial case added: `Scheduled delegate for nonce-x; waiting for completion.` => `false`.
+- Loose `MODEL-TOOL-CHILD` mention without the full marker also => `false`.
+- Metadata-only model equality unchanged (`resolveModelToolChildAuthority` / spawnedBy set-diff).
+- Runbook authority note updated.
 
-**New:** `tools/k6-proofs/lib/repo-root.mjs`
+**Files touched in this fix:**
+- `tools/k6-proofs/lib/r-cd-model-tool-authority.mjs`
+- `tools/k6-proofs/tests/r-cd-model-tool-authority.test.mjs`
+- `RUNBOOKS/project-81/rows/R-CD-MODEL-TOOL.md`
 
-Resolution order, applied identically by every catalog reader:
+## What changed earlier (prior commit a26ca671)
 
-1. `--repo-root <dir>` (also `--repo-root=<dir>`);
-2. `OPENCLAW_PROOFS_REPO_ROOT`;
-3. the nearest ancestor-or-self of the working directory that contains a
-   `tools/k6-proofs` directory.
+### Shared targeted-return authority
+- **New** `tools/k6-proofs/lib/targeted-return-receipt.mjs`
+- **New** `tools/k6-proofs/scripts/collect-targeted-return-receipt.mjs`
+- Wired for R-CD-4 and R-CD-CHAINED-DEPTH-2 as authoritative verdict source.
 
-Rule 3 makes the repository root, `tools/k6-proofs`, and
-`tools/k6-proofs/scripts` all resolve to the same root, so the tool prefix can
-never be joined twice. There is deliberately **no** fallback to the checkout that
-happens to contain the module: a caller standing outside any harness fails closed
-with an explicit contract error instead of silently validating an unrelated
-catalog (or, as before, reporting an infrastructure ENOENT as an empty catalog).
+### R-CD-4 / R-CD-CHAINED-DEPTH-2 / Tempo
+- Journal targeted-return authority; nested fanoutMode=tree; 31-hex Tempo pad.
 
-**Migrated to the shared resolver** (each previously used `process.cwd()` or
-caller-specific path stripping):
+### Untouched
+- Historical `PROOFS/**` preserved; `PROOFS/INDEX.json` not repointed; no product code.
 
-- `tools/k6-proofs/scripts/check-manifest-scenarios.mjs`
-- `tools/k6-proofs/scripts/check-scenario-alignment.mjs`
-- `tools/k6-proofs/scripts/check-proof-row-manifests.mjs`
-- `tools/k6-proofs/scripts/list-runnable-rows.mjs` — this one carried the
-  `process.cwd().endsWith('/tools/k6-proofs') ? … : join(cwd, 'tools/k6-proofs')`
-  stripping the workorder explicitly forbids; it is now the same contract as the
-  other three.
-
-`run-proofs.sh` also resolves its own harness root from its script location and
-`cd`s there, so the runner is no longer sensitive to the caller's directory
-either. `--out-dir` is made absolute before that `cd`.
-
-### 1.1b Ordered verification stages
-
-A live matrix now proceeds strictly as: **byte-only identity** (no catalog is
-parsed) → **immutable snapshot** (`git archive` of `tools/k6-proofs`, `PROOFS`
-and `.github`, then `exec` into the snapshot's own `run-proofs.sh` with an
-authenticated ownership handoff) → **catalog preflight** (validators run from the
-snapshot under `env -i`) → **row selection and contract binding** → **credential
-and session resolution** → **seat readiness** → **provenance** → **rows**.
-
-Nothing the matrix consumes is read from the operator's mutable checkout after
-the snapshot exists, and no credential is present in the process while unproven
-bytes are executing.
-
-### 1.2 Catalog preflight is harness infrastructure, not a product verdict (#495)
-
-`run-proofs.sh` now runs all three catalog validators (with an explicit
-`--repo-root`) **before any row work**. On failure it:
-
-- writes exactly one `"$OUT_ROOT"/harness-control-receipt.json`
-  (`openclaw.k6.harness-control-receipt.v1`, `classification:
-  "harness-infrastructure"`, `rowsExecuted: 0`, `rowVerdictsSynthesized: false`,
-  `productVerdict: null`, `stage`, `reason`, `detail`, `rowSelection`);
-- preserves the raw validator output as `catalog-preflight.log`;
-- exits `78` (`EX_CONFIG`), deliberately distinct from any row's effective exit
-  code so a setup fault can never be read as a candidate outcome;
-- executes **no** rows and synthesizes **no** per-row FAIL/BAD_PROOF.
-
-On success any stale control receipt is removed.
-
-### 1.3 Immutable harness identity (#496)
-
-`run-proofs.sh --docs-ref <40-hex>` (env equivalent `OPENCLAW_PROOFS_DOCS_REF`).
-A **live** run refuses to fire — same control receipt, same exit 78, zero rows —
-unless all of:
-
-| check | `detail.check` |
-| --- | --- |
-| approved ref is a 40-char lowercase SHA | `docs-ref-shape` |
-| repository `HEAD` equals that ref | `head-equals-docs-ref` |
-| every tracked byte under `tools/k6-proofs`, `PROOFS` and `.github` hashes to the approved blob (`git hash-object --no-filters`, never `git status`) | `harness-tree-clean` |
-| the candidate SHA is exact 40-hex | `candidate-sha-shape` |
-| the extracted snapshot matches the approved ref | `harness-snapshot-matches-docs-ref` |
-| the executing runner is the snapshot's own, with a valid ownership sentinel | `snapshot-handoff-authentic` |
-| every selected row is recorded at the approved ref | `row-recorded-at-docs-ref` |
-| a public-safe `<owner>/<repo>` identity exists | `repository-identity` |
-| each selected runnable row's scenario file exists | `scenario-present` |
-| each selected manifest + scenario is tracked at that commit | `tracked-at-docs-ref` |
-| those tracked bytes equal the working-tree bytes | `bytes-match-docs-ref` |
-
-The ref and the per-row `manifestSha256` / `scenarioSha256` are resolved and
-frozen once at startup into read-only state; the row loop refuses to fire any row
-that is not in the frozen binding. The previous ambient
-`DOCS_REF="$(git rev-parse HEAD)"` — which ran **after** each row had already
-executed — is gone.
-
-New/changed artifacts:
-
-- `"$OUT_ROOT"/harness-provenance.json` (`openclaw.k6.harness-provenance.v1`),
-  written before the first row fires: docs ref + source, repository identity,
-  candidate SHA, runtime identity receipt (seat, runtime build SHA,
-  candidate/runtime match, `seat-readiness.json` digest), runner script path +
-  sha256, row selection, per-row manifest/scenario paths + sha256, `mode`,
-  `harnessIdentityVerified`, `candidateOnly`, `foldRequiresReview`, `startedAt`.
-- every `runner-metadata.json` gains `docsRef`, `repository`, `manifestPath`,
-  `manifestSha256`, `scenarioPath`, `scenarioSha256`.
-- every live run directory gains `row-scenario.js` — the exact scenario source
-  bytes that fired, next to the already-copied `row-manifest.json`.
-
-### 1.4 Candidate envelope binding (#496)
-
-`validate-candidate-run-result.mjs` (emit side) now requires the metadata to
-carry `docsRef` (equal to the approved `--docs-ref`), a safe `<owner>/<repo>`
-`repository`, and both 64-hex digests; it recomputes the digests from the copied
-`row-manifest.json` and `row-scenario.js` and refuses to emit on any mismatch or
-omission. The envelope gains a `harness` block carrying those values plus the
-artifact names it bound.
-
-`candidate-run-result-contract.mjs` (`candidateEnvelopeMatchesSiblings`, the
-consumer side used by `summarize-review-debt.mjs` and `render-run-report.mjs`)
-performs the same re-verification, so a sidecar whose harness identity is
-omitted, mismatched, or whose copied source was mutated after capture can no
-longer suppress raw review debt or reach the report as ready-for-human-review.
-
-Review-boundary invariants are unchanged: `candidateOnly:true`,
-`foldRequiresReview:true`, `canonicalFoldForbidden:true`, `behaviorProof:false`.
-
-### 1.5 Public-safety
-
-- The control receipt records only `"malformed"` for a badly-shaped
-  operator-supplied docs ref; it never echoes an arbitrary input string.
-- Repository identity is derived only from a real remote (scheme or scp form) or
-  the explicit `OPENCLAW_PROOFS_DOCS_REPOSITORY` override, so a local clone path
-  can never reach a public receipt. A local-path remote yields no identity and a
-  live run fails closed instead.
-- All new receipt fields are repo-relative paths, SHAs, digests, booleans, and
-  timestamps. No token, session key, prompt, private path, or raw process output
-  is added to any public artifact.
-
-### 1.6 CI
-
-`.github/workflows/project81-k6-proof.yml`:
-
-- `actions/checkout@v4` pinned to `ref: ${{ github.sha }}`;
-- `DOCS_REF: ${{ github.sha }}` and `OPENCLAW_PROOFS_DOCS_REPOSITORY: ${{ github.repository }}`;
-- the runner is invoked with `--docs-ref "$DOCS_REF"`;
-- the catalog validators are invoked with `--repo-root "$GITHUB_WORKSPACE"`.
-
----
-
-## 2. Exact changed files (22 files, +3163 / −134)
-
-New:
-
-```
-tools/k6-proofs/lib/repo-root.mjs
-tools/k6-proofs/scripts/__tests__/catalog-root-contract.test.mjs
-tools/k6-proofs/scripts/__tests__/harness-provenance-runner.test.mjs
-tools/k6-proofs/scripts/__tests__/helpers/harness-checkout.mjs
-```
-
-Modified:
-
-```
-.github/workflows/project81-k6-proof.yml
-RUNBOOKS/project-81/EXECUTABLE-SUITE.md
-RUNBOOKS/project-81/README.md
-tools/k6-proofs/README.md
-tools/k6-proofs/docs/PROOF-RUN-METHOD.md
-tools/k6-proofs/scripts/candidate-run-result-contract.mjs
-tools/k6-proofs/scripts/check-manifest-scenarios.mjs
-tools/k6-proofs/scripts/check-proof-row-manifests.mjs
-tools/k6-proofs/scripts/check-scenario-alignment.mjs
-tools/k6-proofs/scripts/list-runnable-rows.mjs
-tools/k6-proofs/scripts/run-proofs.sh
-tools/k6-proofs/scripts/validate-candidate-run-result.mjs
-tools/k6-proofs/scripts/__tests__/candidate-run-result.test.mjs
-tools/k6-proofs/scripts/__tests__/continuation-row-contract.test.mjs
-tools/k6-proofs/scripts/__tests__/report-render.test.mjs
-tools/k6-proofs/scripts/__tests__/review-debt.test.mjs
-```
-
----
-
-## 3. Validation
-
-### 3.1 Full-suite tally
-
-The repository has no `scripts/test-projects.mjs` and no `package.json`; the
-sanctioned complete k6 proof-script surface documented in
-`tools/k6-proofs/docs/PROOF-RUN-METHOD.md` is `node --test`. No new test runner
-was installed.
-
-```
-node --test tools/k6-proofs/scripts/__tests__/*.test.mjs
-  baseline @ fb9d26b1 : 263 pass / 0 fail
-  final    @ HEAD     : 319 pass / 0 fail   (+56)
-
-node --test tools/k6-proofs/tests/*.test.mjs
-  baseline @ fb9d26b1 :  31 pass / 0 fail
-  final    @ HEAD     :  31 pass / 0 fail
-```
-
-`bash -n` clean. `shellcheck -S warning` reports only the two pre-existing SC2155
-warnings. `git diff --check` clean. `PROOFS/**` diff is empty (0 files).
-
-### 3.2 Exact commands
+## Validation
 
 ```bash
-# full k6 proof-script surface (completion signal)
-node --test tools/k6-proofs/scripts/__tests__/*.test.mjs
-node --test tools/k6-proofs/tests/*.test.mjs
+node --test tools/k6-proofs/tests/r-cd-model-tool-authority.test.mjs
+# 5 pass / 0 fail (includes adversarial schedule paraphrase)
 
-# targeted new suites
-node --test tools/k6-proofs/scripts/__tests__/catalog-root-contract.test.mjs
-node --test tools/k6-proofs/scripts/__tests__/harness-provenance-runner.test.mjs
+node -e "import { parentReturnContainsNonce } from './tools/k6-proofs/lib/r-cd-model-tool-authority.mjs';
+console.log(parentReturnContainsNonce([{role:'assistant',content:'Scheduled delegate for nonce-x; waiting for completion.'}],'nonce-x'));"
+# false
 
-# targeted changed suites
-node --test tools/k6-proofs/scripts/__tests__/candidate-run-result.test.mjs
-node --test tools/k6-proofs/scripts/__tests__/continuation-row-contract.test.mjs
-node --test tools/k6-proofs/scripts/__tests__/report-render.test.mjs
-node --test tools/k6-proofs/scripts/__tests__/review-debt.test.mjs
-node --test tools/k6-proofs/scripts/__tests__/check-proof-row-manifests.test.mjs
+node --test tools/k6-proofs/tests/**/*.test.mjs tools/k6-proofs/scripts/__tests__/**/*.test.mjs
+# full-suite: 363 pass / 1 fail
+# fail is pre-existing: candidate envelope corpus INDEX schema drift
+#   (openclaw.k6.proofs-manifest.v1 vs openclaw.proofs.manifest.v1); INDEX not modified.
 
-# #495 parity, by hand, against the real catalog
-for s in check-manifest-scenarios check-scenario-alignment check-proof-row-manifests list-runnable-rows; do
-  diff <(node tools/k6-proofs/scripts/$s.mjs 2>&1; echo "exit=$?") \
-       <(cd tools/k6-proofs && node scripts/$s.mjs 2>&1; echo "exit=$?") && echo "$s IDENTICAL"
-done
-
-# runner smoke, from both directories
-./tools/k6-proofs/scripts/run-proofs.sh --dry-run --out-dir /tmp/p86-dry all <40-hex>
-(cd tools/k6-proofs && ./scripts/run-proofs.sh --dry-run --out-dir /tmp/p86-dry2 all <40-hex>)
-
-bash -n tools/k6-proofs/scripts/run-proofs.sh
-shellcheck -S warning tools/k6-proofs/scripts/run-proofs.sh   # only pre-existing SC2155
-python3 -c "import yaml; yaml.safe_load(open('.github/workflows/project81-k6-proof.yml'))"
-git --no-pager diff --check
+node tools/k6-proofs/scripts/check-manifest-scenarios.mjs --repo-root "$PWD"  # pass
+node tools/k6-proofs/scripts/check-scenario-alignment.mjs --repo-root "$PWD"  # pass
+node tools/k6-proofs/scripts/check-proof-row-manifests.mjs --repo-root "$PWD" # pass
 ```
 
-### 3.3 Defect reproduction, before and after
+## Coupled fallout inspection
+- No other k6-proofs lib helper used the loose "any assistant/system text containing nonce" return gate.
+- Sibling targeted-return authority remains journal-line bound (not transcript nonce text).
+- Scenario still gates PASS on metadata model equality separately from return marker.
 
-**#495 — empirically confirmed, not assumed.** The pre-change validator was
-extracted from the base commit and run against the same fixture:
+## GitNexus
+- Prior re-analyze: 70,515 nodes on this worktree.
+- `impact` / `detect-changes` blocked by LadybugDB storage version mismatch (file v42 vs runtime v40).
+- Manual blast radius: `parentReturnContainsNonce` callers are only `r-cd-model-tool.js` + unit test — LOW risk.
 
-```bash
-git show fb9d26b1:tools/k6-proofs/scripts/check-manifest-scenarios.mjs > /tmp/old.mjs
-# from the repository root:        "check passed: 1 manifests; 1 scenario files."
-# from tools/k6-proofs:            ENOENT crash (doubled prefix)
-# new script from tools/k6-proofs: identical to the repository-root run
-```
+## Remaining exact-live rerun requirements
+Live disposable-session fires still needed for R-CD-4, R-CD-CHAINED-DEPTH-2, and R-CD-MODEL-TOOL under the new authority. Do not fold old PARTIAL rows as PASS without a new live run.
 
-**#496 — the exact Cael failure mode now fails closed.** Firing with the stale
-detached runner commit while `HEAD` is current docs `main`:
-
-```
-$ ./scripts/run-proofs.sh --live --docs-ref 25d330ef558eefce124fe3b5a787d426e6adf772 ... ; echo $?
-78
-{"stage":"harness-identity",
- "reason":"harness checkout does not match the approved docs ref; refusing to fire a stale or mixed harness",
- "detail":{"check":"head-equals-docs-ref",
-           "head":"fb9d26b10a0fe90f24146015d3800efc60a3fa75",
-           "approved":"25d330ef558eefce124fe3b5a787d426e6adf772"},
- "rowsExecuted":0,"rowVerdictsSynthesized":false,"productVerdict":null}
-```
-
-### 3.4 Adversarial review
-
-The branch went through **seven** rounds with an independent reviewer before it
-was declared shippable. Findings that were real defects, all fixed and each
-pinned by a regression test:
-
-| # | Defect | Round |
-| --- | --- | --- |
-| 1 | Catalog validators executed with the gateway token in their environment, and their raw output was published | 1 |
-| 2 | Digests were frozen at startup but k6 read the ambient worktree (TOCTOU) | 1 |
-| 3 | `git` honours `refs/replace/*`, so `rev-parse` and `cat-file` could describe different trees | 1 |
-| 4 | Failure receipts echoed rejected operator input verbatim | 1 |
-| 5 | The consumer envelope contract accepted unknown keys, so a sidecar could smuggle extra material past review | 1 |
-| 6 | The env-isolation test was vacuous; a denylist could not stop unrelated credentials | 2 |
-| 7 | Only the manifest and top-level scenario were re-hashed — a scenario's `lib/` imports were unguarded | 2 |
-| 8 | A missing file made the digest check abort under `set -e` with no control receipt and no exit 78 | 2 |
-| 9 | A pre-execution failure left a provisional run directory and could let the interruption writer contradict `rowsExecuted:0` | 2 |
-| 10 | `git status` is not byte integrity: `assume-unchanged` / `skip-worktree` hid a modified import | 3 |
-| 11 | The catalog was parsed before it was validated, so a malformed manifest aborted with no receipt | 3 |
-| 12 | `RUN_ID` was second-granular, so the provisional purge could delete a concurrent run's evidence | 3 |
-| 13 | `rowsExecuted:0` was hard-coded and false once a later row failed | 3 |
-| 14 | `git hash-object` applies clean filters by default — a filter could forge the approved blob hash and execute during the identity stage | 4 |
-| 15 | Bracketing hash assertions only narrow a check-then-use window; harness code had to execute from an immutable snapshot | 4 |
-| 16 | Unvalidated candidate input reached artifact paths and metadata | 4 |
-| 17 | `rowsExecuted` counted pre-dispatch gates that never dispatched | 4 |
-| 18 | Bash reads its own source incrementally, so the executing runner had to be the snapshot's copy | 5 |
-| 19 | `PROOFS` was symlinked unverified, and static rows read it — a clean harness could emit `PASS-candidate` from dirty corpus bytes | 5 |
-| 20 | The snapshot handoff was spoofable by setting the handoff variables and skipping `exec` | 6 |
-| 21 | The bootstrap invoked `openclaw` and resolved session state with credentials present | 6 |
-| 22 | **A rejected handoff `rm -rf`'d the directory it claimed** — introduced by the fix for #20 | 7 |
-
-Defect 22 was the most dangerous in the set and was introduced by this work, not
-inherited; it is now covered by a test asserting that an unrelated bystander
-directory claimed as a snapshot survives with its contents intact.
-
-### 3.5 New test coverage
-
-`catalog-root-contract.test.mjs` (6 tests) — all four catalog readers must
-produce byte-identical stdout, stderr and exit status from the repository root,
-from `tools/k6-proofs`, and from `tools/k6-proofs/scripts`, on both the passing
-and a genuine-defect path; `--repo-root` and `OPENCLAW_PROOFS_REPO_ROOT`
-overrides; fail-closed contract error outside any harness; decoy directories
-containing only `notes`, only `scenarios`, or only `manifests`; and an assertion
-that no output ever contains `tools/k6-proofs/tools/k6-proofs`.
-
-`harness-provenance-runner.test.mjs` (28 tests) — missing/malformed/mismatched
-docs refs; the env equivalent; index-hidden (`assume-unchanged`,
-`skip-worktree`) mutation of a shared import; a mutated proof-corpus evidence
-file; an unrecorded row; a catalog-preflight failure; an unvalidated candidate
-SHA; three spoofed-handoff shapes, each also asserting the claimed directory
-survives; mid-matrix mutation before capture and between capture and k6, the
-latter asserting the provisional directory is purged; `env -i` isolation proved
-by a probe validator; log scrubbing proved by that probe printing its own working
-directory; runner cwd-independence; a `git replace` decoy; direct observation
-that k6 executes from the snapshot with the approved scenario bytes; and an
-approved run's full provenance receipt.
-
-Existing suites that would otherwise have started passing for the wrong reason
-were repaired rather than left green: the `report-render` and `review-debt`
-envelope-consumption fixtures now carry the complete canonical envelope shape
-and valid harness identity. The report fixture proves the accepted sidecar path
-by suppressing raw-only timing output, while the debt fixture directly verifies
-the acceptance predicate before checking that the raw sibling is not counted.
-
----
-
-## 4. Uncertainties and agreed follow-ups
-
-The reviewer explicitly confirmed all three of the following are correctly
-classified as follow-ups rather than blockers on this branch.
-
-1. **Committed symlinks, gitlinks and executable-mode changes are not type- or
-   mode-compared.** The verification compares blob content. No such entries
-   exist in the verified trees today, and they fail closed if introduced, but a
-   mode-only change would not be detected. Recommend a follow-up issue.
-
-2. **`analysis/project86-proof-issue-plan.corrected.json` was deliberately not
-   rewritten.** Its 23 emitted commands still read
-   `./scripts/run-proofs.sh --live <ROW> <FINAL_CANDIDATE_SHA>`. Those commands
-   now **fail closed** (exit 78, `docs-ref-shape`) unless the operator exports
-   `OPENCLAW_PROOFS_DOCS_REF` — the correct safety posture, but it means a matrix
-   generated verbatim from that plan will refuse to fire until the ref is
-   supplied. I left it alone because that file is guarded by
-   `apply-project86-plan-corrections.mjs` plus its idempotence and
-   lock-serialization tests, and because adding a `<DOCS_REF>` placeholder would
-   collide with the separate R-CD-2 runtime-selection correction the workorder
-   excludes from this branch. Recommend a follow-up issue.
-
-3. **Inherited-token trust boundary.** The bootstrap phase reads no credential
-   and invokes no product tooling, but if the caller has already exported
-   `OPENCLAW_GATEWAY_TOKEN` then that value is in the bootstrap process's
-   environment by construction and cannot be dropped from inside the same
-   script. The reviewer classified this as a trust-boundary hardening item, not
-   a demonstrated receipt bypass.
-
-Other notes:
-
-4. **Pre-existing candidate artifacts** produced before this change carry no
-   `docsRef`/digests and no `row-scenario.js`. Their sidecar envelopes will no
-   longer suppress raw review debt and will fall back to the raw
-   `run-result.json` path. That is the intended fail-closed behaviour — they
-   genuinely cannot prove which harness contract produced them — but reviewers
-   should expect existing bundles to reappear as review debt rather than
-   silently as ready-for-human-review.
-
-5. **New hard requirements for a live run**, each of which fails closed with a
-   control receipt: an approved `--docs-ref`; an exact 40-hex candidate SHA; a
-   public-safe `<owner>/<repo>` identity (set `OPENCLAW_PROOFS_DOCS_REPOSITORY`
-   when the clone has no public remote); and every selected row being recorded at
-   the approved ref. A live matrix also needs roughly 400MB of `TMPDIR` space for
-   the snapshot, which is removed on exit.
-
-6. **Not exercised end-to-end against a real gateway.** The workorder forbids
-   firing a live row. The R-CD-2 fixture drives the full pipeline — k6 → evidence
-   extraction → trace collection → resolver → sanitizer → candidate envelope →
-   metrics → report — but against a stubbed `k6` and a local HTTP endpoint.
-
-7. **`shellcheck -S warning`** still reports two pre-existing SC2155 warnings in
-   `run-proofs.sh`. They are untouched by this change and out of scope.
+## Product notes
+- R-CD-4 behavior did not regress.
+- Product trace bug remains `karmaterminal/openclaw#1251`.
+- Old artifacts unchanged.

--- a/output.md
+++ b/output.md
@@ -2,7 +2,7 @@
 
 ## Branch / PR
 - Branch: `codeagent/wo1217-proof-harness-authority-fix`
-- Head SHA: (updated after review-fix commit)
+- Head SHA: `dffb1ceb8c78c789442c18135f00618b564da85d`
 - Base: docs `origin/main` @ `513a74ad1db3cfbb5ac10cc45155ee1e1acb911a`
 - PR: https://github.com/karmaterminal/karmaterminal-openclaw-docs/pull/510 (not merged)
 

--- a/output.md
+++ b/output.md
@@ -2,7 +2,7 @@
 
 ## Branch / PR
 - Branch: `codeagent/wo1217-proof-harness-authority-fix`
-- Head SHA: `cd40130b80fd8595c69fff9cf79ce029534be760`
+- Head SHA: `83a8da38b480ae329f55b6c2889b96944f59f763`
 - Base: docs `origin/main` @ `513a74ad1db3cfbb5ac10cc45155ee1e1acb911a`
 - PR: https://github.com/karmaterminal/karmaterminal-openclaw-docs/pull/510 (not merged)
 

--- a/output.md
+++ b/output.md
@@ -2,7 +2,8 @@
 
 ## Branch / PR
 - Branch: `codeagent/wo1217-proof-harness-authority-fix`
-- Head SHA: `bed55dbaa9ec6d58b8413eb23b52e7083b9dde9c`
+- Review-fix code commit: `dffb1ceb8c78c789442c18135f00618b564da85d`
+- Branch tip: use `git rev-parse HEAD` / origin branch tip after push
 - Base: docs `origin/main` @ `513a74ad1db3cfbb5ac10cc45155ee1e1acb911a`
 - PR: https://github.com/karmaterminal/karmaterminal-openclaw-docs/pull/510 (not merged)
 
@@ -10,10 +11,13 @@
 
 **Finding:** `parentReturnContainsNonce` accepted any assistant/system message containing the nonce, so a paraphrased schedule acknowledgement could falsely satisfy `parent_return_nonce_bound`.
 
+**Reproduction (now false):**
+`parentReturnContainsNonce([{role:'assistant', content:'Scheduled delegate for nonce-x; waiting for completion.'}], 'nonce-x')` => `false`
+
 **Fix:**
 - Require the exact `MODEL-TOOL-CHILD <nonce> MODEL <provider/model>` marker for parent return authority (shared via `childReturnMarkerRegex` with auxiliary self-report parse).
-- Adversarial case added: `Scheduled delegate for nonce-x; waiting for completion.` => `false`.
-- Loose `MODEL-TOOL-CHILD` mention without the full marker also => `false`.
+- Adversarial schedule-paraphrase + loose MODEL-TOOL-CHILD mention cases added.
+- Exact marker still accepted on assistant/system history.
 - Metadata-only model equality unchanged (`resolveModelToolChildAuthority` / spawnedBy set-diff).
 - Runbook authority note updated.
 
@@ -21,54 +25,38 @@
 - `tools/k6-proofs/lib/r-cd-model-tool-authority.mjs`
 - `tools/k6-proofs/tests/r-cd-model-tool-authority.test.mjs`
 - `RUNBOOKS/project-81/rows/R-CD-MODEL-TOOL.md`
+- `output.md`
 
-## What changed earlier (prior commit a26ca671)
-
-### Shared targeted-return authority
-- **New** `tools/k6-proofs/lib/targeted-return-receipt.mjs`
-- **New** `tools/k6-proofs/scripts/collect-targeted-return-receipt.mjs`
-- Wired for R-CD-4 and R-CD-CHAINED-DEPTH-2 as authoritative verdict source.
-
-### R-CD-4 / R-CD-CHAINED-DEPTH-2 / Tempo
-- Journal targeted-return authority; nested fanoutMode=tree; 31-hex Tempo pad.
-
-### Untouched
-- Historical `PROOFS/**` preserved; `PROOFS/INDEX.json` not repointed; no product code.
+## Prior WO-1217 work (a26ca671)
+Shared targeted-return collector for R-CD-4 / R-CD-CHAINED-DEPTH-2; disposable-parent spawnedBy set-diff for R-CD-MODEL-TOOL; Tempo 31-hex pad. Historical PROOFS untouched; no product code.
 
 ## Validation
 
 ```bash
 node --test tools/k6-proofs/tests/r-cd-model-tool-authority.test.mjs
-# 5 pass / 0 fail (includes adversarial schedule paraphrase)
-
-node -e "import { parentReturnContainsNonce } from './tools/k6-proofs/lib/r-cd-model-tool-authority.mjs';
-console.log(parentReturnContainsNonce([{role:'assistant',content:'Scheduled delegate for nonce-x; waiting for completion.'}],'nonce-x'));"
-# false
+# 5 pass / 0 fail
 
 node --test tools/k6-proofs/tests/**/*.test.mjs tools/k6-proofs/scripts/__tests__/**/*.test.mjs
-# full-suite: 363 pass / 1 fail
-# fail is pre-existing: candidate envelope corpus INDEX schema drift
-#   (openclaw.k6.proofs-manifest.v1 vs openclaw.proofs.manifest.v1); INDEX not modified.
+# full-suite: 363 pass / 1 fail (pre-existing INDEX schema drift on current_sha proofs-manifest)
 
 node tools/k6-proofs/scripts/check-manifest-scenarios.mjs --repo-root "$PWD"  # pass
 node tools/k6-proofs/scripts/check-scenario-alignment.mjs --repo-root "$PWD"  # pass
 node tools/k6-proofs/scripts/check-proof-row-manifests.mjs --repo-root "$PWD" # pass
 ```
 
-## Coupled fallout inspection
-- No other k6-proofs lib helper used the loose "any assistant/system text containing nonce" return gate.
-- Sibling targeted-return authority remains journal-line bound (not transcript nonce text).
-- Scenario still gates PASS on metadata model equality separately from return marker.
+## Coupled fallout
+- No other k6-proofs lib helper used the loose assistant/system nonce-text return gate.
+- Targeted-return authority remains journal-line bound.
+- Model equality remains metadata-only.
 
 ## GitNexus
-- Prior re-analyze: 70,515 nodes on this worktree.
-- `impact` / `detect-changes` blocked by LadybugDB storage version mismatch (file v42 vs runtime v40).
-- Manual blast radius: `parentReturnContainsNonce` callers are only `r-cd-model-tool.js` + unit test — LOW risk.
+- Index present (70,515 nodes); impact/detect-changes blocked by LadybugDB v42 vs runtime v40.
+- Manual blast radius LOW: only r-cd-model-tool scenario + unit test.
 
-## Remaining exact-live rerun requirements
-Live disposable-session fires still needed for R-CD-4, R-CD-CHAINED-DEPTH-2, and R-CD-MODEL-TOOL under the new authority. Do not fold old PARTIAL rows as PASS without a new live run.
+## Remaining live reruns
+R-CD-4, R-CD-CHAINED-DEPTH-2, R-CD-MODEL-TOOL need fresh disposable-session PASS-candidate fires under new authority.
 
 ## Product notes
 - R-CD-4 behavior did not regress.
-- Product trace bug remains `karmaterminal/openclaw#1251`.
-- Old artifacts unchanged.
+- Product trace bug remains karmaterminal/openclaw#1251.
+- Old artifacts unchanged. Do not merge.

--- a/output.md
+++ b/output.md
@@ -2,7 +2,7 @@
 
 ## Branch / PR
 - Branch: `codeagent/wo1217-proof-harness-authority-fix`
-- Head SHA: `83a8da38b480ae329f55b6c2889b96944f59f763`
+- Head SHA: `bed55dbaa9ec6d58b8413eb23b52e7083b9dde9c`
 - Base: docs `origin/main` @ `513a74ad1db3cfbb5ac10cc45155ee1e1acb911a`
 - PR: https://github.com/karmaterminal/karmaterminal-openclaw-docs/pull/510 (not merged)
 

--- a/tools/k6-proofs/lib/r-cd-4-authority.mjs
+++ b/tools/k6-proofs/lib/r-cd-4-authority.mjs
@@ -220,7 +220,12 @@ export function rCd4ShouldScheduleEarlyClose({ parentReturnReceipt }) {
 
 /**
  * Finalize R-CD-4 return authority from the shared journal collector only.
+ * Requires signingKey (OPENCLAW_GATEWAY_TOKEN) — same HMAC contract as collector.
  */
 export function rCd4JournalReturnAuthority(args) {
-  return resolveTargetedReturnAuthority({ ...args, row: args.row || 'R-CD-4' });
+  return resolveTargetedReturnAuthority({
+    ...args,
+    row: args.row || 'R-CD-4',
+    signingKey: args.signingKey,
+  });
 }

--- a/tools/k6-proofs/lib/r-cd-4-authority.mjs
+++ b/tools/k6-proofs/lib/r-cd-4-authority.mjs
@@ -1,7 +1,15 @@
 import { directChildSessionKeyForRow } from './row-child-correlation.mjs';
+import {
+  resolveTargetedReturnAuthority,
+  fingerprintIdentity,
+} from './targeted-return-receipt.mjs';
 
 export const R_CD_4_OBSERVATION_WINDOW_MS = 90_000;
 export const R_CD_4_DURATION_THRESHOLD_MS = 110_000;
+export {
+  resolveTargetedReturnAuthority,
+  fingerprintIdentity,
+};
 
 const HARNESS_MARKER = '[k6-proof-harness]';
 const R_CD_4_TASK_TOKEN_SUFFIX_CHARS = 16;
@@ -51,14 +59,13 @@ function hasExactSentinel(eventData, marker, nonce) {
 }
 
 /**
- * Identify the target/parent session event that carries the exact row marker.
+ * Diagnostic-only marker observation.
  *
- * This deliberately accepts only the structured top-level event session. A
- * session key or nonce appearing in nested prompt text must not route the
- * receipt. Child identity is bound separately after a nonce-correlated spawn
- * event is observed.
+ * Silent-wake delivery authority is the payload-free gateway
+ * `[continuation:targeted-return]` receipt (see targeted-return-receipt.mjs).
+ * Transcript session.message / sessions.get nonce text must never promote PASS.
  */
-export function rCd4ReturnCandidate({ eventName, eventData, expectedSessionKey, nonce }) {
+export function rCd4DiagnosticMarkerCandidate({ eventName, eventData, expectedSessionKey, nonce }) {
   if (eventName !== 'session.message') return null;
   if (!expectedSessionKey || !nonce) return null;
   const sessionKey = directSessionKey(eventData);
@@ -67,11 +74,17 @@ export function rCd4ReturnCandidate({ eventName, eventData, expectedSessionKey, 
   if (!hasExactSentinel(eventData, 'TARGET-RECEIVED', nonce)) return null;
   return {
     eventName,
-    sessionKey,
-    nonce,
-    marker: `TARGET-RECEIVED ${nonce}`,
+    sessionKeyFingerprint: fingerprintIdentity(sessionKey),
+    nonceFingerprint: fingerprintIdentity(nonce),
+    marker: 'TARGET-RECEIVED',
     role: 'system',
+    authoritative: false,
   };
+}
+
+/** @deprecated message markers are not delivery authority; use resolveTargetedReturnAuthority */
+export function rCd4ReturnCandidate(args) {
+  return rCd4DiagnosticMarkerCandidate(args);
 }
 
 export function rCd4TaskIdentityToken(nonce) {
@@ -100,13 +113,7 @@ export function rCd4ChildAuthority(candidates) {
 }
 
 /**
- * Inspect return authority for every post-dispatch session.message.
- *
- * `wakeGateMs` is intentionally diagnostic-only: it tells the caller whether
- * a generic message arrived after the expected wake delay, but it never gates
- * nonce-bound target or parent authority. A legitimate continuation return can
- * arrive before the generic wake timer, especially when delaySeconds is below
- * the default observation gate.
+ * Inspect diagnostic marker observations only. Never gates silent-wake delivery.
  */
 export function rCd4SessionMessageObservation({
   eventName,
@@ -120,18 +127,21 @@ export function rCd4SessionMessageObservation({
   const elapsed = Number.isFinite(elapsedMs) ? elapsedMs : 0;
   const gate = Number.isFinite(wakeGateMs) ? wakeGateMs : 0;
   return {
-    targetCandidate: rCd4ReturnCandidate({
+    targetDiagnosticMarker: rCd4DiagnosticMarkerCandidate({
       eventName,
       eventData,
       expectedSessionKey: targetSessionKey,
       nonce,
     }),
-    parentCandidate: rCd4ReturnCandidate({
+    parentDiagnosticMarker: rCd4DiagnosticMarkerCandidate({
       eventName,
       eventData,
       expectedSessionKey: parentSessionKey,
       nonce,
     }),
+    // Back-compat aliases — still non-authoritative.
+    targetCandidate: null,
+    parentCandidate: null,
     genericWakeObserved: elapsed >= gate,
   };
 }
@@ -146,6 +156,8 @@ export function rCd4HistoryObservation({
   wakeGateMs,
 }) {
   const result = {
+    targetDiagnosticMarker: null,
+    parentDiagnosticMarker: null,
     targetCandidate: null,
     parentCandidate: null,
     genericWakeObserved: false,
@@ -160,8 +172,8 @@ export function rCd4HistoryObservation({
       elapsedMs,
       wakeGateMs,
     });
-    result.targetCandidate ??= observation.targetCandidate;
-    result.parentCandidate ??= observation.parentCandidate;
+    result.targetDiagnosticMarker ??= observation.targetDiagnosticMarker;
+    result.parentDiagnosticMarker ??= observation.parentDiagnosticMarker;
     result.genericWakeObserved ||= observation.genericWakeObserved;
   }
   return result;
@@ -195,18 +207,20 @@ export function rCd4TaskObservation(task, nonce) {
 }
 
 /**
- * A target receipt still needs the remaining observation window to prove that
- * no matching parent receipt arrives later. A parent receipt is already a
- * terminal target-only failure and may close early.
+ * Message-marker receipts are never authoritative for silent-wake delivery.
+ * Always returns null so callers cannot promote transcript text to PASS.
  */
+export function rCd4ReturnReceipt(_candidate, _childSessionKey) {
+  return null;
+}
+
 export function rCd4ShouldScheduleEarlyClose({ parentReturnReceipt }) {
   return parentReturnReceipt !== null && parentReturnReceipt !== undefined;
 }
 
-/** Finalize only after the row has independently observed its spawned child. */
-export function rCd4ReturnReceipt(candidate, childSessionKey) {
-  if (!candidate || typeof childSessionKey !== 'string' || childSessionKey.length === 0) {
-    return null;
-  }
-  return { ...candidate, childSessionKey };
+/**
+ * Finalize R-CD-4 return authority from the shared journal collector only.
+ */
+export function rCd4JournalReturnAuthority(args) {
+  return resolveTargetedReturnAuthority({ ...args, row: args.row || 'R-CD-4' });
 }

--- a/tools/k6-proofs/lib/r-cd-chained-depth-2-authority.mjs
+++ b/tools/k6-proofs/lib/r-cd-chained-depth-2-authority.mjs
@@ -1,4 +1,7 @@
+import { createHmac } from 'node:crypto';
 import {
+  TARGETED_RETURN_INTEGRITY_ALGORITHM,
+  canonicalTargetedReturnReceipt,
   fingerprintIdentity,
   resolveTargetedReturnAuthority,
 } from './targeted-return-receipt.mjs';
@@ -7,6 +10,21 @@ export {
   resolveTargetedReturnAuthority,
   fingerprintIdentity,
 };
+
+function sealPartial(receipt, signingKey) {
+  if (typeof signingKey !== 'string' || signingKey.length === 0) {
+    throw new Error('missing gateway signing key');
+  }
+  return {
+    ...receipt,
+    integrity: {
+      algorithm: TARGETED_RETURN_INTEGRITY_ALGORITHM,
+      signature: createHmac('sha256', signingKey)
+        .update(canonicalTargetedReturnReceipt(receipt))
+        .digest('hex'),
+    },
+  };
+}
 
 const HARNESS_MARKER = '[k6-proof-harness]';
 
@@ -137,7 +155,7 @@ export function rCdChainJournalReturnAuthority(args) {
     grandchildSessionKey: args.grandchildSessionKey,
   });
   if (!hops.ok) {
-    return {
+    return sealPartial({
       schema: 'openclaw.k6.targeted-return-receipt.v1',
       row: 'R-CD-CHAINED-DEPTH-2',
       authority: 'gateway-journal-targeted-return',
@@ -145,9 +163,16 @@ export function rCdChainJournalReturnAuthority(args) {
       foldRequiresReview: true,
       verdict: 'PARTIAL-candidate',
       failureCategory: hops.reason,
+      structuralOk: false,
       targetMatchCount: 0,
       parentMatchCount: 0,
+      deliveryCountInWindow: 0,
+      deliveryCountTotal: 0,
       childBound: false,
+      window: {
+        startMs: Number.isFinite(args.windowStartMs) ? args.windowStartMs : null,
+        endMs: Number.isFinite(args.windowEndMs) ? args.windowEndMs : null,
+      },
       bindings: {
         targetSessionFingerprint: fingerprintIdentity(args.rootSessionKey),
         parentSessionFingerprint: fingerprintIdentity(args.childSessionKey),
@@ -155,7 +180,7 @@ export function rCdChainJournalReturnAuthority(args) {
         deliveryLineFingerprint: null,
         deliveredTargetFingerprints: [],
       },
-    };
+    }, args.signingKey);
   }
   // Grandchild is the delivering child; root must appear among tree targets.
   // Intermediate depth-1 is an expected co-target under fanoutMode=tree.
@@ -168,5 +193,7 @@ export function rCdChainJournalReturnAuthority(args) {
     windowEndMs: args.windowEndMs,
     row: 'R-CD-CHAINED-DEPTH-2',
     allowIntermediateAncestorTargets: true,
+    structuralOk: args.structuralOk !== false,
+    signingKey: args.signingKey,
   });
 }

--- a/tools/k6-proofs/lib/r-cd-chained-depth-2-authority.mjs
+++ b/tools/k6-proofs/lib/r-cd-chained-depth-2-authority.mjs
@@ -1,3 +1,13 @@
+import {
+  fingerprintIdentity,
+  resolveTargetedReturnAuthority,
+} from './targeted-return-receipt.mjs';
+
+export {
+  resolveTargetedReturnAuthority,
+  fingerprintIdentity,
+};
+
 const HARNESS_MARKER = '[k6-proof-harness]';
 
 function escapeRegex(value) {
@@ -45,11 +55,12 @@ function hasExactGrandchildMarker(eventData, nonce) {
 }
 
 /**
- * Identify the root system-event candidate independently of the grandchild's
- * ordinary assistant output. The event must be a structured session.message
- * for the exact root and must carry the exact row marker as role=system.
+ * Diagnostic-only root marker observation.
+ *
+ * Grandchild→root silent-wake routing authority is the shared payload-free
+ * `[continuation:targeted-return]` collector, not transcript system text.
  */
-export function rCdChainRootReturnCandidate({ eventName, eventData, rootSessionKey, nonce }) {
+export function rCdChainRootDiagnosticMarker({ eventName, eventData, rootSessionKey, nonce }) {
   if (eventName !== 'session.message') return null;
   if (!rootSessionKey || !nonce) return null;
   if (directSessionKey(eventData) !== rootSessionKey) return null;
@@ -57,19 +68,105 @@ export function rCdChainRootReturnCandidate({ eventName, eventData, rootSessionK
   if (!hasExactGrandchildMarker(eventData, nonce)) return null;
   return {
     eventName,
-    rootSessionKey,
-    nonce,
-    marker: `GRANDCHILD-DONE ${nonce}`,
+    rootSessionFingerprint: fingerprintIdentity(rootSessionKey),
+    nonceFingerprint: fingerprintIdentity(nonce),
+    marker: 'GRANDCHILD-DONE',
     role: 'system',
+    authoritative: false,
   };
 }
 
-/** Finalize only when both distinct nonce-bound hop identities are known. */
-export function rCdChainRootReturnReceipt(
-  candidate,
-  { childSessionKey, grandchildSessionKey } = {},
-) {
-  if (!candidate || !childSessionKey || !grandchildSessionKey) return null;
-  if (childSessionKey === grandchildSessionKey) return null;
-  return { ...candidate, childSessionKey, grandchildSessionKey };
+/** @deprecated transcript markers are not routing authority */
+export function rCdChainRootReturnCandidate(args) {
+  return rCdChainRootDiagnosticMarker(args);
+}
+
+/**
+ * Message-marker receipts never establish root routing authority.
+ */
+export function rCdChainRootReturnReceipt(_candidate, _hops) {
+  return null;
+}
+
+/**
+ * Require two distinct nonce-bound hop identities before journal authority
+ * can finalize grandchild→root routing.
+ */
+export function rCdChainHopIdentities({ childSessionKey, grandchildSessionKey } = {}) {
+  if (!childSessionKey || !grandchildSessionKey) {
+    return { ok: false, reason: 'missing-hop' };
+  }
+  if (childSessionKey === grandchildSessionKey) {
+    return { ok: false, reason: 'indistinct-hops' };
+  }
+  return {
+    ok: true,
+    childSessionKey,
+    grandchildSessionKey,
+    childFingerprint: fingerprintIdentity(childSessionKey),
+    grandchildFingerprint: fingerprintIdentity(grandchildSessionKey),
+  };
+}
+
+/**
+ * Nested depth-2 call must request fanoutMode=tree so grandchild completion
+ * routes up the ancestry to root. Outer parent→child call stays unchanged.
+ */
+export function rCdChainNestedDelegateSpec({ nonce, mode = 'silent-wake' } = {}) {
+  if (typeof nonce !== 'string' || nonce.length === 0) return null;
+  return {
+    mode,
+    fanoutMode: 'tree',
+    task: `Grandchild nonce ${nonce}: reply exactly GRANDCHILD-DONE ${nonce} only after you arrive. Do not mutate files.`,
+  };
+}
+
+export function rCdChainPromptTemplate() {
+  return (
+    "Proof chain nonce {{nonce}}: you are depth-1. Fire your own continue_delegate(" +
+    "mode='silent-wake', fanoutMode='tree', " +
+    "task='Grandchild nonce {{nonce}}: reply exactly GRANDCHILD-DONE {{nonce}} only after you arrive. Do not mutate files.'" +
+    "). After the nested continue_delegate tool result reports scheduled, reply exactly " +
+    'CHILD-DONE {{nonce}} CHILD-DELEGATE-SCHEDULED.'
+  );
+}
+
+export function rCdChainJournalReturnAuthority(args) {
+  const hops = rCdChainHopIdentities({
+    childSessionKey: args.childSessionKey,
+    grandchildSessionKey: args.grandchildSessionKey,
+  });
+  if (!hops.ok) {
+    return {
+      schema: 'openclaw.k6.targeted-return-receipt.v1',
+      row: 'R-CD-CHAINED-DEPTH-2',
+      authority: 'gateway-journal-targeted-return',
+      candidateOnly: true,
+      foldRequiresReview: true,
+      verdict: 'PARTIAL-candidate',
+      failureCategory: hops.reason,
+      targetMatchCount: 0,
+      parentMatchCount: 0,
+      childBound: false,
+      bindings: {
+        targetSessionFingerprint: fingerprintIdentity(args.rootSessionKey),
+        parentSessionFingerprint: fingerprintIdentity(args.childSessionKey),
+        childSessionFingerprint: fingerprintIdentity(args.grandchildSessionKey),
+        deliveryLineFingerprint: null,
+        deliveredTargetFingerprints: [],
+      },
+    };
+  }
+  // Grandchild is the delivering child; root must appear among tree targets.
+  // Intermediate depth-1 is an expected co-target under fanoutMode=tree.
+  return resolveTargetedReturnAuthority({
+    journalText: args.journalText,
+    targetSessionKey: args.rootSessionKey,
+    parentSessionKey: args.childSessionKey,
+    childSessionKey: args.grandchildSessionKey,
+    windowStartMs: args.windowStartMs,
+    windowEndMs: args.windowEndMs,
+    row: 'R-CD-CHAINED-DEPTH-2',
+    allowIntermediateAncestorTargets: true,
+  });
 }

--- a/tools/k6-proofs/lib/r-cd-chained-depth-2-authority.mjs
+++ b/tools/k6-proofs/lib/r-cd-chained-depth-2-authority.mjs
@@ -126,6 +126,42 @@ export function rCdChainHopIdentities({ childSessionKey, grandchildSessionKey } 
   };
 }
 
+export function resolveUniqueSpawnedByChild({ sessionsPayload, parentSessionKey } = {}) {
+  if (typeof parentSessionKey !== 'string' || parentSessionKey.length === 0) {
+    return {
+      uniqueChildKey: null,
+      child: null,
+      candidates: [],
+      ambiguous: false,
+      empty: true,
+      failureCategory: 'missing-parent-session',
+    };
+  }
+  const sessions = Array.isArray(sessionsPayload?.sessions)
+    ? sessionsPayload.sessions
+    : (Array.isArray(sessionsPayload) ? sessionsPayload : []);
+  const children = sessions.filter((session) => (
+    typeof session?.key === 'string'
+    && session.key.length > 0
+    && session.key !== parentSessionKey
+    && (session.spawnedBy === parentSessionKey || session.parentSessionKey === parentSessionKey)
+  ));
+  const candidates = [...new Set(children.map((session) => session.key))].sort();
+  const uniqueChildKey = candidates.length === 1 ? candidates[0] : null;
+  return {
+    uniqueChildKey,
+    child: uniqueChildKey
+      ? children.find((session) => session.key === uniqueChildKey) || null
+      : null,
+    candidates,
+    ambiguous: candidates.length > 1,
+    empty: candidates.length === 0,
+    failureCategory: candidates.length > 1
+      ? 'multiple-direct-children'
+      : (candidates.length === 0 ? 'zero-direct-children' : null),
+  };
+}
+
 /**
  * Nested depth-2 call must request fanoutMode=tree so grandchild completion
  * routes up the ancestry to root. Outer parent→child call stays unchanged.

--- a/tools/k6-proofs/lib/r-cd-model-tool-authority.mjs
+++ b/tools/k6-proofs/lib/r-cd-model-tool-authority.mjs
@@ -45,35 +45,170 @@ export function resolveModelToolChildAuthority({
   postKeys,
   sessionsPayload,
   requestedModel,
+  eventChildSessionKey,
+  parentSessionKey,
 }) {
   const diff = diffSpawnedByChildren(preKeys, postKeys);
+  const sessions = Array.isArray(sessionsPayload?.sessions)
+    ? sessionsPayload.sessions
+    : (Array.isArray(sessionsPayload) ? sessionsPayload : []);
+  const pre = new Set(Array.isArray(preKeys) ? preKeys : []);
+  const eventKey = typeof eventChildSessionKey === 'string' && eventChildSessionKey.length > 0
+    ? eventChildSessionKey
+    : null;
   if (!diff.uniqueNewChildKey) {
     return {
       ...diff,
       childSessionKey: null,
+      childSession: null,
       childMetadataModelByte: null,
       modelMatches: false,
-      failureCategory: diff.ambiguous
-        ? 'multiple-new-children'
-        : 'zero-new-children',
+      authoritySource: null,
+      failureCategory: diff.ambiguous ? 'multiple-new-children' : 'zero-new-children',
     };
   }
+  if (eventKey && (pre.has(eventKey) || eventKey !== diff.uniqueNewChildKey)) {
+    const diffChild = sessions.find((session) => session?.key === diff.uniqueNewChildKey) || null;
+    return {
+      ...diff,
+      childSessionKey: diff.uniqueNewChildKey,
+      childSession: diffChild,
+      childMetadataModelByte: modelFromSessionMetadata(diffChild),
+      modelMatches: false,
+      authoritySource: null,
+      failureCategory: pre.has(eventKey)
+        ? 'event-child-preexisting'
+        : 'event-child-diff-mismatch',
+    };
+  }
+  const selectedKey = diff.uniqueNewChildKey;
 
-  const sessions = Array.isArray(sessionsPayload?.sessions)
-    ? sessionsPayload.sessions
-    : (Array.isArray(sessionsPayload) ? sessionsPayload : []);
-  const child = sessions.find((session) => session?.key === diff.uniqueNewChildKey) || null;
+  const child = sessions.find((session) => (
+    session?.key === selectedKey
+    && (!parentSessionKey
+      || session.spawnedBy === parentSessionKey
+      || session.parentSessionKey === parentSessionKey)
+  )) || null;
+  if (!child) {
+    return {
+      ...diff,
+      childSessionKey: null,
+      childSession: null,
+      childMetadataModelByte: null,
+      modelMatches: false,
+      authoritySource: null,
+      failureCategory: 'child-parent-mismatch',
+    };
+  }
   const childMetadataModelByte = modelFromSessionMetadata(child);
   const requested = normalizeModel(requestedModel);
   const modelMatches = !!childMetadataModelByte && childMetadataModelByte === requested;
   return {
     ...diff,
-    childSessionKey: diff.uniqueNewChildKey,
+    childSessionKey: selectedKey,
+    childSession: child,
     childMetadataModelByte,
     modelMatches,
+    authoritySource: eventKey
+      ? 'event-correlated-sessions-list'
+      : 'spawned-by-set-diff',
     failureCategory: !childMetadataModelByte
       ? 'missing-child-model-byte'
       : (modelMatches ? null : 'model-mismatch'),
+  };
+}
+
+export function mergeModelToolChildAuthorityEvidence(currentEvidence, authority) {
+  const current = currentEvidence || {};
+  if (
+    current.child_identity_conflict === true
+    || current.spawned_by_diff_ambiguous === true
+  ) {
+    return { ...current };
+  }
+  if (authority?.ambiguous === true) {
+    return {
+      ...current,
+      spawned_by_diff_ambiguous: true,
+      model_matches: false,
+      model_classification_reason: 'spawnedBy set-diff produced multiple new children',
+    };
+  }
+  const authorityChildKey = typeof authority?.childSessionKey === 'string'
+    && authority.childSessionKey.length > 0
+    ? authority.childSessionKey
+    : null;
+  if (
+    authorityChildKey
+    && (
+      (
+        typeof current.child_session_key === 'string'
+        && current.child_session_key.length > 0
+        && current.child_session_key !== authorityChildKey
+      )
+      || (
+        typeof current.event_child_session_key === 'string'
+        && current.event_child_session_key.length > 0
+        && current.event_child_session_key !== authorityChildKey
+      )
+    )
+  ) {
+    return {
+      ...current,
+      child_identity_conflict: true,
+      spawned_by_diff_ambiguous: true,
+      model_matches: false,
+      model_classification_reason: 'conflicting authoritative child-session keys',
+    };
+  }
+  const hasStickyAuthority = (
+    current.child_session_metadata_observed === true
+    && typeof current.child_session_key === 'string'
+    && current.child_session_key.length > 0
+    && typeof current.child_metadata_model_byte === 'string'
+    && current.child_metadata_model_byte.length > 0
+  );
+  const hasNewAuthority = (
+    typeof authority?.childSessionKey === 'string'
+    && authority.childSessionKey.length > 0
+    && typeof authority.childMetadataModelByte === 'string'
+    && authority.childMetadataModelByte.length > 0
+  );
+
+  if (!hasNewAuthority) {
+    if (hasStickyAuthority) return { ...current };
+    return {
+      ...current,
+      spawned_by_diff_empty: authority?.empty === true,
+      spawned_by_diff_ambiguous: authority?.ambiguous === true,
+      model_classification_reason: authority?.failureCategory || current.model_classification_reason,
+    };
+  }
+
+  const child = authority.childSession || {};
+  return {
+    ...current,
+    child_session_key: authority.childSessionKey,
+    child_session_observed: true,
+    child_session_metadata_observed: true,
+    child_metadata_model_byte: authority.childMetadataModelByte,
+    child_metadata_model_source:
+      `gateway sessions.list ${authority.authoritySource} provider/model metadata`,
+    child_session_metadata: {
+      key: child.key || authority.childSessionKey,
+      provider: child.modelProvider || child.provider || null,
+      model: child.model || null,
+      modelSelectionLocked: child.modelSelectionLocked === true,
+      spawnedBy: child.spawnedBy || child.parentSessionKey || null,
+    },
+    child_authority_source: authority.authoritySource,
+    child_identity_conflict: false,
+    model_matches: authority.modelMatches,
+    spawned_by_diff_empty: false,
+    spawned_by_diff_ambiguous: false,
+    model_classification_reason: authority.failureCategory === 'model-mismatch'
+      ? 'requested model does not match authoritative child-session metadata'
+      : null,
   };
 }
 

--- a/tools/k6-proofs/lib/r-cd-model-tool-authority.mjs
+++ b/tools/k6-proofs/lib/r-cd-model-tool-authority.mjs
@@ -86,28 +86,50 @@ function messageText(message) {
   return parts.length > 0 ? parts.join('\n') : null;
 }
 
+function escapeRegex(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Exact child→parent return marker required for return authority:
+ *   MODEL-TOOL-CHILD <nonce> MODEL <provider/model>
+ *
+ * Generic assistant/system text that merely mentions the nonce (including
+ * paraphrased schedule acknowledgements) is NOT return authority.
+ * Model equality still comes solely from spawnedBy metadata — this marker
+ * only proves a nonce-bound return payload landed in parent history.
+ */
+export function childReturnMarkerRegex(nonce) {
+  if (!nonce || typeof nonce !== 'string') return null;
+  return new RegExp(
+    `\\bMODEL-TOOL-CHILD\\s+${escapeRegex(nonce)}\\s+MODEL\\s+([A-Za-z0-9_.\\/-]+)\\b`,
+  );
+}
+
 /**
  * Parent sessions.get history may confirm a nonce-bound child return.
  *
- * The parent's own schedule ack (MODEL-TOOL-PARENT-SCHEDULED) is NOT a return.
- * Child MODEL-TOOL-CHILD self-report text is auxiliary equality evidence only —
- * when present in parent history it proves a child→parent return payload landed,
- * but model equality still comes solely from spawnedBy metadata.
+ * Authority requires the exact MODEL-TOOL-CHILD <nonce> MODEL ... marker
+ * (or the same typed pattern already used for auxiliary self-report parse).
+ * The parent's own schedule ack (MODEL-TOOL-PARENT-SCHEDULED) and any
+ * paraphrased schedule/waiting text are NOT returns.
+ * When the marker is present in parent history it proves a child→parent
+ * return payload landed, but model equality still comes solely from
+ * spawnedBy metadata.
  */
 export function parentReturnContainsNonce(messages, nonce) {
-  if (!nonce || typeof nonce !== 'string') return false;
+  const marker = childReturnMarkerRegex(nonce);
+  if (!marker) return false;
   for (const message of Array.isArray(messages) ? messages : []) {
     const role = message?.role;
     if (role !== 'user' && role !== 'assistant' && role !== 'system') continue;
     const text = messageText(message);
-    if (typeof text !== 'string' || !text.includes(nonce)) continue;
+    if (typeof text !== 'string') continue;
     if (text.includes('[k6-proof-harness]')) continue;
     // Parent schedule ack is not child→parent return authority.
     if (/\bMODEL-TOOL-PARENT-SCHEDULED\b/.test(text)) continue;
-    // Accept child return marker or other non-schedule nonce-bearing return text.
-    if (/\bMODEL-TOOL-CHILD\b/.test(text) || role === 'system' || role === 'assistant') {
-      return true;
-    }
+    // Strict: only the exact child-return marker counts.
+    if (marker.test(text)) return true;
   }
   return false;
 }
@@ -115,8 +137,8 @@ export function parentReturnContainsNonce(messages, nonce) {
 /** Auxiliary only — never establishes model equality. */
 export function parseAuxiliaryChildSelfReport(text, nonce) {
   if (typeof text !== 'string' || !nonce) return null;
-  const match = text.match(new RegExp(
-    `MODEL-TOOL-CHILD\\s+${String(nonce).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s+MODEL\\s+([A-Za-z0-9_.\\/-]+)`,
-  ));
+  const marker = childReturnMarkerRegex(nonce);
+  if (!marker) return null;
+  const match = text.match(marker);
   return match ? normalizeModel(match[1]) : null;
 }

--- a/tools/k6-proofs/lib/r-cd-model-tool-authority.mjs
+++ b/tools/k6-proofs/lib/r-cd-model-tool-authority.mjs
@@ -1,0 +1,122 @@
+function normalizeModel(value) {
+  return String(value || '').trim().replace(/[.,;:]+$/, '');
+}
+
+export function modelFromSessionMetadata(session) {
+  const model = normalizeModel(session?.model);
+  const provider = normalizeModel(session?.modelProvider || session?.provider);
+  if (!model) return null;
+  return model.includes('/') ? model : (provider ? `${provider}/${model}` : model);
+}
+
+export function sessionKeysFromListPayload(payload) {
+  const sessions = Array.isArray(payload?.sessions)
+    ? payload.sessions
+    : (Array.isArray(payload) ? payload : []);
+  return [...new Set(
+    sessions
+      .map((session) => (typeof session?.key === 'string' ? session.key : null))
+      .filter((value) => typeof value === 'string' && value.length > 0),
+  )].sort();
+}
+
+/**
+ * Diff pre/post sessions.list { spawnedBy } key sets.
+ * PASS authority requires exactly one new child key.
+ */
+export function diffSpawnedByChildren(preKeys, postKeys) {
+  const pre = new Set(Array.isArray(preKeys) ? preKeys : []);
+  const post = new Set(Array.isArray(postKeys) ? postKeys : []);
+  const added = [...post].filter((key) => !pre.has(key)).sort();
+  const removed = [...pre].filter((key) => !post.has(key)).sort();
+  return {
+    preCount: pre.size,
+    postCount: post.size,
+    added,
+    removed,
+    uniqueNewChildKey: added.length === 1 ? added[0] : null,
+    ambiguous: added.length > 1,
+    empty: added.length === 0,
+  };
+}
+
+export function resolveModelToolChildAuthority({
+  preKeys,
+  postKeys,
+  sessionsPayload,
+  requestedModel,
+}) {
+  const diff = diffSpawnedByChildren(preKeys, postKeys);
+  if (!diff.uniqueNewChildKey) {
+    return {
+      ...diff,
+      childSessionKey: null,
+      childMetadataModelByte: null,
+      modelMatches: false,
+      failureCategory: diff.ambiguous
+        ? 'multiple-new-children'
+        : 'zero-new-children',
+    };
+  }
+
+  const sessions = Array.isArray(sessionsPayload?.sessions)
+    ? sessionsPayload.sessions
+    : (Array.isArray(sessionsPayload) ? sessionsPayload : []);
+  const child = sessions.find((session) => session?.key === diff.uniqueNewChildKey) || null;
+  const childMetadataModelByte = modelFromSessionMetadata(child);
+  const requested = normalizeModel(requestedModel);
+  const modelMatches = !!childMetadataModelByte && childMetadataModelByte === requested;
+  return {
+    ...diff,
+    childSessionKey: diff.uniqueNewChildKey,
+    childMetadataModelByte,
+    modelMatches,
+    failureCategory: !childMetadataModelByte
+      ? 'missing-child-model-byte'
+      : (modelMatches ? null : 'model-mismatch'),
+  };
+}
+
+function messageText(message) {
+  if (typeof message?.content === 'string') return message.content;
+  if (!Array.isArray(message?.content)) return null;
+  const parts = message.content
+    .filter((part) => part && typeof part === 'object' && part.type === 'text' && typeof part.text === 'string')
+    .map((part) => part.text);
+  return parts.length > 0 ? parts.join('\n') : null;
+}
+
+/**
+ * Parent sessions.get history may confirm a nonce-bound child return.
+ *
+ * The parent's own schedule ack (MODEL-TOOL-PARENT-SCHEDULED) is NOT a return.
+ * Child MODEL-TOOL-CHILD self-report text is auxiliary equality evidence only —
+ * when present in parent history it proves a child→parent return payload landed,
+ * but model equality still comes solely from spawnedBy metadata.
+ */
+export function parentReturnContainsNonce(messages, nonce) {
+  if (!nonce || typeof nonce !== 'string') return false;
+  for (const message of Array.isArray(messages) ? messages : []) {
+    const role = message?.role;
+    if (role !== 'user' && role !== 'assistant' && role !== 'system') continue;
+    const text = messageText(message);
+    if (typeof text !== 'string' || !text.includes(nonce)) continue;
+    if (text.includes('[k6-proof-harness]')) continue;
+    // Parent schedule ack is not child→parent return authority.
+    if (/\bMODEL-TOOL-PARENT-SCHEDULED\b/.test(text)) continue;
+    // Accept child return marker or other non-schedule nonce-bearing return text.
+    if (/\bMODEL-TOOL-CHILD\b/.test(text) || role === 'system' || role === 'assistant') {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Auxiliary only — never establishes model equality. */
+export function parseAuxiliaryChildSelfReport(text, nonce) {
+  if (typeof text !== 'string' || !nonce) return null;
+  const match = text.match(new RegExp(
+    `MODEL-TOOL-CHILD\\s+${String(nonce).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s+MODEL\\s+([A-Za-z0-9_.\\/-]+)`,
+  ));
+  return match ? normalizeModel(match[1]) : null;
+}

--- a/tools/k6-proofs/lib/r-cd-model-tool-authority.mjs
+++ b/tools/k6-proofs/lib/r-cd-model-tool-authority.mjs
@@ -142,3 +142,44 @@ export function parseAuxiliaryChildSelfReport(text, nonce) {
   const match = text.match(marker);
   return match ? normalizeModel(match[1]) : null;
 }
+
+/**
+ * Baseline-gated dispatch controller for R-CD-MODEL-TOOL.
+ *
+ * The sole sessions.send dispatch fires exactly once from a successful
+ * pre-dispatch sessions.list {spawnedBy} baseline response — never from a
+ * fixed timing gap after subscribe. A watchdog may fail-closed if the
+ * baseline never arrives; after fail-closed, a late baseline cannot dispatch.
+ */
+export function createModelToolDispatchGate() {
+  let baselineCaptured = false;
+  let dispatched = false;
+  let failedClosed = false;
+
+  return {
+    /** Successful pre sessions.list response — may trigger the sole dispatch. */
+    onPreBaselineCaptured() {
+      if (failedClosed) return { action: 'noop', reason: 'already-failed-closed' };
+      if (dispatched) return { action: 'noop', reason: 'already-dispatched' };
+      baselineCaptured = true;
+      dispatched = true;
+      return { action: 'dispatch' };
+    },
+    /** Watchdog: if baseline never arrived, fail closed. */
+    onBaselineWatchdog() {
+      if (dispatched || baselineCaptured) {
+        return { action: 'noop', reason: 'baseline-already-handled' };
+      }
+      failedClosed = true;
+      return { action: 'fail-closed' };
+    },
+    getState() {
+      return {
+        baselineCaptured,
+        dispatched,
+        failedClosed,
+        dispatchCount: dispatched ? 1 : 0,
+      };
+    },
+  };
+}

--- a/tools/k6-proofs/lib/targeted-return-receipt.mjs
+++ b/tools/k6-proofs/lib/targeted-return-receipt.mjs
@@ -1,10 +1,13 @@
-import { createHash } from 'node:crypto';
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
 
 export const TARGETED_RETURN_RECEIPT_SCHEMA = 'openclaw.k6.targeted-return-receipt.v1';
 export const TARGETED_RETURN_MARKER = '[continuation:targeted-return]';
+export const TARGETED_RETURN_INTEGRITY_ALGORITHM = 'hmac-sha256-gateway-token-v1';
 
 const DELIVERED_RE = /\[continuation:targeted-return\]\s+Delivered to\s+(.+?)\s+from\s+(\S+)/i;
 const ISO_RE = /(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2}))/;
+const FP16 = /^[a-f0-9]{16}$/i;
+const HEX64 = /^[a-f0-9]{64}$/i;
 
 export function fingerprintIdentity(value) {
   if (typeof value !== 'string' || value.length === 0) return null;
@@ -59,6 +62,40 @@ function inWindow(timestampMs, windowStartMs, windowEndMs) {
   return true;
 }
 
+/** Canonical closed fields bound by the gateway-token HMAC seal. */
+export function canonicalTargetedReturnReceipt(receipt) {
+  return JSON.stringify({
+    schema: receipt.schema,
+    row: receipt.row,
+    authority: receipt.authority,
+    candidateOnly: receipt.candidateOnly,
+    foldRequiresReview: receipt.foldRequiresReview,
+    verdict: receipt.verdict,
+    failureCategory: receipt.failureCategory || null,
+    structuralOk: receipt.structuralOk === true,
+    window: receipt.window || null,
+    targetMatchCount: receipt.targetMatchCount,
+    parentMatchCount: receipt.parentMatchCount,
+    deliveryCountInWindow: receipt.deliveryCountInWindow,
+    deliveryCountTotal: receipt.deliveryCountTotal,
+    childBound: receipt.childBound === true,
+    bindings: receipt.bindings,
+  });
+}
+
+function seal(receipt, key) {
+  if (typeof key !== 'string' || key.length === 0) {
+    throw new Error('missing gateway signing key');
+  }
+  return {
+    ...receipt,
+    integrity: {
+      algorithm: TARGETED_RETURN_INTEGRITY_ALGORITHM,
+      signature: createHmac('sha256', key).update(canonicalTargetedReturnReceipt(receipt)).digest('hex'),
+    },
+  };
+}
+
 /**
  * Bind exact target/parent/child/window against payload-free gateway receipts.
  *
@@ -71,6 +108,10 @@ function inWindow(timestampMs, windowStartMs, windowEndMs) {
  * solely because an intermediate ancestor also received the delivery. Still
  * fail closed on missing root, wrong child, or duplicate root-bearing lines.
  * Child identity and completion gates stay independent of this authority.
+ *
+ * Structural gates (tool accepted, unique child, completion sentinels) are an
+ * independent boolean. PASS requires structuralOk === true AND journal match.
+ * The receipt is HMAC-sealed to OPENCLAW_GATEWAY_TOKEN like R-CD-2/R-CD-TOKEN.
  */
 export function resolveTargetedReturnAuthority({
   journalText,
@@ -81,6 +122,8 @@ export function resolveTargetedReturnAuthority({
   windowEndMs = null,
   row = null,
   allowIntermediateAncestorTargets = false,
+  structuralOk = true,
+  signingKey,
 } = {}) {
   const deliveries = collectTargetedReturnDeliveries(journalText);
   const windowed = deliveries.filter((delivery) =>
@@ -124,19 +167,26 @@ export function resolveTargetedReturnAuthority({
     failureCategory = 'parent-delivery';
   }
 
-  const pass = failureCategory === null &&
+  const journalPass = failureCategory === null &&
     targetMatches.length === 1 &&
     (allowIntermediateAncestorTargets || parentMatches.length === 0) &&
     childBound;
+  const structural = structuralOk === true;
+  if (!structural) {
+    failureCategory = failureCategory || 'structural-gates-incomplete';
+  }
+  const pass = journalPass && structural;
   const primary = targetMatches[0] || null;
-  return {
+
+  return seal({
     schema: TARGETED_RETURN_RECEIPT_SCHEMA,
     row: row || null,
     authority: 'gateway-journal-targeted-return',
     candidateOnly: true,
     foldRequiresReview: true,
     verdict: pass ? 'PASS-candidate' : 'PARTIAL-candidate',
-    failureCategory,
+    failureCategory: pass ? null : failureCategory,
+    structuralOk: structural,
     window: {
       startMs: Number.isFinite(windowStartMs) ? windowStartMs : null,
       endMs: Number.isFinite(windowEndMs) ? windowEndMs : null,
@@ -155,7 +205,7 @@ export function resolveTargetedReturnAuthority({
         ? primary.targetSessionKeys.map((key) => fingerprintIdentity(key)).filter(Boolean)
         : [],
     },
-  };
+  }, signingKey);
 }
 
 export function assertPublicSafeTargetedReturnReceipt(receipt) {
@@ -172,13 +222,12 @@ export function assertPublicSafeTargetedReturnReceipt(receipt) {
   return true;
 }
 
-const FP16 = /^[a-f0-9]{16}$/i;
-
 /**
- * Shape/public-safety validator for candidate envelope routing.
- * No gateway-token seal: the receipt is already redacted closed fields only.
+ * Authoritative receipt validator for candidate envelope routing.
+ * Requires the gateway-token HMAC seal (same contract as R-CD-2/R-CD-TOKEN).
+ * PASS demands structuralOk === true plus closed journal counts/fingerprints.
  */
-export function validateTargetedReturnReceipt(receipt, expectedRow = null) {
+export function validateTargetedReturnReceipt(receipt, signingKey, expectedRow = null) {
   try {
     if (!receipt || receipt.schema !== TARGETED_RETURN_RECEIPT_SCHEMA) {
       return { valid: false, reason: 'invalid-schema' };
@@ -198,7 +247,26 @@ export function validateTargetedReturnReceipt(receipt, expectedRow = null) {
     if (receipt.verdict !== 'PASS-candidate' && receipt.verdict !== 'PARTIAL-candidate') {
       return { valid: false, reason: 'invalid-verdict' };
     }
+    if (typeof signingKey !== 'string' || signingKey.length === 0) {
+      return { valid: false, reason: 'missing-signing-key' };
+    }
+    if (receipt.integrity?.algorithm !== TARGETED_RETURN_INTEGRITY_ALGORITHM ||
+        !HEX64.test(receipt.integrity?.signature || '')) {
+      return { valid: false, reason: 'invalid-shape' };
+    }
+    const expected = createHmac('sha256', signingKey)
+      .update(canonicalTargetedReturnReceipt(receipt))
+      .digest('hex');
+    const actual = receipt.integrity.signature;
+    if (expected.length !== actual.length ||
+        !timingSafeEqual(Buffer.from(expected, 'hex'), Buffer.from(actual, 'hex'))) {
+      return { valid: false, reason: 'invalid-integrity' };
+    }
+
     if (receipt.verdict === 'PASS-candidate') {
+      if (receipt.structuralOk !== true) {
+        return { valid: false, reason: 'pass-structural-ok' };
+      }
       if (receipt.targetMatchCount !== 1 || receipt.parentMatchCount !== 0 || receipt.childBound !== true) {
         return { valid: false, reason: 'pass-counts' };
       }
@@ -212,7 +280,12 @@ export function validateTargetedReturnReceipt(receipt, expectedRow = null) {
       if (!FP16.test(receipt.bindings?.deliveryLineFingerprint || '')) {
         return { valid: false, reason: 'missing-delivery-fingerprint' };
       }
+    } else if (receipt.verdict === 'PARTIAL-candidate') {
+      if (typeof receipt.failureCategory !== 'string' || receipt.failureCategory.length === 0) {
+        return { valid: false, reason: 'invalid-failure-category' };
+      }
     }
+
     assertPublicSafeTargetedReturnReceipt(receipt);
     return { valid: true, verdict: receipt.verdict };
   } catch (error) {

--- a/tools/k6-proofs/lib/targeted-return-receipt.mjs
+++ b/tools/k6-proofs/lib/targeted-return-receipt.mjs
@@ -1,0 +1,221 @@
+import { createHash } from 'node:crypto';
+
+export const TARGETED_RETURN_RECEIPT_SCHEMA = 'openclaw.k6.targeted-return-receipt.v1';
+export const TARGETED_RETURN_MARKER = '[continuation:targeted-return]';
+
+const DELIVERED_RE = /\[continuation:targeted-return\]\s+Delivered to\s+(.+?)\s+from\s+(\S+)/i;
+const ISO_RE = /(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2}))/;
+
+export function fingerprintIdentity(value) {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  return createHash('sha256').update(value).digest('hex').slice(0, 16);
+}
+
+export function parseJournalLineTimestampMs(line) {
+  const text = String(line || '');
+  const match = text.match(ISO_RE);
+  if (!match) return null;
+  const ms = Date.parse(match[1]);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/**
+ * Parse one payload-free gateway targeted-return delivery line.
+ * Returns raw identities for private binding only — never publish these.
+ */
+export function parseTargetedReturnDeliveryLine(line) {
+  const text = String(line || '');
+  if (!text.includes(TARGETED_RETURN_MARKER)) return null;
+  const match = text.match(DELIVERED_RE);
+  if (!match) return null;
+  const targets = match[1]
+    .split(',')
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+  const childSessionKey = match[2].trim();
+  if (targets.length === 0 || !childSessionKey) return null;
+  return {
+    line: text,
+    timestampMs: parseJournalLineTimestampMs(text),
+    targetSessionKeys: targets,
+    childSessionKey,
+  };
+}
+
+export function collectTargetedReturnDeliveries(journalText) {
+  const lines = String(journalText || '').split(/\r?\n/);
+  const deliveries = [];
+  for (const line of lines) {
+    const delivery = parseTargetedReturnDeliveryLine(line);
+    if (delivery) deliveries.push(delivery);
+  }
+  return deliveries;
+}
+
+function inWindow(timestampMs, windowStartMs, windowEndMs) {
+  if (!Number.isFinite(timestampMs)) return false;
+  if (Number.isFinite(windowStartMs) && timestampMs < windowStartMs) return false;
+  if (Number.isFinite(windowEndMs) && timestampMs > windowEndMs) return false;
+  return true;
+}
+
+/**
+ * Bind exact target/parent/child/window against payload-free gateway receipts.
+ *
+ * Default (R-CD-4 / single-target): PASS requires exactly one in-window delivery
+ * whose target list includes the expected target, whose child matches, and zero
+ * matching parent deliveries.
+ *
+ * Tree fanout (R-CD-CHAINED-DEPTH-2): intermediate ancestors are expected
+ * co-targets. Require root/target presence from the exact child; do not fail
+ * solely because an intermediate ancestor also received the delivery. Still
+ * fail closed on missing root, wrong child, or duplicate root-bearing lines.
+ * Child identity and completion gates stay independent of this authority.
+ */
+export function resolveTargetedReturnAuthority({
+  journalText,
+  targetSessionKey,
+  parentSessionKey = null,
+  childSessionKey = null,
+  windowStartMs = null,
+  windowEndMs = null,
+  row = null,
+  allowIntermediateAncestorTargets = false,
+} = {}) {
+  const deliveries = collectTargetedReturnDeliveries(journalText);
+  const windowed = deliveries.filter((delivery) =>
+    inWindow(delivery.timestampMs, windowStartMs, windowEndMs));
+
+  const childBound = typeof childSessionKey === 'string' && childSessionKey.length > 0;
+  const matchingChild = (delivery) => (
+    !childBound || delivery.childSessionKey === childSessionKey
+  );
+
+  const targetMatches = windowed.filter((delivery) => (
+    matchingChild(delivery) &&
+    delivery.targetSessionKeys.includes(targetSessionKey)
+  ));
+  // Single-target rows fail closed on parent delivery. Tree fanout expects
+  // intermediate ancestors, so those deliveries are never parent-failure.
+  const parentMatches = (!allowIntermediateAncestorTargets &&
+    parentSessionKey && parentSessionKey !== targetSessionKey)
+    ? windowed.filter((delivery) => (
+      matchingChild(delivery) &&
+      delivery.targetSessionKeys.includes(parentSessionKey)
+    ))
+    : [];
+
+  let failureCategory = null;
+  if (!targetSessionKey) failureCategory = 'missing-target';
+  else if (!childBound) failureCategory = 'missing-child';
+  else if (targetMatches.length === 0) {
+    const anyTargetAnyChild = windowed.filter((d) => d.targetSessionKeys.includes(targetSessionKey));
+    const anyChildOutOfWindow = deliveries.filter((d) => (
+      d.childSessionKey === childSessionKey &&
+      d.targetSessionKeys.includes(targetSessionKey) &&
+      !inWindow(d.timestampMs, windowStartMs, windowEndMs)
+    ));
+    if (anyChildOutOfWindow.length > 0) failureCategory = 'out-of-window';
+    else if (anyTargetAnyChild.length > 0) failureCategory = 'wrong-child';
+    else if (deliveries.length > 0) failureCategory = 'no-matching-delivery';
+    else failureCategory = 'no-delivery';
+  } else if (targetMatches.length > 1) failureCategory = 'duplicate-target';
+  else if (!allowIntermediateAncestorTargets && parentMatches.length > 0) {
+    failureCategory = 'parent-delivery';
+  }
+
+  const pass = failureCategory === null &&
+    targetMatches.length === 1 &&
+    (allowIntermediateAncestorTargets || parentMatches.length === 0) &&
+    childBound;
+  const primary = targetMatches[0] || null;
+  return {
+    schema: TARGETED_RETURN_RECEIPT_SCHEMA,
+    row: row || null,
+    authority: 'gateway-journal-targeted-return',
+    candidateOnly: true,
+    foldRequiresReview: true,
+    verdict: pass ? 'PASS-candidate' : 'PARTIAL-candidate',
+    failureCategory,
+    window: {
+      startMs: Number.isFinite(windowStartMs) ? windowStartMs : null,
+      endMs: Number.isFinite(windowEndMs) ? windowEndMs : null,
+    },
+    targetMatchCount: targetMatches.length,
+    parentMatchCount: parentMatches.length,
+    deliveryCountInWindow: windowed.length,
+    deliveryCountTotal: deliveries.length,
+    childBound,
+    bindings: {
+      targetSessionFingerprint: fingerprintIdentity(targetSessionKey),
+      parentSessionFingerprint: fingerprintIdentity(parentSessionKey),
+      childSessionFingerprint: fingerprintIdentity(childSessionKey),
+      deliveryLineFingerprint: primary ? fingerprintIdentity(primary.line) : null,
+      deliveredTargetFingerprints: primary
+        ? primary.targetSessionKeys.map((key) => fingerprintIdentity(key)).filter(Boolean)
+        : [],
+    },
+  };
+}
+
+export function assertPublicSafeTargetedReturnReceipt(receipt) {
+  const serialized = JSON.stringify(receipt);
+  if (/\bagent:[A-Za-z0-9:_-]{6,}\b/.test(serialized)) {
+    throw new Error('targeted-return receipt leaked a raw session key');
+  }
+  if (serialized.includes('TARGET-RECEIVED') || serialized.includes('GRANDCHILD-DONE')) {
+    throw new Error('targeted-return receipt leaked message-body marker text');
+  }
+  if (serialized.includes('[k6-proof-harness]')) {
+    throw new Error('targeted-return receipt leaked harness prompt text');
+  }
+  return true;
+}
+
+const FP16 = /^[a-f0-9]{16}$/i;
+
+/**
+ * Shape/public-safety validator for candidate envelope routing.
+ * No gateway-token seal: the receipt is already redacted closed fields only.
+ */
+export function validateTargetedReturnReceipt(receipt, expectedRow = null) {
+  try {
+    if (!receipt || receipt.schema !== TARGETED_RETURN_RECEIPT_SCHEMA) {
+      return { valid: false, reason: 'invalid-schema' };
+    }
+    if (expectedRow && receipt.row !== expectedRow) {
+      return { valid: false, reason: 'row-mismatch' };
+    }
+    if (receipt.row !== 'R-CD-4' && receipt.row !== 'R-CD-CHAINED-DEPTH-2') {
+      return { valid: false, reason: 'unsupported-row' };
+    }
+    if (receipt.authority !== 'gateway-journal-targeted-return') {
+      return { valid: false, reason: 'invalid-authority' };
+    }
+    if (receipt.candidateOnly !== true || receipt.foldRequiresReview !== true) {
+      return { valid: false, reason: 'review-flags' };
+    }
+    if (receipt.verdict !== 'PASS-candidate' && receipt.verdict !== 'PARTIAL-candidate') {
+      return { valid: false, reason: 'invalid-verdict' };
+    }
+    if (receipt.verdict === 'PASS-candidate') {
+      if (receipt.targetMatchCount !== 1 || receipt.parentMatchCount !== 0 || receipt.childBound !== true) {
+        return { valid: false, reason: 'pass-counts' };
+      }
+      if (receipt.failureCategory != null) return { valid: false, reason: 'pass-failure-category' };
+      if (!FP16.test(receipt.bindings?.targetSessionFingerprint || '')) {
+        return { valid: false, reason: 'missing-target-fingerprint' };
+      }
+      if (!FP16.test(receipt.bindings?.childSessionFingerprint || '')) {
+        return { valid: false, reason: 'missing-child-fingerprint' };
+      }
+      if (!FP16.test(receipt.bindings?.deliveryLineFingerprint || '')) {
+        return { valid: false, reason: 'missing-delivery-fingerprint' };
+      }
+    }
+    assertPublicSafeTargetedReturnReceipt(receipt);
+    return { valid: true, verdict: receipt.verdict };
+  } catch (error) {
+    return { valid: false, reason: error.message || 'invalid' };
+  }
+}

--- a/tools/k6-proofs/manifests/r-cd-4.json
+++ b/tools/k6-proofs/manifests/r-cd-4.json
@@ -50,9 +50,9 @@
       "description": "Gateway accepted the dispatching sessions.send request that asks the agent to call continue_delegate with targetSessionKey"
     },
     {
-      "name": "target-return-event",
+      "name": "target-return-journal-receipt",
       "required": true,
-      "description": "The TARGET session receives the exact TARGET-RECEIVED {{nonce}} marker in a structured role=system session.message event"
+      "description": "Shared post-run collector binds exactly one in-window [continuation:targeted-return] Delivered to <target> from <child> receipt"
     },
     {
       "name": "child-session-identity",
@@ -62,7 +62,7 @@
     {
       "name": "no-parent-return",
       "required": true,
-      "description": "Dispatching parent session does NOT receive the delayed return/wake"
+      "description": "Shared collector finds zero matching parent targeted-return receipts for the same child/window"
     },
     {
       "name": "task-ledger-entry",
@@ -85,7 +85,7 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Cross-session targeted return. PASS-candidate requires dispatch acceptance, a nonce-bound child identity, the exact TARGET-RECEIVED {{nonce}} marker in a role=system TARGET event, and no matching parent receipt. Unrelated/assistant messages and nested session-key mentions fail closed."
+    "notes": "Cross-session targeted return. PASS-candidate requires dispatch acceptance, a nonce-bound child identity, and the shared payload-free gateway [continuation:targeted-return] receipt bound to exact target/parent/child/window. Transcript session.message / sessions.get TARGET-RECEIVED text is not delivery authority."
   },
   "liveRunSafety": {
     "classification": "k6-runnable",
@@ -101,11 +101,11 @@
       "target-session-created",
       "dispatch-accepted",
       "child-session-identity",
-      "target-return-event",
+      "target-return-journal-receipt",
       "no-parent-return",
       "trace-id"
     ],
     "foldRequiresReview": true,
-    "notes": "Live continuation row. Prefer OPENCLAW_CREATE_DISPOSABLE_SESSIONS=true for repeatability; explicit OPENCLAW_TARGET_SESSION_KEY still supported for reviewed manual runs. The detector requires exact row marker, structured target session, and separately nonce-bound child identity."
+    "notes": "Live continuation row. Prefer OPENCLAW_CREATE_DISPOSABLE_SESSIONS=true. Silent-wake delivery authority is the shared journal targeted-return collector, not transcript nonce text."
   }
 }

--- a/tools/k6-proofs/manifests/r-cd-chained-depth-2.json
+++ b/tools/k6-proofs/manifests/r-cd-chained-depth-2.json
@@ -15,17 +15,12 @@
   },
   "scenario": {
     "name": "r-cd-chained-depth-2",
-    "description": "Depth-2 delegate chain: parent→child→grandchild→return path. Three sub-tests: (1) up-tree silent-wake, (2) inter-session return, (3) echo+broadcast via fanoutMode.",
+    "description": "Depth-2 delegate chain: parent\u2192child\u2192grandchild. Nested call requests fanoutMode=tree so grandchild completion routes to root; outer parent\u2192child is unchanged. Routing authority is the shared gateway targeted-return collector.",
     "methods": [
       "sessions.create",
       "sessions.send",
       "sessions.messages.subscribe",
       "tasks.list"
-    ],
-    "subtests": [
-      "chain-1-uptree-silent-wake",
-      "chain-2-inter-session-return",
-      "chain-3-echo-broadcast"
     ],
     "status": "runnable",
     "file": "r-cd-chained-depth-2.js"
@@ -34,14 +29,14 @@
     "tool": "continue_delegate",
     "mode": "silent-wake",
     "delaySeconds": 1,
-    "promptTemplate": "Proof chain nonce {{nonce}}: you are depth-1. Fire your own continue_delegate(mode='silent-wake', task='Grandchild nonce {{nonce}}: reply exactly GRANDCHILD-DONE {{nonce}} only after you arrive. Do not mutate files.'). After the nested continue_delegate tool result reports scheduled, reply exactly CHILD-DONE {{nonce}} CHILD-DELEGATE-SCHEDULED.",
+    "promptTemplate": "Proof chain nonce {{nonce}}: you are depth-1. Fire your own continue_delegate(mode='silent-wake', fanoutMode='tree', task='Grandchild nonce {{nonce}}: reply exactly GRANDCHILD-DONE {{nonce}} only after you arrive. Do not mutate files.'). After the nested continue_delegate tool result reports scheduled, reply exactly CHILD-DONE {{nonce}} CHILD-DELEGATE-SCHEDULED.",
     "idempotencyKeyPrefix": "R-CD-CHAIN"
   },
   "expectedReceipts": [
     {
       "name": "parent-dispatch-accepted",
       "required": true,
-      "description": "Parent fires continue_delegate → accepted"
+      "description": "Parent fires continue_delegate \u2192 accepted"
     },
     {
       "name": "child-spawns",
@@ -66,7 +61,7 @@
     {
       "name": "parent-receives-chain-return",
       "required": true,
-      "description": "The exact root session receives GRANDCHILD-DONE {{nonce}} as a structured role=system return event, bound to distinct child and grandchild identities"
+      "description": "Shared post-run collector binds exactly one in-window [continuation:targeted-return] Delivered to <root> from <grandchild> receipt with zero matching parent(child-session) receipts"
     },
     {
       "name": "trace-id",
@@ -84,7 +79,7 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "Depth-2 chain proof. PASS-candidate requires strict child/grandchild sentinels, two distinct nonce-bound hop identities, and an explicit role=system GRANDCHILD-DONE {{nonce}} receipt in the exact root session. Grandchild assistant output alone is not return authority."
+    "notes": "Depth-2 chain proof. PASS-candidate requires strict child/grandchild sentinels, two distinct nonce-bound hop identities, nested fanoutMode=tree, and the shared payload-free gateway targeted-return collector proving grandchild\u2192root routing. Transcript GRANDCHILD-DONE text is not routing authority."
   },
   "liveRunSafety": {
     "classification": "k6-runnable",
@@ -105,6 +100,6 @@
       "trace-id"
     ],
     "foldRequiresReview": true,
-    "notes": "Live depth-2 chain row. Prefer OPENCLAW_CREATE_DISPOSABLE_SESSION=true. Detector ignores prompt echoes and ordinary GRANDCHILD-DONE assistant output; PASS requires distinct hop identities plus the exact root role=system return receipt."
+    "notes": "Live depth-2 chain row. Prefer OPENCLAW_CREATE_DISPOSABLE_SESSION=true. Nested call must request fanoutMode=tree. Detector ignores prompt echoes and ordinary GRANDCHILD-DONE assistant/system transcript text; PASS requires distinct hop identities plus the shared journal targeted-return receipt."
   }
 }

--- a/tools/k6-proofs/manifests/r-cd-model-tool.json
+++ b/tools/k6-proofs/manifests/r-cd-model-tool.json
@@ -17,12 +17,15 @@
     "name": "r-cd-model-tool",
     "description": "continue_delegate typed tool form forwards an explicit model override to the delegate child.",
     "methods": [
+      "sessions.create",
       "sessions.send",
-      "sessions.messages.subscribe"
+      "sessions.messages.subscribe",
+      "sessions.list",
+      "sessions.get"
     ],
     "status": "runnable",
     "expectedFile": "r-cd-model-tool.js",
-    "notes": "Alternate-model rows are blocked on karmaterminal/openclaw#1103 until the child runtime observes the requested model instead of inheriting gpt-5.5.",
+    "notes": "Requires disposable parent. Authoritative child identity is sessions.list {spawnedBy:parent} pre/post set-diff (exactly one new child); model byte from that row. Child self-report is auxiliary only.",
     "file": "r-cd-model-tool.js",
     "registryNotes": "Runnable k6 scenario exercises typed continue_delegate with explicit model override; authoritative model mismatch is FAIL-candidate and unavailable metadata is PARTIAL-candidate."
   },
@@ -44,17 +47,17 @@
     {
       "name": "child-session-observed",
       "required": true,
-      "description": "A nonce-correlated delegate child session/run is observed on the subscribed session stream or session history"
+      "description": "Exactly one new child key from sessions.list {spawnedBy:<disposable-parent>} pre/post set-diff"
     },
     {
       "name": "child-model-byte",
       "required": true,
-      "description": "Observed child provider/model byte from authoritative gateway child-session metadata or spawn record; child prose is auxiliary only"
+      "description": "provider/model from the unique new spawnedBy child row; child prose cannot establish equality"
     },
     {
       "name": "return-payload",
       "required": true,
-      "description": "Delegate return includes the row nonce and observed model/provider summary"
+      "description": "Parent sessions.get shows nonce-bound normal-mode return; child MODEL-TOOL-CHILD text is auxiliary"
     },
     {
       "name": "trace-or-session-correlation",
@@ -77,7 +80,7 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "PASS-candidate only when the requested model byte matches authoritative gateway child-session metadata or spawn-record model bytes. The child task omits the requested model and its self-report is auxiliary only; mismatch is FAIL-candidate and unavailable metadata is PARTIAL-candidate."
+    "notes": "PASS-candidate only when disposable parent + spawnedBy set-diff binds exactly one new child, that row's provider/model matches the requested model byte, and parent sessions.get shows a nonce-bound return. Child self-report is auxiliary; direct DB queries are forbidden as PASS authority."
   },
   "liveRunSafety": {
     "classification": "k6-runnable",
@@ -96,6 +99,6 @@
       "return-payload"
     ],
     "foldRequiresReview": true,
-    "notes": "Explicit model override row. Prevent echo-based false PASS by omitting requested model from the child task; authoritative fallback/inheritance is FAIL-candidate, while unavailable authoritative metadata is PARTIAL-candidate."
+    "notes": "Requires OPENCLAW_CREATE_DISPOSABLE_SESSION=true. Authoritative child metadata via sessions.list spawnedBy set-diff only."
   }
 }

--- a/tools/k6-proofs/scenarios/r-cd-4-target-session-key.js
+++ b/tools/k6-proofs/scenarios/r-cd-4-target-session-key.js
@@ -3,9 +3,13 @@
  *
  * Repeatable mode creates disposable dispatch/target sessions so the proof does
  * not depend on the live #sprites/main lane. The dispatch session asks the
- * agent to call continue_delegate(..., targetSessionKey=<target>). The harness
- * subscribes to both sessions and verifies the delayed return/wake lands in the
- * target session and not the dispatching parent.
+ * agent to call continue_delegate(..., targetSessionKey=<target>).
+ *
+ * Silent-wake delivery authority is NOT transcript session.message /
+ * sessions.get nonce text. The shared post-run collector binds the payload-free
+ * gateway `[continuation:targeted-return] Delivered to <target> from <child>`
+ * receipt. This VU gathers structural gates (dispatch, child identity) and
+ * leaves return authority to that collector.
  */
 import ws from 'k6/ws';
 import { check } from 'k6';
@@ -129,8 +133,11 @@ export default function () {
     return_in_parent: false,
     target_return_candidate: null,
     parent_return_candidate: null,
+    target_diagnostic_marker: null,
+    parent_diagnostic_marker: null,
     target_return_receipt: null,
     parent_return_receipt: null,
+    return_authority: 'gateway-journal-targeted-return-post-run',
     dispatch_accepted_at_ms: null,
     wake_gate_ms: Number(__ENV.OPENCLAW_MIN_DELEGATE_DELAY_MS || 5000),
     reason_hash: null,
@@ -151,6 +158,8 @@ export default function () {
     let returnHistoryPhase = null;
 
     function finalizeReturnReceipts() {
+      // Transcript markers are diagnostic only. Silent-wake delivery authority
+      // is the shared post-run targeted-return journal collector.
       evidence.target_return_receipt = rCd4ReturnReceipt(
         evidence.target_return_candidate,
         evidence.child_session,
@@ -159,11 +168,8 @@ export default function () {
         evidence.parent_return_candidate,
         evidence.child_session,
       );
-      evidence.return_in_target = evidence.target_return_receipt !== null;
-      evidence.return_in_parent = evidence.parent_return_receipt !== null;
-      if (evidence.return_in_target) {
-        evidence.child_completed = true;
-      }
+      evidence.return_in_target = false;
+      evidence.return_in_parent = false;
     }
 
     function observeChildSessionKey(possibleChild) {
@@ -190,15 +196,16 @@ export default function () {
     }
 
     function applyReturnObservation(observation, source) {
-      if (observation.targetCandidate) {
-        evidence.target_return_candidate = observation.targetCandidate;
+      if (observation.targetDiagnosticMarker) {
+        evidence.target_diagnostic_marker = observation.targetDiagnosticMarker;
         evidence.agent_turn_observed = true;
-        console.log(`✓ nonce-bound TARGET-RECEIVED candidate landed in target session (${source})`);
+        console.log(`ℹ diagnostic TARGET-RECEIVED marker in target session (${source}); not delivery authority`);
       }
-      if (observation.parentCandidate) {
-        evidence.parent_return_candidate = observation.parentCandidate;
-        console.warn(`✗ nonce-bound TARGET-RECEIVED candidate landed in parent session (${source})`);
+      if (observation.parentDiagnosticMarker) {
+        evidence.parent_diagnostic_marker = observation.parentDiagnosticMarker;
+        console.log(`ℹ diagnostic TARGET-RECEIVED marker in parent session (${source}); not delivery authority`);
       }
+      // Intentionally do not promote transcript markers to return receipts.
       finalizeReturnReceipts();
     }
 
@@ -435,38 +442,34 @@ export default function () {
     'nonce-bound child identity observed': () => evidence.child_session !== null,
     'nonce-bound child identity is unambiguous': () => !evidence.child_session_ambiguous,
     'nonce-bound child identity is not parent or target': () => !evidence.child_session_invalid,
-    'nonce-bound target return receipt observed': () => evidence.target_return_receipt !== null,
-    'no nonce-bound parent return receipt': () => evidence.parent_return_receipt === null,
+    // Return authority is post-run journal collector — VU must not claim PASS.
+    'vu does not claim targeted-return authority': () => evidence.target_return_receipt === null,
   });
 
-  if (!evidence.tool_accepted || !evidence.agent_turn_observed || !evidence.child_session ||
-      evidence.child_session_ambiguous || evidence.child_session_invalid ||
-      !evidence.target_return_receipt || evidence.parent_return_receipt) {
+  const structuralOk = evidence.tool_accepted && evidence.agent_turn_observed &&
+    evidence.child_session !== null && !evidence.child_session_ambiguous &&
+    !evidence.child_session_invalid;
+  // VU never emits PASS-candidate; shared post-run collector owns delivery authority.
+  if (!structuralOk) {
     failures.add(1);
   }
-
-  const passed = evidence.tool_accepted && evidence.agent_turn_observed &&
-    evidence.child_session !== null && !evidence.child_session_ambiguous &&
-    !evidence.child_session_invalid &&
-    evidence.target_return_receipt !== null &&
-    evidence.parent_return_receipt === null;
 
   console.log(`R_CD_4_EVIDENCE ${JSON.stringify(evidence)}`);
   console.log(`\n--- R-CD-4 EVIDENCE SUMMARY ---`);
   console.log(JSON.stringify(evidence, null, 2));
   console.log(`--- END EVIDENCE ---`);
-  console.log(`\n[R-CD-4] VERDICT: ${passed ? 'PASS-candidate' : 'PARTIAL-candidate'}`);
+  console.log(`\n[R-CD-4] VERDICT: PARTIAL-candidate`);
 }
 
 export function handleSummary(data) {
   const timestamp = new Date().toISOString();
-  const passRate = data.metrics.proof_failures?.values?.count === 0;
   const summary = {
     row: 'R-CD-4',
     sha: __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
     seat: __ENV.OPENCLAW_SEAT_NAME || 'ronan-dgx',
     timestamp,
-    verdict: passRate ? 'PASS-candidate' : 'PARTIAL-candidate',
+    // VU structural gates only; targeted-return authority is post-run.
+    verdict: 'PARTIAL-candidate',
     metrics: {
       duration_ms: data.metrics.r_cd_4_duration?.values || null,
       failures: data.metrics.proof_failures?.values?.count || 0,

--- a/tools/k6-proofs/scenarios/r-cd-chained-depth-2.js
+++ b/tools/k6-proofs/scenarios/r-cd-chained-depth-2.js
@@ -23,12 +23,12 @@ import { Counter, Trend } from 'k6/metrics';
 import crypto from 'k6/crypto';
 import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
-import { childSessionKeyForRow } from '../lib/row-child-correlation.mjs';
 import {
   rCdChainHopIdentities,
   rCdChainPromptTemplate,
   rCdChainRootReturnCandidate,
   rCdChainRootReturnReceipt,
+  resolveUniqueSpawnedByChild,
 } from '../lib/r-cd-chained-depth-2-authority.mjs';
 
 export const options = {
@@ -59,6 +59,10 @@ const DEFAULTS = {
 };
 const HARNESS_MARKER = '[k6-proof-harness]';
 const POST_DISPATCH_EVIDENCE_GATE_MS = Number(__ENV.OPENCLAW_MIN_CHAIN_EVIDENCE_DELAY_MS || 1500);
+const configuredAncestryStabilityMs = Number(__ENV.OPENCLAW_CHAIN_ANCESTRY_STABILITY_MS);
+const ANCESTRY_STABILITY_MS = Number.isFinite(configuredAncestryStabilityMs)
+  ? Math.max(30000, configuredAncestryStabilityMs)
+  : 30000;
 
 function boolEnv(name) {
   return (__ENV[name] || '').toLowerCase() === 'true';
@@ -89,6 +93,11 @@ export default function () {
     failures.add(1);
     return;
   }
+  if (!createDisposableSession) {
+    console.error('OPENCLAW_CREATE_DISPOSABLE_SESSION=true is required for R-CD-CHAINED-DEPTH-2');
+    failures.add(1);
+    return;
+  }
 
   if (manifest) {
     const errors = validateManifest(manifest);
@@ -112,6 +121,14 @@ export default function () {
     parent_dispatch_accepted: false,
     child_spawned: false,
     grandchild_spawned: false,
+    child_authority_source: null,
+    grandchild_authority_source: null,
+    ancestry_ambiguous: false,
+    ancestry_stable: false,
+    child_ancestry_confirmations: 0,
+    grandchild_ancestry_confirmations: 0,
+    child_ancestry_confirmed_at_ms: null,
+    grandchild_ancestry_confirmed_at_ms: null,
     child_done_sentinel: false,
     grandchild_done_sentinel: false,
     chain_return_received: false,
@@ -136,6 +153,7 @@ export default function () {
 
   const res = ws.connect(url, {}, (socket) => {
     const tracker = new RequestTracker();
+    const ancestryRequests = {};
 
     function finalizeRootReturnReceipt() {
       // Transcript markers are never root routing authority.
@@ -149,18 +167,54 @@ export default function () {
       evidence.chain_return_received = false;
     }
 
-    function observeChainSession(observedSessionKey) {
+    function observeAncestrySession(depth, observedSessionKey) {
       if (!observedSessionKey || observedSessionKey === sessionKey) return;
-      if (!evidence.child_session) {
+      const observedAtMs = Date.now();
+      if (depth === 1 && !evidence.child_session) {
         evidence.child_session = observedSessionKey;
         evidence.child_spawned = true;
+        evidence.child_authority_source = 'sessions.list spawnedBy ancestry';
+        evidence.child_ancestry_confirmations = 1;
+        evidence.child_ancestry_confirmed_at_ms = observedAtMs;
         if (evidence.max_depth_observed < 1) evidence.max_depth_observed = 1;
-      } else if (observedSessionKey !== evidence.child_session && !evidence.grandchild_session) {
+      } else if (depth === 1 && evidence.child_session !== observedSessionKey) {
+        evidence.ancestry_ambiguous = true;
+      } else if (depth === 1) {
+        evidence.child_ancestry_confirmations += 1;
+        evidence.child_ancestry_confirmed_at_ms = observedAtMs;
+      } else if (depth === 2 && observedSessionKey !== evidence.child_session &&
+                 !evidence.grandchild_session) {
         evidence.grandchild_session = observedSessionKey;
         evidence.grandchild_spawned = true;
+        evidence.grandchild_authority_source = 'sessions.list spawnedBy ancestry';
+        evidence.grandchild_ancestry_confirmations = 1;
+        evidence.grandchild_ancestry_confirmed_at_ms = observedAtMs;
         if (evidence.max_depth_observed < 2) evidence.max_depth_observed = 2;
+      } else if (depth === 2 && evidence.grandchild_session !== observedSessionKey) {
+        evidence.ancestry_ambiguous = true;
+      } else if (depth === 2) {
+        evidence.grandchild_ancestry_confirmations += 1;
+        evidence.grandchild_ancestry_confirmed_at_ms = observedAtMs;
       }
+      evidence.ancestry_stable = (
+        evidence.ancestry_ambiguous !== true
+        && evidence.dispatch_accepted_at_ms !== null
+        && evidence.child_ancestry_confirmations >= 2
+        && evidence.grandchild_ancestry_confirmations >= 2
+        && evidence.grandchild_ancestry_confirmed_at_ms !== null
+        && evidence.grandchild_ancestry_confirmed_at_ms - evidence.dispatch_accepted_at_ms
+          >= ANCESTRY_STABILITY_MS
+      );
       finalizeRootReturnReceipt();
+    }
+
+    function requestAncestryList(depth, parentSessionKey) {
+      if (!parentSessionKey) return;
+      const requestId = tracker.send(socket, 'sessions.list', {
+        spawnedBy: parentSessionKey,
+        limit: 100,
+      });
+      ancestryRequests[requestId] = { depth, parentSessionKey };
     }
 
     function startProofFlow(socket) {
@@ -205,6 +259,9 @@ export default function () {
       socket.setTimeout(() => tracker.send(socket, 'tasks.list', { limit: 20 }), 60000);
       socket.setTimeout(() => tracker.send(socket, 'tasks.list', { limit: 20 }), 90000);
       socket.setTimeout(() => tracker.send(socket, 'tasks.list', { limit: 20 }), 120000);
+      for (const delayMs of [4000, 12000, 30000, 60000, 90000, 120000]) {
+        socket.setTimeout(() => requestAncestryList(1, sessionKey), delayMs);
+      }
 
       // Extended timeout for depth-2 chain completion.
       socket.setTimeout(() => socket.close(), 150000);
@@ -221,14 +278,14 @@ export default function () {
             label: `k6 R-CD-CHAINED-DEPTH-2 ${chainNonce}`,
           });
         }, 250);
-      } else {
-        socket.setTimeout(() => startProofFlow(socket), 500);
       }
     });
 
     socket.on('message', (raw) => {
       try {
         const msg = JSON.parse(raw);
+        const ancestryRequest = msg?.id ? ancestryRequests[msg.id] || null : null;
+        if (msg?.id) delete ancestryRequests[msg.id];
         const classified = tracker.classify(msg);
 
         evidence.redacted_events.push({
@@ -269,15 +326,32 @@ export default function () {
           }
         }
 
+        if (classified.kind === 'response' && classified.method === 'sessions.list' &&
+            ancestryRequest) {
+          if (classified.ok) {
+            const resolved = resolveUniqueSpawnedByChild({
+              sessionsPayload: classified.payload || {},
+              parentSessionKey: ancestryRequest.parentSessionKey,
+            });
+            if (resolved.uniqueChildKey) {
+              observeAncestrySession(ancestryRequest.depth, resolved.uniqueChildKey);
+              if (ancestryRequest.depth === 1 && evidence.child_session) {
+                requestAncestryList(2, evidence.child_session);
+              }
+            } else if (resolved.ambiguous) {
+              evidence.ancestry_ambiguous = true;
+            }
+          }
+        }
+
         // Optional TaskFlow ledger context. Absence here is not a failure:
-        // continue_delegate uses pending-delegate/subagent surfaces.
+        // continue_delegate uses pending-delegate/subagent surfaces. Titles are
+        // capped and cannot establish nonce-bound hop identities.
         if (classified.kind === 'response' && classified.method === 'tasks.list') {
           const tasks = classified.payload?.tasks || [];
           for (const task of tasks) {
             const taskStr = JSON.stringify(task);
             if (!taskStr.includes(chainNonce)) continue;
-            observeChainSession(task.sessionKey);
-            observeChainSession(task.childSessionKey);
             if (task.traceId) evidence.trace_id = task.traceId;
           }
         }
@@ -289,7 +363,6 @@ export default function () {
           const eventName = classified.event || '';
           const eventData = classified.data || {};
           const eventStr = JSON.stringify(eventData);
-          observeChainSession(childSessionKeyForRow(eventData, chainNonce));
           if (eventStr.includes(chainNonce)) {
             if (eventStr.includes(HARNESS_MARKER)) {
               console.log('ℹ Ignoring harness prompt echo event');
@@ -329,7 +402,13 @@ export default function () {
         if (evidence.parent_dispatch_accepted &&
             evidence.child_done_sentinel &&
             evidence.grandchild_done_sentinel &&
-            hops.ok) {
+            hops.ok &&
+            evidence.dispatch_accepted_at_ms &&
+            Date.now() - evidence.dispatch_accepted_at_ms >= ANCESTRY_STABILITY_MS &&
+            evidence.child_ancestry_confirmations >= 2 &&
+            evidence.grandchild_ancestry_confirmations >= 2 &&
+            evidence.ancestry_stable === true &&
+            !evidence.ancestry_ambiguous) {
           console.log('Structural chain evidence gathered, closing early (routing authority is post-run)');
           socket.close();
         }
@@ -368,7 +447,11 @@ export default function () {
     evidence.parent_dispatch_accepted &&
     evidence.child_done_sentinel &&
     evidence.grandchild_done_sentinel &&
-    hops.ok;
+    hops.ok &&
+    evidence.child_ancestry_confirmations >= 2 &&
+    evidence.grandchild_ancestry_confirmations >= 2 &&
+    evidence.ancestry_stable === true &&
+    !evidence.ancestry_ambiguous;
   if (!structuralOk) {
     failures.add(1);
   }

--- a/tools/k6-proofs/scenarios/r-cd-chained-depth-2.js
+++ b/tools/k6-proofs/scenarios/r-cd-chained-depth-2.js
@@ -1,13 +1,13 @@
 /**
  * Scenario: R-CD-CHAINED-DEPTH-2 — depth-2 delegate chain.
  *
- * Fires parent→child→grandchild chain and verifies the full return path.
- * The child is instructed to fire its OWN continue_delegate, creating a
- * depth-2 chain. The proof verifies:
- *   1. Parent dispatches (depth-0 → depth-1) via sessions.send (agent turn)
- *   2. Child spawns and fires its own delegate (depth-1 → depth-2)
- *   3. Grandchild spawns and completes
- *   4. Return propagates up-tree to parent
+ * Fires parent→child→grandchild chain. The nested (child→grandchild) call
+ * must request fanoutMode="tree" so grandchild completion routes to root.
+ * Outer parent→child stays unchanged (no fanoutMode).
+ *
+ * Root routing authority is the shared post-run
+ * `[continuation:targeted-return]` collector (grandchild→root), not transcript
+ * GRANDCHILD-DONE system text. This VU gathers hop identities + sentinels.
  *
  * Repeatable mode: set OPENCLAW_CREATE_DISPOSABLE_SESSION=true to create a
  * disposable parent session, so the proof does not touch the live #sprites/main
@@ -25,6 +25,8 @@ import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
 import { childSessionKeyForRow } from '../lib/row-child-correlation.mjs';
 import {
+  rCdChainHopIdentities,
+  rCdChainPromptTemplate,
   rCdChainRootReturnCandidate,
   rCdChainRootReturnReceipt,
 } from '../lib/r-cd-chained-depth-2-authority.mjs';
@@ -115,6 +117,9 @@ export default function () {
     chain_return_received: false,
     root_return_candidate: null,
     root_return_receipt: null,
+    root_diagnostic_marker: null,
+    return_authority: 'gateway-journal-targeted-return-post-run',
+    nested_fanout_mode: 'tree',
     dispatch_accepted_at_ms: null,
     // Depth tracking
     max_depth_observed: 0,
@@ -133,6 +138,7 @@ export default function () {
     const tracker = new RequestTracker();
 
     function finalizeRootReturnReceipt() {
+      // Transcript markers are never root routing authority.
       evidence.root_return_receipt = rCdChainRootReturnReceipt(
         evidence.root_return_candidate,
         {
@@ -140,7 +146,7 @@ export default function () {
           grandchildSessionKey: evidence.grandchild_session,
         },
       );
-      evidence.chain_return_received = evidence.root_return_receipt !== null;
+      evidence.chain_return_received = false;
     }
 
     function observeChainSession(observedSessionKey) {
@@ -166,10 +172,19 @@ export default function () {
       // tools; sessions.send is the correct E2E path.
       socket.setTimeout(() => {
         const inv = invocationCfg();
-        const task = inv.promptTemplate.replace(/\{\{nonce\}\}/g, chainNonce);
+        // Prefer manifest template; fall back to the fanoutMode=tree canonical form.
+        const template = inv.promptTemplate || rCdChainPromptTemplate();
+        if (!template.includes("fanoutMode='tree'") && !template.includes('fanoutMode="tree"')) {
+          console.error('✗ nested chain prompt must request fanoutMode="tree"');
+          failures.add(1);
+          socket.close();
+          return;
+        }
+        const task = template.replace(/\{\{nonce\}\}/g, chainNonce);
         evidence.reason_hash = crypto.sha256(task, 'hex').slice(0, 16);
         evidence.reason_length = task.length;
         evidence.delegate_mode = inv.mode;
+        // Outer parent→child call is unchanged: no fanoutMode on the root dispatch.
         const agentInstruction =
           `[k6-proof-harness] Chain proof nonce ${chainNonce}. ` +
           `Call continue_delegate with: mode="${inv.mode}", delaySeconds=${inv.delaySeconds}, ` +
@@ -289,16 +304,17 @@ export default function () {
                   evidence.grandchild_done_sentinel = true;
                   console.log('✓ GRANDCHILD-DONE sentinel observed post-dispatch');
                 }
-                const rootReturnCandidate = rCdChainRootReturnCandidate({
+                const rootDiagnostic = rCdChainRootReturnCandidate({
                   eventName,
                   eventData,
                   rootSessionKey: sessionKey,
                   nonce: chainNonce,
                 });
-                if (rootReturnCandidate) {
-                  evidence.root_return_candidate = rootReturnCandidate;
+                if (rootDiagnostic) {
+                  evidence.root_diagnostic_marker = rootDiagnostic;
+                  evidence.root_return_candidate = null;
                   finalizeRootReturnReceipt();
-                  console.log('✓ explicit nonce-bound root system return candidate observed');
+                  console.log('ℹ diagnostic root GRANDCHILD-DONE marker observed; not routing authority');
                 }
               }
             }
@@ -306,13 +322,15 @@ export default function () {
         }
 
         // Early close only on strict post-dispatch sentinels.
+        const hops = rCdChainHopIdentities({
+          childSessionKey: evidence.child_session,
+          grandchildSessionKey: evidence.grandchild_session,
+        });
         if (evidence.parent_dispatch_accepted &&
             evidence.child_done_sentinel &&
             evidence.grandchild_done_sentinel &&
-            evidence.child_session &&
-            evidence.grandchild_session &&
-            evidence.root_return_receipt) {
-          console.log('Full chain evidence gathered, closing early');
+            hops.ok) {
+          console.log('Structural chain evidence gathered, closing early (routing authority is post-run)');
           socket.close();
         }
       } catch (e) {
@@ -331,46 +349,45 @@ export default function () {
   chainDuration.add(evidence.duration_ms);
 
   check(res, { 'websocket connected': (r) => r && r.status === 101 });
+  const hops = rCdChainHopIdentities({
+    childSessionKey: evidence.child_session,
+    grandchildSessionKey: evidence.grandchild_session,
+  });
   check(null, {
     'parent dispatch accepted': () => evidence.parent_dispatch_accepted,
     'child sentinel observed post-dispatch': () => evidence.child_done_sentinel,
     'grandchild sentinel observed post-dispatch': () => evidence.grandchild_done_sentinel,
     'nonce-bound child identity observed': () => evidence.child_session !== null,
     'nonce-bound grandchild identity observed': () => evidence.grandchild_session !== null,
-    'explicit root return receipt observed': () => evidence.root_return_receipt !== null,
+    'two distinct hop identities': () => hops.ok,
+    'vu does not claim root routing authority': () => evidence.root_return_receipt === null,
     'max depth >= 2': () => evidence.max_depth_observed >= 2,
   });
 
-  if (!evidence.parent_dispatch_accepted || !evidence.child_done_sentinel ||
-      !evidence.grandchild_done_sentinel || !evidence.child_session ||
-      !evidence.grandchild_session || !evidence.root_return_receipt) {
-    failures.add(1);
-  }
-
-  const passed = (!createDisposableSession || evidence.session_created) &&
+  const structuralOk = (!createDisposableSession || evidence.session_created) &&
     evidence.parent_dispatch_accepted &&
     evidence.child_done_sentinel &&
     evidence.grandchild_done_sentinel &&
-    evidence.child_session !== null &&
-    evidence.grandchild_session !== null &&
-    evidence.root_return_receipt !== null;
+    hops.ok;
+  if (!structuralOk) {
+    failures.add(1);
+  }
 
   console.log(`\n--- R-CD-CHAINED-DEPTH-2 EVIDENCE SUMMARY ---`);
   console.log(JSON.stringify(evidence, null, 2));
   console.log(`--- END EVIDENCE ---`);
-  console.log(`\n[R-CD-CHAINED-DEPTH-2] VERDICT: ${passed ? 'PASS-candidate' : 'PARTIAL-candidate'}`);
+  console.log(`\n[R-CD-CHAINED-DEPTH-2] VERDICT: PARTIAL-candidate`);
   console.log(`  Max depth observed: ${evidence.max_depth_observed}`);
 }
 
 export function handleSummary(data) {
   const timestamp = new Date().toISOString();
-  const passRate = data.metrics.proof_failures?.values?.count === 0;
   const summary = {
     row: 'R-CD-CHAINED-DEPTH-2',
     sha: __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
     seat: __ENV.OPENCLAW_SEAT_NAME || 'ronan-dgx',
     timestamp,
-    verdict: passRate ? 'PASS-candidate' : 'PARTIAL-candidate',
+    verdict: 'PARTIAL-candidate',
     metrics: {
       duration_ms: data.metrics.r_cd_chain_duration?.values || null,
       failures: data.metrics.proof_failures?.values?.count || 0,

--- a/tools/k6-proofs/scenarios/r-cd-model-tool.js
+++ b/tools/k6-proofs/scenarios/r-cd-model-tool.js
@@ -4,7 +4,11 @@ import { check } from 'k6';
 import { Counter, Trend } from 'k6/metrics';
 import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
-import { childSessionKeyForRow } from '../lib/row-child-correlation.mjs';
+import {
+  parentReturnContainsNonce,
+  resolveModelToolChildAuthority,
+  sessionKeysFromListPayload,
+} from '../lib/r-cd-model-tool-authority.mjs';
 
 export const options = {
   scenarios: { r_cd_model_tool: { executor: 'shared-iterations', vus: 1, iterations: 1, maxDuration: '210s' } },
@@ -26,12 +30,6 @@ const HARNESS_MARKER = '[k6-proof-harness]';
 function boolEnv(name) { return (__ENV[name] || '').toLowerCase() === 'true'; }
 function normalizeModel(value) { return String(value || '').trim().replace(/[.,;:]+$/, ''); }
 function escapeRegex(value) { return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
-function modelFromSessionMetadata(session) {
-  const model = normalizeModel(session?.model);
-  const provider = normalizeModel(session?.modelProvider || session?.provider);
-  if (!model) return null;
-  return model.includes('/') ? model : (provider ? `${provider}/${model}` : model);
-}
 let finalEvidence = null;
 
 export default function() {
@@ -47,6 +45,12 @@ export default function() {
   const delaySeconds = Number(inv.delaySeconds ?? __ENV.OPENCLAW_DELAY_SECONDS ?? DEFAULTS.delaySeconds);
   const idPrefix = inv.idempotencyKeyPrefix || DEFAULTS.idempotencyKeyPrefix;
   if (!token) { console.error('OPENCLAW_GATEWAY_TOKEN is required'); failures.add(1); return; }
+  // Disposable parent is mandatory so spawnedBy set-diff is unambiguous.
+  if (!createDisposableSession) {
+    console.error('OPENCLAW_CREATE_DISPOSABLE_SESSION=true is required for R-CD-MODEL-TOOL');
+    failures.add(1);
+    return;
+  }
   if (manifest) { const errors = validateManifest(manifest); if (errors.length) console.warn('Manifest validation warnings: ' + errors.join('; ')); }
 
   const evidence = {
@@ -58,12 +62,20 @@ export default function() {
     sessionKey,
     session_created: false,
     created_session_key: null,
+    disposable_parent_required: true,
     candidateSha: manifest?.candidateSha || __ENV.OPENCLAW_CANDIDATE_SHA || 'unset',
     started: new Date().toISOString(),
     requested_model_byte: requestedModel,
     requested_model_source: 'continue_delegate.model parameter',
+    pre_spawned_by_keys: [],
+    post_spawned_by_keys: [],
+    pre_spawned_by_captured: false,
+    post_spawned_by_captured: false,
+    spawned_by_diff_empty: false,
+    spawned_by_diff_ambiguous: false,
     dispatch_accepted: false,
     parent_scheduled_sentinel: false,
+    parent_return_nonce_bound: false,
     child_session_observed: false,
     child_session_key: null,
     child_session_metadata_observed: false,
@@ -83,11 +95,81 @@ export default function() {
 
   const res = ws.connect(url, {}, (socket) => {
     const tracker = new RequestTracker();
+    let listPhase = null; // 'pre' | 'post' | 'parent-history'
+    let postListPolls = 0;
+    let parentHistoryPolls = 0;
+
+    function requestSpawnedByList(phase) {
+      listPhase = phase;
+      evidence.child_metadata_requested = true;
+      tracker.send(socket, 'sessions.list', { spawnedBy: sessionKey, limit: 100 });
+    }
+
+    function requestParentHistory() {
+      listPhase = 'parent-history';
+      tracker.send(socket, 'sessions.get', { key: sessionKey, limit: 200 });
+    }
+
+    function applyChildAuthority(payload) {
+      const authority = resolveModelToolChildAuthority({
+        preKeys: evidence.pre_spawned_by_keys,
+        postKeys: sessionKeysFromListPayload(payload),
+        sessionsPayload: payload,
+        requestedModel,
+      });
+      evidence.post_spawned_by_keys = sessionKeysFromListPayload(payload);
+      evidence.post_spawned_by_captured = true;
+      evidence.spawned_by_diff_empty = authority.empty;
+      evidence.spawned_by_diff_ambiguous = authority.ambiguous;
+      if (authority.uniqueNewChildKey) {
+        evidence.child_session_key = authority.uniqueNewChildKey;
+        evidence.child_session_observed = true;
+        evidence.child_session_metadata_observed = !!authority.childMetadataModelByte;
+        evidence.child_metadata_model_byte = authority.childMetadataModelByte;
+        evidence.child_metadata_model_source = 'gateway sessions.list spawnedBy set-diff provider/model metadata';
+        evidence.child_session_metadata = {
+          keyFingerprint: null,
+          provider: null,
+          model: authority.childMetadataModelByte,
+        };
+        const sessions = Array.isArray(payload?.sessions) ? payload.sessions : [];
+        const child = sessions.find((s) => s?.key === authority.uniqueNewChildKey);
+        if (child) {
+          evidence.child_session_metadata = {
+            key: child.key || null,
+            provider: child.modelProvider || child.provider || null,
+            model: child.model || null,
+            modelSelectionLocked: child.modelSelectionLocked === true,
+          };
+        }
+        evidence.model_matches = authority.modelMatches;
+        if (!evidence.model_matches) {
+          evidence.model_classification_reason = authority.failureCategory === 'model-mismatch'
+            ? 'requested model does not match authoritative child-session metadata'
+            : 'authoritative child-session model byte unavailable';
+        }
+        console.log('✓ spawnedBy set-diff bound exactly one new child');
+      } else if (authority.ambiguous) {
+        evidence.model_classification_reason = 'spawnedBy set-diff produced multiple new children';
+        console.warn('✗ spawnedBy set-diff ambiguous (multiple new children)');
+      } else {
+        evidence.model_classification_reason = 'spawnedBy set-diff produced zero new children';
+      }
+    }
+
     function start(socket) {
       tracker.send(socket, 'sessions.messages.subscribe', { key: sessionKey });
+      // Pre-dispatch baseline: server-filtered children of this disposable parent.
+      socket.setTimeout(() => requestSpawnedByList('pre'), 300);
       socket.setTimeout(() => {
-        // Deliberately do NOT include requestedModel in the child task. The child
-        // must report its own runtime identity instead of echoing the request.
+        if (!evidence.pre_spawned_by_captured) {
+          console.error('✗ pre-dispatch sessions.list {spawnedBy} baseline missing');
+          failures.add(1);
+          socket.close();
+        }
+      }, 5000);
+      socket.setTimeout(() => {
+        if (!evidence.pre_spawned_by_captured) return;
         const childTask =
           'Proof nonce ' + rowNonce + ': read your runtime context/current model identity. ' +
           'Reply exactly MODEL-TOOL-CHILD ' + rowNonce + ' MODEL <provider/model>. ' +
@@ -104,17 +186,23 @@ export default function() {
           message: instruction,
           idempotencyKey: idPrefix + '-DISPATCH-' + rowNonce,
         });
-      }, 500);
+      }, 800);
+      // Independent post-dispatch polls (not event-correlation gated).
+      socket.setTimeout(() => { if (evidence.dispatch_accepted) requestSpawnedByList('post'); }, 4000);
+      socket.setTimeout(() => { if (evidence.dispatch_accepted) requestSpawnedByList('post'); }, 12000);
+      socket.setTimeout(() => { if (evidence.dispatch_accepted) requestSpawnedByList('post'); }, 30000);
+      socket.setTimeout(() => { if (evidence.dispatch_accepted) requestSpawnedByList('post'); }, 60000);
+      socket.setTimeout(() => { if (evidence.dispatch_accepted) requestParentHistory(); }, 8000);
+      socket.setTimeout(() => { if (evidence.dispatch_accepted) requestParentHistory(); }, 25000);
+      socket.setTimeout(() => { if (evidence.dispatch_accepted) requestParentHistory(); }, 70000);
       socket.setTimeout(() => socket.close(), 180000);
     }
     socket.on('open', () => {
       socket.send(connectFrame(token));
-      if (createDisposableSession) {
-        socket.setTimeout(() => {
-          const key = ('r-cd-model-tool-' + rowNonce).toLowerCase().replace(/[^a-z0-9-]/g, '-');
-          tracker.send(socket, 'sessions.create', { key, label: 'k6 R-CD-MODEL-TOOL ' + rowNonce });
-        }, 250);
-      } else socket.setTimeout(() => start(socket), 500);
+      socket.setTimeout(() => {
+        const key = ('r-cd-model-tool-' + rowNonce).toLowerCase().replace(/[^a-z0-9-]/g, '-');
+        tracker.send(socket, 'sessions.create', { key, label: 'k6 R-CD-MODEL-TOOL ' + rowNonce });
+      }, 250);
     });
     socket.on('message', (raw) => {
       try {
@@ -145,60 +233,54 @@ export default function() {
           } else { console.error('✗ sessions.send rejected: ' + JSON.stringify(classified.error)); failures.add(1); }
         }
         if (classified.kind === 'response' && classified.method === 'sessions.list') {
-          const sessions = Array.isArray(classified.payload?.sessions) ? classified.payload.sessions : [];
-          const child = sessions.find((session) => session?.key === evidence.child_session_key);
-          if (child) {
-            evidence.child_session_observed = true;
-            evidence.child_session_metadata_observed = true;
-            evidence.child_metadata_model_byte = modelFromSessionMetadata(child);
-            evidence.child_metadata_model_source = 'gateway sessions.list persisted provider/model metadata';
-            evidence.child_session_metadata = {
-              key: child.key || null,
-              provider: child.modelProvider || child.provider || null,
-              model: child.model || null,
-              modelSelectionLocked: child.modelSelectionLocked === true,
-            };
-            evidence.model_matches = evidence.child_metadata_model_byte === requestedModel;
-            if (!evidence.model_matches) {
+          if (listPhase === 'pre') {
+            evidence.pre_spawned_by_keys = sessionKeysFromListPayload(classified.payload);
+            evidence.pre_spawned_by_captured = true;
+            console.log('✓ pre-dispatch spawnedBy baseline captured (' + evidence.pre_spawned_by_keys.length + ')');
+            listPhase = null;
+          } else if (listPhase === 'post' || evidence.dispatch_accepted) {
+            postListPolls += 1;
+            if (classified.ok) applyChildAuthority(classified.payload || {});
+            else {
               evidence.model_classification_reason =
-                'requested model does not match authoritative child-session metadata';
+                'gateway sessions.list unavailable while resolving child session metadata';
             }
-            console.log('✓ child session metadata observed');
-          } else if (!classified.ok) {
-            evidence.model_classification_reason =
-              'gateway sessions.list unavailable while resolving child session metadata';
+            listPhase = null;
           }
+        }
+        if (classified.kind === 'response' && classified.method === 'sessions.get') {
+          parentHistoryPolls += 1;
+          if (classified.ok) {
+            const messages = Array.isArray(classified.payload?.messages) ? classified.payload.messages : [];
+            if (parentReturnContainsNonce(messages, rowNonce)) {
+              evidence.parent_return_nonce_bound = true;
+              console.log('✓ parent sessions.get nonce-bound normal-mode return observed');
+            }
+          }
+          listPhase = null;
         }
         if (classified.kind === 'event') {
           const eventData = classified.data || {}; const eventStr = JSON.stringify(eventData);
           if (eventData.traceId) evidence.trace_id = eventData.traceId;
-          const eventBelongsToRow = eventStr.includes(rowNonce);
-          const observedChildSessionKey = childSessionKeyForRow(eventData, rowNonce);
-          if (observedChildSessionKey) {
-            evidence.child_session_observed = true;
-            evidence.child_session_key = observedChildSessionKey;
-            if (!evidence.child_metadata_requested) {
-              evidence.child_metadata_requested = true;
-              socket.setTimeout(() => tracker.send(socket, 'sessions.list', { limit: 100 }), 500);
-            }
-          }
-          if (eventBelongsToRow && !eventStr.includes(HARNESS_MARKER)) {
+          // Event correlation may observe child text, but cannot establish model equality
+          // or replace the spawnedBy set-diff authority.
+          if (eventStr.includes(rowNonce) && !eventStr.includes(HARNESS_MARKER)) {
             if (eventStr.includes('MODEL-TOOL-PARENT-SCHEDULED')) {
               evidence.parent_scheduled_sentinel = true;
               console.log('✓ parent scheduled sentinel observed');
             }
             const childMatch = eventStr.match(new RegExp('MODEL-TOOL-CHILD\\s+' + escapeRegex(rowNonce) + '\\s+MODEL\\s+([A-Za-z0-9_.\\/-]+)'));
             if (childMatch) {
-              evidence.child_session_observed = true;
               evidence.return_payload = true;
               evidence.child_self_reported_model = normalizeModel(childMatch[1]);
               evidence.child_self_reported_model_source = 'auxiliary child runtime-context self-report (not used for equality)';
-              console.log('✓ MODEL-TOOL-CHILD return payload observed');
+              console.log('✓ MODEL-TOOL-CHILD return payload observed (auxiliary only)');
             }
           }
         }
-        if (evidence.dispatch_accepted && evidence.child_session_metadata_observed && evidence.return_payload) {
-          console.log('R-CD-MODEL-TOOL return gathered, closing early');
+        if (evidence.dispatch_accepted && evidence.child_session_metadata_observed &&
+            evidence.parent_return_nonce_bound) {
+          console.log('R-CD-MODEL-TOOL authority gathered, closing early');
           socket.close();
         }
       } catch (e) { console.warn('parse error: ' + e); }
@@ -208,14 +290,21 @@ export default function() {
 
   evidence.ended = new Date().toISOString(); evidence.duration_ms = Date.now() - started; duration.add(evidence.duration_ms);
   finalEvidence = evidence;
-  const complete = (!createDisposableSession || evidence.session_created) && evidence.dispatch_accepted && evidence.parent_scheduled_sentinel && evidence.child_session_metadata_observed && evidence.child_metadata_model_byte && evidence.return_payload;
+  // Child self-report (return_payload) is auxiliary and never required for PASS.
+  const complete = evidence.session_created && evidence.dispatch_accepted &&
+    evidence.pre_spawned_by_captured && evidence.post_spawned_by_captured &&
+    evidence.child_session_metadata_observed && evidence.child_metadata_model_byte &&
+    evidence.parent_return_nonce_bound &&
+    !evidence.spawned_by_diff_ambiguous && !evidence.spawned_by_diff_empty;
   check(res, { 'websocket connected': (r) => r && r.status === 101 });
   check(null, {
+    'disposable parent created': () => evidence.session_created,
+    'pre spawnedBy baseline': () => evidence.pre_spawned_by_captured,
     'dispatch accepted': () => evidence.dispatch_accepted,
-    'parent scheduled sentinel': () => evidence.parent_scheduled_sentinel,
-    'child session observed': () => evidence.child_session_observed,
+    'post spawnedBy poll': () => evidence.post_spawned_by_captured,
+    'exactly one new child': () => !!evidence.child_session_key && !evidence.spawned_by_diff_ambiguous,
     'authoritative child-session model byte': () => !!evidence.child_metadata_model_byte,
-    'return payload': () => evidence.return_payload,
+    'parent nonce-bound return': () => evidence.parent_return_nonce_bound,
     'requested model observed': () => evidence.model_matches,
   });
   const authoritativeMismatch =
@@ -232,7 +321,11 @@ export default function() {
 export function handleSummary(data) {
   const timestamp = new Date().toISOString();
   const failuresCount = data.metrics.proof_failures?.values?.count || 0;
-  const complete = !!(finalEvidence?.dispatch_accepted && finalEvidence?.parent_scheduled_sentinel && finalEvidence?.child_session_metadata_observed && finalEvidence?.child_metadata_model_byte && finalEvidence?.return_payload);
+  const complete = !!(finalEvidence?.session_created && finalEvidence?.dispatch_accepted &&
+    finalEvidence?.pre_spawned_by_captured && finalEvidence?.post_spawned_by_captured &&
+    finalEvidence?.child_session_metadata_observed && finalEvidence?.child_metadata_model_byte &&
+    finalEvidence?.parent_return_nonce_bound &&
+    !finalEvidence?.spawned_by_diff_ambiguous && !finalEvidence?.spawned_by_diff_empty);
   const authoritativeMismatch =
     finalEvidence?.child_session_metadata_observed &&
     !!finalEvidence?.child_metadata_model_byte &&

--- a/tools/k6-proofs/scenarios/r-cd-model-tool.js
+++ b/tools/k6-proofs/scenarios/r-cd-model-tool.js
@@ -4,8 +4,10 @@ import { check } from 'k6';
 import { Counter, Trend } from 'k6/metrics';
 import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
+import { childSessionKeysForRow } from '../lib/row-child-correlation.mjs';
 import {
   createModelToolDispatchGate,
+  mergeModelToolChildAuthorityEvidence,
   parentReturnContainsNonce,
   resolveModelToolChildAuthority,
   sessionKeysFromListPayload,
@@ -27,6 +29,7 @@ const DEFAULTS = {
   requestedModel: 'openai/gpt-5.6-luna',
 };
 const HARNESS_MARKER = '[k6-proof-harness]';
+const CHILD_AUTHORITY_STABILITY_MS = 30000;
 
 function boolEnv(name) { return (__ENV[name] || '').toLowerCase() === 'true'; }
 function normalizeModel(value) { return String(value || '').trim().replace(/[.,;:]+$/, ''); }
@@ -75,13 +78,21 @@ export default function() {
     spawned_by_diff_empty: false,
     spawned_by_diff_ambiguous: false,
     dispatch_accepted: false,
+    dispatch_accepted_at_ms: null,
     parent_scheduled_sentinel: false,
     parent_return_nonce_bound: false,
     child_session_observed: false,
     child_session_key: null,
+    event_child_session_key: null,
+    event_child_session_observed: false,
+    child_identity_conflict: false,
     child_session_metadata_observed: false,
     child_metadata_model_byte: null,
     child_metadata_model_source: null,
+    child_authority_source: null,
+    child_authority_confirmations: 0,
+    child_authority_confirmed_at_ms: null,
+    child_authority_stable: false,
     child_self_reported_model: null,
     child_self_reported_model_source: null,
     child_session_metadata: null,
@@ -97,18 +108,17 @@ export default function() {
   const res = ws.connect(url, {}, (socket) => {
     const tracker = new RequestTracker();
     const dispatchGate = createModelToolDispatchGate();
-    let listPhase = null; // 'pre' | 'post' | 'parent-history'
+    const listRequestPhases = {};
     let postListPolls = 0;
     let parentHistoryPolls = 0;
 
     function requestSpawnedByList(phase) {
-      listPhase = phase;
       evidence.child_metadata_requested = true;
-      tracker.send(socket, 'sessions.list', { spawnedBy: sessionKey, limit: 100 });
+      const requestId = tracker.send(socket, 'sessions.list', { spawnedBy: sessionKey, limit: 100 });
+      listRequestPhases[requestId] = phase;
     }
 
     function requestParentHistory() {
-      listPhase = 'parent-history';
       tracker.send(socket, 'sessions.get', { key: sessionKey, limit: 200 });
     }
 
@@ -118,44 +128,25 @@ export default function() {
         postKeys: sessionKeysFromListPayload(payload),
         sessionsPayload: payload,
         requestedModel,
+        eventChildSessionKey: evidence.event_child_session_key,
+        parentSessionKey: sessionKey,
       });
       evidence.post_spawned_by_keys = sessionKeysFromListPayload(payload);
       evidence.post_spawned_by_captured = true;
-      evidence.spawned_by_diff_empty = authority.empty;
-      evidence.spawned_by_diff_ambiguous = authority.ambiguous;
-      if (authority.uniqueNewChildKey) {
-        evidence.child_session_key = authority.uniqueNewChildKey;
-        evidence.child_session_observed = true;
-        evidence.child_session_metadata_observed = !!authority.childMetadataModelByte;
-        evidence.child_metadata_model_byte = authority.childMetadataModelByte;
-        evidence.child_metadata_model_source = 'gateway sessions.list spawnedBy set-diff provider/model metadata';
-        evidence.child_session_metadata = {
-          keyFingerprint: null,
-          provider: null,
-          model: authority.childMetadataModelByte,
-        };
-        const sessions = Array.isArray(payload?.sessions) ? payload.sessions : [];
-        const child = sessions.find((s) => s?.key === authority.uniqueNewChildKey);
-        if (child) {
-          evidence.child_session_metadata = {
-            key: child.key || null,
-            provider: child.modelProvider || child.provider || null,
-            model: child.model || null,
-            modelSelectionLocked: child.modelSelectionLocked === true,
-          };
-        }
-        evidence.model_matches = authority.modelMatches;
-        if (!evidence.model_matches) {
-          evidence.model_classification_reason = authority.failureCategory === 'model-mismatch'
-            ? 'requested model does not match authoritative child-session metadata'
-            : 'authoritative child-session model byte unavailable';
-        }
-        console.log('✓ spawnedBy set-diff bound exactly one new child');
-      } else if (authority.ambiguous) {
-        evidence.model_classification_reason = 'spawnedBy set-diff produced multiple new children';
-        console.warn('✗ spawnedBy set-diff ambiguous (multiple new children)');
-      } else {
-        evidence.model_classification_reason = 'spawnedBy set-diff produced zero new children';
+      Object.assign(evidence, mergeModelToolChildAuthorityEvidence(evidence, authority));
+      if (authority.childSessionKey && authority.childMetadataModelByte) {
+        evidence.child_authority_confirmations += 1;
+        evidence.child_authority_confirmed_at_ms = Date.now();
+        evidence.child_authority_stable = (
+          evidence.child_identity_conflict !== true
+          && evidence.spawned_by_diff_ambiguous !== true
+          && evidence.dispatch_accepted_at_ms !== null
+          && evidence.child_authority_confirmed_at_ms - evidence.dispatch_accepted_at_ms
+            >= CHILD_AUTHORITY_STABILITY_MS
+        );
+        console.log('✓ authoritative child metadata bound via ' + authority.authoritySource);
+      } else if (!evidence.child_session_metadata_observed) {
+        console.warn('✗ child metadata unresolved: ' + authority.failureCategory);
       }
     }
 
@@ -212,7 +203,10 @@ export default function() {
     });
     socket.on('message', (raw) => {
       try {
-        const msg = JSON.parse(raw); const classified = tracker.classify(msg);
+        const msg = JSON.parse(raw);
+        const listPhase = msg?.id ? listRequestPhases[msg.id] || null : null;
+        if (msg?.id) delete listRequestPhases[msg.id];
+        const classified = tracker.classify(msg);
         evidence.redacted_events.push({
           ts: Date.now(),
           kind: classified.kind,
@@ -234,6 +228,7 @@ export default function() {
         if (classified.kind === 'response' && classified.method === 'sessions.send') {
           if (classified.ok) {
             evidence.dispatch_accepted = true;
+            evidence.dispatch_accepted_at_ms = Date.now();
             if (classified.payload?.traceId) evidence.trace_id = classified.payload.traceId;
             console.log('✓ sessions.send accepted — explicit model delegate turn triggered');
           } else { console.error('✗ sessions.send rejected: ' + JSON.stringify(classified.error)); failures.add(1); }
@@ -247,7 +242,6 @@ export default function() {
               evidence.pre_spawned_by_keys = sessionKeysFromListPayload(classified.payload || {});
               evidence.pre_spawned_by_captured = true;
               console.log('✓ pre-dispatch spawnedBy baseline captured (' + evidence.pre_spawned_by_keys.length + ')');
-              listPhase = null;
               const gateResult = dispatchGate.onPreBaselineCaptured();
               if (gateResult.action === 'dispatch') {
                 console.log('✓ baseline-gated model-tool dispatch armed (once)');
@@ -255,17 +249,15 @@ export default function() {
               }
             } else {
               console.error('✗ pre-dispatch sessions.list rejected: ' + JSON.stringify(classified.error));
-              listPhase = null;
               // Leave pre_spawned_by_captured false so the watchdog fail-closes.
             }
-          } else if (listPhase === 'post' || evidence.dispatch_accepted) {
+          } else if (listPhase === 'post') {
             postListPolls += 1;
             if (classified.ok) applyChildAuthority(classified.payload || {});
             else {
               evidence.model_classification_reason =
                 'gateway sessions.list unavailable while resolving child session metadata';
             }
-            listPhase = null;
           }
         }
         if (classified.kind === 'response' && classified.method === 'sessions.get') {
@@ -277,13 +269,43 @@ export default function() {
               console.log('✓ parent sessions.get nonce-bound normal-mode return observed');
             }
           }
-          listPhase = null;
         }
         if (classified.kind === 'event') {
           const eventData = classified.data || {}; const eventStr = JSON.stringify(eventData);
           if (eventData.traceId) evidence.trace_id = eventData.traceId;
+          const observedChildSessionKeys = childSessionKeysForRow(eventData, rowNonce);
+          if (observedChildSessionKeys.length > 1) {
+            evidence.child_identity_conflict = true;
+            evidence.spawned_by_diff_ambiguous = true;
+            evidence.model_matches = false;
+            evidence.model_classification_reason =
+              'multiple nonce-bound child-session keys observed in one event';
+          }
+          const observedChildSessionKey = observedChildSessionKeys.length === 1
+            ? observedChildSessionKeys[0]
+            : null;
+          if (observedChildSessionKey) {
+            evidence.event_child_session_observed = true;
+            if (!evidence.event_child_session_key) {
+              evidence.event_child_session_key = observedChildSessionKey;
+              console.log('✓ event-correlated child session key observed');
+              if (!evidence.child_session_metadata_observed) requestSpawnedByList('post');
+            } else if (evidence.event_child_session_key !== observedChildSessionKey) {
+              evidence.child_identity_conflict = true;
+              evidence.spawned_by_diff_ambiguous = true;
+              evidence.model_classification_reason =
+                'multiple event-correlated child-session keys observed';
+            }
+            if (evidence.child_session_key &&
+                evidence.child_session_key !== observedChildSessionKey) {
+              evidence.child_identity_conflict = true;
+              evidence.model_matches = false;
+              evidence.model_classification_reason =
+                'event-correlated child differs from authoritative metadata child';
+            }
+          }
           // Event correlation may observe child text, but cannot establish model equality
-          // or replace the spawnedBy set-diff authority.
+          // without the matching sessions.list provider/model metadata row.
           if (eventStr.includes(rowNonce) && !eventStr.includes(HARNESS_MARKER)) {
             if (eventStr.includes('MODEL-TOOL-PARENT-SCHEDULED')) {
               evidence.parent_scheduled_sentinel = true;
@@ -298,8 +320,14 @@ export default function() {
             }
           }
         }
+        const childIdentityConsistent = (
+          (!evidence.event_child_session_observed
+            || evidence.event_child_session_key === evidence.child_session_key)
+          && evidence.child_identity_conflict !== true
+        );
         if (evidence.dispatch_accepted && evidence.child_session_metadata_observed &&
-            evidence.parent_return_nonce_bound) {
+            evidence.parent_return_nonce_bound && childIdentityConsistent &&
+            evidence.child_authority_stable === true) {
           console.log('R-CD-MODEL-TOOL authority gathered, closing early');
           socket.close();
         }
@@ -314,6 +342,10 @@ export default function() {
   const complete = evidence.session_created && evidence.dispatch_accepted &&
     evidence.pre_spawned_by_captured && evidence.post_spawned_by_captured &&
     evidence.child_session_metadata_observed && evidence.child_metadata_model_byte &&
+    (!evidence.event_child_session_observed ||
+      evidence.event_child_session_key === evidence.child_session_key) &&
+    evidence.child_identity_conflict !== true &&
+    evidence.child_authority_stable === true &&
     evidence.parent_return_nonce_bound &&
     !evidence.spawned_by_diff_ambiguous && !evidence.spawned_by_diff_empty;
   check(res, { 'websocket connected': (r) => r && r.status === 101 });
@@ -323,7 +355,12 @@ export default function() {
     'dispatch accepted': () => evidence.dispatch_accepted,
     'post spawnedBy poll': () => evidence.post_spawned_by_captured,
     'exactly one new child': () => !!evidence.child_session_key && !evidence.spawned_by_diff_ambiguous,
+    'event identity agrees with metadata when observed': () =>
+      (!evidence.event_child_session_observed ||
+        evidence.event_child_session_key === evidence.child_session_key) &&
+      evidence.child_identity_conflict !== true,
     'authoritative child-session model byte': () => !!evidence.child_metadata_model_byte,
+    'child authority stable through 30s poll': () => evidence.child_authority_stable === true,
     'parent nonce-bound return': () => evidence.parent_return_nonce_bound,
     'requested model observed': () => evidence.model_matches,
   });
@@ -344,6 +381,10 @@ export function handleSummary(data) {
   const complete = !!(finalEvidence?.session_created && finalEvidence?.dispatch_accepted &&
     finalEvidence?.pre_spawned_by_captured && finalEvidence?.post_spawned_by_captured &&
     finalEvidence?.child_session_metadata_observed && finalEvidence?.child_metadata_model_byte &&
+    (!finalEvidence?.event_child_session_observed ||
+      finalEvidence?.event_child_session_key === finalEvidence?.child_session_key) &&
+    finalEvidence?.child_identity_conflict !== true &&
+    finalEvidence?.child_authority_stable === true &&
     finalEvidence?.parent_return_nonce_bound &&
     !finalEvidence?.spawned_by_diff_ambiguous && !finalEvidence?.spawned_by_diff_empty);
   const authoritativeMismatch =

--- a/tools/k6-proofs/scenarios/r-cd-model-tool.js
+++ b/tools/k6-proofs/scenarios/r-cd-model-tool.js
@@ -5,6 +5,7 @@ import { Counter, Trend } from 'k6/metrics';
 import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
 import {
+  createModelToolDispatchGate,
   parentReturnContainsNonce,
   resolveModelToolChildAuthority,
   sessionKeysFromListPayload,
@@ -95,6 +96,7 @@ export default function() {
 
   const res = ws.connect(url, {}, (socket) => {
     const tracker = new RequestTracker();
+    const dispatchGate = createModelToolDispatchGate();
     let listPhase = null; // 'pre' | 'post' | 'parent-history'
     let postListPolls = 0;
     let parentHistoryPolls = 0;
@@ -157,36 +159,40 @@ export default function() {
       }
     }
 
+    // Sole dispatch: armed only by a successful pre-baseline response (once).
+    function dispatchModelToolTurn() {
+      const childTask =
+        'Proof nonce ' + rowNonce + ': read your runtime context/current model identity. ' +
+        'Reply exactly MODEL-TOOL-CHILD ' + rowNonce + ' MODEL <provider/model>. ' +
+        'Use UNKNOWN only if no runtime model identity is available. Do not mutate files. Do not post externally.';
+      const instruction =
+        HARNESS_MARKER + ' R-CD-MODEL-TOOL nonce ' + rowNonce + '. ' +
+        'Call continue_delegate with task=' + JSON.stringify(childTask) +
+        ', mode="normal", delaySeconds=' + delaySeconds +
+        ', model=' + JSON.stringify(requestedModel) + '. ' +
+        'After the continue_delegate tool result reports scheduled, reply exactly ' +
+        'MODEL-TOOL-PARENT-SCHEDULED ' + rowNonce + ' REQUESTED ' + requestedModel + '. No other action.';
+      tracker.send(socket, 'sessions.send', {
+        key: sessionKey,
+        message: instruction,
+        idempotencyKey: idPrefix + '-DISPATCH-' + rowNonce,
+      });
+    }
+
     function start(socket) {
       tracker.send(socket, 'sessions.messages.subscribe', { key: sessionKey });
       // Pre-dispatch baseline: server-filtered children of this disposable parent.
+      // Dispatch is NOT on a fixed gap after this request — it fires from the
+      // successful pre response via createModelToolDispatchGate (exactly once).
       socket.setTimeout(() => requestSpawnedByList('pre'), 300);
       socket.setTimeout(() => {
-        if (!evidence.pre_spawned_by_captured) {
+        const watchdog = dispatchGate.onBaselineWatchdog();
+        if (watchdog.action === 'fail-closed') {
           console.error('✗ pre-dispatch sessions.list {spawnedBy} baseline missing');
           failures.add(1);
           socket.close();
         }
       }, 5000);
-      socket.setTimeout(() => {
-        if (!evidence.pre_spawned_by_captured) return;
-        const childTask =
-          'Proof nonce ' + rowNonce + ': read your runtime context/current model identity. ' +
-          'Reply exactly MODEL-TOOL-CHILD ' + rowNonce + ' MODEL <provider/model>. ' +
-          'Use UNKNOWN only if no runtime model identity is available. Do not mutate files. Do not post externally.';
-        const instruction =
-          HARNESS_MARKER + ' R-CD-MODEL-TOOL nonce ' + rowNonce + '. ' +
-          'Call continue_delegate with task=' + JSON.stringify(childTask) +
-          ', mode="normal", delaySeconds=' + delaySeconds +
-          ', model=' + JSON.stringify(requestedModel) + '. ' +
-          'After the continue_delegate tool result reports scheduled, reply exactly ' +
-          'MODEL-TOOL-PARENT-SCHEDULED ' + rowNonce + ' REQUESTED ' + requestedModel + '. No other action.';
-        tracker.send(socket, 'sessions.send', {
-          key: sessionKey,
-          message: instruction,
-          idempotencyKey: idPrefix + '-DISPATCH-' + rowNonce,
-        });
-      }, 800);
       // Independent post-dispatch polls (not event-correlation gated).
       socket.setTimeout(() => { if (evidence.dispatch_accepted) requestSpawnedByList('post'); }, 4000);
       socket.setTimeout(() => { if (evidence.dispatch_accepted) requestSpawnedByList('post'); }, 12000);
@@ -234,10 +240,24 @@ export default function() {
         }
         if (classified.kind === 'response' && classified.method === 'sessions.list') {
           if (listPhase === 'pre') {
-            evidence.pre_spawned_by_keys = sessionKeysFromListPayload(classified.payload);
-            evidence.pre_spawned_by_captured = true;
-            console.log('✓ pre-dispatch spawnedBy baseline captured (' + evidence.pre_spawned_by_keys.length + ')');
-            listPhase = null;
+            // Dispatch exactly once from the successful pre-baseline response.
+            // A late baseline (e.g. RPC >500ms) still arms dispatch; a fixed
+            // +800ms timer must never be the sole dispatch trigger.
+            if (classified.ok) {
+              evidence.pre_spawned_by_keys = sessionKeysFromListPayload(classified.payload || {});
+              evidence.pre_spawned_by_captured = true;
+              console.log('✓ pre-dispatch spawnedBy baseline captured (' + evidence.pre_spawned_by_keys.length + ')');
+              listPhase = null;
+              const gateResult = dispatchGate.onPreBaselineCaptured();
+              if (gateResult.action === 'dispatch') {
+                console.log('✓ baseline-gated model-tool dispatch armed (once)');
+                dispatchModelToolTurn();
+              }
+            } else {
+              console.error('✗ pre-dispatch sessions.list rejected: ' + JSON.stringify(classified.error));
+              listPhase = null;
+              // Leave pre_spawned_by_captured false so the watchdog fail-closes.
+            }
           } else if (listPhase === 'post' || evidence.dispatch_accepted) {
             postListPolls += 1;
             if (classified.ok) applyChildAuthority(classified.payload || {});

--- a/tools/k6-proofs/scripts/__tests__/continuation-row-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/continuation-row-contract.test.mjs
@@ -161,6 +161,11 @@ test('every trace-required continue_delegate row persists the safe fingerprint c
       if (manifest.rowId === 'R-CD-4') {
         assert.match(manifest.invocation.promptTemplate, /^RCD4:\{\{nonceSuffix16\}\}/);
         assert.match(scenario, /rCd4TaskPrompt\(inv\.promptTemplate,\s*rowNonce\)/);
+        assert.match(scenario, /return_authority:\s*'gateway-journal-targeted-return-post-run'/);
+      } else if (manifest.rowId === 'R-CD-CHAINED-DEPTH-2') {
+        assert.match(manifest.invocation.promptTemplate, /fanoutMode='tree'/);
+        assert.match(scenario, /(?:promptTemplate|template)\.replace\(\/\\\{\\\{nonce\\\}\\\}\/g,/);
+        assert.match(scenario, /return_authority:\s*'gateway-journal-targeted-return-post-run'/);
       } else {
         assert.match(scenario, /promptTemplate\.replace\(\/\\\{\\\{nonce\\\}\\\}\/g,/);
       }
@@ -231,8 +236,14 @@ test('every trace-required continue_work row persists the safe fingerprint contr
 
 test('depth-2 chain dispatch uses the exact committed manifest task', async () => {
   const source = await readFile(path.join(scenariosDir, 'r-cd-chained-depth-2.js'), 'utf8');
-  assert.match(source, /const task = inv\.promptTemplate\.replace\(\/\\\{\\\{nonce\\\}\\\}\/g, chainNonce\)/);
+  const manifest = JSON.parse(await readFile(path.join(manifestsDir, 'r-cd-chained-depth-2.json'), 'utf8'));
+  // Nested call must request fanoutMode=tree; outer parent→child has no fanoutMode.
+  assert.match(manifest.invocation.promptTemplate, /fanoutMode='tree'/);
+  assert.match(source, /const template = inv\.promptTemplate \|\| rCdChainPromptTemplate\(\)/);
+  assert.match(source, /const task = template\.replace\(\/\\\{\\\{nonce\\\}\\\}\/g, chainNonce\)/);
   assert.match(source, /task=\$\{JSON\.stringify\(task\)\}/);
+  assert.match(source, /fanoutMode='tree'/);
+  assert.equal(manifest.scenario.subtests, undefined);
 });
 
 test('row runner keeps private acquisition transient and publishes sanitized evidence', async () => {

--- a/tools/k6-proofs/scripts/__tests__/tempo-search-id-normalize.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/tempo-search-id-normalize.test.mjs
@@ -1,0 +1,157 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+import { normalizeTempoSearchTraceId } from '../collect-continuation-trace.mjs';
+
+const execFileAsync = promisify(execFile);
+const script = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../collect-continuation-trace.mjs');
+
+function b64(hex) {
+  return Buffer.from(hex, 'hex').toString('base64');
+}
+
+function attr(key, value) {
+  return {
+    key,
+    value: typeof value === 'number' ? { intValue: String(value) } : { stringValue: value },
+  };
+}
+
+test('normalizeTempoSearchTraceId left-pads exactly 31 hex chars', () => {
+  const short = '1234567890abcdef1234567890abcde'; // 31
+  assert.equal(short.length, 31);
+  assert.equal(normalizeTempoSearchTraceId(short), `0${short}`);
+  assert.equal(normalizeTempoSearchTraceId(`0${short}`), `0${short}`);
+});
+
+test('normalizeTempoSearchTraceId rejects other lengths and all-zero IDs', () => {
+  assert.throws(() => normalizeTempoSearchTraceId('abc'), /invalid search trace id/);
+  assert.throws(() => normalizeTempoSearchTraceId('1'.repeat(30)), /invalid search trace id/);
+  assert.throws(() => normalizeTempoSearchTraceId('1'.repeat(33)), /invalid search trace id/);
+  assert.throws(() => normalizeTempoSearchTraceId('0'.repeat(32)), /invalid search trace id/);
+  assert.throws(() => normalizeTempoSearchTraceId('0'.repeat(31)), /invalid search trace id/);
+});
+
+test('collector accepts 31-hex search IDs and verifies nonzero payload IDs', async () => {
+  const fullTraceId = '0123456789abcdef0123456789abcdef';
+  const shortSearchId = fullTraceId.slice(1); // strip leading 0 → 31 hex
+  assert.equal(shortSearchId.length, 31);
+
+  const reason = 'Proof nonce TEMPO-31: task body for normalize test';
+  const reasonHash = createHash('sha256').update(reason).digest('hex').slice(0, 16);
+  const reasonLength = reason.length;
+  const parent = 'dddddddddddddddd';
+  const dispatch = 'aaaaaaaaaaaaaaaa';
+  const fire = 'bbbbbbbbbbbbbbbb';
+  const tool = 'cccccccccccccccc';
+  const toolOriginNs = 1785580554339000000n;
+  const fireNs = toolOriginNs + 5000000000n;
+  const continuationAttrs = [
+    attr('chain.id', '11111111-1111-4111-8111-111111111111'),
+    attr('reason.hash', reasonHash),
+    attr('reason.length', reasonLength),
+    attr('delegate.mode', 'silent-wake'),
+  ];
+  const trace = {
+    batches: [{
+      scopeSpans: [{
+        spans: [
+          {
+            name: 'continuation.delegate.dispatch',
+            traceId: b64(fullTraceId),
+            spanId: b64(dispatch),
+            parentSpanId: b64(parent),
+            status: { code: 'OK' },
+            attributes: continuationAttrs,
+            startTimeUnixNano: String(fireNs),
+            endTimeUnixNano: String(fireNs + 1000n),
+          },
+          {
+            name: 'continuation.delegate.fire',
+            traceId: b64(fullTraceId),
+            spanId: b64(fire),
+            parentSpanId: b64(parent),
+            status: { code: 'OK' },
+            attributes: [...continuationAttrs, attr('fire.deferred_ms', 5000)],
+            startTimeUnixNano: String(fireNs),
+            endTimeUnixNano: String(fireNs + 1000n),
+          },
+          {
+            name: 'openclaw.tool.execution',
+            traceId: b64(fullTraceId),
+            spanId: b64(tool),
+            parentSpanId: b64(parent),
+            status: { code: 'OK' },
+            attributes: [attr('gen_ai.tool.name', 'continue_delegate')],
+            startTimeUnixNano: String(toolOriginNs),
+            endTimeUnixNano: String(toolOriginNs + 1000n),
+          },
+        ],
+      }],
+    }],
+  };
+
+  const server = http.createServer((req, res) => {
+    if (req.url.startsWith('/api/search')) {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ traces: [{ traceID: shortSearchId }] }));
+      return;
+    }
+    if (req.url.startsWith('/api/traces/')) {
+      const requested = decodeURIComponent(req.url.split('/').pop());
+      assert.equal(requested, fullTraceId);
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(trace));
+      return;
+    }
+    res.writeHead(404).end();
+  });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address();
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'tempo-31-'));
+  try {
+    const nonce = 'TEMPO-31';
+    const manifest = {
+      invocation: {
+        tool: 'continue_delegate',
+        mode: 'silent-wake',
+        promptTemplate: 'Proof nonce {{nonce}}: task body for normalize test',
+      },
+    };
+    const evidence = {
+      nonce,
+      reason_hash: reasonHash,
+      reason_length: reasonLength,
+      delegate_mode: 'silent-wake',
+      dispatch_accepted_at_ms: Date.now(),
+      started: new Date().toISOString(),
+      ended: new Date().toISOString(),
+    };
+    await writeFile(path.join(dir, 'manifest.json'), JSON.stringify(manifest));
+    await writeFile(path.join(dir, 'evidence.jsonl'), `${JSON.stringify(evidence)}\n`);
+    const { stdout } = await execFileAsync('node', [
+      script,
+      '--run-dir', dir,
+      '--manifest', path.join(dir, 'manifest.json'),
+      '--seat', 'cael-dgx',
+      '--evidence', path.join(dir, 'evidence.jsonl'),
+      '--tempo-url', `http://127.0.0.1:${port}`,
+      '--timeout-ms', '2000',
+      '--poll-ms', '50',
+    ], { timeout: 15000 });
+    const result = JSON.parse(stdout);
+    assert.equal(result.traceId, fullTraceId);
+    const receipt = JSON.parse(await readFile(path.join(dir, 'continuation-trace-correlation.json'), 'utf8'));
+    assert.equal(receipt.traceId, fullTraceId);
+  } finally {
+    server.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tools/k6-proofs/scripts/candidate-run-result-contract.mjs
+++ b/tools/k6-proofs/scripts/candidate-run-result-contract.mjs
@@ -206,7 +206,8 @@ function authoritativeReceiptContract(rowId) {
       file: 'targeted-return-receipt.json',
       source: 'shared-targeted-return-collector',
       verdictSource: 'targeted-return-receipt',
-      validate: (receipt) => validateTargetedReturnReceipt(receipt, rowId),
+      // Same gateway-token HMAC contract as R-CD-2/R-CD-TOKEN authoritative receipts.
+      validate: (receipt, signingKey) => validateTargetedReturnReceipt(receipt, signingKey, rowId),
     };
   }
   return null;

--- a/tools/k6-proofs/scripts/candidate-run-result-contract.mjs
+++ b/tools/k6-proofs/scripts/candidate-run-result-contract.mjs
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { validateRcd2AuthoritativeReceipt } from '../lib/r-cd-2-authoritative-receipt.mjs';
 import { validateRcdTokenAuthoritativeReceipt } from '../lib/r-cd-token-authoritative-receipt.mjs';
+import { validateTargetedReturnReceipt } from '../lib/targeted-return-receipt.mjs';
 
 export const CANDIDATE_RUN_RESULT_SCHEMA = 'openclaw.k6.candidate-run-result.v1';
 export const PROOF_ROW_MANIFEST_SCHEMA = 'openclaw.k6.proof-row-manifest.v1';
@@ -24,6 +25,8 @@ export const SAFE_CANDIDATE_ARTIFACTS = new Set([
   'r-cd-2-authoritative-receipt.json',
   'attempt-state.json', 'build-identity-gate.json', 'interruption-receipt.json',
   'r-cd-token-authoritative-receipt.json',
+  'targeted-return-receipt.json',
+  'targeted-return-resolution.json',
   'evidence-lines.log', 'evidence-redaction.json', 'gateway-journal.log',
   'gateway-journal-capture.json', 'gateway-journal-redaction.json',
 ]);
@@ -196,6 +199,14 @@ function authoritativeReceiptContract(rowId) {
       source: 'r-cd-token-row-scoped-resolver',
       verdictSource: 'r-cd-token-authoritative-receipt',
       validate: validateRcdTokenAuthoritativeReceipt,
+    };
+  }
+  if (rowId === 'R-CD-4' || rowId === 'R-CD-CHAINED-DEPTH-2') {
+    return {
+      file: 'targeted-return-receipt.json',
+      source: 'shared-targeted-return-collector',
+      verdictSource: 'targeted-return-receipt',
+      validate: (receipt) => validateTargetedReturnReceipt(receipt, rowId),
     };
   }
   return null;

--- a/tools/k6-proofs/scripts/collect-continuation-trace.mjs
+++ b/tools/k6-proofs/scripts/collect-continuation-trace.mjs
@@ -65,9 +65,25 @@ function safeHex(value, length, label) {
   return text;
 }
 
+/**
+ * Tempo search sometimes strips one leading zero from 16-byte trace IDs,
+ * yielding 31 hex characters. Accept exactly that form by left-padding one
+ * `0`; reject every other malformed length and all-zero IDs.
+ */
+export function normalizeTempoSearchTraceId(value, label = 'search trace id') {
+  const text = String(value ?? '').toLowerCase();
+  if (/^[0-9a-f]{32}$/.test(text)) return safeHex(text, 32, label);
+  if (/^[0-9a-f]{31}$/.test(text)) return safeHex(`0${text}`, 32, label);
+  throw new Error(`invalid ${label}: ${text || '(empty)'}`);
+}
+
 function idHex(value, bytes, label) {
   const text = String(value ?? '');
   if (text.length === bytes * 2 && /^[0-9a-f]+$/i.test(text)) return safeHex(text, bytes * 2, label);
+  // Tempo search may emit a 31-hex trace id for a 16-byte value.
+  if (bytes === 16 && text.length === 31 && /^[0-9a-f]+$/i.test(text)) {
+    return normalizeTempoSearchTraceId(text, label);
+  }
   const decoded = Buffer.from(text, 'base64');
   if (decoded.length !== bytes) throw new Error(`invalid ${label} byte length`);
   return safeHex(decoded.toString('hex'), bytes * 2, label);
@@ -486,7 +502,10 @@ async function main() {
       throw new Error(`trace correlation is ambiguous: ${candidates.length} Tempo traces matched`);
     }
     if (candidates.length === 1) {
-      traceId = safeHex(candidates[0].traceID || candidates[0].traceId || candidates[0].trace_id, 32, 'search trace id');
+      traceId = normalizeTempoSearchTraceId(
+        candidates[0].traceID || candidates[0].traceId || candidates[0].trace_id,
+        'search trace id',
+      );
       trace = await fetchTrace(args.tempoUrl, traceId);
       try {
         topology = contract.kind === 'continuation'

--- a/tools/k6-proofs/scripts/collect-targeted-return-receipt.mjs
+++ b/tools/k6-proofs/scripts/collect-targeted-return-receipt.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import {
+  assertPublicSafeTargetedReturnReceipt,
+  resolveTargetedReturnAuthority,
+} from '../lib/targeted-return-receipt.mjs';
+
+function usage() {
+  console.error(`Usage: node collect-targeted-return-receipt.mjs \\
+  --run-dir <dir> --evidence <private-evidence.json> --journal <private-gateway.log> \\
+  [--row R-CD-4|R-CD-CHAINED-DEPTH-2]`);
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (!['--run-dir', '--evidence', '--journal', '--row'].includes(arg)) {
+      throw new Error(`unexpected argument: ${arg}`);
+    }
+    const value = argv[i + 1];
+    if (!value || value.startsWith('--')) throw new Error(`missing value for ${arg}`);
+    out[arg.slice(2).replace(/-([a-z])/g, (_, c) => c.toUpperCase())] = value;
+    i += 1;
+  }
+  return out;
+}
+
+function windowFromEvidence(evidence) {
+  const startMs = Number(evidence?.dispatch_accepted_at_ms);
+  const endedMs = Date.parse(evidence?.ended);
+  const startedMs = Date.parse(evidence?.started);
+  const windowStartMs = Number.isFinite(startMs)
+    ? startMs
+    : (Number.isFinite(startedMs) ? startedMs : null);
+  // Small pad absorbs journal clock skew after the VU closes.
+  const windowEndMs = Number.isFinite(endedMs) ? endedMs + 15_000 : null;
+  return { windowStartMs, windowEndMs };
+}
+
+function bindRow(evidence, rowHint) {
+  const row = rowHint || evidence?.row;
+  if (row === 'R-CD-4') {
+    return {
+      row,
+      targetSessionKey: evidence?.targetSessionKey || evidence?.created_target_session_key || null,
+      parentSessionKey: evidence?.sessionKey || evidence?.created_parent_session_key || null,
+      childSessionKey: evidence?.child_session || null,
+      structuralOk: evidence?.tool_accepted === true &&
+        !!evidence?.child_session &&
+        evidence?.child_session_ambiguous !== true &&
+        evidence?.child_session_invalid !== true,
+    };
+  }
+  if (row === 'R-CD-CHAINED-DEPTH-2') {
+    return {
+      row,
+      // fanoutMode=tree routes grandchild completion up the ancestry to root
+      // (and intermediate ancestors). Intermediate child is not a forbidden parent.
+      targetSessionKey: evidence?.sessionKey || evidence?.created_session_key || null,
+      parentSessionKey: evidence?.child_session || null,
+      childSessionKey: evidence?.grandchild_session || null,
+      allowIntermediateAncestorTargets: true,
+      structuralOk: evidence?.parent_dispatch_accepted === true &&
+        evidence?.child_done_sentinel === true &&
+        evidence?.grandchild_done_sentinel === true &&
+        !!evidence?.child_session &&
+        !!evidence?.grandchild_session &&
+        evidence.child_session !== evidence.grandchild_session,
+    };
+  }
+  throw new Error(`unsupported targeted-return row: ${row || '(missing)'}`);
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (!args.runDir || !args.evidence || !args.journal) {
+    usage();
+    process.exitCode = 2;
+    return;
+  }
+
+  const runDir = path.resolve(args.runDir);
+  const evidence = JSON.parse(await readFile(path.resolve(args.evidence), 'utf8'));
+  const journalText = await readFile(path.resolve(args.journal), 'utf8');
+  const binding = bindRow(evidence, args.row);
+  const { windowStartMs, windowEndMs } = windowFromEvidence(evidence);
+
+  const authority = resolveTargetedReturnAuthority({
+    journalText,
+    targetSessionKey: binding.targetSessionKey,
+    parentSessionKey: binding.parentSessionKey,
+    childSessionKey: binding.childSessionKey,
+    windowStartMs,
+    windowEndMs,
+    row: binding.row,
+    allowIntermediateAncestorTargets: binding.allowIntermediateAncestorTargets === true,
+  });
+
+  // Structural child/completion gates stay independent of journal routing.
+  let verdict = authority.verdict;
+  let failureCategory = authority.failureCategory;
+  if (!binding.structuralOk) {
+    verdict = 'PARTIAL-candidate';
+    failureCategory = failureCategory || 'structural-gates-incomplete';
+  } else if (authority.verdict !== 'PASS-candidate') {
+    verdict = 'PARTIAL-candidate';
+  }
+
+  const receipt = {
+    ...authority,
+    verdict,
+    failureCategory,
+    structuralOk: binding.structuralOk,
+  };
+  assertPublicSafeTargetedReturnReceipt(receipt);
+
+  const outName = 'targeted-return-receipt.json';
+  const outPath = path.join(runDir, outName);
+  await writeFile(outPath, `${JSON.stringify(receipt, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify({
+    row: binding.row,
+    verdict: receipt.verdict,
+    failureCategory: receipt.failureCategory,
+    receipt: outName,
+    targetMatchCount: receipt.targetMatchCount,
+    parentMatchCount: receipt.parentMatchCount,
+  })}\n`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`targeted-return collector failed: ${error.message}\n`);
+  process.exitCode = 1;
+});

--- a/tools/k6-proofs/scripts/collect-targeted-return-receipt.mjs
+++ b/tools/k6-proofs/scripts/collect-targeted-return-receipt.mjs
@@ -4,12 +4,15 @@ import path from 'node:path';
 import {
   assertPublicSafeTargetedReturnReceipt,
   resolveTargetedReturnAuthority,
+  validateTargetedReturnReceipt,
 } from '../lib/targeted-return-receipt.mjs';
 
 function usage() {
   console.error(`Usage: node collect-targeted-return-receipt.mjs \\
   --run-dir <dir> --evidence <private-evidence.json> --journal <private-gateway.log> \\
-  [--row R-CD-4|R-CD-CHAINED-DEPTH-2]`);
+  [--row R-CD-4|R-CD-CHAINED-DEPTH-2]
+
+Requires OPENCLAW_GATEWAY_TOKEN in the environment to HMAC-seal the receipt.`);
 }
 
 function parseArgs(argv) {
@@ -81,13 +84,18 @@ async function main() {
     return;
   }
 
+  const signingKey = process.env.OPENCLAW_GATEWAY_TOKEN;
+  if (typeof signingKey !== 'string' || signingKey.length === 0) {
+    throw new Error('OPENCLAW_GATEWAY_TOKEN is required to seal targeted-return receipts');
+  }
+
   const runDir = path.resolve(args.runDir);
   const evidence = JSON.parse(await readFile(path.resolve(args.evidence), 'utf8'));
   const journalText = await readFile(path.resolve(args.journal), 'utf8');
   const binding = bindRow(evidence, args.row);
   const { windowStartMs, windowEndMs } = windowFromEvidence(evidence);
 
-  const authority = resolveTargetedReturnAuthority({
+  const receipt = resolveTargetedReturnAuthority({
     journalText,
     targetSessionKey: binding.targetSessionKey,
     parentSessionKey: binding.parentSessionKey,
@@ -96,24 +104,14 @@ async function main() {
     windowEndMs,
     row: binding.row,
     allowIntermediateAncestorTargets: binding.allowIntermediateAncestorTargets === true,
+    structuralOk: binding.structuralOk === true,
+    signingKey,
   });
 
-  // Structural child/completion gates stay independent of journal routing.
-  let verdict = authority.verdict;
-  let failureCategory = authority.failureCategory;
-  if (!binding.structuralOk) {
-    verdict = 'PARTIAL-candidate';
-    failureCategory = failureCategory || 'structural-gates-incomplete';
-  } else if (authority.verdict !== 'PASS-candidate') {
-    verdict = 'PARTIAL-candidate';
+  const integrity = validateTargetedReturnReceipt(receipt, signingKey, binding.row);
+  if (!integrity.valid) {
+    throw new Error(`sealed targeted-return receipt failed self-validation: ${integrity.reason}`);
   }
-
-  const receipt = {
-    ...authority,
-    verdict,
-    failureCategory,
-    structuralOk: binding.structuralOk,
-  };
   assertPublicSafeTargetedReturnReceipt(receipt);
 
   const outName = 'targeted-return-receipt.json';
@@ -123,9 +121,11 @@ async function main() {
     row: binding.row,
     verdict: receipt.verdict,
     failureCategory: receipt.failureCategory,
+    structuralOk: receipt.structuralOk === true,
     receipt: outName,
     targetMatchCount: receipt.targetMatchCount,
     parentMatchCount: receipt.parentMatchCount,
+    integrity: receipt.integrity?.algorithm || null,
   })}\n`);
 }
 

--- a/tools/k6-proofs/scripts/collect-targeted-return-receipt.mjs
+++ b/tools/k6-proofs/scripts/collect-targeted-return-receipt.mjs
@@ -70,7 +70,17 @@ function bindRow(evidence, rowHint) {
         evidence?.grandchild_done_sentinel === true &&
         !!evidence?.child_session &&
         !!evidence?.grandchild_session &&
-        evidence.child_session !== evidence.grandchild_session,
+        evidence.child_session !== evidence.grandchild_session &&
+        evidence?.ancestry_ambiguous !== true &&
+        evidence?.ancestry_stable === true &&
+        Number(evidence?.child_ancestry_confirmations) >= 2 &&
+        Number(evidence?.grandchild_ancestry_confirmations) >= 2 &&
+        Number.isFinite(Number(evidence?.dispatch_accepted_at_ms)) &&
+        Number.isFinite(Number(evidence?.grandchild_ancestry_confirmed_at_ms)) &&
+        Number(evidence.grandchild_ancestry_confirmed_at_ms) -
+          Number(evidence.dispatch_accepted_at_ms) >= 30_000 &&
+        evidence?.child_authority_source === 'sessions.list spawnedBy ancestry' &&
+        evidence?.grandchild_authority_source === 'sessions.list spawnedBy ancestry',
     };
   }
   throw new Error(`unsupported targeted-return row: ${row || '(missing)'}`);

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -52,6 +52,7 @@ bind_execution_roots() {
   EVIDENCE_EXTRACTOR="$SCRIPT_DIR/extract-k6-evidence.mjs"
   CONTINUATION_TRACE_COLLECTOR="$SCRIPT_DIR/collect-continuation-trace.mjs"
   R_CD_2_RECEIPT_RESOLVER="$SCRIPT_DIR/resolve-r-cd-2-authoritative-receipt.mjs"
+  TARGETED_RETURN_COLLECTOR="$SCRIPT_DIR/collect-targeted-return-receipt.mjs"
   ARTIFACT_SANITIZER="$SCRIPT_DIR/sanitize-k6-artifacts.mjs"
   CANDIDATE_RESULT_VALIDATOR="$SCRIPT_DIR/validate-candidate-run-result.mjs"
   INTERRUPTED_RESULT_WRITER="$SCRIPT_DIR/write-interrupted-run-result.mjs"
@@ -1391,6 +1392,38 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
       fi
     fi
 
+    # R-CD-4 and R-CD-CHAINED-DEPTH-2 share one payload-free journal collector.
+    # Transcript session.message markers never promote silent-wake routing.
+    TARGETED_RETURN_RECEIPT=""
+    TARGETED_RETURN_RECEIPT_SHA256=""
+    if [[ "$ROW_ID" == "R-CD-4" || "$ROW_ID" == "R-CD-CHAINED-DEPTH-2" ]]; then
+      TARGETED_RETURN_RECEIPT="targeted-return-receipt.json"
+      if [[ -s "$PRIVATE_EVIDENCE_FILE" && -f "$PRIVATE_GATEWAY_LOG" ]] && \
+        node "$TARGETED_RETURN_COLLECTOR" \
+          --run-dir "$RUN_DIR" \
+          --evidence "$PRIVATE_EVIDENCE_FILE" \
+          --journal "$PRIVATE_GATEWAY_LOG" \
+          --row "$ROW_ID" \
+          > "$RUN_DIR/targeted-return-resolution.json" 2> "$RUN_DIR/targeted-return-collector.error.log"; then
+        TARGETED_RETURN_RECEIPT_SHA256="$(node --input-type=module -e 'import { createHash } from "node:crypto"; import { readFileSync } from "node:fs"; process.stdout.write(createHash("sha256").update(readFileSync(process.argv[1])).digest("hex"));' "$RUN_DIR/$TARGETED_RETURN_RECEIPT")"
+        SUMMARY_VERDICT="$(jq -r '.verdict // "PARTIAL-candidate"' "$RUN_DIR/$TARGETED_RETURN_RECEIPT")"
+        SUMMARY_VERDICT_SOURCE="targeted-return-receipt"
+        SUMMARY_FILE_VERDICT="$SUMMARY_VERDICT"
+        VU_LOG_VERDICT=""
+        rm -f "$RUN_DIR/targeted-return-collector.error.log"
+        echo "[$ROW_ID] TARGETED-RETURN RECEIPT: $RUN_DIR/$TARGETED_RETURN_RECEIPT ($SUMMARY_VERDICT)"
+      else
+        SUMMARY_VERDICT="PARTIAL-candidate"
+        SUMMARY_VERDICT_SOURCE="targeted-return-receipt-missing"
+        REVIEW_PENDING_RECEIPTS="$(
+          jq -cn --argjson current "$REVIEW_PENDING_RECEIPTS" \
+            '$current + ["targeted-return-receipt"] | unique'
+        )"
+        echo "[$ROW_ID] TARGETED-RETURN COLLECTOR FAILED; see $RUN_DIR/targeted-return-collector.error.log" >&2
+        POSTPROCESS_RC=1
+      fi
+    fi
+
     if ! node "$ARTIFACT_SANITIZER" \
       --input "$PRIVATE_EVIDENCE_FILE" \
       --out "$RUN_DIR/evidence.jsonl" \
@@ -1462,6 +1495,10 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
       AUTHORITATIVE_RECEIPT="$R_CD_TOKEN_RECEIPT"
       AUTHORITATIVE_RECEIPT_SHA256="$R_CD_TOKEN_RECEIPT_SHA256"
       AUTHORITATIVE_RECEIPT_SOURCE="r-cd-token-row-scoped-resolver"
+    elif [[ "$ROW_ID" == "R-CD-4" || "$ROW_ID" == "R-CD-CHAINED-DEPTH-2" ]]; then
+      AUTHORITATIVE_RECEIPT="$TARGETED_RETURN_RECEIPT"
+      AUTHORITATIVE_RECEIPT_SHA256="$TARGETED_RETURN_RECEIPT_SHA256"
+      AUTHORITATIVE_RECEIPT_SOURCE="shared-targeted-return-collector"
     fi
     jq -n \
       --argjson rc "$k6_rc" \

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -1398,7 +1398,18 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
     TARGETED_RETURN_RECEIPT_SHA256=""
     if [[ "$ROW_ID" == "R-CD-4" || "$ROW_ID" == "R-CD-CHAINED-DEPTH-2" ]]; then
       TARGETED_RETURN_RECEIPT="targeted-return-receipt.json"
-      if [[ -s "$PRIVATE_EVIDENCE_FILE" && -f "$PRIVATE_GATEWAY_LOG" ]] && \
+      # Collector HMAC-seals with OPENCLAW_GATEWAY_TOKEN (same contract as R-CD-2/TOKEN).
+      # Candidate validator re-checks the seal via validateTargetedReturnReceipt(receipt, token).
+      if [[ -z "${OPENCLAW_GATEWAY_TOKEN:-}" ]]; then
+        echo "[$ROW_ID] TARGETED-RETURN COLLECTOR FAILED: OPENCLAW_GATEWAY_TOKEN required for HMAC seal" >&2
+        SUMMARY_VERDICT="PARTIAL-candidate"
+        SUMMARY_VERDICT_SOURCE="targeted-return-receipt-missing"
+        REVIEW_PENDING_RECEIPTS="$(
+          jq -cn --argjson current "$REVIEW_PENDING_RECEIPTS" \
+            '$current + ["targeted-return-receipt"] | unique'
+        )"
+        POSTPROCESS_RC=1
+      elif [[ -s "$PRIVATE_EVIDENCE_FILE" && -f "$PRIVATE_GATEWAY_LOG" ]] && \
         node "$TARGETED_RETURN_COLLECTOR" \
           --run-dir "$RUN_DIR" \
           --evidence "$PRIVATE_EVIDENCE_FILE" \

--- a/tools/k6-proofs/scripts/validate-candidate-run-result.mjs
+++ b/tools/k6-proofs/scripts/validate-candidate-run-result.mjs
@@ -10,6 +10,7 @@ import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { validateRcd2AuthoritativeReceipt } from '../lib/r-cd-2-authoritative-receipt.mjs';
 import { validateRcdTokenAuthoritativeReceipt } from '../lib/r-cd-token-authoritative-receipt.mjs';
+import { validateTargetedReturnReceipt } from '../lib/targeted-return-receipt.mjs';
 import { COPIED_MANIFEST, COPIED_SCENARIO, isSafeArtifactReference, isSafeCandidateArtifact } from './candidate-run-result-contract.mjs';
 
 const SHA = /^[0-9a-f]{40}$/;
@@ -185,6 +186,13 @@ function authoritativeReceiptContract(rowId) {
       file: 'r-cd-token-authoritative-receipt.json',
       verdictSource: 'r-cd-token-authoritative-receipt',
       validate: validateRcdTokenAuthoritativeReceipt,
+    };
+  }
+  if (rowId === 'R-CD-4' || rowId === 'R-CD-CHAINED-DEPTH-2') {
+    return {
+      file: 'targeted-return-receipt.json',
+      verdictSource: 'targeted-return-receipt',
+      validate: (receipt) => validateTargetedReturnReceipt(receipt, rowId),
     };
   }
   return null;

--- a/tools/k6-proofs/scripts/validate-candidate-run-result.mjs
+++ b/tools/k6-proofs/scripts/validate-candidate-run-result.mjs
@@ -192,7 +192,8 @@ function authoritativeReceiptContract(rowId) {
     return {
       file: 'targeted-return-receipt.json',
       verdictSource: 'targeted-return-receipt',
-      validate: (receipt) => validateTargetedReturnReceipt(receipt, rowId),
+      // Same gateway-token HMAC contract as R-CD-2/R-CD-TOKEN authoritative receipts.
+      validate: (receipt, signingKey) => validateTargetedReturnReceipt(receipt, signingKey, rowId),
     };
   }
   return null;

--- a/tools/k6-proofs/tests/r-cd-4-authority.test.mjs
+++ b/tools/k6-proofs/tests/r-cd-4-authority.test.mjs
@@ -4,11 +4,12 @@ import {
   R_CD_4_DURATION_THRESHOLD_MS,
   R_CD_4_OBSERVATION_WINDOW_MS,
   rCd4ChildAuthority,
+  rCd4DiagnosticMarkerCandidate,
   rCd4HistoryObservation,
+  rCd4JournalReturnAuthority,
   rCd4ReturnCandidate,
   rCd4ReturnReceipt,
   rCd4SessionMessageObservation,
-  rCd4ShouldScheduleEarlyClose,
   rCd4TaskIdentityToken,
   rCd4TaskObservation,
   rCd4TaskPrompt,
@@ -17,6 +18,7 @@ import {
 const nonce = 'R-CD-4-EXACT-NONCE';
 const target = 'agent:main:r-cd-4-target';
 const parent = 'agent:main:r-cd-4-parent';
+const child = 'agent:main:subagent:child';
 
 test('R-CD-4 duration threshold leaves headroom after the full observation window', () => {
   assert.ok(R_CD_4_DURATION_THRESHOLD_MS > R_CD_4_OBSERVATION_WINDOW_MS);
@@ -29,18 +31,10 @@ test('R-CD-4 child authority fails closed across conflicting observations', () =
     childSessionKey: 'agent:main:subagent:child-a',
     ambiguous: false,
   });
-  assert.deepEqual(rCd4ChildAuthority([
+  assert.equal(rCd4ChildAuthority([
     'agent:main:subagent:child-a',
     'agent:main:subagent:child-b',
-    'agent:main:subagent:child-a',
-  ]), {
-    observedChildSessionKeys: [
-      'agent:main:subagent:child-a',
-      'agent:main:subagent:child-b',
-    ],
-    childSessionKey: null,
-    ambiguous: true,
-  });
+  ]).ambiguous, true);
 });
 
 test('R-CD-4 task prompt keeps the compact token in the traced reason', () => {
@@ -52,8 +46,8 @@ test('R-CD-4 task prompt keeps the compact token in the traced reason', () => {
   assert.ok(prompt.startsWith(rCd4TaskIdentityToken(nonce)));
 });
 
-test('R-CD-4 accepts only the exact target marker and binds child identity', () => {
-  const candidate = rCd4ReturnCandidate({
+test('R-CD-4 transcript TARGET-RECEIVED is diagnostic only and never delivery authority', () => {
+  const marker = rCd4DiagnosticMarkerCandidate({
     eventName: 'session.message',
     eventData: {
       sessionKey: target,
@@ -62,93 +56,18 @@ test('R-CD-4 accepts only the exact target marker and binds child identity', () 
     expectedSessionKey: target,
     nonce,
   });
-  assert.deepEqual(rCd4ReturnReceipt(candidate, 'agent:main:subagent:child'), {
-    eventName: 'session.message',
-    sessionKey: target,
-    nonce,
-    marker: `TARGET-RECEIVED ${nonce}`,
-    role: 'system',
-    childSessionKey: 'agent:main:subagent:child',
-  });
-});
-
-test('R-CD-4 rejects an unrelated delayed target message', () => {
-  assert.equal(rCd4ReturnCandidate({
-    eventName: 'session.message',
-    eventData: { sessionKey: target, message: { role: 'system', content: 'ordinary delayed target output' } },
-    expectedSessionKey: target,
-    nonce,
-  }), null);
-});
-
-test('R-CD-4 rejects prompt echo and nonce-prefix lookalikes', () => {
-  assert.equal(rCd4ReturnCandidate({
-    eventName: 'session.message',
-    eventData: {
-      sessionKey: target,
-      message: { role: 'system', content: `[k6-proof-harness] ask for TARGET-RECEIVED ${nonce}` },
-    },
-    expectedSessionKey: target,
-    nonce,
-  }), null);
-  assert.equal(rCd4ReturnCandidate({
-    eventName: 'session.message',
-    eventData: { sessionKey: target, message: { role: 'system', content: `TARGET-RECEIVED ${nonce}-STALE` } },
-    expectedSessionKey: target,
-    nonce,
-  }), null);
-});
-
-test('R-CD-4 never routes from a nested session-key mention', () => {
-  assert.equal(rCd4ReturnCandidate({
-    eventName: 'session.message',
-    eventData: { sessionKey: parent, message: { role: 'system', content: `for ${target}: TARGET-RECEIVED ${nonce}` } },
-    expectedSessionKey: target,
-    nonce,
-  }), null);
-});
-
-test('R-CD-4 withholds a marker candidate until child identity is available', () => {
-  const candidate = rCd4ReturnCandidate({
+  assert.equal(marker.authoritative, false);
+  assert.equal(rCd4ReturnReceipt(marker, child), null);
+  // Deprecated alias still cannot promote PASS.
+  assert.equal(rCd4ReturnReceipt(rCd4ReturnCandidate({
     eventName: 'session.message',
     eventData: { sessionKey: target, message: { role: 'system', content: `TARGET-RECEIVED ${nonce}` } },
     expectedSessionKey: target,
     nonce,
-  });
-  assert.equal(rCd4ReturnReceipt(candidate, null), null);
+  }), child), null);
 });
 
-test('R-CD-4 rejects an assistant-authored marker in the target session', () => {
-  assert.equal(rCd4ReturnCandidate({
-    eventName: 'session.message',
-    eventData: {
-      sessionKey: target,
-      message: { role: 'assistant', content: `TARGET-RECEIVED ${nonce}` },
-    },
-    expectedSessionKey: target,
-    nonce,
-  }), null);
-});
-
-test('R-CD-4 rejects a marker present only in sibling or nested metadata', () => {
-  const eventData = {
-    sessionKey: target,
-    message: {
-      role: 'system',
-      content: [{ type: 'text', text: 'unrelated target system message' }],
-      metadata: { echoedMarker: `TARGET-RECEIVED ${nonce}` },
-    },
-    metadata: { returnMarker: `TARGET-RECEIVED ${nonce}` },
-  };
-  assert.equal(rCd4ReturnCandidate({
-    eventName: 'session.message',
-    eventData,
-    expectedSessionKey: target,
-    nonce,
-  }), null);
-});
-
-test('R-CD-4 retains an authoritative target receipt before the generic wake gate', () => {
+test('R-CD-4 session/history observations never populate authoritative candidates', () => {
   const observation = rCd4SessionMessageObservation({
     eventName: 'session.message',
     eventData: {
@@ -158,94 +77,64 @@ test('R-CD-4 retains an authoritative target receipt before the generic wake gat
     targetSessionKey: target,
     parentSessionKey: parent,
     nonce,
-    elapsedMs: 1_000,
-    wakeGateMs: 5_000,
+    elapsedMs: 1000,
+    wakeGateMs: 5000,
   });
-  assert.equal(observation.genericWakeObserved, false);
+  assert.equal(observation.targetCandidate, null);
   assert.equal(observation.parentCandidate, null);
-  assert.equal(observation.targetCandidate?.sessionKey, target);
-  assert.notEqual(rCd4ReturnReceipt(
-    observation.targetCandidate,
-    'agent:main:subagent:child',
-  ), null);
-});
+  assert.equal(observation.targetDiagnosticMarker?.authoritative, false);
 
-test('R-CD-4 recovers an authoritative target return from sessions.get history', () => {
-  const observation = rCd4HistoryObservation({
-    messages: [
-      { role: 'user', content: `[k6-proof-harness] ask for TARGET-RECEIVED ${nonce}` },
-      { role: 'system', content: `TARGET-RECEIVED ${nonce}` },
-    ],
+  const history = rCd4HistoryObservation({
+    messages: [{ role: 'system', content: `TARGET-RECEIVED ${nonce}` }],
     sessionKey: target,
     targetSessionKey: target,
     parentSessionKey: parent,
     nonce,
-    elapsedMs: 6_000,
-    wakeGateMs: 5_000,
+    elapsedMs: 6000,
+    wakeGateMs: 5000,
   });
-  assert.equal(observation.parentCandidate, null);
-  assert.equal(observation.targetCandidate?.sessionKey, target);
-  assert.equal(observation.genericWakeObserved, true);
+  assert.equal(history.targetCandidate, null);
+  assert.equal(history.targetDiagnosticMarker?.marker, 'TARGET-RECEIVED');
 });
 
-test('R-CD-4 history recovery still identifies a parent-session misroute', () => {
-  const observation = rCd4HistoryObservation({
-    messages: [{ role: 'system', content: `TARGET-RECEIVED ${nonce}` }],
-    sessionKey: parent,
+test('R-CD-4 journal authority PASSes on exact target delivery and rejects parent', () => {
+  const ts = '2026-08-09T17:13:29.848-07:00';
+  const start = Date.parse('2026-08-09T17:13:00.000-07:00');
+  const end = Date.parse('2026-08-09T17:14:00.000-07:00');
+  const journal = `${ts} node: [continuation:targeted-return] Delivered to ${target} from ${child}\n`;
+  const pass = rCd4JournalReturnAuthority({
+    journalText: journal,
     targetSessionKey: target,
     parentSessionKey: parent,
-    nonce,
-    elapsedMs: 6_000,
-    wakeGateMs: 5_000,
+    childSessionKey: child,
+    windowStartMs: start,
+    windowEndMs: end,
   });
-  assert.equal(observation.targetCandidate, null);
-  assert.equal(observation.parentCandidate?.sessionKey, parent);
-});
+  assert.equal(pass.verdict, 'PASS-candidate');
 
-test('R-CD-4 retains an early parent receipt so a later target cannot false-PASS', () => {
-  const earlyParent = rCd4SessionMessageObservation({
-    eventName: 'session.message',
-    eventData: {
-      sessionKey: parent,
-      message: { role: 'system', content: `TARGET-RECEIVED ${nonce}` },
-    },
+  const withParent = rCd4JournalReturnAuthority({
+    journalText: journal + `${ts} node: [continuation:targeted-return] Delivered to ${parent} from ${child}\n`,
     targetSessionKey: target,
     parentSessionKey: parent,
-    nonce,
-    elapsedMs: 1_000,
-    wakeGateMs: 5_000,
+    childSessionKey: child,
+    windowStartMs: start,
+    windowEndMs: end,
   });
-  const laterTarget = rCd4SessionMessageObservation({
-    eventName: 'session.message',
-    eventData: {
-      sessionKey: target,
-      message: { role: 'system', content: `TARGET-RECEIVED ${nonce}` },
-    },
-    targetSessionKey: target,
-    parentSessionKey: parent,
-    nonce,
-    elapsedMs: 6_000,
-    wakeGateMs: 5_000,
-  });
-  const child = 'agent:main:subagent:child';
-  assert.equal(earlyParent.genericWakeObserved, false);
-  assert.notEqual(rCd4ReturnReceipt(earlyParent.parentCandidate, child), null);
-  assert.notEqual(rCd4ReturnReceipt(laterTarget.targetCandidate, child), null);
+  assert.equal(withParent.failureCategory, 'parent-delivery');
 });
 
 test('R-CD-4 accepts tasks.list child authority only from a nonce-bound childSessionKey', () => {
   const taskIdentityToken = rCd4TaskIdentityToken(nonce);
   const title = `[continuation:chain-hop:1] Delegated task (turn 1/3): ${taskIdentityToken} Proof nonce ${nonce}`
     .slice(0, 80);
-  assert.ok(title.includes(taskIdentityToken));
   assert.deepEqual(rCd4TaskObservation({
     sessionKey: parent,
-    childSessionKey: 'agent:main:subagent:child',
+    childSessionKey: child,
     title,
     status: 'completed',
     traceId: 'a'.repeat(32),
   }, nonce), {
-    childSessionKey: 'agent:main:subagent:child',
+    childSessionKey: child,
     completed: true,
     traceId: 'a'.repeat(32),
   });
@@ -261,72 +150,5 @@ test('R-CD-4 rejects requester sessionKey and nested nonce as tasks.list child a
       task: `unrelated ${nonce}`,
     },
   }, nonce);
-  assert.deepEqual(observation, {
-    childSessionKey: null,
-    completed: false,
-    traceId: null,
-  });
-  const targetCandidate = rCd4ReturnCandidate({
-    eventName: 'session.message',
-    eventData: {
-      sessionKey: target,
-      message: { role: 'system', content: `TARGET-RECEIVED ${nonce}` },
-    },
-    expectedSessionKey: target,
-    nonce,
-  });
-  assert.equal(rCd4ReturnReceipt(targetCandidate, observation.childSessionKey), null);
-});
-
-test('R-CD-4 rejects nonce-bearing routing keys with an unrelated stale child', () => {
-  assert.deepEqual(rCd4TaskObservation({
-    sessionKey: `agent:main:r-cd-4-parent-${nonce}`,
-    childSessionKey: 'agent:main:subagent:stale-child',
-    title: 'unrelated completed task',
-    status: 'completed',
-  }, nonce), {
-    childSessionKey: null,
-    completed: false,
-    traceId: null,
-  });
-
-  assert.deepEqual(rCd4TaskObservation({
-    sessionKey: 'agent:main:requester',
-    childSessionKey: `agent:main:subagent:stale-${nonce}`,
-    title: 'unrelated completed task',
-    status: 'completed',
-  }, nonce), {
-    childSessionKey: null,
-    completed: false,
-    traceId: null,
-  });
-});
-
-test('R-CD-4 keeps observing after a target receipt but closes early on parent failure', () => {
-  const child = 'agent:main:subagent:child';
-  const targetReceipt = rCd4ReturnReceipt(rCd4ReturnCandidate({
-    eventName: 'session.message',
-    eventData: {
-      sessionKey: target,
-      message: { role: 'system', content: `TARGET-RECEIVED ${nonce}` },
-    },
-    expectedSessionKey: target,
-    nonce,
-  }), child);
-  const parentReceipt = rCd4ReturnReceipt(rCd4ReturnCandidate({
-    eventName: 'session.message',
-    eventData: {
-      sessionKey: parent,
-      message: { role: 'system', content: `TARGET-RECEIVED ${nonce}` },
-    },
-    expectedSessionKey: parent,
-    nonce,
-  }), child);
-
-  assert.equal(rCd4ShouldScheduleEarlyClose({ parentReturnReceipt: null }), false);
-  assert.equal(rCd4ShouldScheduleEarlyClose({
-    targetReturnReceipt: targetReceipt,
-    parentReturnReceipt: null,
-  }), false);
-  assert.equal(rCd4ShouldScheduleEarlyClose({ parentReturnReceipt: parentReceipt }), true);
+  assert.equal(observation.childSessionKey, null);
 });

--- a/tools/k6-proofs/tests/r-cd-4-authority.test.mjs
+++ b/tools/k6-proofs/tests/r-cd-4-authority.test.mjs
@@ -98,6 +98,7 @@ test('R-CD-4 session/history observations never populate authoritative candidate
 });
 
 test('R-CD-4 journal authority PASSes on exact target delivery and rejects parent', () => {
+  const signingKey = 'r-cd-4-unit-gateway-token';
   const ts = '2026-08-09T17:13:29.848-07:00';
   const start = Date.parse('2026-08-09T17:13:00.000-07:00');
   const end = Date.parse('2026-08-09T17:14:00.000-07:00');
@@ -109,8 +110,11 @@ test('R-CD-4 journal authority PASSes on exact target delivery and rejects paren
     childSessionKey: child,
     windowStartMs: start,
     windowEndMs: end,
+    signingKey,
   });
   assert.equal(pass.verdict, 'PASS-candidate');
+  assert.equal(pass.structuralOk, true);
+  assert.equal(pass.integrity?.algorithm, 'hmac-sha256-gateway-token-v1');
 
   const withParent = rCd4JournalReturnAuthority({
     journalText: journal + `${ts} node: [continuation:targeted-return] Delivered to ${parent} from ${child}\n`,
@@ -119,6 +123,7 @@ test('R-CD-4 journal authority PASSes on exact target delivery and rejects paren
     childSessionKey: child,
     windowStartMs: start,
     windowEndMs: end,
+    signingKey,
   });
   assert.equal(withParent.failureCategory, 'parent-delivery');
 });

--- a/tools/k6-proofs/tests/r-cd-chained-depth-2-authority.test.mjs
+++ b/tools/k6-proofs/tests/r-cd-chained-depth-2-authority.test.mjs
@@ -14,6 +14,7 @@ const nonce = 'R-CD-CHAIN-EXACT-NONCE';
 const root = 'agent:main:r-cd-chain-root';
 const child = 'agent:main:subagent:child';
 const grandchild = 'agent:main:subagent:grandchild';
+const signingKey = 'r-cd-chained-depth-2-unit-gateway-token';
 
 function systemEvent(text, sessionKey = root) {
   return { sessionKey, message: { role: 'system', content: [{ type: 'text', text }] } };
@@ -68,10 +69,13 @@ test('depth-2 shared journal collector binds grandchild→root under fanoutMode=
     grandchildSessionKey: grandchild,
     windowStartMs: start,
     windowEndMs: end,
+    signingKey,
   });
   assert.equal(receipt.verdict, 'PASS-candidate');
   assert.equal(receipt.targetMatchCount, 1);
   assert.equal(receipt.parentMatchCount, 0);
+  assert.equal(receipt.structuralOk, true);
+  assert.equal(receipt.integrity?.algorithm, 'hmac-sha256-gateway-token-v1');
 });
 
 test('depth-2 journal authority fails when hops are missing', () => {
@@ -80,9 +84,12 @@ test('depth-2 journal authority fails when hops are missing', () => {
     rootSessionKey: root,
     childSessionKey: child,
     grandchildSessionKey: null,
+    signingKey,
   });
   assert.equal(receipt.failureCategory, 'missing-hop');
   assert.equal(receipt.verdict, 'PARTIAL-candidate');
+  assert.equal(receipt.structuralOk, false);
+  assert.equal(receipt.integrity?.algorithm, 'hmac-sha256-gateway-token-v1');
 });
 
 test('depth-2 tree multi-target delivery to root+intermediate PASSes', () => {
@@ -98,6 +105,7 @@ test('depth-2 tree multi-target delivery to root+intermediate PASSes', () => {
     grandchildSessionKey: grandchild,
     windowStartMs: start,
     windowEndMs: end,
+    signingKey,
   });
   assert.equal(receipt.verdict, 'PASS-candidate');
   assert.equal(receipt.targetMatchCount, 1);
@@ -117,6 +125,7 @@ test('depth-2 separate intermediate+root lines still PASS under tree fanout', ()
     grandchildSessionKey: grandchild,
     windowStartMs: start,
     windowEndMs: end,
+    signingKey,
   });
   assert.equal(receipt.verdict, 'PASS-candidate');
 });

--- a/tools/k6-proofs/tests/r-cd-chained-depth-2-authority.test.mjs
+++ b/tools/k6-proofs/tests/r-cd-chained-depth-2-authority.test.mjs
@@ -1,99 +1,123 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import {
+  rCdChainHopIdentities,
+  rCdChainJournalReturnAuthority,
+  rCdChainNestedDelegateSpec,
+  rCdChainPromptTemplate,
   rCdChainRootReturnCandidate,
   rCdChainRootReturnReceipt,
 } from '../lib/r-cd-chained-depth-2-authority.mjs';
 
 const nonce = 'R-CD-CHAIN-EXACT-NONCE';
 const root = 'agent:main:r-cd-chain-root';
+const child = 'agent:main:subagent:child';
+const grandchild = 'agent:main:subagent:grandchild';
 
 function systemEvent(text, sessionKey = root) {
   return { sessionKey, message: { role: 'system', content: [{ type: 'text', text }] } };
 }
 
-test('depth-2 chain binds an explicit root system receipt to both hop identities', () => {
+test('depth-2 nested call explicitly requests fanoutMode=tree', () => {
+  const nested = rCdChainNestedDelegateSpec({ nonce });
+  assert.equal(nested.fanoutMode, 'tree');
+  assert.equal(nested.mode, 'silent-wake');
+  const template = rCdChainPromptTemplate();
+  assert.match(template, /fanoutMode='tree'/);
+  assert.match(template, /GRANDCHILD-DONE \{\{nonce\}\}/);
+  assert.match(template, /CHILD-DONE \{\{nonce\}\} CHILD-DELEGATE-SCHEDULED/);
+});
+
+test('manifest nested prompt includes fanoutMode=tree and no fictional three-subtest list', async () => {
+  const manifest = JSON.parse(await readFile(new URL('../manifests/r-cd-chained-depth-2.json', import.meta.url), 'utf8'));
+  assert.match(manifest.invocation.promptTemplate, /fanoutMode='tree'/);
+  assert.equal(manifest.scenario.subtests, undefined);
+  assert.doesNotMatch(manifest.scenario.description, /Three sub-tests/i);
+});
+
+test('depth-2 requires two distinct hop identities', () => {
+  assert.equal(rCdChainHopIdentities({ childSessionKey: child, grandchildSessionKey: null }).ok, false);
+  assert.equal(rCdChainHopIdentities({ childSessionKey: child, grandchildSessionKey: child }).ok, false);
+  assert.equal(rCdChainHopIdentities({ childSessionKey: child, grandchildSessionKey: grandchild }).ok, true);
+});
+
+test('depth-2 transcript root marker is never routing authority', () => {
   const candidate = rCdChainRootReturnCandidate({
     eventName: 'session.message',
     eventData: systemEvent(`GRANDCHILD-DONE ${nonce}`),
     rootSessionKey: root,
     nonce,
   });
-  assert.deepEqual(rCdChainRootReturnReceipt(candidate, {
-    childSessionKey: 'agent:main:subagent:child',
-    grandchildSessionKey: 'agent:main:subagent:grandchild',
-  }), {
-    eventName: 'session.message',
-    rootSessionKey: root,
-    nonce,
-    marker: `GRANDCHILD-DONE ${nonce}`,
-    role: 'system',
-    childSessionKey: 'agent:main:subagent:child',
-    grandchildSessionKey: 'agent:main:subagent:grandchild',
-  });
-});
-
-test('depth-2 chain rejects ordinary GRANDCHILD-DONE assistant output', () => {
-  assert.equal(rCdChainRootReturnCandidate({
-    eventName: 'session.message',
-    eventData: {
-      sessionKey: root,
-      message: { role: 'assistant', content: `GRANDCHILD-DONE ${nonce}` },
-    },
-    rootSessionKey: root,
-    nonce,
-  }), null);
-});
-
-test('depth-2 chain rejects a correct marker delivered outside the root', () => {
-  assert.equal(rCdChainRootReturnCandidate({
-    eventName: 'session.message',
-    eventData: systemEvent(`GRANDCHILD-DONE ${nonce}`, 'agent:main:subagent:child'),
-    rootSessionKey: root,
-    nonce,
-  }), null);
-});
-
-test('depth-2 chain rejects prompt echoes and nonce-prefix lookalikes', () => {
-  assert.equal(rCdChainRootReturnCandidate({
-    eventName: 'session.message',
-    eventData: systemEvent(`[k6-proof-harness] expect GRANDCHILD-DONE ${nonce}`),
-    rootSessionKey: root,
-    nonce,
-  }), null);
-  assert.equal(rCdChainRootReturnCandidate({
-    eventName: 'session.message',
-    eventData: systemEvent(`GRANDCHILD-DONE ${nonce}-STALE`),
-    rootSessionKey: root,
-    nonce,
-  }), null);
-});
-
-test('depth-2 chain rejects a marker present only in sibling or nested metadata', () => {
-  const eventData = systemEvent('unrelated root system message');
-  eventData.metadata = { returnMarker: `GRANDCHILD-DONE ${nonce}` };
-  eventData.message.metadata = { echoedMarker: `GRANDCHILD-DONE ${nonce}` };
-  assert.equal(rCdChainRootReturnCandidate({
-    eventName: 'session.message',
-    eventData,
-    rootSessionKey: root,
-    nonce,
-  }), null);
-});
-
-test('depth-2 chain withholds return authority without two distinct hop identities', () => {
-  const candidate = rCdChainRootReturnCandidate({
-    eventName: 'session.message',
-    eventData: systemEvent(`GRANDCHILD-DONE ${nonce}`),
-    rootSessionKey: root,
-    nonce,
-  });
+  assert.equal(candidate.authoritative, false);
   assert.equal(rCdChainRootReturnReceipt(candidate, {
-    childSessionKey: 'agent:main:subagent:child',
+    childSessionKey: child,
+    grandchildSessionKey: grandchild,
+  }), null);
+});
+
+test('depth-2 shared journal collector binds grandchild→root under fanoutMode=tree', () => {
+  const ts = '2026-08-09T17:15:19.000-07:00';
+  const start = Date.parse('2026-08-09T17:14:00.000-07:00');
+  const end = Date.parse('2026-08-09T17:16:00.000-07:00');
+  const journal = `${ts} node: [continuation:targeted-return] Delivered to ${root} from ${grandchild}\n`;
+  const receipt = rCdChainJournalReturnAuthority({
+    journalText: journal,
+    rootSessionKey: root,
+    childSessionKey: child,
+    grandchildSessionKey: grandchild,
+    windowStartMs: start,
+    windowEndMs: end,
+  });
+  assert.equal(receipt.verdict, 'PASS-candidate');
+  assert.equal(receipt.targetMatchCount, 1);
+  assert.equal(receipt.parentMatchCount, 0);
+});
+
+test('depth-2 journal authority fails when hops are missing', () => {
+  const receipt = rCdChainJournalReturnAuthority({
+    journalText: '',
+    rootSessionKey: root,
+    childSessionKey: child,
     grandchildSessionKey: null,
-  }), null);
-  assert.equal(rCdChainRootReturnReceipt(candidate, {
-    childSessionKey: 'agent:main:subagent:same',
-    grandchildSessionKey: 'agent:main:subagent:same',
-  }), null);
+  });
+  assert.equal(receipt.failureCategory, 'missing-hop');
+  assert.equal(receipt.verdict, 'PARTIAL-candidate');
 });
+
+test('depth-2 tree multi-target delivery to root+intermediate PASSes', () => {
+  const ts = '2026-08-09T17:15:19.000-07:00';
+  const start = Date.parse('2026-08-09T17:14:00.000-07:00');
+  const end = Date.parse('2026-08-09T17:16:00.000-07:00');
+  const journal =
+    `${ts} node: [continuation:targeted-return] Delivered to ${child},${root} from ${grandchild}\n`;
+  const receipt = rCdChainJournalReturnAuthority({
+    journalText: journal,
+    rootSessionKey: root,
+    childSessionKey: child,
+    grandchildSessionKey: grandchild,
+    windowStartMs: start,
+    windowEndMs: end,
+  });
+  assert.equal(receipt.verdict, 'PASS-candidate');
+  assert.equal(receipt.targetMatchCount, 1);
+});
+
+test('depth-2 separate intermediate+root lines still PASS under tree fanout', () => {
+  const start = Date.parse('2026-08-09T17:14:00.000-07:00');
+  const end = Date.parse('2026-08-09T17:16:00.000-07:00');
+  const journal = [
+    '2026-08-09T17:15:18.000-07:00 node: [continuation:targeted-return] Delivered to ' + child + ' from ' + grandchild,
+    '2026-08-09T17:15:19.000-07:00 node: [continuation:targeted-return] Delivered to ' + root + ' from ' + grandchild,
+  ].join('\n');
+  const receipt = rCdChainJournalReturnAuthority({
+    journalText: journal,
+    rootSessionKey: root,
+    childSessionKey: child,
+    grandchildSessionKey: grandchild,
+    windowStartMs: start,
+    windowEndMs: end,
+  });
+  assert.equal(receipt.verdict, 'PASS-candidate');
+});
+

--- a/tools/k6-proofs/tests/r-cd-chained-depth-2-authority.test.mjs
+++ b/tools/k6-proofs/tests/r-cd-chained-depth-2-authority.test.mjs
@@ -8,6 +8,7 @@ import {
   rCdChainPromptTemplate,
   rCdChainRootReturnCandidate,
   rCdChainRootReturnReceipt,
+  resolveUniqueSpawnedByChild,
 } from '../lib/r-cd-chained-depth-2-authority.mjs';
 
 const nonce = 'R-CD-CHAIN-EXACT-NONCE';
@@ -37,10 +38,82 @@ test('manifest nested prompt includes fanoutMode=tree and no fictional three-sub
   assert.doesNotMatch(manifest.scenario.description, /Three sub-tests/i);
 });
 
+test('depth-2 scenario requires a disposable ancestry root', async () => {
+  const scenario = await readFile(
+    new URL('../scenarios/r-cd-chained-depth-2.js', import.meta.url),
+    'utf8',
+  );
+  assert.match(
+    scenario,
+    /OPENCLAW_CREATE_DISPOSABLE_SESSION=true is required for R-CD-CHAINED-DEPTH-2/,
+  );
+  assert.match(scenario, /sessions\.list',\s*\{\s*spawnedBy:\s*parentSessionKey/);
+  assert.doesNotMatch(scenario, /observeChainSession\(task\.childSessionKey\)/);
+  assert.match(scenario, /child_ancestry_confirmations\s*>=\s*2/);
+  assert.match(scenario, /grandchild_ancestry_confirmations\s*>=\s*2/);
+  assert.match(scenario, /grandchild_ancestry_confirmed_at_ms\s*-\s*evidence\.dispatch_accepted_at_ms/);
+  assert.match(scenario, /evidence\.ancestry_stable === true/);
+  assert.match(scenario, /Math\.max\(30000,\s*configuredAncestryStabilityMs\)/);
+  assert.doesNotMatch(
+    scenario,
+    /ancestryRequest\.depth === 1 && evidence\.child_session &&\s*!evidence\.grandchild_session/,
+  );
+});
+
 test('depth-2 requires two distinct hop identities', () => {
   assert.equal(rCdChainHopIdentities({ childSessionKey: child, grandchildSessionKey: null }).ok, false);
   assert.equal(rCdChainHopIdentities({ childSessionKey: child, grandchildSessionKey: child }).ok, false);
   assert.equal(rCdChainHopIdentities({ childSessionKey: child, grandchildSessionKey: grandchild }).ok, true);
+});
+
+test('depth-2 resolves direct hops from spawnedBy ancestry despite truncated titles', () => {
+  const childPayload = {
+    sessions: [{
+      key: child,
+      spawnedBy: root,
+      title: 'Proof chain nonce R-CD-CHAIN-EXACT-NONCE-TRUNCATED-BEFORE-THE-REST',
+    }],
+  };
+  const childResult = resolveUniqueSpawnedByChild({
+    sessionsPayload: childPayload,
+    parentSessionKey: root,
+  });
+  assert.equal(childResult.uniqueChildKey, child);
+
+  const grandchildPayload = {
+    sessions: [{
+      key: grandchild,
+      spawnedBy: child,
+      title: 'Grandchild nonce R-CD-CHAIN-EXACT-NONCE-TRUNCATED-BEFORE-THE-REST',
+    }],
+  };
+  const grandchildResult = resolveUniqueSpawnedByChild({
+    sessionsPayload: grandchildPayload,
+    parentSessionKey: child,
+  });
+  assert.equal(grandchildResult.uniqueChildKey, grandchild);
+  assert.equal(
+    rCdChainHopIdentities({
+      childSessionKey: childResult.uniqueChildKey,
+      grandchildSessionKey: grandchildResult.uniqueChildKey,
+    }).ok,
+    true,
+  );
+});
+
+test('depth-2 ancestry fails closed on ambiguous direct children', () => {
+  const resolved = resolveUniqueSpawnedByChild({
+    sessionsPayload: {
+      sessions: [
+        { key: child, spawnedBy: root },
+        { key: 'agent:main:subagent:other', parentSessionKey: root },
+      ],
+    },
+    parentSessionKey: root,
+  });
+  assert.equal(resolved.uniqueChildKey, null);
+  assert.equal(resolved.ambiguous, true);
+  assert.equal(resolved.failureCategory, 'multiple-direct-children');
 });
 
 test('depth-2 transcript root marker is never routing authority', () => {
@@ -129,4 +202,3 @@ test('depth-2 separate intermediate+root lines still PASS under tree fanout', ()
   });
   assert.equal(receipt.verdict, 'PASS-candidate');
 });
-

--- a/tools/k6-proofs/tests/r-cd-model-tool-authority.test.mjs
+++ b/tools/k6-proofs/tests/r-cd-model-tool-authority.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {
   createModelToolDispatchGate,
   diffSpawnedByChildren,
+  mergeModelToolChildAuthorityEvidence,
   modelFromSessionMetadata,
   parentReturnContainsNonce,
   resolveModelToolChildAuthority,
@@ -40,6 +41,243 @@ test('model authority reads provider/model from the unique new child row only', 
     postKeys: sessionKeysFromListPayload(payload),
     sessionsPayload: payload,
     requestedModel: 'openai/gpt-5.6-luna',
+  });
+
+  test('event correlation confirms but never disambiguates the unique set-diff child', () => {
+    const payload = {
+      sessions: [
+        {
+          key: childA,
+          spawnedBy: parent,
+          modelProvider: 'openai',
+          model: 'gpt-5.6-luna',
+        },
+        {
+          key: childB,
+          spawnedBy: parent,
+          modelProvider: 'openai',
+          model: 'gpt-5.5',
+        },
+      ],
+    };
+    const ambiguous = resolveModelToolChildAuthority({
+      preKeys: [],
+      postKeys: [childA, childB],
+      sessionsPayload: payload,
+      requestedModel: 'openai/gpt-5.6-luna',
+      eventChildSessionKey: childA,
+      parentSessionKey: parent,
+    });
+    assert.equal(ambiguous.childSessionKey, null);
+    assert.equal(ambiguous.failureCategory, 'multiple-new-children');
+
+    const authority = resolveModelToolChildAuthority({
+      preKeys: [],
+      postKeys: [childA],
+      sessionsPayload: payload,
+      requestedModel: 'openai/gpt-5.6-luna',
+      eventChildSessionKey: childA,
+      parentSessionKey: parent,
+    });
+    assert.equal(authority.childSessionKey, childA);
+    assert.equal(authority.authoritySource, 'event-correlated-sessions-list');
+    assert.equal(authority.modelMatches, true);
+
+    const wrongParent = resolveModelToolChildAuthority({
+      preKeys: [],
+      postKeys: [childA],
+      sessionsPayload: payload,
+      requestedModel: 'openai/gpt-5.6-luna',
+      eventChildSessionKey: childA,
+      parentSessionKey: 'agent:main:other-parent',
+    });
+    assert.equal(wrongParent.childSessionKey, null);
+    assert.equal(wrongParent.failureCategory, 'child-parent-mismatch');
+  });
+
+  test('positive child metadata evidence is sticky across later empty polls', () => {
+    const positive = mergeModelToolChildAuthorityEvidence({}, {
+      childSessionKey: childA,
+      childSession: {
+        key: childA,
+        spawnedBy: parent,
+        modelProvider: 'openai',
+        model: 'gpt-5.6-luna',
+      },
+      childMetadataModelByte: 'openai/gpt-5.6-luna',
+      modelMatches: true,
+      authoritySource: 'event-correlated-sessions-list',
+      empty: false,
+      ambiguous: false,
+      failureCategory: null,
+    });
+    const afterEmptyPoll = mergeModelToolChildAuthorityEvidence(positive, {
+      childSessionKey: null,
+      childMetadataModelByte: null,
+      empty: true,
+      ambiguous: false,
+      failureCategory: 'zero-new-children',
+    });
+    assert.equal(afterEmptyPoll.child_session_key, childA);
+    assert.equal(afterEmptyPoll.child_session_metadata_observed, true);
+    assert.equal(afterEmptyPoll.model_matches, true);
+    assert.equal(afterEmptyPoll.spawned_by_diff_empty, false);
+    assert.equal(afterEmptyPoll.model_classification_reason, null);
+  });
+
+  test('later multiple-child ambiguity is sticky and invalidates prior authority', () => {
+    const positive = mergeModelToolChildAuthorityEvidence({}, {
+      childSessionKey: childA,
+      childSession: {
+        key: childA,
+        spawnedBy: parent,
+        modelProvider: 'openai',
+        model: 'gpt-5.6-luna',
+      },
+      childMetadataModelByte: 'openai/gpt-5.6-luna',
+      modelMatches: true,
+      authoritySource: 'spawned-by-set-diff',
+      empty: false,
+      ambiguous: false,
+      failureCategory: null,
+    });
+    const ambiguous = mergeModelToolChildAuthorityEvidence(positive, {
+      childSessionKey: null,
+      childMetadataModelByte: null,
+      empty: false,
+      ambiguous: true,
+      failureCategory: 'multiple-new-children',
+    });
+    assert.equal(ambiguous.spawned_by_diff_ambiguous, true);
+    assert.equal(ambiguous.model_matches, false);
+
+    const afterUniquePoll = mergeModelToolChildAuthorityEvidence(ambiguous, {
+      childSessionKey: childA,
+      childSession: {
+        key: childA,
+        spawnedBy: parent,
+        modelProvider: 'openai',
+        model: 'gpt-5.6-luna',
+      },
+      childMetadataModelByte: 'openai/gpt-5.6-luna',
+      modelMatches: true,
+      authoritySource: 'spawned-by-set-diff',
+      empty: false,
+      ambiguous: false,
+      failureCategory: null,
+    });
+    assert.equal(afterUniquePoll.spawned_by_diff_ambiguous, true);
+    assert.equal(afterUniquePoll.model_matches, false);
+  });
+
+  test('event and metadata child conflicts remain sticky and cannot be cleared', () => {
+    const conflict = mergeModelToolChildAuthorityEvidence({
+      event_child_session_key: childB,
+      event_child_session_observed: true,
+    }, {
+      childSessionKey: childA,
+      childSession: {
+        key: childA,
+        spawnedBy: parent,
+        modelProvider: 'openai',
+        model: 'gpt-5.6-luna',
+      },
+      childMetadataModelByte: 'openai/gpt-5.6-luna',
+      modelMatches: true,
+      authoritySource: 'spawned-by-set-diff',
+    });
+    assert.equal(conflict.child_identity_conflict, true);
+    assert.equal(conflict.model_matches, false);
+
+    const afterMatchingPoll = mergeModelToolChildAuthorityEvidence(conflict, {
+      childSessionKey: childB,
+      childSession: {
+        key: childB,
+        spawnedBy: parent,
+        modelProvider: 'openai',
+        model: 'gpt-5.6-luna',
+      },
+      childMetadataModelByte: 'openai/gpt-5.6-luna',
+      modelMatches: true,
+      authoritySource: 'event-correlated-sessions-list',
+    });
+    assert.equal(afterMatchingPoll.child_identity_conflict, true);
+    assert.equal(afterMatchingPoll.model_matches, false);
+  });
+
+  test('metadata-less replacement child invalidates prior authority', () => {
+    const positive = mergeModelToolChildAuthorityEvidence({}, {
+      childSessionKey: childA,
+      childSession: {
+        key: childA,
+        spawnedBy: parent,
+        modelProvider: 'openai',
+        model: 'gpt-5.6-luna',
+      },
+      childMetadataModelByte: 'openai/gpt-5.6-luna',
+      modelMatches: true,
+      authoritySource: 'spawned-by-set-diff',
+      empty: false,
+      ambiguous: false,
+    });
+    const replacementWithoutModel = mergeModelToolChildAuthorityEvidence(positive, {
+      childSessionKey: childB,
+      childSession: {
+        key: childB,
+        spawnedBy: parent,
+        model: null,
+      },
+      childMetadataModelByte: null,
+      modelMatches: false,
+      authoritySource: 'spawned-by-set-diff',
+      empty: false,
+      ambiguous: false,
+      failureCategory: 'missing-child-model-byte',
+    });
+    assert.equal(replacementWithoutModel.child_identity_conflict, true);
+    assert.equal(replacementWithoutModel.model_matches, false);
+  });
+
+  test('event-correlated authority cannot mask a later unique replacement child', () => {
+    const positive = mergeModelToolChildAuthorityEvidence({
+      event_child_session_key: childA,
+      event_child_session_observed: true,
+    }, resolveModelToolChildAuthority({
+      preKeys: [],
+      postKeys: [childA],
+      sessionsPayload: {
+        sessions: [{
+          key: childA,
+          spawnedBy: parent,
+          modelProvider: 'openai',
+          model: 'gpt-5.6-luna',
+        }],
+      },
+      requestedModel: 'openai/gpt-5.6-luna',
+      eventChildSessionKey: childA,
+      parentSessionKey: parent,
+    }));
+    const replacementAuthority = resolveModelToolChildAuthority({
+      preKeys: [childA],
+      postKeys: [childA, childB],
+      sessionsPayload: {
+        sessions: [{
+          key: childB,
+          spawnedBy: parent,
+          modelProvider: 'openai',
+          model: 'gpt-5.5',
+        }],
+      },
+      requestedModel: 'openai/gpt-5.6-luna',
+      eventChildSessionKey: childA,
+      parentSessionKey: parent,
+    });
+    assert.equal(replacementAuthority.childSessionKey, childB);
+    assert.equal(replacementAuthority.failureCategory, 'event-child-preexisting');
+
+    const merged = mergeModelToolChildAuthorityEvidence(positive, replacementAuthority);
+    assert.equal(merged.child_identity_conflict, true);
+    assert.equal(merged.model_matches, false);
   });
   assert.equal(ok.uniqueNewChildKey, null); // two added
   assert.equal(ok.failureCategory, 'multiple-new-children');
@@ -178,6 +416,12 @@ test('scenario requires disposable parent, spawnedBy filter, and baseline-gated 
   const scenario = await readFile(new URL('../scenarios/r-cd-model-tool.js', import.meta.url), 'utf8');
   assert.match(scenario, /OPENCLAW_CREATE_DISPOSABLE_SESSION=true is required/);
   assert.match(scenario, /sessions\.list',\s*\{\s*spawnedBy:\s*sessionKey,\s*limit:\s*100\s*\}/);
+  assert.match(scenario, /childSessionKeysForRow/);
+  assert.match(scenario, /event_child_session_key/);
+  assert.match(scenario, /listRequestPhases/);
+  assert.match(scenario, /mergeModelToolChildAuthorityEvidence/);
+  assert.match(scenario, /CHILD_AUTHORITY_STABILITY_MS = 30000/);
+  assert.match(scenario, /child_authority_stable === true/);
   assert.match(scenario, /pre_spawned_by_keys/);
   assert.match(scenario, /post_spawned_by_keys/);
   assert.match(scenario, /auxiliary child runtime-context self-report \(not used for equality\)/);

--- a/tools/k6-proofs/tests/r-cd-model-tool-authority.test.mjs
+++ b/tools/k6-proofs/tests/r-cd-model-tool-authority.test.mjs
@@ -84,10 +84,30 @@ test('child self-report cannot establish equality; parent schedule ack is not re
     ], 'nonce-x'),
     false,
   );
+  // Adversarial: paraphrased schedule acknowledgement must NOT prove return.
+  assert.equal(
+    parentReturnContainsNonce([
+      { role: 'assistant', content: 'Scheduled delegate for nonce-x; waiting for completion.' },
+    ], 'nonce-x'),
+    false,
+  );
+  // Loose MODEL-TOOL-CHILD mention without exact MODEL byte is not authority.
+  assert.equal(
+    parentReturnContainsNonce([
+      { role: 'assistant', content: 'saw MODEL-TOOL-CHILD for nonce-x earlier' },
+    ], 'nonce-x'),
+    false,
+  );
   // Child return marker in parent history IS a return receipt (auxiliary model text).
   assert.equal(
     parentReturnContainsNonce([
       { role: 'system', content: 'MODEL-TOOL-CHILD nonce-x MODEL openai/gpt-5.6-luna' },
+    ], 'nonce-x'),
+    true,
+  );
+  assert.equal(
+    parentReturnContainsNonce([
+      { role: 'assistant', content: 'Child finished: MODEL-TOOL-CHILD nonce-x MODEL openai/gpt-5.6-luna' },
     ], 'nonce-x'),
     true,
   );

--- a/tools/k6-proofs/tests/r-cd-model-tool-authority.test.mjs
+++ b/tools/k6-proofs/tests/r-cd-model-tool-authority.test.mjs
@@ -1,0 +1,119 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  diffSpawnedByChildren,
+  modelFromSessionMetadata,
+  parentReturnContainsNonce,
+  resolveModelToolChildAuthority,
+  sessionKeysFromListPayload,
+} from '../lib/r-cd-model-tool-authority.mjs';
+
+const parent = 'agent:main:r-cd-model-tool-parent';
+const childA = 'agent:main:subagent:child-a';
+const childB = 'agent:main:subagent:child-b';
+
+test('spawnedBy set-diff requires exactly one new child', () => {
+  assert.deepEqual(diffSpawnedByChildren([], [childA]), {
+    preCount: 0,
+    postCount: 1,
+    added: [childA],
+    removed: [],
+    uniqueNewChildKey: childA,
+    ambiguous: false,
+    empty: false,
+  });
+  assert.equal(diffSpawnedByChildren([], []).empty, true);
+  assert.equal(diffSpawnedByChildren([], [childA, childB]).ambiguous, true);
+  assert.equal(diffSpawnedByChildren([childA], [childA]).empty, true);
+});
+
+test('model authority reads provider/model from the unique new child row only', () => {
+  const payload = {
+    sessions: [
+      { key: childA, modelProvider: 'openai', model: 'gpt-5.6-luna' },
+      { key: childB, modelProvider: 'openai', model: 'gpt-5.5' },
+    ],
+  };
+  const ok = resolveModelToolChildAuthority({
+    preKeys: [],
+    postKeys: sessionKeysFromListPayload(payload),
+    sessionsPayload: payload,
+    requestedModel: 'openai/gpt-5.6-luna',
+  });
+  assert.equal(ok.uniqueNewChildKey, null); // two added
+  assert.equal(ok.failureCategory, 'multiple-new-children');
+
+  const single = resolveModelToolChildAuthority({
+    preKeys: [],
+    postKeys: [childA],
+    sessionsPayload: payload,
+    requestedModel: 'openai/gpt-5.6-luna',
+  });
+  assert.equal(single.childSessionKey, childA);
+  assert.equal(single.childMetadataModelByte, 'openai/gpt-5.6-luna');
+  assert.equal(single.modelMatches, true);
+  assert.equal(single.failureCategory, null);
+});
+
+test('zero new children and model mismatch fail closed', () => {
+  const zero = resolveModelToolChildAuthority({
+    preKeys: [childA],
+    postKeys: [childA],
+    sessionsPayload: { sessions: [{ key: childA, model: 'openai/gpt-5.6-luna' }] },
+    requestedModel: 'openai/gpt-5.6-luna',
+  });
+  assert.equal(zero.failureCategory, 'zero-new-children');
+
+  const mismatch = resolveModelToolChildAuthority({
+    preKeys: [],
+    postKeys: [childA],
+    sessionsPayload: { sessions: [{ key: childA, provider: 'openai', model: 'gpt-5.5' }] },
+    requestedModel: 'openai/gpt-5.6-luna',
+  });
+  assert.equal(mismatch.modelMatches, false);
+  assert.equal(mismatch.failureCategory, 'model-mismatch');
+});
+
+test('child self-report cannot establish equality; parent schedule ack is not return', () => {
+  assert.equal(modelFromSessionMetadata({ model: 'gpt-5.6-luna', provider: 'openai' }), 'openai/gpt-5.6-luna');
+  // Parent schedule ack alone is NOT child→parent return authority.
+  assert.equal(
+    parentReturnContainsNonce([
+      { role: 'user', content: '[k6-proof-harness] ignore MODEL-TOOL nonce-x' },
+      { role: 'assistant', content: 'MODEL-TOOL-PARENT-SCHEDULED nonce-x REQUESTED openai/gpt-5.6-luna' },
+    ], 'nonce-x'),
+    false,
+  );
+  // Child return marker in parent history IS a return receipt (auxiliary model text).
+  assert.equal(
+    parentReturnContainsNonce([
+      { role: 'system', content: 'MODEL-TOOL-CHILD nonce-x MODEL openai/gpt-5.6-luna' },
+    ], 'nonce-x'),
+    true,
+  );
+  assert.equal(
+    parentReturnContainsNonce([
+      { role: 'assistant', content: 'unrelated' },
+    ], 'nonce-x'),
+    false,
+  );
+  // Harness prompt alone is not a return.
+  assert.equal(
+    parentReturnContainsNonce([
+      { role: 'user', content: '[k6-proof-harness] nonce-x' },
+    ], 'nonce-x'),
+    false,
+  );
+});
+
+test('scenario requires disposable parent and spawnedBy list filter', async () => {
+  const { readFile } = await import('node:fs/promises');
+  const scenario = await readFile(new URL('../scenarios/r-cd-model-tool.js', import.meta.url), 'utf8');
+  assert.match(scenario, /OPENCLAW_CREATE_DISPOSABLE_SESSION=true is required/);
+  assert.match(scenario, /sessions\.list',\s*\{\s*spawnedBy:\s*sessionKey,\s*limit:\s*100\s*\}/);
+  assert.match(scenario, /pre_spawned_by_keys/);
+  assert.match(scenario, /post_spawned_by_keys/);
+  assert.match(scenario, /auxiliary child runtime-context self-report \(not used for equality\)/);
+  assert.match(scenario, /sessions\.get/);
+  assert.doesNotMatch(scenario, /production DB|sqlite|better-sqlite/i);
+});

--- a/tools/k6-proofs/tests/r-cd-model-tool-authority.test.mjs
+++ b/tools/k6-proofs/tests/r-cd-model-tool-authority.test.mjs
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  createModelToolDispatchGate,
   diffSpawnedByChildren,
   modelFromSessionMetadata,
   parentReturnContainsNonce,
@@ -126,7 +127,53 @@ test('child self-report cannot establish equality; parent schedule ack is not re
   );
 });
 
-test('scenario requires disposable parent and spawnedBy list filter', async () => {
+test('delayed pre-baseline still dispatches exactly once and never before baseline', () => {
+  const gate = createModelToolDispatchGate();
+  // Simulate the old fixed +800ms gap elapsing while pre sessions.list is still
+  // in flight: no dispatch may occur before baseline capture.
+  assert.deepEqual(gate.getState(), {
+    baselineCaptured: false,
+    dispatched: false,
+    failedClosed: false,
+    dispatchCount: 0,
+  });
+
+  // Baseline arrives late (e.g. RPC took >500ms). Dispatch arms exactly once.
+  assert.deepEqual(gate.onPreBaselineCaptured(), { action: 'dispatch' });
+  assert.equal(gate.getState().dispatchCount, 1);
+  assert.equal(gate.getState().dispatched, true);
+  assert.equal(gate.getState().baselineCaptured, true);
+
+  // Duplicate/late baseline responses must not re-dispatch.
+  assert.deepEqual(gate.onPreBaselineCaptured(), {
+    action: 'noop',
+    reason: 'already-dispatched',
+  });
+  assert.equal(gate.getState().dispatchCount, 1);
+
+  // Watchdog after a successful baseline is a no-op (preserve post polls).
+  assert.deepEqual(gate.onBaselineWatchdog(), {
+    action: 'noop',
+    reason: 'baseline-already-handled',
+  });
+  assert.equal(gate.getState().failedClosed, false);
+  assert.equal(gate.getState().dispatchCount, 1);
+});
+
+test('baseline watchdog fail-closes when pre list never arrives; late baseline cannot dispatch', () => {
+  const gate = createModelToolDispatchGate();
+  assert.deepEqual(gate.onBaselineWatchdog(), { action: 'fail-closed' });
+  assert.equal(gate.getState().failedClosed, true);
+  assert.equal(gate.getState().dispatched, false);
+  // A baseline that arrives after the watchdog must not resurrect dispatch.
+  assert.deepEqual(gate.onPreBaselineCaptured(), {
+    action: 'noop',
+    reason: 'already-failed-closed',
+  });
+  assert.equal(gate.getState().dispatchCount, 0);
+});
+
+test('scenario requires disposable parent, spawnedBy filter, and baseline-gated dispatch', async () => {
   const { readFile } = await import('node:fs/promises');
   const scenario = await readFile(new URL('../scenarios/r-cd-model-tool.js', import.meta.url), 'utf8');
   assert.match(scenario, /OPENCLAW_CREATE_DISPOSABLE_SESSION=true is required/);
@@ -135,5 +182,11 @@ test('scenario requires disposable parent and spawnedBy list filter', async () =
   assert.match(scenario, /post_spawned_by_keys/);
   assert.match(scenario, /auxiliary child runtime-context self-report \(not used for equality\)/);
   assert.match(scenario, /sessions\.get/);
+  assert.match(scenario, /createModelToolDispatchGate/);
+  assert.match(scenario, /onPreBaselineCaptured/);
+  assert.match(scenario, /dispatchModelToolTurn/);
+  assert.match(scenario, /onBaselineWatchdog/);
+  // Fixed +800ms sole dispatch timer must not remain (latency-dependent drop).
+  assert.doesNotMatch(scenario, /setTimeout\(\s*\(\)\s*=>\s*\{[^}]*pre_spawned_by_captured[^}]*sessions\.send[\s\S]*?\},\s*800\s*\)/);
   assert.doesNotMatch(scenario, /production DB|sqlite|better-sqlite/i);
 });

--- a/tools/k6-proofs/tests/targeted-return-receipt.test.mjs
+++ b/tools/k6-proofs/tests/targeted-return-receipt.test.mjs
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { createHmac } from 'node:crypto';
 import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -8,15 +9,18 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import {
   assertPublicSafeTargetedReturnReceipt,
+  canonicalTargetedReturnReceipt,
   collectTargetedReturnDeliveries,
   fingerprintIdentity,
   parseTargetedReturnDeliveryLine,
   resolveTargetedReturnAuthority,
+  validateTargetedReturnReceipt,
 } from '../lib/targeted-return-receipt.mjs';
 
 const run = promisify(execFile);
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
 const collector = path.join(repoRoot, 'tools/k6-proofs/scripts/collect-targeted-return-receipt.mjs');
+const signingKey = 'targeted-return-unit-gateway-token';
 
 const target = 'agent:main:r-cd-4-target';
 const parent = 'agent:main:r-cd-4-parent';
@@ -32,6 +36,21 @@ function line(ts, to, from) {
 const inWindow = '2026-08-09T17:13:29.848-07:00';
 const outWindow = '2026-08-09T17:20:29.848-07:00';
 
+function resolve(overrides = {}) {
+  return resolveTargetedReturnAuthority({
+    journalText: line(inWindow, target, child),
+    targetSessionKey: target,
+    parentSessionKey: parent,
+    childSessionKey: child,
+    windowStartMs: windowStart,
+    windowEndMs: windowEnd,
+    row: 'R-CD-4',
+    structuralOk: true,
+    signingKey,
+    ...overrides,
+  });
+}
+
 test('parses payload-free targeted-return delivery lines', () => {
   const parsed = parseTargetedReturnDeliveryLine(line(inWindow, target, child));
   assert.deepEqual(parsed.targetSessionKeys, [target]);
@@ -39,132 +58,169 @@ test('parses payload-free targeted-return delivery lines', () => {
   assert.equal(parsed.timestampMs, Date.parse(inWindow));
 });
 
-test('exact single target receipt PASSes with zero parent receipts', () => {
-  const journal = [
-    line(inWindow, target, child),
-    'unrelated noise',
-  ].join('\n');
-  const receipt = resolveTargetedReturnAuthority({
-    journalText: journal,
-    targetSessionKey: target,
-    parentSessionKey: parent,
-    childSessionKey: child,
-    windowStartMs: windowStart,
-    windowEndMs: windowEnd,
-    row: 'R-CD-4',
+test('exact single target receipt PASSes with zero parent receipts and HMAC seal', () => {
+  const receipt = resolve({
+    journalText: [line(inWindow, target, child), 'unrelated noise'].join('\n'),
   });
   assert.equal(receipt.verdict, 'PASS-candidate');
   assert.equal(receipt.targetMatchCount, 1);
   assert.equal(receipt.parentMatchCount, 0);
   assert.equal(receipt.failureCategory, null);
+  assert.equal(receipt.structuralOk, true);
+  assert.equal(receipt.integrity.algorithm, 'hmac-sha256-gateway-token-v1');
+  assert.match(receipt.integrity.signature, /^[a-f0-9]{64}$/i);
+  assert.deepEqual(validateTargetedReturnReceipt(receipt, signingKey, 'R-CD-4'), {
+    valid: true,
+    verdict: 'PASS-candidate',
+  });
   assertPublicSafeTargetedReturnReceipt(receipt);
 });
 
 test('no delivery fails closed', () => {
-  const receipt = resolveTargetedReturnAuthority({
-    journalText: 'no targeted return here\n',
-    targetSessionKey: target,
-    parentSessionKey: parent,
-    childSessionKey: child,
-    windowStartMs: windowStart,
-    windowEndMs: windowEnd,
-  });
+  const receipt = resolve({ journalText: 'no targeted return here\n' });
   assert.equal(receipt.verdict, 'PARTIAL-candidate');
   assert.equal(receipt.failureCategory, 'no-delivery');
+  assert.equal(validateTargetedReturnReceipt(receipt, signingKey).valid, true);
 });
 
 test('duplicate target receipts fail closed', () => {
-  const journal = [
-    line(inWindow, target, child),
-    line('2026-08-09T17:13:40.000-07:00', target, child),
-  ].join('\n');
-  const receipt = resolveTargetedReturnAuthority({
-    journalText: journal,
-    targetSessionKey: target,
-    parentSessionKey: parent,
-    childSessionKey: child,
-    windowStartMs: windowStart,
-    windowEndMs: windowEnd,
+  const receipt = resolve({
+    journalText: [
+      line(inWindow, target, child),
+      line('2026-08-09T17:13:40.000-07:00', target, child),
+    ].join('\n'),
   });
   assert.equal(receipt.failureCategory, 'duplicate-target');
   assert.equal(receipt.verdict, 'PARTIAL-candidate');
 });
 
 test('wrong-target delivery does not PASS', () => {
-  const journal = line(inWindow, 'agent:main:other-target', child);
-  const receipt = resolveTargetedReturnAuthority({
-    journalText: journal,
-    targetSessionKey: target,
-    parentSessionKey: parent,
-    childSessionKey: child,
-    windowStartMs: windowStart,
-    windowEndMs: windowEnd,
-  });
+  const receipt = resolve({ journalText: line(inWindow, 'agent:main:other-target', child) });
   assert.equal(receipt.failureCategory, 'no-matching-delivery');
 });
 
 test('wrong-child delivery does not PASS', () => {
-  const journal = line(inWindow, target, wrongChild);
-  const receipt = resolveTargetedReturnAuthority({
-    journalText: journal,
-    targetSessionKey: target,
-    parentSessionKey: parent,
-    childSessionKey: child,
-    windowStartMs: windowStart,
-    windowEndMs: windowEnd,
-  });
+  const receipt = resolve({ journalText: line(inWindow, target, wrongChild) });
   assert.equal(receipt.failureCategory, 'wrong-child');
 });
 
 test('out-of-window delivery does not PASS', () => {
-  const journal = line(outWindow, target, child);
-  const receipt = resolveTargetedReturnAuthority({
-    journalText: journal,
-    targetSessionKey: target,
-    parentSessionKey: parent,
-    childSessionKey: child,
-    windowStartMs: windowStart,
-    windowEndMs: windowEnd,
-  });
+  const receipt = resolve({ journalText: line(outWindow, target, child) });
   assert.equal(receipt.failureCategory, 'out-of-window');
 });
 
 test('parent delivery fails closed even with target match', () => {
-  const journal = [
-    line(inWindow, target, child),
-    line('2026-08-09T17:13:35.000-07:00', parent, child),
-  ].join('\n');
-  const receipt = resolveTargetedReturnAuthority({
-    journalText: journal,
-    targetSessionKey: target,
-    parentSessionKey: parent,
-    childSessionKey: child,
-    windowStartMs: windowStart,
-    windowEndMs: windowEnd,
+  const receipt = resolve({
+    journalText: [
+      line(inWindow, target, child),
+      line('2026-08-09T17:13:35.000-07:00', parent, child),
+    ].join('\n'),
   });
   assert.equal(receipt.failureCategory, 'parent-delivery');
   assert.equal(receipt.parentMatchCount, 1);
 });
 
 test('public receipt redacts raw identities and message bodies', () => {
-  const receipt = resolveTargetedReturnAuthority({
-    journalText: line(inWindow, target, child),
-    targetSessionKey: target,
-    parentSessionKey: parent,
-    childSessionKey: child,
-    windowStartMs: windowStart,
-    windowEndMs: windowEnd,
-  });
+  const receipt = resolve();
   const serialized = JSON.stringify(receipt);
   assert.equal(serialized.includes(target), false);
   assert.equal(serialized.includes(parent), false);
   assert.equal(serialized.includes(child), false);
+  assert.equal(serialized.includes(signingKey), false);
   assert.equal(receipt.bindings.targetSessionFingerprint, fingerprintIdentity(target));
   assert.equal(receipt.bindings.childSessionFingerprint, fingerprintIdentity(child));
   assertPublicSafeTargetedReturnReceipt(receipt);
 });
 
-test('collector CLI emits public-safe receipt for R-CD-4 structural+journal PASS', async () => {
+test('structuralOk false cannot PASS even with perfect journal match', () => {
+  const receipt = resolve({ structuralOk: false });
+  assert.equal(receipt.verdict, 'PARTIAL-candidate');
+  assert.equal(receipt.structuralOk, false);
+  assert.equal(receipt.failureCategory, 'structural-gates-incomplete');
+  assert.deepEqual(validateTargetedReturnReceipt(receipt, signingKey, 'R-CD-4'), {
+    valid: true,
+    verdict: 'PARTIAL-candidate',
+  });
+
+  // Hand-forged PASS with structuralOk:false must be rejected by validator,
+  // even when counts/fingerprints look valid and a signature is present.
+  const forged = {
+    ...receipt,
+    verdict: 'PASS-candidate',
+    failureCategory: null,
+    structuralOk: false,
+  };
+  forged.integrity = {
+    algorithm: 'hmac-sha256-gateway-token-v1',
+    signature: createHmac('sha256', signingKey)
+      .update(canonicalTargetedReturnReceipt(forged))
+      .digest('hex'),
+  };
+  assert.deepEqual(validateTargetedReturnReceipt(forged, signingKey, 'R-CD-4'), {
+    valid: false,
+    reason: 'pass-structural-ok',
+  });
+});
+
+test('missing token, forged unsigned PASS, and tampered seal are rejected', () => {
+  const good = resolve();
+  assert.equal(validateTargetedReturnReceipt(good, signingKey).valid, true);
+  assert.deepEqual(validateTargetedReturnReceipt(good, ''), {
+    valid: false,
+    reason: 'missing-signing-key',
+  });
+  assert.deepEqual(validateTargetedReturnReceipt(good, undefined), {
+    valid: false,
+    reason: 'missing-signing-key',
+  });
+  assert.deepEqual(validateTargetedReturnReceipt(good, 'wrong-token'), {
+    valid: false,
+    reason: 'invalid-integrity',
+  });
+
+  const unsigned = { ...good };
+  delete unsigned.integrity;
+  assert.deepEqual(validateTargetedReturnReceipt(unsigned, signingKey), {
+    valid: false,
+    reason: 'invalid-shape',
+  });
+
+  const forgedPass = {
+    schema: good.schema,
+    row: 'R-CD-4',
+    authority: 'gateway-journal-targeted-return',
+    candidateOnly: true,
+    foldRequiresReview: true,
+    verdict: 'PASS-candidate',
+    failureCategory: null,
+    structuralOk: false,
+    window: good.window,
+    targetMatchCount: 1,
+    parentMatchCount: 0,
+    deliveryCountInWindow: 1,
+    deliveryCountTotal: 1,
+    childBound: true,
+    bindings: good.bindings,
+  };
+  assert.equal(validateTargetedReturnReceipt(forgedPass, signingKey).valid, false);
+  assert.equal(validateTargetedReturnReceipt(forgedPass, signingKey).reason, 'invalid-shape');
+
+  const tampered = {
+    ...good,
+    targetMatchCount: 99,
+  };
+  assert.deepEqual(validateTargetedReturnReceipt(tampered, signingKey), {
+    valid: false,
+    reason: 'invalid-integrity',
+  });
+
+  assert.throws(
+    () => resolve({ signingKey: '' }),
+    /missing gateway signing key/,
+  );
+});
+
+test('collector CLI seals with OPENCLAW_GATEWAY_TOKEN and rejects missing token', async () => {
   const dir = await mkdtemp(path.join(tmpdir(), 'targeted-return-cli-'));
   const evidence = {
     row: 'R-CD-4',
@@ -182,32 +238,64 @@ test('collector CLI emits public-safe receipt for R-CD-4 structural+journal PASS
   const journalPath = path.join(dir, 'journal.log');
   await writeFile(evidencePath, JSON.stringify(evidence));
   await writeFile(journalPath, `${line(inWindow, target, child)}\n`);
+
+  await assert.rejects(
+    () => run('node', [
+      collector,
+      '--run-dir', dir,
+      '--evidence', evidencePath,
+      '--journal', journalPath,
+      '--row', 'R-CD-4',
+    ], { env: { ...process.env, OPENCLAW_GATEWAY_TOKEN: '' } }),
+    /targeted-return collector failed|OPENCLAW_GATEWAY_TOKEN/,
+  );
+
   const { stdout } = await run('node', [
     collector,
     '--run-dir', dir,
     '--evidence', evidencePath,
     '--journal', journalPath,
     '--row', 'R-CD-4',
-  ]);
+  ], { env: { ...process.env, OPENCLAW_GATEWAY_TOKEN: signingKey } });
   const summary = JSON.parse(stdout);
   assert.equal(summary.verdict, 'PASS-candidate');
+  assert.equal(summary.structuralOk, true);
+  assert.equal(summary.integrity, 'hmac-sha256-gateway-token-v1');
   const receipt = JSON.parse(await readFile(path.join(dir, 'targeted-return-receipt.json'), 'utf8'));
   assert.equal(receipt.verdict, 'PASS-candidate');
+  assert.equal(receipt.structuralOk, true);
+  assert.deepEqual(validateTargetedReturnReceipt(receipt, signingKey, 'R-CD-4'), {
+    valid: true,
+    verdict: 'PASS-candidate',
+  });
   assertPublicSafeTargetedReturnReceipt(receipt);
+  assert.equal(JSON.stringify(receipt).includes(signingKey), false);
+  assert.equal(JSON.stringify(receipt).includes(child), false);
+
+  // Structural incomplete evidence cannot mint PASS even with journal match.
+  const incomplete = {
+    ...evidence,
+    tool_accepted: false,
+  };
+  const incompletePath = path.join(dir, 'evidence-incomplete.json');
+  await writeFile(incompletePath, JSON.stringify(incomplete));
+  const partial = await run('node', [
+    collector,
+    '--run-dir', dir,
+    '--evidence', incompletePath,
+    '--journal', journalPath,
+    '--row', 'R-CD-4',
+  ], { env: { ...process.env, OPENCLAW_GATEWAY_TOKEN: signingKey } });
+  const partialSummary = JSON.parse(partial.stdout);
+  assert.equal(partialSummary.verdict, 'PARTIAL-candidate');
+  assert.equal(partialSummary.structuralOk, false);
 });
 
 test('replay redacted historical journal remains unproven (no manufactured PASS)', () => {
   const redacted = [
     '2026-08-09T17:13:29.848-07:00 cael node[1]: [continuation:targeted-return] Delivered to <redacted-session-key> from <redacted-session-key>',
   ].join('\n');
-  const receipt = resolveTargetedReturnAuthority({
-    journalText: redacted,
-    targetSessionKey: target,
-    parentSessionKey: parent,
-    childSessionKey: child,
-    windowStartMs: windowStart,
-    windowEndMs: windowEnd,
-  });
+  const receipt = resolve({ journalText: redacted });
   assert.notEqual(receipt.verdict, 'PASS-candidate');
   assert.equal(collectTargetedReturnDeliveries(redacted).length, 1);
 });

--- a/tools/k6-proofs/tests/targeted-return-receipt.test.mjs
+++ b/tools/k6-proofs/tests/targeted-return-receipt.test.mjs
@@ -291,6 +291,88 @@ test('collector CLI seals with OPENCLAW_GATEWAY_TOKEN and rejects missing token'
   assert.equal(partialSummary.structuralOk, false);
 });
 
+test('depth-2 collector cannot seal PASS when spawnedBy ancestry is ambiguous', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'targeted-return-chain-'));
+  const root = 'agent:main:r-cd-chain-root';
+  const depthOne = 'agent:main:subagent:depth-one';
+  const depthTwo = 'agent:main:subagent:depth-two';
+  const evidence = {
+    row: 'R-CD-CHAINED-DEPTH-2',
+    sessionKey: root,
+    parent_dispatch_accepted: true,
+    child_done_sentinel: true,
+    grandchild_done_sentinel: true,
+    child_session: depthOne,
+    grandchild_session: depthTwo,
+    child_authority_source: 'sessions.list spawnedBy ancestry',
+    grandchild_authority_source: 'sessions.list spawnedBy ancestry',
+    child_ancestry_confirmations: 2,
+    grandchild_ancestry_confirmations: 2,
+    grandchild_ancestry_confirmed_at_ms: windowStart + 30_000,
+    ancestry_stable: true,
+    ancestry_ambiguous: true,
+    dispatch_accepted_at_ms: windowStart,
+    started: new Date(windowStart).toISOString(),
+    ended: new Date(windowEnd - 1000).toISOString(),
+  };
+  const evidencePath = path.join(dir, 'evidence.json');
+  const journalPath = path.join(dir, 'journal.log');
+  await writeFile(evidencePath, JSON.stringify(evidence));
+  await writeFile(journalPath, `${line(inWindow, root, depthTwo)}\n`);
+
+  const { stdout } = await run('node', [
+    collector,
+    '--run-dir', dir,
+    '--evidence', evidencePath,
+    '--journal', journalPath,
+    '--row', 'R-CD-CHAINED-DEPTH-2',
+  ], { env: { ...process.env, OPENCLAW_GATEWAY_TOKEN: signingKey } });
+  const summary = JSON.parse(stdout);
+  assert.equal(summary.verdict, 'PARTIAL-candidate');
+  assert.equal(summary.structuralOk, false);
+});
+
+test('depth-2 collector independently rejects a sub-30s stability claim', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'targeted-return-chain-fast-'));
+  const root = 'agent:main:r-cd-chain-root';
+  const depthOne = 'agent:main:subagent:depth-one';
+  const depthTwo = 'agent:main:subagent:depth-two';
+  const evidence = {
+    row: 'R-CD-CHAINED-DEPTH-2',
+    sessionKey: root,
+    parent_dispatch_accepted: true,
+    child_done_sentinel: true,
+    grandchild_done_sentinel: true,
+    child_session: depthOne,
+    grandchild_session: depthTwo,
+    child_authority_source: 'sessions.list spawnedBy ancestry',
+    grandchild_authority_source: 'sessions.list spawnedBy ancestry',
+    child_ancestry_confirmations: 2,
+    grandchild_ancestry_confirmations: 2,
+    ancestry_stable: true,
+    ancestry_ambiguous: false,
+    dispatch_accepted_at_ms: windowStart,
+    grandchild_ancestry_confirmed_at_ms: windowStart + 12_000,
+    started: new Date(windowStart).toISOString(),
+    ended: new Date(windowEnd - 1000).toISOString(),
+  };
+  const evidencePath = path.join(dir, 'evidence.json');
+  const journalPath = path.join(dir, 'journal.log');
+  await writeFile(evidencePath, JSON.stringify(evidence));
+  await writeFile(journalPath, `${line(inWindow, root, depthTwo)}\n`);
+
+  const { stdout } = await run('node', [
+    collector,
+    '--run-dir', dir,
+    '--evidence', evidencePath,
+    '--journal', journalPath,
+    '--row', 'R-CD-CHAINED-DEPTH-2',
+  ], { env: { ...process.env, OPENCLAW_GATEWAY_TOKEN: signingKey } });
+  const summary = JSON.parse(stdout);
+  assert.equal(summary.verdict, 'PARTIAL-candidate');
+  assert.equal(summary.structuralOk, false);
+});
+
 test('replay redacted historical journal remains unproven (no manufactured PASS)', () => {
   const redacted = [
     '2026-08-09T17:13:29.848-07:00 cael node[1]: [continuation:targeted-return] Delivered to <redacted-session-key> from <redacted-session-key>',

--- a/tools/k6-proofs/tests/targeted-return-receipt.test.mjs
+++ b/tools/k6-proofs/tests/targeted-return-receipt.test.mjs
@@ -1,0 +1,213 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import {
+  assertPublicSafeTargetedReturnReceipt,
+  collectTargetedReturnDeliveries,
+  fingerprintIdentity,
+  parseTargetedReturnDeliveryLine,
+  resolveTargetedReturnAuthority,
+} from '../lib/targeted-return-receipt.mjs';
+
+const run = promisify(execFile);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const collector = path.join(repoRoot, 'tools/k6-proofs/scripts/collect-targeted-return-receipt.mjs');
+
+const target = 'agent:main:r-cd-4-target';
+const parent = 'agent:main:r-cd-4-parent';
+const child = 'agent:main:subagent:child-aaa';
+const wrongChild = 'agent:main:subagent:child-bbb';
+const windowStart = Date.parse('2026-08-09T17:13:00.000-07:00');
+const windowEnd = Date.parse('2026-08-09T17:14:00.000-07:00');
+
+function line(ts, to, from) {
+  return `${ts} cael node[1]: ${ts} [continuation:targeted-return] Delivered to ${to} from ${from}`;
+}
+
+const inWindow = '2026-08-09T17:13:29.848-07:00';
+const outWindow = '2026-08-09T17:20:29.848-07:00';
+
+test('parses payload-free targeted-return delivery lines', () => {
+  const parsed = parseTargetedReturnDeliveryLine(line(inWindow, target, child));
+  assert.deepEqual(parsed.targetSessionKeys, [target]);
+  assert.equal(parsed.childSessionKey, child);
+  assert.equal(parsed.timestampMs, Date.parse(inWindow));
+});
+
+test('exact single target receipt PASSes with zero parent receipts', () => {
+  const journal = [
+    line(inWindow, target, child),
+    'unrelated noise',
+  ].join('\n');
+  const receipt = resolveTargetedReturnAuthority({
+    journalText: journal,
+    targetSessionKey: target,
+    parentSessionKey: parent,
+    childSessionKey: child,
+    windowStartMs: windowStart,
+    windowEndMs: windowEnd,
+    row: 'R-CD-4',
+  });
+  assert.equal(receipt.verdict, 'PASS-candidate');
+  assert.equal(receipt.targetMatchCount, 1);
+  assert.equal(receipt.parentMatchCount, 0);
+  assert.equal(receipt.failureCategory, null);
+  assertPublicSafeTargetedReturnReceipt(receipt);
+});
+
+test('no delivery fails closed', () => {
+  const receipt = resolveTargetedReturnAuthority({
+    journalText: 'no targeted return here\n',
+    targetSessionKey: target,
+    parentSessionKey: parent,
+    childSessionKey: child,
+    windowStartMs: windowStart,
+    windowEndMs: windowEnd,
+  });
+  assert.equal(receipt.verdict, 'PARTIAL-candidate');
+  assert.equal(receipt.failureCategory, 'no-delivery');
+});
+
+test('duplicate target receipts fail closed', () => {
+  const journal = [
+    line(inWindow, target, child),
+    line('2026-08-09T17:13:40.000-07:00', target, child),
+  ].join('\n');
+  const receipt = resolveTargetedReturnAuthority({
+    journalText: journal,
+    targetSessionKey: target,
+    parentSessionKey: parent,
+    childSessionKey: child,
+    windowStartMs: windowStart,
+    windowEndMs: windowEnd,
+  });
+  assert.equal(receipt.failureCategory, 'duplicate-target');
+  assert.equal(receipt.verdict, 'PARTIAL-candidate');
+});
+
+test('wrong-target delivery does not PASS', () => {
+  const journal = line(inWindow, 'agent:main:other-target', child);
+  const receipt = resolveTargetedReturnAuthority({
+    journalText: journal,
+    targetSessionKey: target,
+    parentSessionKey: parent,
+    childSessionKey: child,
+    windowStartMs: windowStart,
+    windowEndMs: windowEnd,
+  });
+  assert.equal(receipt.failureCategory, 'no-matching-delivery');
+});
+
+test('wrong-child delivery does not PASS', () => {
+  const journal = line(inWindow, target, wrongChild);
+  const receipt = resolveTargetedReturnAuthority({
+    journalText: journal,
+    targetSessionKey: target,
+    parentSessionKey: parent,
+    childSessionKey: child,
+    windowStartMs: windowStart,
+    windowEndMs: windowEnd,
+  });
+  assert.equal(receipt.failureCategory, 'wrong-child');
+});
+
+test('out-of-window delivery does not PASS', () => {
+  const journal = line(outWindow, target, child);
+  const receipt = resolveTargetedReturnAuthority({
+    journalText: journal,
+    targetSessionKey: target,
+    parentSessionKey: parent,
+    childSessionKey: child,
+    windowStartMs: windowStart,
+    windowEndMs: windowEnd,
+  });
+  assert.equal(receipt.failureCategory, 'out-of-window');
+});
+
+test('parent delivery fails closed even with target match', () => {
+  const journal = [
+    line(inWindow, target, child),
+    line('2026-08-09T17:13:35.000-07:00', parent, child),
+  ].join('\n');
+  const receipt = resolveTargetedReturnAuthority({
+    journalText: journal,
+    targetSessionKey: target,
+    parentSessionKey: parent,
+    childSessionKey: child,
+    windowStartMs: windowStart,
+    windowEndMs: windowEnd,
+  });
+  assert.equal(receipt.failureCategory, 'parent-delivery');
+  assert.equal(receipt.parentMatchCount, 1);
+});
+
+test('public receipt redacts raw identities and message bodies', () => {
+  const receipt = resolveTargetedReturnAuthority({
+    journalText: line(inWindow, target, child),
+    targetSessionKey: target,
+    parentSessionKey: parent,
+    childSessionKey: child,
+    windowStartMs: windowStart,
+    windowEndMs: windowEnd,
+  });
+  const serialized = JSON.stringify(receipt);
+  assert.equal(serialized.includes(target), false);
+  assert.equal(serialized.includes(parent), false);
+  assert.equal(serialized.includes(child), false);
+  assert.equal(receipt.bindings.targetSessionFingerprint, fingerprintIdentity(target));
+  assert.equal(receipt.bindings.childSessionFingerprint, fingerprintIdentity(child));
+  assertPublicSafeTargetedReturnReceipt(receipt);
+});
+
+test('collector CLI emits public-safe receipt for R-CD-4 structural+journal PASS', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'targeted-return-cli-'));
+  const evidence = {
+    row: 'R-CD-4',
+    tool_accepted: true,
+    child_session: child,
+    child_session_ambiguous: false,
+    child_session_invalid: false,
+    targetSessionKey: target,
+    sessionKey: parent,
+    dispatch_accepted_at_ms: windowStart,
+    started: new Date(windowStart).toISOString(),
+    ended: new Date(windowEnd - 1000).toISOString(),
+  };
+  const evidencePath = path.join(dir, 'evidence.json');
+  const journalPath = path.join(dir, 'journal.log');
+  await writeFile(evidencePath, JSON.stringify(evidence));
+  await writeFile(journalPath, `${line(inWindow, target, child)}\n`);
+  const { stdout } = await run('node', [
+    collector,
+    '--run-dir', dir,
+    '--evidence', evidencePath,
+    '--journal', journalPath,
+    '--row', 'R-CD-4',
+  ]);
+  const summary = JSON.parse(stdout);
+  assert.equal(summary.verdict, 'PASS-candidate');
+  const receipt = JSON.parse(await readFile(path.join(dir, 'targeted-return-receipt.json'), 'utf8'));
+  assert.equal(receipt.verdict, 'PASS-candidate');
+  assertPublicSafeTargetedReturnReceipt(receipt);
+});
+
+test('replay redacted historical journal remains unproven (no manufactured PASS)', () => {
+  const redacted = [
+    '2026-08-09T17:13:29.848-07:00 cael node[1]: [continuation:targeted-return] Delivered to <redacted-session-key> from <redacted-session-key>',
+  ].join('\n');
+  const receipt = resolveTargetedReturnAuthority({
+    journalText: redacted,
+    targetSessionKey: target,
+    parentSessionKey: parent,
+    childSessionKey: child,
+    windowStartMs: windowStart,
+    windowEndMs: windowEnd,
+  });
+  assert.notEqual(receipt.verdict, 'PASS-candidate');
+  assert.equal(collectTargetedReturnDeliveries(redacted).length, 1);
+});


### PR DESCRIPTION
## Summary

Repairs invalid continuation proof-row authority in the k6 harness (docs/harness only; no OpenClaw product change).

### R-CD-4
- **No OpenClaw behavior regression** in the prior failing runs: delegate spawned, exact debug log recorded `[continuation:targeted-return] Delivered to <target> from <child>`, diagnostics-otel present.
- Silent-wake delivery authority is now the shared post-run collector over the payload-free gateway journal line, not transcript `session.message` / `sessions.get` `TARGET-RECEIVED` text.
- PASS requires exactly one in-window target receipt and zero matching parent receipts, with independent child-identity gates.
- Public receipt publishes fingerprints/closed fields only.

### Product trace bug
- The product trace-parent bug remains tracked in **karmaterminal/openclaw#1251**. This PR does not compensate for it in behavioral assertions.

### R-CD-CHAINED-DEPTH-2
- Nested child→grandchild call now explicitly requests `fanoutMode="tree"`; outer parent→child is unchanged.
- Requires two distinct nonce-bound hop identities.
- Uses the **same** shared targeted-return collector for grandchild→root routing (tree multi-target / intermediate ancestors allowed).
- Removed the fictional three-subtest claim from the manifest.

### R-CD-MODEL-TOOL
- Requires disposable parent.
- Pre/post `sessions.list { spawnedBy: <parent>, limit: 100 }` set-diff; exactly one new child; model byte from that row.
- Parent `sessions.get` must show a nonce-bound **return** via the exact `MODEL-TOOL-CHILD <nonce> MODEL <provider/model>` marker.
- Paraphrased schedule acknowledgements and generic nonce-bearing assistant text are **not** return authority (review fix for review 4920192489).
- Child self-report is auxiliary and cannot establish model equality.
- No direct production DB query as PASS authority.

### Tempo search IDs
- Accept exactly 31 hex characters by left-padding one `0`.
- Fetch and verify decoded nonzero payload trace/span IDs.
- Reject other malformed lengths and all-zero IDs.

### Historical artifacts
- **Old PROOFS artifacts remain unchanged.** `PROOFS/INDEX.json` was not repointed.
- Replay of redacted journals remains unproven (no manufactured PASS).

## Review follow-up
- Tightened `parentReturnContainsNonce` to require the exact child-return marker.
- Added adversarial case: `Scheduled delegate for nonce-x; waiting for completion.` => `false`.
- Code fix commit: `dffb1ceb8c78c789442c18135f00618b564da85d`.

## Tests
```text
node --test tools/k6-proofs/tests/r-cd-model-tool-authority.test.mjs
# 5 pass / 0 fail

node --test tools/k6-proofs/tests/**/*.test.mjs tools/k6-proofs/scripts/__tests__/**/*.test.mjs
# 363 pass / 1 fail (pre-existing: candidate envelope corpus INDEX schema drift on current_sha proofs-manifest.v1 vs k6.proofs-manifest.v1; unrelated to this harness authority change)
node tools/k6-proofs/scripts/check-manifest-scenarios.mjs --repo-root "$PWD"  # pass
node tools/k6-proofs/scripts/check-scenario-alignment.mjs --repo-root "$PWD"  # pass
node tools/k6-proofs/scripts/check-proof-row-manifests.mjs --repo-root "$PWD" # pass
```

## Remaining live-proof gap
Exact live re-runs still required on prince seats with disposable sessions to mint fresh PASS-candidate artifacts under the new authority for:
- R-CD-4
- R-CD-CHAINED-DEPTH-2 (with nested `fanoutMode=tree`)
- R-CD-MODEL-TOOL (disposable parent + spawnedBy set-diff + exact child-return marker)

Do not fold historical PARTIAL runs as PASS under the new detector without a new live fire.

## Base
- docs `origin/main` @ `513a74ad1db3cfbb5ac10cc45155ee1e1acb911a`
