### PR TITLE
fix(proofs): restore Project 81 row authority (#514)

### DIFF
--- a/.github/workflows/project81-k6-proof.yml
+++ b/.github/workflows/project81-k6-proof.yml
@@ -176,6 +176,23 @@ jobs:
           command -v k6 >/dev/null || { echo "k6 is required for live runs: https://grafana.com/docs/k6/latest/set-up/install-k6/"; exit 1; }
           test -n "${OPENCLAW_GATEWAY_TOKEN:-}" || { echo "no gateway token: this seat's ~/.openclaw/openclaw.json has no gateway.auth.token and no OPENCLAW_GATEWAY_TOKEN secret is set"; exit 1; }
 
+      - name: Resolve independent runtime identity
+        if: ${{ !inputs.dry_run }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$K6_PROOF_OUT_DIR"
+          node tools/k6-proofs/scripts/resolve-runtime-identity.mjs \
+            --write "$K6_PROOF_OUT_DIR/runtime-identity.json"
+          exact="$(jq -r '.exact // false' "$K6_PROOF_OUT_DIR/runtime-identity.json")"
+          sha="$(jq -r '.runtimeBuildSha // empty' "$K6_PROOF_OUT_DIR/runtime-identity.json")"
+          source="$(jq -r '.runtimeBuildShaSource // empty' "$K6_PROOF_OUT_DIR/runtime-identity.json")"
+          echo "runtime identity exact=$exact source=${source:-none}"
+          if [[ "$exact" == "true" && "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "OPENCLAW_RUNTIME_BUILD_SHA=$sha" >> "$GITHUB_ENV"
+            echo "OPENCLAW_RUNTIME_BUILD_SHA_SOURCE=$source" >> "$GITHUB_ENV"
+          fi
+
       - name: Run Project 81 proof suite
         shell: bash
         run: |

--- a/output.md
+++ b/output.md
@@ -1,425 +1,91 @@
-# Continuation telemetry remedy rows — `karmaterminal/openclaw#1254`
+# Proof harness authority repair — #514
 
-Branch: `codeagent/continuation-telemetry-remedy-rows`
-Base: `ead47a618c539c535e6845c52207f7a16b23d677` (docs `main`)
-Commits: `85454fff`, `b0f373f2`, and the review-fix commit that carries this report
+Branch: `codeagent/proof-harness-authority-514`
+Base: `de315e25aad6871e51341de7916c7383fa3d06a7`
+Head: `2aea6cde`
+Bound issue: `karmaterminal/karmaterminal-openclaw-docs#514`
 
-Scope: docs / catalog / harness-contract only. No `karmaterminal/openclaw`
-product change. No live row fired, no gateway touched, no fleet mutation. No
-`PROOFS/**` corpus bytes, no `proofs-manifest.json`, no `PROOFS/INDEX.json`.
+No OpenClaw product change. No live proofs. No edits under `PROOFS/c3a0e5a...`.
+`replayInvalid` remains public safety metadata.
 
-Inputs:
+## What changed
 
-- census report branch `karmaterminal/openclaw:codeagent/continuation-tempo-usage-census`
-- census commit `39803b297bd4786db3971eb82a3a7fd0b29bc643`
-- exact product basis `6b09b1dbe938ab6b5f56eaf4e58f1ed243f89955`
-- k6 library consolidation branch `codeagent/k6-scenario-library-consolidation@249f7dc9` — read as context only. **Nothing was absorbed from it.** No code, scenario, or library file from that 53-file branch appears in this change, and this branch has no dependency on it.
+### Defect 1 — R-CD-2 replay safety vs lifecycle success
+- `gatewayLifecycleSucceeded()` no longer treats `replayInvalid=true` as failure.
+- `gatewayLifecycleReplayInvalid()` records the flag separately.
+- `r-cd-2-silent-wake.js` keeps `dispatch_replay_invalid` evidence and never maps replay safety to `delegate-replay-unsafe`.
+- Authoritative receipt still fail-closes genuine `provider-or-turn-failure` / abort / missing sentinel. Historical `delegate-replay-unsafe` packets are PARTIAL, not FAIL.
 
----
+### Defect 2 — R-CD-TOKEN exact runtime identity
+- New fail-closed resolver: `lib/runtime-identity.mjs` + `scripts/resolve-runtime-identity.mjs`.
+- Sources: structured receipt file, installed `~/.openclaw/*receipt.json`, `openclaw version --json`, operator exact env SHA.
+- Never copies `candidate_sha`, never expands a short stamp into a full SHA.
+- Ambiguous/malformed identity is rejected before token dispatch.
+- Public metadata records `runtimeBuildShaSource`.
+- Non-token rows may still publish a human version stamp.
+- Workflow `project81-k6-proof.yml` resolves identity independently before the suite.
 
-## 1. What the census forced
+### Defect 3 — R-CW-3 shared-trace tool attribution
+- `collect-continuation-trace.mjs` now scopes `continue_work` tool spans to the reason-bound work/fire topology.
+- One matching tool on a reason-bound trace is accepted (preserves historical R-CW-1 packets).
+- Multiple tools require a unique causal (parent/child/same-generation) origin; timing is only used to disambiguate causal candidates.
+- Zero or multiple in-scope origins remain fail-closed. Time-window-only attribution is rejected.
+- Repeated fire attempts still allowed.
 
-The census measured the fleet's actual continuation telemetry and found that a
-proof row can execute real behavior and still be impossible to rebind or
-correlate later:
+### Defect 4 — R-RC-2 honest-limit policy
+- Shared helper `lib/r-rc-2-honest-limit.mjs` is the single authority for bound threshold receipts.
+- `HONEST-LIMIT-candidate` still requires nonce-bound `request_compaction` `toolResult` (`status=rejected`, `guard=context_threshold`) plus the matching child return.
+- Prose / unbound tool results cannot promote.
+- Runner, review-debt, report, candidate validation, and the R-RC-2 manifest notes agree: those receipts are sufficient; missing Tempo is not review debt on the honest-limit path.
 
-| Finding | Number | Consequence for this catalog |
-|---|---|---|
-| Accepted continuation entry spans are rare | 23 / 24h, 366 / 7d vs 585 / 23,796 model-turn spans | Continuation alone does not explain fleet symptom prevalence. Causation unproven. |
-| Accepted entry spans omit identity | no `signal.kind`, no origin/session/turn/run | Typed-tool spans and accepted-entry spans **cannot be causally joined** |
-| Proof traffic has no marker | 0 k6 / Project-81 resource matches | Proof traffic cannot be excluded honestly; classification is `unknown_without_stable_marker` |
-| No canonical terminal outcome | 147 / 115 (24h), 12,722 / 1,664 (7d) log-string matches | Zero-payload and finalization-failure are heuristics, not counters |
-| Backend degrades silently | Tempo 200 live-store-only, no `totalBlocks`, `/ready` still 200 | Zero must never be read as absence |
+## GitNexus
 
-**No product instrumentation for any of the remedy attributes exists.** This
-change publishes the contract, not a claim that the contract is satisfied.
-
----
-
-## 2. Row mapping
-
-### 2a. New cross-cutting remedy rows (4, all `construct-only`)
-
-Added only where a contract is genuinely cross-cutting and cannot honestly live
-inside one behavioral row. Each census concern is owned by **exactly one** row,
-and `check-telemetry-contracts.mjs` fails the catalog if a concern is orphaned
-or double-claimed.
-
-| Row | Manifest | Concern | Product instrumentation prerequisite |
-|---|---|---|---|
-| `R-OBS-CONT-PROVENANCE` | `tools/k6-proofs/manifests/r-obs-cont-provenance.json` | `origin-provenance` | **yes** |
-| `R-OBS-PROOF-MARKER` | `tools/k6-proofs/manifests/r-obs-proof-marker.json` | `proof-run-classification` | **yes** |
-| `R-OBS-TERMINAL-OUTCOME` | `tools/k6-proofs/manifests/r-obs-terminal-outcome.json` | `terminal-outcome` | **yes** |
-| `R-OBS-BACKEND-DISPOSITION` | `tools/k6-proofs/manifests/r-obs-backend-disposition.json` | `backend-disposition` | **no — harness-side** |
-
-All four are `scenario.status: construct-only` +
-`liveRunSafety.classification: construct-only` +
-`expectedArtifactClass: construct-only`, so they are rejected by the live-run
-guard, skipped by `run-proofs.sh`, and excluded from `list-runnable-rows.mjs`.
-
-`R-OBS-BACKEND-DISPOSITION` is deliberately the odd one out: it is blocked on
-harness receipt work (out of scope for a contract PR), **not** on OpenClaw.
-Keeping that distinction machine-readable is the point of the
-`productInstrumentationPrerequisite` flag.
-
-### 2b. Existing rows extended (9, contract is intrinsic to the proof)
-
-The workorder named eight rows at minimum. The validator's rule — "a row whose
-required receipts include a telemetry receipt must declare a contract" —
-resolves to eight rows, seven of which overlap the named set; `R-CD-1` is caught
-by the rule and `R-CD-MODEL-TOOL` declares a contract voluntarily because the
-workorder names it (its telemetry receipt is optional, not required). Nine
-total.
-
-| Row | Why the contract is intrinsic | What it can and cannot prove today |
-|---|---|---|
-| `R-CD-1` | required `trace-id` | Behavioral schedule/spawn/return holds. The dispatch cannot be re-identified from telemetry. |
-| `R-CD-2` | required `tempo-trace-json` | Same-trace + `chain.id` topology is the only join available. Not equivalent to identity. |
-| `R-CD-4` | required `trace-id`; claim is *which session* | Tempo drops session identifiers, so the cross-session claim rests entirely on the captured gateway event stream. |
-| `R-CD-CHAINED-DEPTH-2` | required `trace-id` | `chain.id` makes the chain visible; **no span says which hop was which**. |
-| `R-CD-MODEL-TOOL` | optional `trace-or-session-correlation` | Authority is gateway child-session metadata by design; telemetry cannot corroborate it. Separately blocked on `openclaw#1103`. |
-| `R-CD-TOKEN` | required `tempo-trace-json` + `continuation-trace-correlation` | Bracket origin is proven by the **absence** of a typed-tool span — a heuristic until an origin attribute exists. Positive bracket evidence lives only in payload-free Loki `effective-signal` logs, unbound to the trace. |
-| `R-CW-1` | required `trace-id` | Same-trace join only; 8 accepted `continuation.work` spans fleet-wide in 24h. |
-| `R-CW-3` | required `tempo-trace-json` + review | Redaction half **is** telemetry-backed (`reason.hash`, `reason.length` are exported). Provenance half is not. |
-| `R-RC-2` | required `trace-id` | Accept-vs-refuse has no canonical span; the distinction lives only in the structured tool result. |
-
-All nine declare `enforcement: advisory`, `rebindable: false`,
-`passScope: behavioral-only`, `productInstrumentationPrerequisite: true`. Their
-behavioral verdicts are unchanged; the rebind debt is recorded, not enacted.
-
-### 2c. What every changed/new row defines
-
-Enforced by schema and validator, per the workorder's eight requirements:
-
-| Requirement | Field |
-|---|---|
-| expected product attributes/spans | `expectedTelemetry.spans[]` / `.attributes[]` with `emittedByProduct` + `productIssue` |
-| public-safe identity and redaction | `attributes[].publicSafeForm`, `redaction.rule`, `redaction.forbiddenInArtifacts[]` |
-| positive/negative controls | `controls.positive`, `controls.negative` |
-| backend-unavailable disposition | `backendUnavailable.*` (`treatZeroAsAbsence` pinned `false` by schema) |
-| artifact schema | `artifact.schema`, `artifact.requiredFiles[]` |
-| PASS/PARTIAL/FAIL authority | `verdictAuthority.*` incl. `passScope`, `honestLimit` (R-RC-2 only) |
-| manual vs deterministic k6 | `execution.deterministicK6` / `.manual` / `.relationship` |
-| product instrumentation prerequisite | `productInstrumentationPrerequisite`, `prerequisiteRows[]` |
-
----
-
-## 3. Product prerequisites (owed on `karmaterminal/openclaw`)
-
-Nothing below exists on `6b09b1dbe938ab6b5f56eaf4e58f1ed243f89955`.
-
-### 3a. Accepted continuation entry provenance — `R-OBS-CONT-PROVENANCE`
-
-On `continuation.work` and `continuation.delegate.dispatch`:
-
-| Attribute | Public-safe form | Notes |
-|---|---|---|
-| `continuation.signal.origin` | enum | `typed-tool \| tool-call \| bracket \| post-compaction \| queue-drain` |
-| `continuation.signal.kind` | enum | `work \| delegate \| compaction`, on the **entry** span (today it is only on `continuation.disabled` and compaction-release) |
-| `continuation.origin.run.fingerprint` | salted fingerprint | |
-| `continuation.session.fingerprint` | salted fingerprint | Tempo drops raw session ids by design; the remedy is a stable salted fingerprint, not the raw key |
-| `continuation.turn.fingerprint` | salted fingerprint | No exported span retains a stable turn id today |
-
-`continuation.chain.id` already exists and is retained.
-
-### 3b. Proof-run classification — `R-OBS-PROOF-MARKER`
-
-On every span a proof run causes: `openclaw.proof.run_id` (sha256-16),
-`openclaw.proof.row_id` (enum over the committed catalog),
-`openclaw.proof.candidate_sha` (40-char), `openclaw.proof.harness_ref`
-(40-char docs commit), `openclaw.proof.synthetic` (boolean).
-
-The harness already knows all four values
-(`harness-provenance.json`, `runner-metadata.json`); what is missing is a path
-for them to reach the product's exported spans.
-
-### 3c. Canonical terminal outcomes — `R-OBS-TERMINAL-OUTCOME`
-
-New span `continuation.finalization`, plus on terminal spans:
-`continuation.outcome` (closed enum: `delivered | superseded | folded |
-evaporated | rejected-cap | rejected-threshold | zero-payload |
-finalization-failed | interrupted | disabled`),
-`continuation.outcome.reason` (closed enum), `continuation.payload.bytes`
-(integer — the canonical zero-payload signal), `continuation.finalization.status`.
-
-### 3d. Backend disposition — `R-OBS-BACKEND-DISPOSITION` (harness-side, not product)
-
-`telemetry.backend.status` (`complete | partial | unavailable | capped |
-unknown`), `total_blocks`, `completed_jobs`, `result_capped`,
-`window_start_utc`, `query_fingerprint`, written to `backend-status.json` for
-every telemetry interaction — including healthy ones, so an absent file is a
-defect rather than an assumption of health.
-
----
-
-## 4. Enforcement added
-
-### 4a. Catalog time — `tools/k6-proofs/scripts/check-telemetry-contracts.mjs`
-
-Wired into `CATALOG_CHECKS` in `run-proofs.sh`, so a defect fails once as
-harness infrastructure (`harness-control-receipt.json`, exit 78, zero rows
-executed) and never synthesizes a row verdict.
-
-- A row whose `liveRunSafety.requiredReceipts` include `trace-id`,
-  `tempo-trace-json`, `continuation-trace-correlation`,
-  `trace-or-session-correlation`, or `reason-telemetry-redaction-review` **must**
-  declare a `telemetryContract`.
-- **`rebindable: true` requires all four identity purposes (origin, session,
-  turn, run) *and* a `proof-run` marker attribute declared
-  `emittedByProduct: true`, and forbids `productInstrumentationPrerequisite`.**
-  This is the "missing origin/session/turn/proof marker cannot become PASS"
-  gate. No committed row can satisfy it today, so no row can declare a
-  telemetry-rebindable PASS.
-- `passScope: behavioral-and-telemetry-rebindable` requires `rebindable: true`.
-- `productInstrumentationPrerequisite: true` requires `rebindable: false` and a
-  non-empty `prerequisiteRows[]` naming existing rows, never itself.
-- Any span/attribute with `emittedByProduct: false` must name a `productIssue`.
-- `backendUnavailable.disposition ∈ {PARTIAL-candidate, FAIL-candidate}` and
-  `treatZeroAsAbsence` must be `false`.
-- `census.{issue,reportCommit,productBasis}` must equal the exact census values.
-- Each remedy concern owned by exactly one row.
-
-### 4b. Run time — `tools/k6-proofs/scripts/postprocess-k6-summary.mjs`
-
-- Emits a `telemetryRebind` block into `row-result.json` for every row with a
-  contract (enforcement, rebindable, passScope, prerequisite rows, backend
-  disposition, unproven rebind receipts), so the debt is durable in the artifact.
-- Withholds a summary-derived `PASS-candidate` when a receipt required by
-  **either** `expectedReceipts[].required` or `liveRunSafety.requiredReceipts` is
-  explicitly reported `missing` (`failureClass: missing-receipt`). This closed a
-  real pre-existing hole: `outcomeFromSummary` returned `PASS-candidate` on a
-  clean check rate even when `failureClass` was already `missing-receipt`. The
-  union matters: `R-CD-1`, `R-CD-4` and `R-CD-CHAINED-DEPTH-2` had drifted, with
-  `trace-id` required in `liveRunSafety.requiredReceipts` and `required: false`
-  in `expectedReceipts`. The three manifests were aligned and the validator now
-  rejects that drift for any telemetry receipt.
-- Withholds a summary-derived `PASS-candidate` when a row with
-  `enforcement: blocking` has a rebind receipt that is not explicitly `present`,
-  **or** when a row claims `rebindable: true` / the rebindable pass scope and its
-  rebind status is not `proven` (`failureClass: telemetry-rebind-unproven`).
-- A row with a signed authoritative receipt (`R-CD-2`) keeps that receipt as its
-  sole verdict authority and is **not** re-judged. `construct-only` and
-  `HONEST-LIMIT-candidate` outcomes are untouched (the gate only fires on
-  `PASS-candidate` from `verdictSource === 'k6-summary'`).
-
-No scenario in the repository emits `proof_receipts` today, so the
-`missing`-receipt gate changes no current live verdict; it removes the future
-possibility. The gate's scope limits are stated in §8.
-
----
-
-## 5. Files changed
+Indexed this exact worktree (not a stale OpenClaw product index):
 
 ```
-RUNBOOKS/PROOF-CORPUS-METHOD.md                                  (+ 4 rows, + census section)
-tools/k6-proofs/CONTRIBUTING-ROWS.md                             (contract requirement, backend debt rule)
-tools/k6-proofs/docs/CONTINUATION-TELEMETRY-REMEDY-ROWS.md       (new — full contract doc)
-tools/k6-proofs/docs/PROOF-RUN-METHOD.md                         (4th validator, contract section)
-tools/k6-proofs/k6-proofs-pipeline.xml                           (4 rows, telemetry-rebind mandate)
-tools/k6-proofs/row-manifest.schema.json                         (telemetryContract + schema truthfulness)
-tools/k6-proofs/scripts/check-telemetry-contracts.mjs            (new — validator)
-tools/k6-proofs/scripts/postprocess-k6-summary.mjs               (telemetryRebind + PASS gate)
-tools/k6-proofs/scripts/run-proofs.sh                            (CATALOG_CHECKS + 1)
-tools/k6-proofs/scripts/__tests__/catalog-root-contract.test.mjs (CHECKS + 1)
-tools/k6-proofs/scripts/__tests__/telemetry-contract.test.mjs    (new — 18 tests)
-tools/k6-proofs/manifests/r-obs-cont-provenance.json             (new)
-tools/k6-proofs/manifests/r-obs-proof-marker.json                (new)
-tools/k6-proofs/manifests/r-obs-terminal-outcome.json            (new)
-tools/k6-proofs/manifests/r-obs-backend-disposition.json         (new)
-tools/k6-proofs/manifests/{r-cd-1,r-cd-2,r-cd-4,r-cd-chained-depth-2,
-  r-cd-model-tool,r-cd-token,r-cw-1,r-cw-3,r-rc-2}.json          (+ telemetryContract)
-output.md                                                        (this report)
+npx gitnexus analyze --force
+# 74,308 nodes | 84,398 edges | 670 clusters | 272 flows
 ```
 
-The schema also stopped lying: `invocation`, `seatClassExpectation`,
-`sourceContract`, `liveRunSafety.requiresHumanConfirmation` and
-`liveRunSafety.requiresDisposableSession` are all used by shipped manifests but
-were absent from a schema declaring `additionalProperties: false`.
+MCP GitNexus could not read the new LadybugDB (file v42 vs server v40). Queries used CLI `gitnexus@1.6.9` with `--repo` set to this worktree.
 
----
+Pre-edit: `gatewayLifecycleSucceeded` consumers in-repo are `r-cd-2-silent-wake.js:res` plus frozen `PROOFS/**` copies (not edited).
 
-## 6. Validation
-
-### 6a. Baseline (origin/main `ead47a61`, before any change)
-
-```bash
-node --test tools/k6-proofs/scripts/__tests__/*.test.mjs
-```
-
-**320 tests · 319 pass · 1 fail.**
-
-The single failure is `candidate envelope is outside and invisible to canonical
-corpus validation` (`candidate-run-result.test.mjs:474`). It fails because
-`validate-corpus.mjs --index` rejects the committed
-`PROOFS/a7ef03177e0f42831a087521e6eb7720102d6be1/proofs-manifest.json`:
+Post-edit compare to `de315e25`:
 
 ```
-schema-manifest            ✗ expected openclaw.proofs.manifest.v1, got "openclaw.k6.proofs-manifest.v1"
-schema-manifest-capture-sha ✗ missing capture_sha
-schema-manifest-rows       ✗ rows[] missing or not an array
+npx gitnexus detect-changes --scope compare --base-ref de315e25aad6871e51341de7916c7383fa3d06a7
+# Changes: 22 files, 44 symbols
+# Affected processes: 2 (Res → AgentIdFromSessionKey, Res → BuildRequest)
+# Risk: medium
 ```
 
-**Classification: pre-existing on `origin/main`, out of this lane.** It is a
-corpus/manifest-schema divergence in published `PROOFS/**` bytes. Repairing it
-would require editing the published corpus manifest or `validate-corpus.mjs`
-verdict schema, both of which this workorder explicitly forbids ("preserve the
-current never-regress corpus/index rules", "no corpus verdict publication or
-INDEX movement"). Not repaired here.
+Helper context:
+- `gatewayLifecycleReplayInvalid` <- `r-cd-2-silent-wake.js:res`
+- `scopeWorkToolSpans` <- `validateTrace`
+- `rrc2HonestLimitReceiptsSufficient` <- `receiptSummary`, `filterHonestLimitReviewDebt`
+- `resolveExactRuntimeIdentity` used by `resolve-runtime-identity.mjs` / runner / workflow
 
-### 6b. After the change
+## Validation
 
-```bash
-node --test tools/k6-proofs/scripts/__tests__/*.test.mjs
+```
+node --test tools/k6-proofs/scripts/__tests__/*.mjs tools/k6-proofs/tests/*.mjs
+# 399 pass, 0 fail, 19759 ms
+
+node tools/k6-proofs/scripts/check-manifest-scenarios.mjs --repo-root .
+node tools/k6-proofs/scripts/check-scenario-alignment.mjs --repo-root .
+node tools/k6-proofs/scripts/check-proof-row-manifests.mjs --repo-root .
+node tools/k6-proofs/scripts/check-telemetry-contracts.mjs --repo-root .
+node tools/k6-proofs/scripts/validate-corpus.mjs --index
+git diff --check
 ```
 
-**344 tests · 343 pass · 1 fail** — the same single pre-existing failure, byte
-for byte. Net **+24 tests, all passing**; zero new failures; zero previously
-passing tests broken.
+All catalog/telemetry/corpus/whitespace checks passed.
 
-### 6c. Focused
+## Uncertainties
+- Live rows were not refired; this lane only repairs harness authority.
+- When an operator already supplies an exact 40-char `OPENCLAW_RUNTIME_BUILD_SHA`, the CLI is not probed unless an explicit receipt file is also present (avoids host-SHA collisions in tests and accidental overwrite).
+- Historical public R-CW-1 traces have one `continue_work` tool whose parent is not the work/fire parent; a unique reason-bound tool remains accepted.
 
-```bash
-node --test tools/k6-proofs/scripts/__tests__/telemetry-contract.test.mjs
-# 24 tests · 24 pass · 0 fail
-```
-
-### 6d. Catalog validators
-
-```bash
-node tools/k6-proofs/scripts/check-manifest-scenarios.mjs      # 42 manifests; 35 scenario files — passed
-node tools/k6-proofs/scripts/check-scenario-alignment.mjs      # ok:true
-node tools/k6-proofs/scripts/check-proof-row-manifests.mjs     # Missing manifests: 0 — passed
-node tools/k6-proofs/scripts/check-telemetry-contracts.mjs     # 13 contracts; 9 telemetry-required; 0 rebindable — passed
-node tools/k6-proofs/scripts/list-runnable-rows.mjs --all      # 36 rows; the 4 construct-only remedy rows correctly absent
-```
-
-### 6e. Dry catalog selection — affected rows only, no live dispatch
-
-```bash
-cd tools/k6-proofs
-K6_PROOF_OUT_DIR=/tmp/p81-remedy-dryrun \
-OPENCLAW_CANDIDATE_SHA=6b09b1dbe938ab6b5f56eaf4e58f1ed243f89955 \
-  ./scripts/run-proofs.sh --dry-run \
-  R-CD-1,R-CD-2,R-CD-4,R-CD-CHAINED-DEPTH-2,R-CD-MODEL-TOOL,R-CD-TOKEN,R-CW-1,R-CW-3,R-RC-2,\
-R-OBS-CONT-PROVENANCE,R-OBS-PROOF-MARKER,R-OBS-TERMINAL-OUTCOME,R-OBS-BACKEND-DISPOSITION \
-  6b09b1dbe938ab6b5f56eaf4e58f1ed243f89955
-# exit 0
-```
-
-- Catalog preflight ran all four validators including the new one.
-- 9 runnable rows: `DRY RUN: Would execute k6 run …` — nothing fired.
-- 4 construct-only rows: `SKIPPED: Scenario status is construct-only (not runnable).`
-- 0 live gateway connections, 0 product dispatches, 0 corpus writes.
-
-### 6f. Independent review
-
-A read-only `code-review` agent reviewed the full `origin/main...HEAD` diff
-against the census brief, targeting validator loopholes, post-processor
-ordering, schema/validator/doc consistency, and any implication that the product
-instrumentation exists. It reported six findings; **all six were accepted and
-fixed** in the third commit on this branch. Dispositions:
-
-| # | Severity | Finding | Disposition |
-|---|---|---|---|
-| 1 | Critical | `check-telemetry-contracts.mjs` CLI entrypoint guard compared `import.meta.url` (realpath-resolved) against a non-realpath `process.argv[1]`, so any symlinked invocation path — a symlinked `TMPDIR` snapshot root, an operator-supplied `OPENCLAW_PROOFS_ORIGIN_ROOT` — made the validator a **silent exit-0 no-op inside the catalog preflight**, while the other three validators still ran and the preflight looked green. Reproduced. | **Fixed.** `invokedAsCli()` now compares against `realpathSync(process.argv[1])` with a non-realpath fallback. New regression test `the validator still runs when it is reached through a symlinked path` runs the validator through a symlinked scripts dir and asserts exit 1 on a stripped contract. |
-| 2 | High | `enforcement` was author-chosen and independent of `rebindable`, so a manifest could declare `rebindable:true` + `passScope:behavioral-and-telemetry-rebindable` with `enforcement:advisory` and no `rebindReceipts`, and the post-processor would publish a full `PASS-candidate` carrying `status:"unproven"` — a self-contradictory artifact that defeated the documented gate. Reproduced. | **Fixed, both layers.** Validator: a telemetry-rebindable claim now requires `enforcement:blocking` **and** a non-empty `rebindReceipts[]`. Post-processor: withholds PASS whenever a rebindable claim's status is not `proven`, regardless of `enforcement`. Two new tests. |
-| 3 | High | The new missing-receipt downgrade read `expectedReceipts[].required`, while the rule that *pulls a row into the contract* reads `liveRunSafety.requiredReceipts`. Three shipped rows disagreed on exactly the receipt that scoped them in — `R-CD-1`, `R-CD-4`, `R-CD-CHAINED-DEPTH-2` all had `trace-id` required in `liveRunSafety` and `required:false` in `expectedReceipts` — so a row could report its required telemetry receipt missing and still publish a clean PASS. Reproduced. (The reviewer also named `R-CD-MODEL-TOOL`; verified **not** applicable — its telemetry receipt is in neither required list.) | **Fixed three ways.** Post-processor takes the **union** of both lists. Validator now fails any telemetry receipt whose required-ness disagrees between the lists. The three drifted manifests were aligned to `required:true`. Two new tests, one of which pins the whole committed catalog. |
-| 4 | Medium | `enforcement:blocking` is unreachable on every committed row (the four blocking rows are `construct-only`, so their outcome short-circuits before any PASS), and receipt "proven" status is self-asserted by the same k6 summary that produced the PASS. | **Accepted; documented rather than redesigned.** `CONTINUATION-TELEMETRY-REMEDY-ROWS.md` now carries an explicit "Scope and known limits of that gate" section stating that the blocking path is a forward guarantee exercised by tests, not a currently active downgrade, and that receipt corroboration against `artifact.requiredFiles` / the Tempo projection / backend completeness keys is owed alongside the product instrumentation. Redesigning the harness receipt model is out of scope for a contract PR. |
-| 5 | Medium | `run-proofs.sh` never calls `postprocess-k6-summary.mjs` — the row-list runner builds its own `run-result.json` inline with `jq`. The `CONTRIBUTING-ROWS.md` edit claimed every run dir carries `telemetryRebind`, which the runner cannot produce. Verified: `grep -c postprocess-k6-summary run-proofs.sh` → 0. | **Fixed (honesty).** The `CONTRIBUTING-ROWS.md` claim is now scoped to the summary-driven path, and the remedy doc names the runner gap explicitly as follow-up work. |
-| 6 | Low | `AUDITED_ROWS` in the test omitted `R-CD-1`, so one of the nine bound rows was not pinned by the census-binding and eight-definitions assertions. | **Fixed.** `R-CD-1` added; the test now covers all nine. |
-
-Categories the reviewer found clean: corpus/verdict/instrumentation-implication
-(no `PROOFS/**` or `INDEX.json` byte touched, all four remedy rows guard-rejected
-and excluded from `list-runnable-rows.mjs`, every non-emitted attribute carries a
-`productIssue`, every doc carries a "does not exist yet" banner); secrets
-(validator reads no `process.env`, `telemetryRebind` is composed solely of
-manifest-derived fields, no new artifact write path); the `R-CD-2` authoritative
-receipt path (genuinely untouched — `verdictSource` is set before the gate reads
-it); and `validateTelemetryContract` robustness against null/partial inputs.
-
----
-
-## 7. Constraints honoured
-
-| Constraint | Status |
-|---|---|
-| No OpenClaw product edits | ✅ nothing outside this repo touched |
-| No live proofs | ✅ dry-run only; construct-only rows are guard-rejected |
-| No fleet mutation | ✅ no gateway, no seat, no config |
-| No corpus verdict publication | ✅ zero `PROOFS/**` bytes changed |
-| No INDEX movement | ✅ `PROOFS/INDEX.json` untouched |
-| Never-regress corpus/index rules preserved | ✅ existing rows keep their behavioral verdict authority; contracts are `advisory` |
-| Severable from k6 library consolidation | ✅ no file, code, or dependency from `249f7dc9` |
-| Publication convention for future product PRs | ✅ `PR-NNNNNN/PROOFS/<FULL_SHA>/`, documented in all four remedy manifests, the remedy doc, and the corpus runbook |
-
----
-
-## 8. Uncertainties and follow-ups
-
-1. **Three limits of the run-time gate are stated, not hidden** (review findings
-   4 and 5). The gate lives on the summary-driven `postprocess-k6-summary.mjs`
-   path; the row-list runner `run-proofs.sh` builds its own `run-result.json`
-   inline and does not yet carry `telemetryRebind`. No committed row can trigger
-   the blocking downgrade today, because the four blocking rows are
-   `construct-only` and short-circuit before any PASS exists — the blocking path
-   is a forward guarantee exercised by tests. And receipt `present` status is
-   self-asserted by the row's own k6 summary, with no cross-check yet against
-   `artifact.requiredFiles`, the Tempo projection, or the backend completeness
-   keys. All three are recorded in
-   `tools/k6-proofs/docs/CONTINUATION-TELEMETRY-REMEDY-ROWS.md` under "Scope and
-   known limits of that gate". Wiring the contract into the runner's verdict
-   policy (near the existing `R-RC-2` policy at `run-proofs.sh:1212-1229`) is the
-   natural follow-up.
-2. **`enforcement: advisory` on the nine existing rows is a deliberate choice.**
-   Flipping them to `blocking` today would downgrade live PASS rows to
-   `PARTIAL-candidate` fleet-wide — a corpus-policy change that needs cohort
-   ratification and is outside a contract PR. The contract records the debt and
-   names the flip condition (prerequisite rows landing). If the cohort wants the
-   downgrade now, it is a one-word change per manifest.
-3. **The pre-existing `validate-corpus --index` red (§6a) is still red.** It is a
-   published-corpus schema divergence, not this lane's.
-4. **`R-OBS-BACKEND-DISPOSITION` is implementable today** (Tempo already returns
-   `totalBlocks` / `completedJobs`), but implementing the harness receipt is
-   harness work, not contract work, so the row ships `construct-only`. It is the
-   cheapest next step and the only remedy row not gated on OpenClaw.
-5. **No `.github/PULL_REQUEST_TEMPLATE` exists in this repository.** The PR body
-   follows the repository's documented PR contract in
-   `tools/k6-proofs/CONTRIBUTING-ROWS.md` § "PR contract" instead. Flagged, not
-   silently substituted.
-6. **Salt management for the identity fingerprints is unspecified.** The
-   contracts state a per-fleet salt supplied at runtime and never committed;
-   where it lives and how it rotates is an OpenClaw implementation decision, not
-   a catalog one.
-7. **`publicSafeForm: "enum"` is used for a literal ISO-8601 instant** in
-   `R-OBS-BACKEND-DISPOSITION` (`telemetry.backend.window_start_utc`), meaning
-   "fixed machine-parseable value, not prose". If a future contract needs more
-   temporal forms, the enum should gain an explicit `timestamp` member.
-
----
-
-## 9. Exact commands to reproduce
-
-```bash
-git clone https://github.com/karmaterminal/karmaterminal-openclaw-docs.git
-cd karmaterminal-openclaw-docs
-git checkout codeagent/continuation-telemetry-remedy-rows
-
-# catalog
-node tools/k6-proofs/scripts/check-manifest-scenarios.mjs
-node tools/k6-proofs/scripts/check-scenario-alignment.mjs
-node tools/k6-proofs/scripts/check-proof-row-manifests.mjs
-node tools/k6-proofs/scripts/check-telemetry-contracts.mjs
-node tools/k6-proofs/scripts/list-runnable-rows.mjs --all
-
-# focused
-node --test tools/k6-proofs/scripts/__tests__/telemetry-contract.test.mjs
-
-# full sanctioned docs harness suite
-node --test tools/k6-proofs/scripts/__tests__/*.test.mjs
-
-# dry catalog selection, no live dispatch
-cd tools/k6-proofs
-K6_PROOF_OUT_DIR=/tmp/p81-remedy-dryrun \
-OPENCLAW_CANDIDATE_SHA=6b09b1dbe938ab6b5f56eaf4e58f1ed243f89955 \
-  ./scripts/run-proofs.sh --dry-run R-CD-1,R-CD-2,R-CD-4,R-CD-CHAINED-DEPTH-2,R-CD-MODEL-TOOL,R-CD-TOKEN,R-CW-1,R-CW-3,R-RC-2,R-OBS-CONT-PROVENANCE,R-OBS-PROOF-MARKER,R-OBS-TERMINAL-OUTCOME,R-OBS-BACKEND-DISPOSITION 6b09b1dbe938ab6b5f56eaf4e58f1ed243f89955
-```
+## Verdict
+Harness authority repair is complete and covered. Frond review still owns any sanctioned replacement fire / corpus fold.

--- a/tools/k6-proofs/lib/gateway-lifecycle.js
+++ b/tools/k6-proofs/lib/gateway-lifecycle.js
@@ -19,10 +19,18 @@ export function gatewayLifecyclePhase(value) {
   return phase === 'start' || phase === 'end' ? phase : null;
 }
 
+export function gatewayLifecycleReplayInvalid(value) {
+  return gatewayLifecyclePhase(value) === 'end' && value.data?.replayInvalid === true;
+}
+
 export function gatewayLifecycleSucceeded(value) {
   if (gatewayLifecyclePhase(value) !== 'end') return false;
   const status = String(value.data?.status || value.status || '').toLowerCase();
-  return !['error', 'failed', 'failure', 'aborted'].includes(status) && value.data?.replayInvalid !== true;
+  if (['error', 'failed', 'failure', 'aborted'].includes(status)) return false;
+  // replayInvalid is replay-safety metadata after a possibly side-effecting
+  // turn. It is independent from lifecycle success and must not fail the end.
+  if (value.data?.aborted === true || value.aborted === true) return false;
+  return true;
 }
 
 export function gatewayWakeRunId(value, acceptedRunId) {

--- a/tools/k6-proofs/lib/r-cd-2-authoritative-receipt.mjs
+++ b/tools/k6-proofs/lib/r-cd-2-authoritative-receipt.mjs
@@ -17,7 +17,6 @@ const FAILURE_CATEGORIES = new Set([
 ]);
 const CONCLUSIVE_FAILURE_CATEGORIES = new Set([
   'provider-or-turn-failure',
-  'delegate-replay-unsafe',
   'missing-terminal-sentinel',
 ]);
 
@@ -103,6 +102,8 @@ function sameRowBinding(evidence, correlation) {
 }
 
 function categoryFor(evidence, correlation) {
+  // Replay-safety metadata is not a product failure. Preserve the historical
+  // category as review-only PARTIAL so old packets cannot promote to FAIL.
   if (evidence?.failureCategory === 'delegate-replay-unsafe') return 'delegate-replay-unsafe';
   if (evidence?.failureCategory === 'missing-terminal-sentinel') return 'missing-terminal-sentinel';
   if (evidence?.dispatch_failure_observed) return 'provider-or-turn-failure';
@@ -140,6 +141,7 @@ export function resolveRcd2AuthoritativeReceipt({ evidence, correlation, signing
         typedDelegate: evidence?.typed_delegate_success_same_run === true,
         quiet: evidence?.post_wake_quiet === true,
         failed: evidence?.dispatch_failure_observed === true,
+        replayInvalid: evidence?.dispatch_replay_invalid === true,
       }),
       topologyFingerprint: binding({
         trace: correlation?.traceId || null,
@@ -183,6 +185,7 @@ export function resolveRcd2AuthoritativeReceipt({ evidence, correlation, signing
       wakeLifecycleObserved: true,
       unboundSessionVerified: true,
       noChannelVerified: true,
+      replayInvalid: evidence.dispatch_replay_invalid === true,
       traceFingerprint: fingerprint(correlation.traceId),
       acceptedSendTraceFingerprint: fingerprint(evidence.accepted_send_trace_id),
       acceptedSendRunFingerprint: fingerprint(evidence.send_run_fingerprint),

--- a/tools/k6-proofs/lib/r-rc-2-honest-limit.mjs
+++ b/tools/k6-proofs/lib/r-rc-2-honest-limit.mjs
@@ -1,0 +1,56 @@
+export const RRC2_HONEST_LIMIT_TEMPO_RECEIPTS = new Set([
+  'tempo-trace-json',
+  'continuation-trace-correlation',
+  'trace-id',
+  'tool-trace-correlation',
+]);
+
+export function verifiedRrc2ThresholdEvidence(evidence) {
+  return evidence?.row === 'R-RC-2' &&
+    evidence.parent_dispatch_accepted === true &&
+    evidence.delegate_requested === true &&
+    evidence.child_session_observed === true &&
+    evidence.delegate_child_report_observed === true &&
+    evidence.child_reported_context_threshold === true &&
+    evidence.request_compaction_tool_result_observed === true &&
+    evidence.request_compaction_receipt_role === 'toolResult' &&
+    evidence.request_compaction_receipt_tool_name === 'request_compaction' &&
+    evidence.request_compaction_receipt_status === 'rejected' &&
+    evidence.request_compaction_invocation_bound === true &&
+    evidence.request_compaction_rejected_context_threshold === true &&
+    evidence.guard === 'context_threshold';
+}
+
+export function verifiedRrc2AcceptedEvidence(evidence) {
+  return evidence?.row === 'R-RC-2' &&
+    evidence.parent_dispatch_accepted === true &&
+    evidence.delegate_requested === true &&
+    evidence.child_session_observed === true &&
+    evidence.delegate_child_report_observed === true &&
+    evidence.post_compaction_path_observed === true &&
+    evidence.request_compaction_tool_result_observed === true &&
+    evidence.request_compaction_receipt_role === 'toolResult' &&
+    evidence.request_compaction_receipt_tool_name === 'request_compaction' &&
+    evidence.request_compaction_receipt_status === 'accepted' &&
+    evidence.request_compaction_invocation_bound === true &&
+    evidence.request_compaction_accepted === true;
+}
+
+export function hasVerifiedRrc2Outcome(rowId, verdict, evidence) {
+  if (rowId !== 'R-RC-2') return verdict !== 'HONEST-LIMIT-candidate';
+  if (verdict === 'HONEST-LIMIT-candidate') return verifiedRrc2ThresholdEvidence(evidence);
+  if (verdict === 'PASS-candidate') return verifiedRrc2AcceptedEvidence(evidence);
+  return true;
+}
+
+export function rrc2HonestLimitReceiptsSufficient({ rowId, verdict, evidence } = {}) {
+  return rowId === 'R-RC-2' &&
+    verdict === 'HONEST-LIMIT-candidate' &&
+    verifiedRrc2ThresholdEvidence(evidence);
+}
+
+export function filterHonestLimitReviewDebt(pendingReceipts, context = {}) {
+  const pending = Array.isArray(pendingReceipts) ? pendingReceipts : [];
+  if (!rrc2HonestLimitReceiptsSufficient(context)) return pending;
+  return pending.filter((receipt) => !RRC2_HONEST_LIMIT_TEMPO_RECEIPTS.has(receipt));
+}

--- a/tools/k6-proofs/lib/runtime-identity.mjs
+++ b/tools/k6-proofs/lib/runtime-identity.mjs
@@ -1,0 +1,174 @@
+const EXACT_SHA = /^[a-f0-9]{40}$/;
+const SHORT_SHA = /^[a-f0-9]{7,39}$/;
+const RECEIPT_SCHEMAS = new Set([
+  'openclaw.k6.runtime-build-receipt.v1',
+  'openclaw.runtime-build-receipt.v1',
+]);
+
+export const RUNTIME_IDENTITY_SCHEMA = 'openclaw.k6.runtime-identity.v1';
+
+export function exactRuntimeSha(value) {
+  const text = typeof value === 'string' ? value.trim().toLowerCase() : '';
+  return EXACT_SHA.test(text) ? text : null;
+}
+
+function firstExact(...values) {
+  for (const value of values) {
+    const sha = exactRuntimeSha(value);
+    if (sha) return sha;
+  }
+  return null;
+}
+
+function asObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : null;
+}
+
+export function extractExactShaFromStructured(value) {
+  const object = asObject(value);
+  if (!object) return null;
+  return firstExact(
+    object.sha,
+    object.commit,
+    object.buildSha,
+    object.runtimeBuildSha,
+    object.build?.sha,
+    object.build?.commit,
+    object.git?.sha,
+    object.git?.commit,
+    object.version?.sha,
+    object.version?.commit,
+  );
+}
+
+export function parseRuntimeBuildReceipt(value, { source = 'runtime-build-receipt', path = null } = {}) {
+  const object = asObject(value);
+  if (!object) return { ok: false, reason: 'malformed', source, path };
+  if (object.schema && !RECEIPT_SCHEMAS.has(object.schema)) {
+    return { ok: false, reason: 'malformed', source, path };
+  }
+  const sha = extractExactShaFromStructured(object);
+  if (!sha) {
+    return {
+      ok: false,
+      reason: firstExact(object.sha, object.build?.sha) ? 'malformed' : 'absent',
+      source,
+      path,
+    };
+  }
+  return { ok: true, sha, source, path, schema: object.schema || null };
+}
+
+export function classifyRuntimeStamp(value) {
+  if (value == null || value === '') return { kind: 'absent', value: null };
+  const text = String(value).trim();
+  if (!text || text === 'unknown') return { kind: 'absent', value: null };
+  const exact = exactRuntimeSha(text);
+  if (exact) return { kind: 'exact-sha', value: exact };
+  if (SHORT_SHA.test(text.toLowerCase())) return { kind: 'short-only', value: text };
+  const shortFromStamp = text.match(/\(([a-f0-9]{7,39})\)/i)?.[1];
+  if (shortFromStamp) return { kind: 'version-stamp', value: text, shortSha: shortFromStamp.toLowerCase() };
+  return { kind: 'version-stamp', value: text };
+}
+
+/**
+ * Fail-closed merge of independently observed runtime identity sources.
+ * Never accepts the candidate SHA as a source and never expands a short SHA.
+ */
+export function resolveExactRuntimeIdentity(sources = []) {
+  const observed = [];
+  const exact = [];
+  let versionStamp = null;
+  let shortOnly = false;
+  let malformed = false;
+
+  for (const source of Array.isArray(sources) ? sources : []) {
+    if (!source || source.kind === 'candidate-sha') continue;
+    const label = source.source || source.kind || 'unknown';
+    const path = source.path || null;
+    if (source.receipt != null) {
+      const parsed = parseRuntimeBuildReceipt(source.receipt, { source: label, path });
+      observed.push({ source: label, path, result: parsed.ok ? 'exact-sha' : parsed.reason });
+      if (parsed.ok) exact.push({ sha: parsed.sha, source: label, path });
+      else if (parsed.reason === 'malformed') malformed = true;
+      continue;
+    }
+    if (source.sha != null) {
+      const sha = exactRuntimeSha(source.sha);
+      observed.push({ source: label, path, result: sha ? 'exact-sha' : 'malformed' });
+      if (sha) exact.push({ sha, source: label, path });
+      else malformed = true;
+      continue;
+    }
+    if (source.stamp != null) {
+      const classified = classifyRuntimeStamp(source.stamp);
+      observed.push({ source: label, path, result: classified.kind });
+      if (classified.kind === 'exact-sha') exact.push({ sha: classified.value, source: label, path });
+      else if (classified.kind === 'short-only') shortOnly = true;
+      else if (classified.kind === 'version-stamp') {
+        versionStamp = versionStamp || classified.value;
+        if (classified.shortSha) shortOnly = true;
+      }
+    }
+  }
+
+  const unique = [...new Set(exact.map((entry) => entry.sha))];
+  if (unique.length > 1) {
+    return {
+      schema: RUNTIME_IDENTITY_SCHEMA,
+      ok: false,
+      exact: false,
+      reason: 'ambiguous',
+      sha: null,
+      source: null,
+      path: null,
+      versionStamp,
+      observed,
+    };
+  }
+  if (unique.length === 1) {
+    const chosen = exact.find((entry) => entry.sha === unique[0]);
+    return {
+      schema: RUNTIME_IDENTITY_SCHEMA,
+      ok: true,
+      exact: true,
+      reason: null,
+      sha: chosen.sha,
+      source: chosen.source,
+      path: chosen.path,
+      versionStamp,
+      observed,
+    };
+  }
+
+  let reason = 'absent';
+  if (malformed) reason = 'malformed';
+  else if (shortOnly) reason = 'short-only';
+  else if (versionStamp) reason = 'short-only';
+
+  return {
+    schema: RUNTIME_IDENTITY_SCHEMA,
+    ok: false,
+    exact: false,
+    reason,
+    sha: null,
+    source: null,
+    path: null,
+    versionStamp,
+    observed,
+  };
+}
+
+export function publicRuntimeIdentity(identity, { candidateSha = null } = {}) {
+  const sha = identity?.exact ? identity.sha : null;
+  return {
+    schema: RUNTIME_IDENTITY_SCHEMA,
+    exact: identity?.exact === true,
+    runtimeBuildSha: sha,
+    runtimeBuildShaSource: identity?.exact ? identity.source : null,
+    runtimeBuildReceiptPath: identity?.exact ? identity.path : null,
+    versionStamp: identity?.versionStamp || null,
+    reason: identity?.ok ? null : (identity?.reason || 'absent'),
+    candidateMatchesRuntime: Boolean(sha && candidateSha && sha === candidateSha),
+  };
+}

--- a/tools/k6-proofs/manifests/r-rc-2.json
+++ b/tools/k6-proofs/manifests/r-rc-2.json
@@ -67,7 +67,7 @@
   "review": {
     "candidateOnly": true,
     "foldRequiresReview": true,
-    "notes": "R-RC-2 is HONEST-LIMIT-candidate when the delegated child reaches request_compaction and receives a structured below-threshold rejection. A true accepted compaction path remains fixture-gated until reviewed tiny-context env/config exists."
+    "notes": "R-RC-2 is HONEST-LIMIT-candidate when the delegated child reaches request_compaction and receives a nonce-bound structured below-threshold rejection plus the matching child return. Those receipts are sufficient for the honest-limit fold review; missing Tempo is not debt on this path. A true accepted compaction path remains fixture-gated until reviewed tiny-context env/config exists."
   },
   "telemetryContract": {
     "schema": "openclaw.k6.row-telemetry-contract.v1",
@@ -235,9 +235,9 @@
     "verdictAuthority": {
       "passScope": "behavioral-only",
       "pass": "A genuine accepted compaction with the post-compaction path observed and the structured accepted toolResult receipt.",
-      "partial": "Any other incomplete substrate, including a degraded or partial telemetry backend, a missing trace receipt, or a prose-only child report.",
+      "partial": "Any other incomplete substrate, including a degraded or partial telemetry backend on the accepted path, or a prose-only/unbound child report.",
       "fail": "The structured receipt contradicts the observed path, or request_compaction is never reached by the child.",
-      "honestLimit": "The sole corpus HONEST-LIMIT: a structured toolResult receipt proving request_compaction was refused because context pressure remained below threshold. It requires the structured receipt and is never inferred from absence."
+      "honestLimit": "The sole corpus HONEST-LIMIT: a nonce-bound structured toolResult receipt (status=rejected, guard=context_threshold) plus the matching child threshold return. Those receipts are sufficient; Tempo continuation topology is optional corroboration and must never be inferred from assistant prose or an unbound tool result."
     },
     "execution": {
       "deterministicK6": "r-rc-2-delegate-request-compaction.js runs in a disposable session, delegates request_compaction to a child, and captures the structured receipt without mutating config.",

--- a/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
+++ b/tools/k6-proofs/scenarios/r-cd-2-silent-wake.js
@@ -23,7 +23,7 @@ import { Counter, Trend } from 'k6/metrics';
 import crypto from 'k6/crypto';
 import { connectFrame, nonce, RequestTracker, redactEvent } from '../lib/gateway-ws.js';
 import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js';
-import { gatewayLifecycleRunId, gatewayLifecyclePhase, gatewayLifecycleSucceeded, gatewayWakeRunId } from '../lib/gateway-lifecycle.js';
+import { gatewayLifecycleRunId, gatewayLifecyclePhase, gatewayLifecycleReplayInvalid, gatewayLifecycleSucceeded, gatewayWakeRunId } from '../lib/gateway-lifecycle.js';
 import { observesRcd2DispatchTerminalSentinel } from '../lib/r-cd-2-terminal-sentinel.js';
 
 export const options = {
@@ -142,6 +142,7 @@ export default function () {
     post_wake_quiet: false,
     post_wake_quiet_timer_started: false,
     dispatch_failure_observed: false,
+    dispatch_replay_invalid: false,
     send_run_mismatch: false,
     task_created: false,
     task_mode: null,
@@ -334,11 +335,13 @@ export default function () {
             }
             if (phase === 'end' && eventRunId === acceptedRunId) {
               dispatchLifecycleActive = false;
+              if (gatewayLifecycleReplayInvalid(eventData)) {
+                evidence.dispatch_replay_invalid = true;
+              }
               if (!sameRun) evidence.send_run_mismatch = true;
               else if (!gatewayLifecycleSucceeded(eventData)) {
                 evidence.dispatch_failure_observed = true;
-                evidence.failureCategory = eventData.data?.replayInvalid === true
-                  ? 'delegate-replay-unsafe' : 'provider-or-turn-failure';
+                evidence.failureCategory = 'provider-or-turn-failure';
               } else {
                 evidence.send_run_success_end_observed = true;
                 maybeRecordDispatchTerminalSuccess();

--- a/tools/k6-proofs/scripts/__tests__/collect-continuation-trace.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/collect-continuation-trace.test.mjs
@@ -1659,3 +1659,140 @@ test('bracket-token topology rejects a typed tool origin and duplicate dispatch 
     });
   }
 });
+
+test('R-CW-3 scopes one causal continue_work origin on a shared trace', async () => {
+  const fixture = await fixtureDir({ tool: 'continue_work', workVariant: 'reason-prefix' });
+  const traceId = '9'.repeat(32);
+  const trace = traceFixture({
+    traceId,
+    reasonHash: fixture.reasonHash,
+    reasonLength: fixture.reasonLength,
+    tool: 'continue_work',
+  });
+  const spans = trace.batches[0].scopeSpans[0].spans;
+  spans.unshift(
+    span(
+      'openclaw.tool.execution',
+      traceId,
+      '9999999999999999',
+      '8888888888888888',
+      [attr('gen_ai.tool.name', 'continue_work')],
+      'OK',
+      {
+        startTimeUnixNano: '1785580554338000000',
+        endTimeUnixNano: '1785580554339000000',
+      },
+    ),
+    span(
+      'openclaw.tool.execution',
+      traceId,
+      '7777777777777777',
+      '6666666666666666',
+      [attr('gen_ai.tool.name', 'continue_work')],
+      'OK',
+      {
+        startTimeUnixNano: '1785580550000000000',
+        endTimeUnixNano: '1785580550001000000',
+      },
+    ),
+  );
+  const server = await listen((request, response) => {
+    response.setHeader('content-type', 'application/json');
+    response.end(JSON.stringify(
+      new URL(request.url, 'http://localhost').pathname === '/api/search'
+        ? { traces: [{ traceID: traceId }] }
+        : trace,
+    ));
+  });
+  try {
+    const { stdout } = await execFileAsync(process.execPath, [
+      script, '--run-dir', fixture.dir, '--manifest', fixture.manifestPath,
+      '--seat', 'ronan', '--tempo-url', server.url, '--timeout-ms', '100', '--poll-ms', '10',
+    ]);
+    const result = JSON.parse(stdout);
+    const receipt = JSON.parse(await readFile(path.join(fixture.dir, result.receiptFile), 'utf8'));
+    assert.deepEqual(receipt.toolSpanIds, ['aaaaaaaaaaaaaaaa']);
+  } finally {
+    await server.close();
+    await rm(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test('R-CW-3 remains fail-closed on ambiguous in-scope continue_work origins', async () => {
+  const fixture = await fixtureDir({ tool: 'continue_work', workVariant: 'reason-prefix' });
+  const traceId = 'c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1c1';
+  const trace = traceFixture({
+    traceId,
+    reasonHash: fixture.reasonHash,
+    reasonLength: fixture.reasonLength,
+    tool: 'continue_work',
+    toolCount: 2,
+  });
+  const server = await listen((request, response) => {
+    response.setHeader('content-type', 'application/json');
+    response.end(JSON.stringify(
+      new URL(request.url, 'http://localhost').pathname === '/api/search'
+        ? { traces: [{ traceID: traceId }] }
+        : trace,
+    ));
+  });
+  try {
+    await assert.rejects(
+      execFileAsync(process.execPath, [
+        script, '--run-dir', fixture.dir, '--manifest', fixture.manifestPath,
+        '--seat', 'ronan', '--tempo-url', server.url, '--timeout-ms', '40', '--poll-ms', '10',
+      ]),
+      /in-scope continue_work tool spans|contains 2 continue_work tool spans/,
+    );
+  } finally {
+    await server.close();
+    await rm(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test('R-CW-3 rejects time-window-only continue_work attribution without causal scope', async () => {
+  const fixture = await fixtureDir({ tool: 'continue_work', workVariant: 'reason-prefix' });
+  const traceId = 'd1d1d1d1d1d1d1d1d1d1d1d1d1d1d1d1';
+  const trace = traceFixture({
+    traceId,
+    reasonHash: fixture.reasonHash,
+    reasonLength: fixture.reasonLength,
+    tool: 'continue_work',
+  });
+  const spans = trace.batches[0].scopeSpans[0].spans;
+  const tool = spans.find((entry) => entry.name === 'openclaw.tool.execution');
+  tool.parentSpanId = b64('8888888888888888');
+  tool.spanId = b64('9999999999999999');
+  spans.unshift(span(
+    'openclaw.tool.execution',
+    traceId,
+    '7777777777777777',
+    '6666666666666666',
+    [attr('gen_ai.tool.name', 'continue_work')],
+    'OK',
+    {
+      startTimeUnixNano: String(1785580554339000000n),
+      endTimeUnixNano: String(1785580554339001000n),
+    },
+  ));
+  const server = await listen((request, response) => {
+    response.setHeader('content-type', 'application/json');
+    response.end(JSON.stringify(
+      new URL(request.url, 'http://localhost').pathname === '/api/search'
+        ? { traces: [{ traceID: traceId }] }
+        : trace,
+    ));
+  });
+  try {
+    await assert.rejects(
+      execFileAsync(process.execPath, [
+        script, '--run-dir', fixture.dir, '--manifest', fixture.manifestPath,
+        '--seat', 'ronan', '--tempo-url', server.url, '--timeout-ms', '40', '--poll-ms', '10',
+      ]),
+      /in-scope continue_work tool spans|lacks the originating continue_work tool span/,
+    );
+  } finally {
+    await server.close();
+    await rm(fixture.dir, { recursive: true, force: true });
+  }
+});

--- a/tools/k6-proofs/scripts/__tests__/gateway-lifecycle.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/gateway-lifecycle.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { gatewayLifecyclePhase, gatewayLifecycleRunId, gatewayLifecycleSucceeded, gatewayWakeRunId } from '../../lib/gateway-lifecycle.js';
+import { gatewayLifecyclePhase, gatewayLifecycleReplayInvalid, gatewayLifecycleRunId, gatewayLifecycleSucceeded, gatewayWakeRunId } from '../../lib/gateway-lifecycle.js';
 
 test('R-CD-2 accepts only the documented top-level gateway lifecycle runId', () => {
   assert.equal(gatewayLifecycleRunId({ runId: 'send-run-1', stream: 'lifecycle' }), 'send-run-1');
@@ -23,4 +23,27 @@ test('uses only top-level lifecycle envelopes for terminal and wake identity', (
   assert.equal(gatewayWakeRunId(wake, 'send-run-1'), 'wake-run-2');
   assert.equal(gatewayWakeRunId({ stream: 'lifecycle', data: { phase: 'start', runId: 'nested' } }, 'send-run-1'), null);
   assert.equal(gatewayWakeRunId({ runId: 'send-run-1', stream: 'lifecycle', data: { phase: 'start' } }, 'send-run-1'), null);
+});
+
+test('successful phase=end remains successful when replayInvalid is true', () => {
+  const event = {
+    runId: 'send-run-1',
+    stream: 'lifecycle',
+    data: { phase: 'end', status: 'ok', replayInvalid: true },
+  };
+  assert.equal(gatewayLifecycleSucceeded(event), true);
+  assert.equal(gatewayLifecycleReplayInvalid(event), true);
+});
+
+test('failed or aborted lifecycle ends remain unsuccessful', () => {
+  for (const event of [
+    { runId: 'send-run-1', stream: 'lifecycle', data: { phase: 'error', status: 'ok' } },
+    { runId: 'send-run-1', stream: 'lifecycle', data: { phase: 'end', status: 'failed' } },
+    { runId: 'send-run-1', stream: 'lifecycle', data: { phase: 'end', status: 'error' } },
+    { runId: 'send-run-1', stream: 'lifecycle', data: { phase: 'end', status: 'failure' } },
+    { runId: 'send-run-1', stream: 'lifecycle', data: { phase: 'end', status: 'aborted' } },
+    { runId: 'send-run-1', stream: 'lifecycle', data: { phase: 'end', status: 'ok', aborted: true } },
+  ]) {
+    assert.equal(gatewayLifecycleSucceeded(event), false);
+  }
 });

--- a/tools/k6-proofs/scripts/__tests__/r-cd-2-authoritative-receipt.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cd-2-authoritative-receipt.test.mjs
@@ -49,6 +49,13 @@ function correlation(overrides = {}) {
   };
 }
 
+test('R-CD-2 scenario keeps replayInvalid as evidence and never maps it to FAIL', async () => {
+  const scenario = await readFile(path.join(repoRoot, 'scenarios/r-cd-2-silent-wake.js'), 'utf8');
+  assert.match(scenario, /gatewayLifecycleReplayInvalid/);
+  assert.match(scenario, /dispatch_replay_invalid/);
+  assert.doesNotMatch(scenario, /delegate-replay-unsafe/);
+});
+
 test('R-CD-2 promotes only a same-run typed silent-wake topology', () => {
   const receipt = resolveRcd2AuthoritativeReceipt({ evidence: evidence(), correlation: correlation(), signingKey });
   assert.equal(receipt.verdict, 'PASS-candidate');
@@ -88,16 +95,38 @@ test('R-CD-2 rejects a same-trace/chain topology with another row run or nonce',
   }
 });
 
-test('R-CD-2 rejects replay failure, wrong mode, and mismatched trace topology', () => {
-  const replay = resolveRcd2AuthoritativeReceipt({
+test('R-CD-2 keeps successful replayInvalid evidence and does not conclusive-fail it', () => {
+  const replaySafe = resolveRcd2AuthoritativeReceipt({
+    evidence: evidence({ dispatch_replay_invalid: true }),
+    correlation: correlation(), signingKey,
+  });
+  assert.equal(replaySafe.verdict, 'PASS-candidate');
+  assert.equal(replaySafe.lifecycle.replayInvalid, true);
+  assert.equal(validateRcd2AuthoritativeReceipt(replaySafe, signingKey).valid, true);
+
+  const historical = resolveRcd2AuthoritativeReceipt({
     evidence: evidence({ dispatch_failure_observed: true, failureCategory: 'delegate-replay-unsafe' }),
     correlation: correlation(), signingKey,
   });
   assert.deepEqual(
-    [replay.verdict, replay.failureCategory],
-    ['FAIL-candidate', 'delegate-replay-unsafe'],
+    [historical.verdict, historical.failureCategory],
+    ['PARTIAL-candidate', 'delegate-replay-unsafe'],
   );
-  assert.equal(validateRcd2AuthoritativeReceipt(replay, signingKey).valid, true);
+  assert.equal(validateRcd2AuthoritativeReceipt(historical, signingKey).valid, true);
+});
+
+test('R-CD-2 still conclusive-fails genuine provider or abort failures', () => {
+  const failed = resolveRcd2AuthoritativeReceipt({
+    evidence: evidence({ dispatch_failure_observed: true, failureCategory: 'provider-or-turn-failure' }),
+    correlation: correlation(), signingKey,
+  });
+  assert.deepEqual(
+    [failed.verdict, failed.failureCategory],
+    ['FAIL-candidate', 'provider-or-turn-failure'],
+  );
+});
+
+test('R-CD-2 rejects wrong mode and mismatched trace topology', () => {
   for (const bad of [correlation({ delegate: { mode: 'normal' } }), correlation({ toolSpanIds: ['a'.repeat(16), 'b'.repeat(16)] })]) {
     const receipt = resolveRcd2AuthoritativeReceipt({ evidence: evidence(), correlation: bad, signingKey });
     assert.deepEqual([receipt.verdict, receipt.failureCategory], ['PARTIAL-candidate', 'invalid-continuation-topology']);

--- a/tools/k6-proofs/scripts/__tests__/r-cd-token-runner-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cd-token-runner-contract.test.mjs
@@ -17,6 +17,9 @@ test('runner gates exact build and surface identity before token dispatch', asyn
   assert.ok(buildGate > 0 && prepared > buildGate && surfaceGate > prepared &&
     disposableGate > surfaceGate && k6 > disposableGate);
   assert.match(source, /OPENCLAW_CANDIDATE_SHA" != "\$OPENCLAW_RUNTIME_BUILD_SHA/);
+  assert.match(source, /resolve-runtime-identity\.mjs/);
+  assert.match(source, /runtimeBuildShaSource/);
+  assert.doesNotMatch(source, /OPENCLAW_RUNTIME_BUILD_SHA="\$OPENCLAW_CANDIDATE_SHA"/);
   assert.match(source, /trap finalize_interrupted_token_run EXIT/);
   assert.match(source, /signal-int/);
   assert.match(source, /signal-term/);

--- a/tools/k6-proofs/scripts/__tests__/r-rc-2-honest-limit-policy.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-rc-2-honest-limit-policy.test.mjs
@@ -4,6 +4,11 @@ import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
+import {
+  filterHonestLimitReviewDebt,
+  hasVerifiedRrc2Outcome,
+  rrc2HonestLimitReceiptsSufficient,
+} from '../../lib/r-rc-2-honest-limit.mjs';
 import test from 'node:test';
 
 const scenarioPath = 'tools/k6-proofs/scenarios/r-rc-2-delegate-request-compaction.js';
@@ -143,6 +148,48 @@ test('R-RC-2 summary processing cannot promote report-only evidence', async () =
     },
     runId: 'accepted-receipt',
   }), 'PASS-candidate');
+});
+
+const boundHonestLimit = {
+  row: 'R-RC-2',
+  parent_dispatch_accepted: true,
+  delegate_requested: true,
+  child_session_observed: true,
+  delegate_child_report_observed: true,
+  child_reported_context_threshold: true,
+  request_compaction_tool_result_observed: true,
+  request_compaction_receipt_role: 'toolResult',
+  request_compaction_receipt_tool_name: 'request_compaction',
+  request_compaction_receipt_status: 'rejected',
+  request_compaction_invocation_bound: true,
+  request_compaction_rejected_context_threshold: true,
+  guard: 'context_threshold',
+};
+
+test('R-RC-2 honest-limit requires bound structured receipts, not prose or unbound tools', () => {
+  assert.equal(hasVerifiedRrc2Outcome('R-RC-2', 'HONEST-LIMIT-candidate', boundHonestLimit), true);
+  assert.equal(rrc2HonestLimitReceiptsSufficient({
+    rowId: 'R-RC-2',
+    verdict: 'HONEST-LIMIT-candidate',
+    evidence: boundHonestLimit,
+  }), true);
+  assert.equal(hasVerifiedRrc2Outcome('R-RC-2', 'HONEST-LIMIT-candidate', {
+    ...boundHonestLimit,
+    request_compaction_tool_result_observed: false,
+    request_compaction_receipt_role: 'assistant',
+    request_compaction_invocation_bound: false,
+  }), false);
+  assert.equal(hasVerifiedRrc2Outcome('R-RC-2', 'HONEST-LIMIT-candidate', {
+    ...boundHonestLimit,
+    request_compaction_invocation_bound: false,
+  }), false);
+  assert.deepEqual(
+    filterHonestLimitReviewDebt(
+      ['tempo-trace-json', 'continuation-trace-correlation', 'gateway-journal'],
+      { rowId: 'R-RC-2', verdict: 'HONEST-LIMIT-candidate', evidence: boundHonestLimit },
+    ),
+    ['gateway-journal'],
+  );
 });
 
 test('summary processing honors partial manifest and scenario ceilings', async () => {

--- a/tools/k6-proofs/scripts/__tests__/review-debt.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/review-debt.test.mjs
@@ -115,6 +115,41 @@ test('summarizes trace-missing debt as unfetchable when no trace id exists', asy
   }
 });
 
+test('R-RC-2 bound honest-limit receipts clear Tempo review debt', async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'review-debt-rrc2-'));
+  try {
+    await writeResult(root, 'R-RC-2', {
+      verdict: 'HONEST-LIMIT-candidate',
+      evidence: {
+        row: 'R-RC-2',
+        parent_dispatch_accepted: true,
+        delegate_requested: true,
+        child_session_observed: true,
+        delegate_child_report_observed: true,
+        child_reported_context_threshold: true,
+        request_compaction_tool_result_observed: true,
+        request_compaction_receipt_role: 'toolResult',
+        request_compaction_receipt_tool_name: 'request_compaction',
+        request_compaction_receipt_status: 'rejected',
+        request_compaction_invocation_bound: true,
+        request_compaction_rejected_context_threshold: true,
+        guard: 'context_threshold',
+      },
+      observability: { traceStatus: 'missing', traceId: null, tempoTraceJson: null },
+      review: {
+        status: 'review-pending',
+        pendingReceipts: ['tempo-trace-json', 'continuation-trace-correlation'],
+      },
+    });
+    const run = await runNode(process.execPath, [script, '--run-root', root, '--json'], { encoding: 'utf8' });
+    const summary = JSON.parse(run.stdout);
+    assert.equal(summary.totalRows, 1);
+    assert.equal(summary.pendingRows, 0);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test('renders human-readable review debt table', async () => {
   const root = await mkdtemp(path.join(tmpdir(), 'review-debt-text-'));
   try {

--- a/tools/k6-proofs/scripts/__tests__/runtime-identity.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/runtime-identity.test.mjs
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  classifyRuntimeStamp,
+  parseRuntimeBuildReceipt,
+  resolveExactRuntimeIdentity,
+} from '../../lib/runtime-identity.mjs';
+
+const sha = '46f4d2115700d574501bb3c4763abf6b2ba977fe';
+const other = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+test('accepts an exact structured build receipt', () => {
+  const parsed = parseRuntimeBuildReceipt({
+    schema: 'openclaw.k6.runtime-build-receipt.v1',
+    sha,
+  }, { source: 'runtime-build-receipt', path: '/tmp/receipt.json' });
+  assert.deepEqual(
+    { ok: parsed.ok, sha: parsed.sha, source: parsed.source },
+    { ok: true, sha, source: 'runtime-build-receipt' },
+  );
+});
+
+test('resolves exact identity from installed version JSON independently of the candidate', () => {
+  const identity = resolveExactRuntimeIdentity([
+    { source: 'openclaw-version-json', receipt: { build: { sha } } },
+    { kind: 'candidate-sha', sha: other },
+  ]);
+  assert.equal(identity.ok, true);
+  assert.equal(identity.sha, sha);
+  assert.equal(identity.source, 'openclaw-version-json');
+});
+
+test('rejects mismatched independent exact sources', () => {
+  const identity = resolveExactRuntimeIdentity([
+    { source: 'operator-env-exact-sha', sha },
+    { source: 'openclaw-version-json', receipt: { build: { sha: other } } },
+  ]);
+  assert.equal(identity.ok, false);
+  assert.equal(identity.reason, 'ambiguous');
+  assert.equal(identity.sha, null);
+});
+
+test('rejects malformed, absent, and short-only stamps without inventing a full SHA', () => {
+  assert.equal(resolveExactRuntimeIdentity([]).reason, 'absent');
+  assert.equal(resolveExactRuntimeIdentity([
+    { source: 'runtime-build-receipt', receipt: { schema: 'nope', sha: 'not-a-sha' } },
+  ]).reason, 'malformed');
+  const short = resolveExactRuntimeIdentity([
+    { source: 'openclaw-version-stamp', stamp: 'OpenClaw 2026.8.1 (46f4d21)' },
+  ]);
+  assert.equal(short.ok, false);
+  assert.equal(short.reason, 'short-only');
+  assert.equal(short.sha, null);
+  assert.equal(classifyRuntimeStamp('46f4d21').kind, 'short-only');
+});

--- a/tools/k6-proofs/scripts/candidate-run-result-contract.mjs
+++ b/tools/k6-proofs/scripts/candidate-run-result-contract.mjs
@@ -3,6 +3,9 @@ import { existsSync, readFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { validateRcd2AuthoritativeReceipt } from '../lib/r-cd-2-authoritative-receipt.mjs';
 import { validateRcdTokenAuthoritativeReceipt } from '../lib/r-cd-token-authoritative-receipt.mjs';
+import { hasVerifiedRrc2Outcome } from '../lib/r-rc-2-honest-limit.mjs';
+
+export { hasVerifiedRrc2Outcome };
 
 export const CANDIDATE_RUN_RESULT_SCHEMA = 'openclaw.k6.candidate-run-result.v1';
 export const PROOF_ROW_MANIFEST_SCHEMA = 'openclaw.k6.proof-row-manifest.v1';
@@ -145,40 +148,6 @@ function harnessIdentityMatches({ envelope, metadata, runDir }) {
 
 function scenarioName(manifest) {
   return manifest?.scenario?.name || manifest?.scenario?.file?.replace(/\.js$/, '') || null;
-}
-
-function hasVerifiedRrc2Outcome(rowId, verdict, evidence) {
-  if (rowId !== 'R-RC-2') return verdict !== 'HONEST-LIMIT-candidate';
-  if (verdict === 'HONEST-LIMIT-candidate') return (
-    evidence?.row === 'R-RC-2' &&
-    evidence.parent_dispatch_accepted === true &&
-    evidence.delegate_requested === true &&
-    evidence.child_session_observed === true &&
-    evidence.delegate_child_report_observed === true &&
-    evidence.child_reported_context_threshold === true &&
-    evidence.request_compaction_tool_result_observed === true &&
-    evidence.request_compaction_receipt_role === 'toolResult' &&
-    evidence.request_compaction_receipt_tool_name === 'request_compaction' &&
-    evidence.request_compaction_receipt_status === 'rejected' &&
-    evidence.request_compaction_invocation_bound === true &&
-    evidence.request_compaction_rejected_context_threshold === true &&
-    evidence.guard === 'context_threshold'
-  );
-  if (verdict === 'PASS-candidate') return (
-    evidence?.row === 'R-RC-2' &&
-    evidence.parent_dispatch_accepted === true &&
-    evidence.delegate_requested === true &&
-    evidence.child_session_observed === true &&
-    evidence.delegate_child_report_observed === true &&
-    evidence.post_compaction_path_observed === true &&
-    evidence.request_compaction_tool_result_observed === true &&
-    evidence.request_compaction_receipt_role === 'toolResult' &&
-    evidence.request_compaction_receipt_tool_name === 'request_compaction' &&
-    evidence.request_compaction_receipt_status === 'accepted' &&
-    evidence.request_compaction_invocation_bound === true &&
-    evidence.request_compaction_accepted === true
-  );
-  return true;
 }
 
 function authoritativeReceiptContract(rowId) {

--- a/tools/k6-proofs/scripts/collect-continuation-trace.mjs
+++ b/tools/k6-proofs/scripts/collect-continuation-trace.mjs
@@ -236,6 +236,40 @@ function positiveIntegerAttribute(spansAndKeys) {
   return null;
 }
 
+function spanIdHexOrNull(span, field) {
+  try {
+    const value = span?.[field];
+    if (!value) return null;
+    return idHex(value, 8, field);
+  } catch {
+    return null;
+  }
+}
+
+function toolCausallyScopedToTopology(tool, accept, fires) {
+  const toolId = spanIdHexOrNull(tool, 'spanId');
+  const toolParent = spanIdHexOrNull(tool, 'parentSpanId');
+  const acceptId = spanIdHexOrNull(accept, 'spanId');
+  const acceptParent = spanIdHexOrNull(accept, 'parentSpanId');
+  const fireIds = new Set(fires.map((span) => spanIdHexOrNull(span, 'spanId')).filter(Boolean));
+  const fireParents = new Set(fires.map((span) => spanIdHexOrNull(span, 'parentSpanId')).filter(Boolean));
+  if (!toolId) return false;
+  if (toolId === acceptParent || fireParents.has(toolId)) return true;
+  if (toolParent && (toolParent === acceptId || fireIds.has(toolParent))) return true;
+  if (toolParent && (toolParent === acceptParent || fireParents.has(toolParent))) return true;
+  return false;
+}
+
+function scopeWorkToolSpans(trace, tools, accept, fires) {
+  if (tools.length <= 1) return { kind: 'scoped', tools };
+  const causal = tools.filter((span) => toolCausallyScopedToTopology(span, accept, fires));
+  if (causal.length === 1) return { kind: 'scoped', tools: causal };
+  if (causal.length === 0) return { kind: 'ambiguous', tools };
+  const timing = scopeDelegateToolSpans(trace, causal, accept, fires);
+  if (timing.kind === 'scoped' && timing.tools.length === 1) return timing;
+  return { kind: 'ambiguous', tools: timing.tools || causal };
+}
+
 function scopeDelegateToolSpans(trace, tools, accept, fires) {
   const fire = fires[0];
   const lifecycleSpans = [accept, ...fires, ...tools];
@@ -329,9 +363,16 @@ function validateTrace(trace, expected) {
   });
   const toolScope = expected.tool === 'continue_delegate'
     ? scopeDelegateToolSpans(trace, matchingTools, accept, fires)
-    : null;
+    : expected.tool === 'continue_work'
+      ? scopeWorkToolSpans(trace, matchingTools, accept, fires)
+      : null;
   if (toolScope?.kind === 'invalid-timing') {
     throw new Error('matched raw trace lacks complete causal timing for continue_delegate generation scope');
+  }
+  if (toolScope?.kind === 'ambiguous') {
+    throw new Error(
+      `matched trace contains ${toolScope.tools.length || matchingTools.length} in-scope ${expected.tool} tool spans`,
+    );
   }
   const tools = toolScope?.tools ?? matchingTools;
   if (expected.originSurface === 'raw-final-text') {

--- a/tools/k6-proofs/scripts/postprocess-k6-summary.mjs
+++ b/tools/k6-proofs/scripts/postprocess-k6-summary.mjs
@@ -4,6 +4,7 @@ import { createHash } from 'node:crypto';
 import path from 'node:path';
 import { readFileSync } from 'node:fs';
 import { validateRcd2AuthoritativeReceipt } from '../lib/r-cd-2-authoritative-receipt.mjs';
+import { verifiedRrc2AcceptedEvidence, verifiedRrc2ThresholdEvidence } from '../lib/r-rc-2-honest-limit.mjs';
 
 function usage() {
   console.error(`Usage: node tools/k6-proofs/scripts/postprocess-k6-summary.mjs \\
@@ -116,37 +117,6 @@ function receiptStatusFromName(name, summary) {
     default:
       return 'unknown';
   }
-}
-
-function verifiedRrc2ThresholdEvidence(evidence) {
-  return evidence?.row === 'R-RC-2' &&
-    evidence.parent_dispatch_accepted === true &&
-    evidence.delegate_requested === true &&
-    evidence.child_session_observed === true &&
-    evidence.delegate_child_report_observed === true &&
-    evidence.child_reported_context_threshold === true &&
-    evidence.request_compaction_tool_result_observed === true &&
-    evidence.request_compaction_receipt_role === 'toolResult' &&
-    evidence.request_compaction_receipt_tool_name === 'request_compaction' &&
-    evidence.request_compaction_receipt_status === 'rejected' &&
-    evidence.request_compaction_invocation_bound === true &&
-    evidence.request_compaction_rejected_context_threshold === true &&
-    evidence.guard === 'context_threshold';
-}
-
-function verifiedRrc2AcceptedEvidence(evidence) {
-  return evidence?.row === 'R-RC-2' &&
-    evidence.parent_dispatch_accepted === true &&
-    evidence.delegate_requested === true &&
-    evidence.child_session_observed === true &&
-    evidence.delegate_child_report_observed === true &&
-    evidence.post_compaction_path_observed === true &&
-    evidence.request_compaction_tool_result_observed === true &&
-    evidence.request_compaction_receipt_role === 'toolResult' &&
-    evidence.request_compaction_receipt_tool_name === 'request_compaction' &&
-    evidence.request_compaction_receipt_status === 'accepted' &&
-    evidence.request_compaction_invocation_bound === true &&
-    evidence.request_compaction_accepted === true;
 }
 
 function outcomeFromSummary(summary, expectedArtifactClass, rowId) {

--- a/tools/k6-proofs/scripts/render-run-report.mjs
+++ b/tools/k6-proofs/scripts/render-run-report.mjs
@@ -15,6 +15,7 @@ import { createHash } from 'node:crypto';
 import { candidateEnvelopeMatchesSiblings } from './candidate-run-result-contract.mjs';
 import { validateRcd2AuthoritativeReceipt } from '../lib/r-cd-2-authoritative-receipt.mjs';
 import { validateRcdTokenAuthoritativeReceipt } from '../lib/r-cd-token-authoritative-receipt.mjs';
+import { filterHonestLimitReviewDebt, rrc2HonestLimitReceiptsSufficient } from '../lib/r-rc-2-honest-limit.mjs';
 
 function usage() {
   console.error('Usage: node render-run-report.mjs --root <run-out-root> [--out report.html]');
@@ -104,17 +105,34 @@ function receiptSummary({ manifest, runResult, evidenceRows }) {
   for (const name of manifest?.liveRunSafety?.requiredReceipts || []) {
     receipts.push({ name: safeText(name), required: true, status: 'unknown' });
   }
-  const pending = runResult?.review?.pendingReceipts || [];
+  const pending = filterHonestLimitReviewDebt(runResult?.review?.pendingReceipts || [], {
+    rowId: manifest?.rowId,
+    verdict: runResult?.verdict,
+    evidence: runResult?.evidence || evidenceRows[0],
+  });
   for (const name of pending) {
     const safe = safeText(name);
     const existing = receipts.find((r) => r.name === safe);
     if (existing) existing.status = 'missing';
     else receipts.push({ name: safe, required: true, status: 'missing' });
   }
+  const honestLimitSufficient = rrc2HonestLimitReceiptsSufficient({
+    rowId: manifest?.rowId,
+    verdict: runResult?.verdict,
+    evidence: runResult?.evidence || evidenceRows[0],
+  });
   const traceStatus = runResult?.observability?.traceStatus;
-  if (traceStatus === 'missing') {
+  if (traceStatus === 'missing' && !honestLimitSufficient) {
     const existing = receipts.find((r) => r.name === 'tempo-trace-json' || r.name === 'trace-id');
     if (existing) existing.status = 'missing';
+  }
+  if (honestLimitSufficient) {
+    for (const receipt of receipts) {
+      if (['tempo-trace-json', 'trace-id', 'continuation-trace-correlation'].includes(receipt.name) &&
+          receipt.status === 'missing') {
+        receipt.status = 'honest-limit-sufficient';
+      }
+    }
   }
   const evidence = evidenceRows[0] || {};
   for (const receipt of receipts) {

--- a/tools/k6-proofs/scripts/resolve-runtime-identity.mjs
+++ b/tools/k6-proofs/scripts/resolve-runtime-identity.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import {
+  classifyRuntimeStamp,
+  publicRuntimeIdentity,
+  resolveExactRuntimeIdentity,
+} from '../lib/runtime-identity.mjs';
+
+function usage() {
+  console.error(`Usage: node resolve-runtime-identity.mjs [--write <path>] [--json]
+Independently resolve the deployed OpenClaw runtime SHA from a structured
+build receipt or installed build metadata. Never copies candidate_sha.`);
+}
+
+function parseArgs(argv) {
+  const out = { write: '', json: true };
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') out.help = true;
+    else if (arg === '--json') out.json = true;
+    else if (arg === '--write') out.write = argv[++i] || '';
+    else throw new Error(`unexpected argument: ${arg}`);
+  }
+  return out;
+}
+
+async function readJsonIfPresent(file) {
+  if (!file) return null;
+  try {
+    return JSON.parse(await readFile(file, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function runOpenClawVersionJson() {
+  const result = spawnSync('openclaw', ['version', '--json'], {
+    encoding: 'utf8',
+    timeout: 8000,
+  });
+  if (result.status !== 0) return null;
+  try {
+    return JSON.parse(result.stdout);
+  } catch {
+    return null;
+  }
+}
+
+function runOpenClawVersionStamp() {
+  const result = spawnSync('openclaw', ['--version'], {
+    encoding: 'utf8',
+    timeout: 8000,
+  });
+  if (result.status !== 0) return null;
+  const line = String(result.stdout || '').split(/\r?\n/).find((entry) => entry.trim());
+  return line ? line.trim() : null;
+}
+
+export async function collectRuntimeIdentitySources(env = process.env) {
+  const sources = [];
+  const receiptPath = env.OPENCLAW_RUNTIME_BUILD_RECEIPT ||
+    env.OPENCLAW_RUNTIME_BUILD_RECEIPT_PATH ||
+    '';
+  const defaultReceipts = [
+    receiptPath,
+    path.join(homedir(), '.openclaw', 'runtime-build-receipt.json'),
+    path.join(homedir(), '.openclaw', 'build-receipt.json'),
+  ].filter(Boolean);
+  const seen = new Set();
+  for (const file of defaultReceipts) {
+    const resolved = path.resolve(file);
+    if (seen.has(resolved)) continue;
+    seen.add(resolved);
+    const receipt = await readJsonIfPresent(resolved);
+    if (receipt) sources.push({ kind: 'receipt', source: 'runtime-build-receipt', path: resolved, receipt });
+  }
+
+  const envStamp = classifyRuntimeStamp(env.OPENCLAW_RUNTIME_BUILD_SHA);
+  if (envStamp.kind === 'exact-sha') {
+    sources.push({ kind: 'env-exact-sha', source: 'operator-env-exact-sha', sha: envStamp.value });
+  } else if (envStamp.kind !== 'absent') {
+    sources.push({ kind: 'env-stamp', source: 'operator-env-stamp', stamp: envStamp.value });
+  }
+
+  const disableProbes = env.OPENCLAW_RUNTIME_IDENTITY_DISABLE_PROBES === '1' ||
+    env.OPENCLAW_RUNTIME_IDENTITY_DISABLE_PROBES === 'true';
+  // An operator-supplied exact SHA is already an independent receipt. Probe
+  // the installed CLI only when we still need an exact identity, or when an
+  // explicit receipt file was supplied as a second source.
+  const shouldProbeCli = !disableProbes &&
+    (envStamp.kind !== 'exact-sha' || Boolean(receiptPath));
+  if (shouldProbeCli) {
+    const versionJson = runOpenClawVersionJson();
+    if (versionJson) {
+      sources.push({
+        kind: 'receipt',
+        source: 'openclaw-version-json',
+        receipt: versionJson,
+      });
+    }
+    const versionStamp = runOpenClawVersionStamp();
+    if (versionStamp) {
+      sources.push({ kind: 'stamp', source: 'openclaw-version-stamp', stamp: versionStamp });
+    }
+  }
+  return sources;
+}
+
+export async function resolveDeployedRuntimeIdentity(env = process.env) {
+  const sources = await collectRuntimeIdentitySources(env);
+  const identity = resolveExactRuntimeIdentity(sources);
+  return publicRuntimeIdentity(identity, { candidateSha: env.OPENCLAW_CANDIDATE_SHA || null });
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    usage();
+    return;
+  }
+  const identity = await resolveDeployedRuntimeIdentity();
+  const text = `${JSON.stringify(identity, null, 2)}\n`;
+  if (args.write) await writeFile(args.write, text);
+  process.stdout.write(text);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error?.message || String(error));
+    process.exitCode = 1;
+  });
+}

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -732,19 +732,35 @@ fi
 # Runtime and session resolution run only in the verified snapshot runner: the
 # bootstrap must not invoke external tooling or resolve session state while it is
 # still executing unproven bytes.
-# Fetch deployed runtime build stamp explicitly (do not collapse into CANDIDATE_SHA).
-# Operators may provide OPENCLAW_RUNTIME_BUILD_SHA when they have an external deploy
-# receipt for the exact SHA. Otherwise prefer a structured CLI receipt when available
-# and fall back to the human version string (for example, "OpenClaw ... (1cc8f4e)").
-DEPLOYED_BUILD_STAMP="${OPENCLAW_RUNTIME_BUILD_SHA:-unknown}"
-if [[ "$DEPLOYED_BUILD_STAMP" == "unknown" && -f ~/.openclaw/openclaw.json ]]; then
-  if openclaw version --json >/dev/null 2>&1; then
-    DEPLOYED_BUILD_STAMP="$(openclaw version --json | jq -r '.build.sha // empty')"
-  elif openclaw --version >/dev/null 2>&1; then
-    DEPLOYED_BUILD_STAMP="$(openclaw --version | head -n 1)"
+# Fetch deployed runtime identity independently of CANDIDATE_SHA.
+# The resolver may use a structured build receipt, installed metadata, or
+# `openclaw version --json`. It never copies the candidate SHA or expands a
+# short stamp into an invented full SHA.
+RUNTIME_IDENTITY_JSON="$OUT_ROOT/runtime-identity.json"
+mkdir -p "$OUT_ROOT"
+if ! node "$SCRIPT_DIR/resolve-runtime-identity.mjs" --write "$RUNTIME_IDENTITY_JSON" >/dev/null; then
+  echo "WARNING: runtime identity resolver failed; token rows will remain fail-closed." >&2
+  echo '{"schema":"openclaw.k6.runtime-identity.v1","exact":false,"reason":"absent"}' > "$RUNTIME_IDENTITY_JSON"
+fi
+RUNTIME_IDENTITY_EXACT="$(jq -r '.exact // false' "$RUNTIME_IDENTITY_JSON")"
+RUNTIME_IDENTITY_SOURCE="$(jq -r '.runtimeBuildShaSource // empty' "$RUNTIME_IDENTITY_JSON")"
+RUNTIME_VERSION_STAMP="$(jq -r '.versionStamp // empty' "$RUNTIME_IDENTITY_JSON")"
+RESOLVED_RUNTIME_SHA="$(jq -r '.runtimeBuildSha // empty' "$RUNTIME_IDENTITY_JSON")"
+if [[ "$RUNTIME_IDENTITY_EXACT" == "true" && "$RESOLVED_RUNTIME_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  export OPENCLAW_RUNTIME_BUILD_SHA="$RESOLVED_RUNTIME_SHA"
+else
+  RUNTIME_IDENTITY_REASON="$(jq -r '.reason // "absent"' "$RUNTIME_IDENTITY_JSON")"
+  # Fail closed on ambiguous/malformed identity: do not keep a colliding env
+  # SHA and do not invent one from a short stamp.
+  if [[ "$RUNTIME_IDENTITY_REASON" == "ambiguous" || "$RUNTIME_IDENTITY_REASON" == "malformed" ]]; then
+    export OPENCLAW_RUNTIME_BUILD_SHA="malformed"
+  elif [[ -n "$RUNTIME_VERSION_STAMP" ]]; then
+    # Non-token rows may still publish a human version stamp.
+    export OPENCLAW_RUNTIME_BUILD_SHA="$RUNTIME_VERSION_STAMP"
+  elif [[ -z "${OPENCLAW_RUNTIME_BUILD_SHA:-}" ]]; then
+    export OPENCLAW_RUNTIME_BUILD_SHA="unknown"
   fi
 fi
-export OPENCLAW_RUNTIME_BUILD_SHA="$DEPLOYED_BUILD_STAMP"
 
 # Resolve Session Key
 if [[ -z "${OPENCLAW_SESSION_KEY:-}" ]]; then
@@ -839,6 +855,9 @@ jq -n \
   --arg repository "$(safe_repository_or_marker "$DOCS_REPOSITORY")" \
   --arg candidate "$(safe_sha_or_marker "$OPENCLAW_CANDIDATE_SHA")" \
   --arg runtimeBuildSha "$(safe_runtime_stamp "$OPENCLAW_RUNTIME_BUILD_SHA")" \
+  --arg runtimeBuildShaSource "$RUNTIME_IDENTITY_SOURCE" \
+  --arg runtimeVersionStamp "$(safe_runtime_stamp "$RUNTIME_VERSION_STAMP")" \
+  --argjson runtimeIdentityExact "$([[ "$RUNTIME_IDENTITY_EXACT" == "true" ]] && echo true || echo false)" \
   --arg seat "$OPENCLAW_SEAT_NAME" \
   --arg seatReadinessSha256 "$SEAT_READINESS_SHA256" \
   --arg runnerScript "$PROOFS_TOOL_RELPATH/scripts/run-proofs.sh" \
@@ -862,6 +881,9 @@ jq -n \
     runtimeIdentity: {
       seat: $seat,
       runtimeBuildSha: (if $runtimeBuildSha == "" or $runtimeBuildSha == "unknown" then null else $runtimeBuildSha end),
+      runtimeBuildShaSource: (if $runtimeBuildShaSource == "" then null else $runtimeBuildShaSource end),
+      versionStamp: (if $runtimeVersionStamp == "" then null else $runtimeVersionStamp end),
+      exact: $runtimeIdentityExact,
       candidateMatchesRuntime: ($candidate != "" and $candidate == $runtimeBuildSha),
       seatReadinessReceipt: (if $seatReadinessSha256 == "" then null else "seat-readiness.json" end),
       seatReadinessSha256: (if $seatReadinessSha256 == "" then null else $seatReadinessSha256 end)
@@ -968,6 +990,8 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
       --arg scenario "$SCENARIO_FILE" \
       --arg candidate "$OPENCLAW_CANDIDATE_SHA" \
       --arg runtime "$(safe_runtime_stamp "$OPENCLAW_RUNTIME_BUILD_SHA")" \
+      --arg runtimeSource "$RUNTIME_IDENTITY_SOURCE" \
+      --argjson runtimeExact "$([[ "$RUNTIME_IDENTITY_EXACT" == "true" ]] && echo true || echo false)" \
       --arg seat "$OPENCLAW_SEAT_NAME" \
       --arg started "$RUN_STARTED_AT" \
       --arg docsRef "$DOCS_REF" \
@@ -977,7 +1001,7 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
       --arg manifestSha256 "$ROW_MANIFEST_DIGEST" \
       --arg scenarioPath "$ROW_SCENARIO_REL" \
       --arg scenarioSha256 "$ROW_SCENARIO_DIGEST" \
-      '{row:$row, scenario:$scenario, candidateSha:$candidate, runtimeBuildSha:$runtime, seat:$seat, sessionConfigured:true, startedAt:$started, docsRef:$docsRef, repository:$repository, matrixId:$matrixId, manifestPath:$manifestPath, manifestSha256:$manifestSha256, scenarioPath:$scenarioPath, scenarioSha256:$scenarioSha256}' \
+      '{row:$row, scenario:$scenario, candidateSha:$candidate, runtimeBuildSha:$runtime, runtimeBuildShaSource:(if $runtimeSource == "" then null else $runtimeSource end), runtimeIdentityExact:$runtimeExact, seat:$seat, sessionConfigured:true, startedAt:$started, docsRef:$docsRef, repository:$repository, matrixId:$matrixId, manifestPath:$manifestPath, manifestSha256:$manifestSha256, scenarioPath:$scenarioPath, scenarioSha256:$scenarioSha256}' \
       > "$RUN_DIR/runner-metadata.json"
     if [[ "$ROW_ID" == "R-CD-TOKEN" ]]; then
       if [[ ! "$OPENCLAW_CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ||
@@ -987,8 +1011,9 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
         jq -n \
           --arg candidateSha "$(safe_sha_or_marker "$OPENCLAW_CANDIDATE_SHA")" \
           --arg runtimeBuildSha "$(safe_sha_or_marker "$OPENCLAW_RUNTIME_BUILD_SHA")" \
+          --arg runtimeBuildShaSource "$RUNTIME_IDENTITY_SOURCE" \
           --arg endedAt "$RUN_ENDED_AT" \
-          '{schema:"openclaw.k6.r-cd-token.build-identity-gate.v1",row:"R-CD-TOKEN",candidateSha:$candidateSha,runtimeBuildSha:$runtimeBuildSha,equalExactSha:false,dispatched:false,verdict:"PARTIAL-candidate",endedAt:$endedAt}' \
+          '{schema:"openclaw.k6.r-cd-token.build-identity-gate.v1",row:"R-CD-TOKEN",candidateSha:$candidateSha,runtimeBuildSha:$runtimeBuildSha,runtimeBuildShaSource:(if $runtimeBuildShaSource == "" then null else $runtimeBuildShaSource end),equalExactSha:false,dispatched:false,verdict:"PARTIAL-candidate",endedAt:$endedAt}' \
           > "$RUN_DIR/build-identity-gate.json"
         jq -n \
           --arg endedAt "$RUN_ENDED_AT" \
@@ -1340,6 +1365,14 @@ for ROW_ID in "${ROW_ARRAY[@]}"; do
       REVIEW_PENDING_RECEIPTS="$(
         jq -cn --argjson current "$REVIEW_PENDING_RECEIPTS" \
           '$current + ["tempo-trace-json"] | unique'
+      )"
+    fi
+    if [[ "$SUMMARY_VERDICT" == "HONEST-LIMIT-candidate" && "$ROW_ID" == "R-RC-2" ]]; then
+      # Bound nonce/toolResult + child threshold receipts are sufficient for
+      # this row's documented HONEST-LIMIT. Missing Tempo is not review debt.
+      REVIEW_PENDING_RECEIPTS="$(
+        jq -cn --argjson current "$REVIEW_PENDING_RECEIPTS" \
+          '$current - ["tempo-trace-json","continuation-trace-correlation","trace-id","tool-trace-correlation"]'
       )"
     fi
 

--- a/tools/k6-proofs/scripts/summarize-review-debt.mjs
+++ b/tools/k6-proofs/scripts/summarize-review-debt.mjs
@@ -2,6 +2,7 @@
 import { readdir, readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
 import { candidateEnvelopeMatchesSiblings } from './candidate-run-result-contract.mjs';
+import { filterHonestLimitReviewDebt } from '../lib/r-rc-2-honest-limit.mjs';
 
 function usage() {
   return `Usage: node tools/k6-proofs/scripts/summarize-review-debt.mjs --run-root <candidate-run-dir> [--json]\n\nScans row run-result.json files and summarizes review-pending receipts.\nFor tempo-trace-json debt, distinguishes fetchable trace ids from trace-missing rows where no Tempo fetch can be attempted.\n`;
@@ -80,11 +81,15 @@ async function loadRows(root) {
       continue;
     }
     if (!candidateEnvelopeMatchesSiblings({ envelope: raw, manifest, metadata, runResult, runDir: dir })) continue;
-    const pendingReceipts = asArray(raw.review?.pendingReceipts);
+    const pendingReceipts = filterHonestLimitReviewDebt(asArray(raw.review?.pendingReceipts), {
+      rowId: raw.run?.rowId || rowFromPath(file),
+      verdict: raw.result?.outcome,
+      evidence: runResult?.evidence,
+    });
     rows.push({
       rowId: raw.run?.rowId || rowFromPath(file) || 'unknown-row',
       file: path.relative(root, file),
-      reviewStatus: raw.review?.status || 'unknown',
+      reviewStatus: pendingReceipts.length ? (raw.review?.status || 'review-pending') : 'ready-for-human-review',
       pendingReceipts,
       traceId: null,
       pending: pendingReceipts.map((receipt) => classifyPending({ traceId: null }, receipt)),
@@ -99,13 +104,21 @@ async function loadRows(root) {
       readJson(file),
     ]);
     if (candidateEnvelopeMatchesSiblings({ envelope: candidate, manifest, metadata, runResult: raw, runDir: dir })) continue;
-    const pendingReceipts = asArray(raw.review?.pendingReceipts);
     const rowId = raw.rowId || raw.row || rowFromPath(file) || 'unknown-row';
+    const pendingReceipts = filterHonestLimitReviewDebt(asArray(raw.review?.pendingReceipts), {
+      rowId,
+      verdict: raw.verdict || raw.result?.outcome,
+      evidence: raw.evidence,
+    });
     const traceId = raw.observability?.traceId || raw.traceId || null;
     rows.push({
       rowId,
       file: path.relative(root, file),
-      reviewStatus: raw.review?.status || (pendingReceipts.length ? 'review-pending' : 'ready-for-human-review'),
+      reviewStatus: pendingReceipts.length
+        ? (raw.review?.status || 'review-pending')
+        : (raw.review?.status === 'review-pending' && pendingReceipts.length === 0
+          ? 'ready-for-human-review'
+          : (raw.review?.status || 'ready-for-human-review')),
       pendingReceipts,
       traceId,
       pending: pendingReceipts.map((receipt) => classifyPending({ traceId }, receipt)),

--- a/tools/k6-proofs/scripts/validate-candidate-run-result.mjs
+++ b/tools/k6-proofs/scripts/validate-candidate-run-result.mjs
@@ -11,6 +11,7 @@ import { createHash } from 'node:crypto';
 import { validateRcd2AuthoritativeReceipt } from '../lib/r-cd-2-authoritative-receipt.mjs';
 import { validateRcdTokenAuthoritativeReceipt } from '../lib/r-cd-token-authoritative-receipt.mjs';
 import { COPIED_MANIFEST, COPIED_SCENARIO, isSafeArtifactReference, isSafeCandidateArtifact } from './candidate-run-result-contract.mjs';
+import { hasVerifiedRrc2Outcome } from '../lib/r-rc-2-honest-limit.mjs';
 
 const SHA = /^[0-9a-f]{40}$/;
 const DIGEST = /^[0-9a-f]{64}$/;
@@ -136,40 +137,6 @@ function scenarioName(manifest) {
 function manifestCandidateSha(manifest) {
   const value = manifest?.candidateSha;
   return SHA.test(value || '') ? value : null;
-}
-
-function hasVerifiedRrc2Outcome(rowId, verdict, evidence) {
-  if (rowId !== 'R-RC-2') return verdict !== 'HONEST-LIMIT-candidate';
-  if (verdict === 'HONEST-LIMIT-candidate') return (
-    evidence?.row === 'R-RC-2' &&
-    evidence.parent_dispatch_accepted === true &&
-    evidence.delegate_requested === true &&
-    evidence.child_session_observed === true &&
-    evidence.delegate_child_report_observed === true &&
-    evidence.child_reported_context_threshold === true &&
-    evidence.request_compaction_tool_result_observed === true &&
-    evidence.request_compaction_receipt_role === 'toolResult' &&
-    evidence.request_compaction_receipt_tool_name === 'request_compaction' &&
-    evidence.request_compaction_receipt_status === 'rejected' &&
-    evidence.request_compaction_invocation_bound === true &&
-    evidence.request_compaction_rejected_context_threshold === true &&
-    evidence.guard === 'context_threshold'
-  );
-  if (verdict === 'PASS-candidate') return (
-    evidence?.row === 'R-RC-2' &&
-    evidence.parent_dispatch_accepted === true &&
-    evidence.delegate_requested === true &&
-    evidence.child_session_observed === true &&
-    evidence.delegate_child_report_observed === true &&
-    evidence.post_compaction_path_observed === true &&
-    evidence.request_compaction_tool_result_observed === true &&
-    evidence.request_compaction_receipt_role === 'toolResult' &&
-    evidence.request_compaction_receipt_tool_name === 'request_compaction' &&
-    evidence.request_compaction_receipt_status === 'accepted' &&
-    evidence.request_compaction_invocation_bound === true &&
-    evidence.request_compaction_accepted === true
-  );
-  return true;
 }
 
 function authoritativeReceiptContract(rowId) {


### PR DESCRIPTION
## Summary

Repair four Project 81 proof-harness authority defects from issue 514. Product `replayInvalid` semantics are unchanged. No live proofs and no published `PROOFS/c3a0e5a...` corpus edits.

1. **R-CD-2** — successful `phase=end` with `replayInvalid=true` is no longer a lifecycle failure or conclusive `FAIL-candidate`. The flag remains separate evidence. Genuine error/failed/aborted terminals still fail closed.
2. **R-CD-TOKEN** — fail-closed exact runtime receipt from structured build metadata / `openclaw version --json` / operator exact SHA. Never copies `candidate_sha` or invents a full SHA from a short stamp. Source is recorded in public-safe metadata.
3. **R-CW-3** — reason-bound `continue_work` tool spans are causally scoped. Multiple in-scope origins stay fail-closed. Time-window-only attribution is rejected. Repeated fire attempts remain valid.
4. **R-RC-2** — nonce-bound structured `request_compaction` rejection plus matching child threshold return is sufficient for `HONEST-LIMIT-candidate`. Prose/unbound results cannot promote. Validation, review-debt, report, and fold guidance agree.

## GitNexus

Indexed this worktree (`npx gitnexus analyze --force`: 74,308 nodes / 84,398 edges). MCP server could not read LadybugDB v42; CLI `gitnexus@1.6.9` was used against this path.

`detect-changes --scope compare --base-ref de315e25`: 22 files, 44 symbols, 2 affected processes (`Res → AgentIdFromSessionKey`, `Res → BuildRequest`), risk **medium**.

Consumers of changed helpers: `r-cd-2-silent-wake.js`, `collect-continuation-trace.mjs` / `validateTrace`, review-debt / report / candidate-envelope, runner + `project81-k6-proof.yml`. Frozen `PROOFS/**` copies were not edited.

## Validation

```
node --test tools/k6-proofs/scripts/__tests__/*.mjs tools/k6-proofs/tests/*.mjs
# 399 pass, 0 fail

node tools/k6-proofs/scripts/check-manifest-scenarios.mjs --repo-root .
node tools/k6-proofs/scripts/check-scenario-alignment.mjs --repo-root .
node tools/k6-proofs/scripts/check-proof-row-manifests.mjs --repo-root .
node tools/k6-proofs/scripts/check-telemetry-contracts.mjs --repo-root .
node tools/k6-proofs/scripts/validate-corpus.mjs --index
git diff --check
```

See `output.md` for commands, GitNexus notes, and uncertainties.

Refs karmaterminal/karmaterminal-openclaw-docs#514