### PR TITLE
fix(proofs): close R-CD-2, depth, and token observer debt

### DIFF
--- a/tools/k6-proofs/lib/r-cd-2-authoritative-receipt.mjs
+++ b/tools/k6-proofs/lib/r-cd-2-authoritative-receipt.mjs
@@ -179,6 +179,15 @@ export function rCd2AuthorityChecks(evidence, correlation) {
   };
 }
 
+/** Public-safe resolver stdout. Booleans only; HMAC receipt remains verdict authority. */
+export function rCd2PublicResolutionOutput(receipt, evidence, correlation) {
+  return {
+    verdict: receipt?.verdict || null,
+    receipt: 'r-cd-2-authoritative-receipt.json',
+    checks: rCd2AuthorityChecks(evidence, correlation),
+  };
+}
+
 function categoryFor(evidence, correlation) {
   if (evidence?.channel_message_observed === true) return 'silent-channel-delivery';
   if (evidence?.failureCategory === 'delegate-replay-unsafe' &&

--- a/tools/k6-proofs/lib/r-cd-token-contract.js
+++ b/tools/k6-proofs/lib/r-cd-token-contract.js
@@ -245,6 +245,55 @@ export function tokenOriginCursorFromMessages(
 }
 
 /**
+ * Decide the first public cursor recovery action. The first sessions.get must
+ * fire synchronously once subscription and exact origin lineage are ready.
+ * Positive-delay timers are only for later recovery polls; delay <= 0 is idle.
+ */
+export function tokenOriginCursorSnapshotDispatch({
+  closed = false,
+  originSubscriptionAccepted = false,
+  originCursorSnapshotAccepted = false,
+  originReturnEventCount = 0,
+  originCursorPollPending = false,
+  originChildSessionKey = null,
+  originRunId = null,
+  recoveryPollDelayMs = null,
+} = {}) {
+  if (closed === true ||
+      originSubscriptionAccepted !== true ||
+      originCursorPollPending === true ||
+      (originCursorSnapshotAccepted === true &&
+        Number(originReturnEventCount) > 0)) {
+    return { action: 'idle' };
+  }
+  const originKey = String(originChildSessionKey || '').trim();
+  const originRun = String(originRunId || '').trim();
+  if (originKey && originRun) {
+    return {
+      action: 'sessions.get',
+      method: 'sessions.get',
+      params: { key: originKey, limit: 50 },
+    };
+  }
+  const delayMs = Number(recoveryPollDelayMs);
+  if (!Number.isFinite(delayMs) || delayMs <= 0) return { action: 'idle' };
+  return { action: 'schedule', delayMs };
+}
+
+export function createTokenReturnObservationState() {
+  return { seen: Object.create(null), count: 0 };
+}
+
+export function rememberTokenReturnReceipt(state, receipt) {
+  if (!state || !receipt) return false;
+  const seq = receipt.messageSeq;
+  if (!Number.isSafeInteger(seq) || seq < 0 || state.seen[seq]) return false;
+  state.seen[seq] = true;
+  state.count += 1;
+  return true;
+}
+
+/**
  * Bind the public normal-origin assistant event to the exact accepted delegate
  * child/run. The inter-session input is intentionally hidden by the product's
  * display projection, so textual provenance headers are not an event contract.

--- a/tools/k6-proofs/scenarios/r-cd-token-bracket-delegate.js
+++ b/tools/k6-proofs/scenarios/r-cd-token-bracket-delegate.js
@@ -8,15 +8,18 @@ import { loadManifestFromEnv, validateManifest } from '../lib/manifest-loader.js
 import {
   classifyTokenEvidence,
   createTokenLedger,
+  createTokenReturnObservationState,
   observeTokenTaskLedger,
   parseTokenReturnEvent,
   parseTokenReturnTranscriptMessage,
   rejectTokenTaskLedgerObservation,
+  rememberTokenReturnReceipt,
   summarizeTokenLedger,
   tokenDisposableOriginReady,
   tokenLedgerHasTerminalTasks,
   tokenLedgerRuntimeIdentity,
   tokenOriginCursorFromMessages,
+  tokenOriginCursorSnapshotDispatch,
 } from '../lib/r-cd-token-contract.js';
 
 export const options = {
@@ -124,7 +127,7 @@ export default function () {
     let originCursorPollPending = false;
     let originCursorPollScheduled = false;
     const pendingReturnEvents = [];
-    const observedReturnMessageSeqs = {};
+    const returnObservations = createTokenReturnObservationState();
 
     function returnBindingReady() {
       const identity = tokenLedgerRuntimeIdentity(ledger);
@@ -139,9 +142,8 @@ export default function () {
     }
 
     function rememberReturnReceipt(receipt, kind) {
-      if (!receipt || observedReturnMessageSeqs[receipt.messageSeq]) return false;
-      observedReturnMessageSeqs[receipt.messageSeq] = true;
-      evidence.origin_return_event_count += 1;
+      if (!rememberTokenReturnReceipt(returnObservations, receipt)) return false;
+      evidence.origin_return_event_count = returnObservations.count;
       evidence.delegate_return_observed = evidence.origin_return_event_count === 1;
       if (evidence.origin_return_event_count === 1) {
         evidence.return_target_session_hash = receipt.targetSessionHash;
@@ -177,25 +179,29 @@ export default function () {
     }
 
     function requestOriginCursorSnapshot() {
-      if (closed ||
-          !evidence.origin_subscription_accepted ||
-          (evidence.origin_cursor_snapshot_accepted &&
-            evidence.origin_return_event_count > 0) ||
-          originCursorPollPending) return;
       const identity = tokenLedgerRuntimeIdentity(ledger);
-      if (!identity.originChildSessionKey || !identity.originRunId) {
-        scheduleOriginCursorPoll();
+      const dispatch = tokenOriginCursorSnapshotDispatch({
+        closed,
+        originSubscriptionAccepted: evidence.origin_subscription_accepted,
+        originCursorSnapshotAccepted: evidence.origin_cursor_snapshot_accepted,
+        originReturnEventCount: evidence.origin_return_event_count,
+        originCursorPollPending,
+        originChildSessionKey: identity.originChildSessionKey,
+        originRunId: identity.originRunId,
+        recoveryPollDelayMs: ORIGIN_CURSOR_POLL_MS,
+      });
+      if (dispatch.action === 'schedule') {
+        scheduleOriginCursorPoll(dispatch.delayMs);
         return;
       }
+      if (dispatch.action !== 'sessions.get') return;
       originCursorPollPending = true;
-      tracker.send(socket, 'sessions.get', {
-        key: identity.originChildSessionKey,
-        limit: 50,
-      });
+      tracker.send(socket, dispatch.method, dispatch.params);
     }
 
     function scheduleOriginCursorPoll(delay = ORIGIN_CURSOR_POLL_MS) {
       if (closed ||
+          !(Number(delay) > 0) ||
           !evidence.origin_subscription_accepted ||
           (evidence.origin_cursor_snapshot_accepted &&
             evidence.origin_return_event_count > 0) ||

--- a/tools/k6-proofs/scripts/__tests__/proof-harness-closure-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/proof-harness-closure-contract.test.mjs
@@ -66,6 +66,7 @@ test('R-CD-TOKEN closes normal-origin return authority on the public event bound
   assert.ok(manifest.scenario.methods.includes('sessions.messages.subscribe'));
   assert.ok(manifest.scenario.methods.includes('sessions.get'));
   assert.match(scenario, /tokenOriginCursorFromMessages/);
+  assert.match(scenario, /tokenOriginCursorSnapshotDispatch/);
   assert.match(scenario, /origin_return_event_count === 1/);
   assert.match(scenario, /root_substituted_return_count === 0/);
   assert.match(contract, /announce:v1:/);

--- a/tools/k6-proofs/scripts/__tests__/r-cd-2-authoritative-receipt.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cd-2-authoritative-receipt.test.mjs
@@ -7,9 +7,11 @@ import path from 'node:path';
 import { tmpdir } from 'node:os';
 import {
   rCd2AuthorityChecks,
+  rCd2PublicResolutionOutput,
   resolveRcd2AuthoritativeReceipt,
   validateRcd2AuthoritativeReceipt,
 } from '../../lib/r-cd-2-authoritative-receipt.mjs';
+import { sanitizeEvidenceRecords } from '../sanitize-k6-artifacts.mjs';
 import {
   buildTelemetryBackendStatusReceipt,
   classifyTelemetryBackendInteraction,
@@ -22,6 +24,7 @@ const repoRoot = path.resolve(import.meta.dirname, '../..');
 const manifestPath = path.join(repoRoot, 'manifests/r-cd-2.json');
 const writerPath = path.join(repoRoot, 'scripts/evidence-writer.mjs');
 const postprocessorPath = path.join(repoRoot, 'scripts/postprocess-k6-summary.mjs');
+const resolverPath = path.join(repoRoot, 'scripts/resolve-r-cd-2-authoritative-receipt.mjs');
 
 function evidence(overrides = {}) {
   return {
@@ -92,10 +95,30 @@ function completeBackendStatus(rebindKeys) {
   });
 }
 
+function flattenGates(checks) {
+  return ['lifecycle', 'topology', 'joins'].flatMap((group) => (
+    Object.entries(checks[group]).map(([name, value]) => ({ group, name, value }))
+  ));
+}
+
+function expectedTrueChecks() {
+  return rCd2AuthorityChecks(evidence(), correlation());
+}
+
 test('R-CD-2 promotes only a same-run typed silent-wake topology', () => {
-  const receipt = resolveRcd2AuthoritativeReceipt({ evidence: evidence(), correlation: correlation(), signingKey });
+  const rowEvidence = evidence();
+  const rowCorrelation = correlation();
+  const receipt = resolveRcd2AuthoritativeReceipt({
+    evidence: rowEvidence, correlation: rowCorrelation, signingKey,
+  });
+  const checks = rCd2AuthorityChecks(rowEvidence, rowCorrelation);
   assert.equal(receipt.verdict, 'PASS-candidate');
   assert.equal(validateRcd2AuthoritativeReceipt(receipt, signingKey).valid, true);
+  assert.equal(flattenGates(checks).every((gate) => gate.value === true), true);
+  assert.deepEqual(
+    { evidencePasses: checks.evidencePasses, topologyPasses: checks.topologyPasses, joinsPass: checks.joinsPass },
+    { evidencePasses: true, topologyPasses: true, joinsPass: true },
+  );
   assert.doesNotMatch(JSON.stringify(receipt), /private-chain-id|bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/);
 });
 
@@ -126,6 +149,133 @@ test('R-CD-2 binds the accepted run to its unique nonce-reason trace when sessio
     },
     { evidencePasses: true, topologyPasses: true, joinsPass: true },
   );
+});
+
+test('R-CD-2 public diagnostics invert each lifecycle, topology, and join gate', () => {
+  const baseline = flattenGates(expectedTrueChecks());
+  const inversions = [
+    { group: 'lifecycle', name: 'sessionCreated', evidence: { session_created: false } },
+    { group: 'lifecycle', name: 'sessionUnbound', evidence: { session_unbound_confirmed: false } },
+    { group: 'lifecycle', name: 'sendAccepted', evidence: { send_accepted: false } },
+    { group: 'lifecycle', name: 'sendRunCaptured', evidence: { send_run_captured: false } },
+    { group: 'lifecycle', name: 'dispatchTerminalSentinel', evidence: { dispatch_terminal_sentinel_observed: false } },
+    { group: 'lifecycle', name: 'dispatchTerminalSentinelSameRun', evidence: { dispatch_terminal_sentinel_same_run_window: false } },
+    { group: 'lifecycle', name: 'terminalSuccessSameRun', evidence: { terminal_success_same_run: false } },
+    { group: 'lifecycle', name: 'typedDelegateSuccessSameRun', evidence: { typed_delegate_success_same_run: false } },
+    { group: 'lifecycle', name: 'wakeLifecycle', evidence: { wake_lifecycle_observed: false } },
+    { group: 'lifecycle', name: 'postWakeQuiet', evidence: { post_wake_quiet: false } },
+    { group: 'lifecycle', name: 'noChannelDelivery', evidence: { channel_message_observed: true } },
+    {
+      group: 'lifecycle', name: 'sendRunFingerprint', evidence: { send_run_fingerprint: 'not-hex' },
+      coupled: [{ group: 'lifecycle', name: 'terminalRunMatchesSend' }, { group: 'joins', name: 'rowBinding' }],
+    },
+    {
+      group: 'lifecycle', name: 'rowNonceFingerprint', evidence: { row_nonce_fingerprint: 'not-hex' },
+      coupled: [{ group: 'joins', name: 'rowBinding' }],
+    },
+    { group: 'lifecycle', name: 'terminalRunMatchesSend', evidence: { terminal_run_fingerprint: 'f'.repeat(16) } },
+    {
+      group: 'lifecycle', name: 'acceptedSendTraceShape', evidence: { accepted_send_trace_id: 'not-a-trace' },
+      coupled: [{ group: 'joins', name: 'acceptedTrace' }, { group: 'joins', name: 'rowBinding' }],
+    },
+    { group: 'topology', name: 'typedTool', correlation: { continuation: { tool: 'continue_work' } } },
+    { group: 'topology', name: 'silentWake', correlation: { delegate: { mode: 'normal' } } },
+    { group: 'topology', name: 'exactlyOneToolSpan', correlation: { toolSpanIds: ['a'.repeat(16), 'b'.repeat(16)] } },
+    {
+      group: 'topology', name: 'traceId', correlation: { traceId: 'not-a-trace' },
+      coupled: [{ group: 'joins', name: 'acceptedTrace' }, { group: 'joins', name: 'rowBinding' }],
+    },
+    { group: 'topology', name: 'chainId', correlation: { chainId: '' } },
+    {
+      group: 'topology', name: 'dispatchSpan', correlation: { dispatchSpanId: 'not-hex' },
+      coupled: [{ group: 'topology', name: 'distinctDispatchAndFire' }],
+    },
+    {
+      group: 'topology', name: 'fireSpan', correlation: { fireSpanId: 'not-hex' },
+      coupled: [{ group: 'topology', name: 'distinctDispatchAndFire' }],
+    },
+    { group: 'topology', name: 'distinctDispatchAndFire', correlation: { fireSpanId: 'c'.repeat(16) } },
+    {
+      group: 'topology', name: 'sendRunBinding',
+      correlation: { rowBinding: { ...correlation().rowBinding, acceptedSendRunFingerprint: 'not-hex' } },
+      coupled: [{ group: 'joins', name: 'rowBinding' }],
+    },
+    {
+      group: 'topology', name: 'nonceBinding',
+      correlation: { rowBinding: { ...correlation().rowBinding, nonceFingerprint: 'not-hex' } },
+      coupled: [{ group: 'joins', name: 'rowBinding' }],
+    },
+    { group: 'topology', name: 'acceptedTraceBinding', correlation: { rowBinding: { ...correlation().rowBinding, acceptedSendTraceId: 'not-a-trace' } } },
+    {
+      group: 'topology', name: 'acceptedTraceSource',
+      correlation: { rowBinding: { ...correlation().rowBinding, acceptedSendTraceSource: 'unknown' } },
+      coupled: [{ group: 'joins', name: 'acceptedTrace' }, { group: 'joins', name: 'rowBinding' }],
+    },
+    {
+      group: 'joins', name: 'acceptedTrace', evidence: { accepted_send_trace_id: 'c'.repeat(32) },
+      coupled: [{ group: 'joins', name: 'rowBinding' }],
+    },
+    {
+      group: 'joins', name: 'rowBinding',
+      correlation: { rowBinding: { ...correlation().rowBinding, acceptedSendRunFingerprint: 'f'.repeat(16) } },
+    },
+  ];
+
+  assert.deepEqual(
+    inversions.map((entry) => `${entry.group}.${entry.name}`).sort(),
+    baseline.map((entry) => `${entry.group}.${entry.name}`).sort(),
+  );
+
+  for (const inversion of inversions) {
+    const rowEvidence = evidence(inversion.evidence || {});
+    const rowCorrelation = correlation(inversion.correlation || {});
+    const checks = rCd2AuthorityChecks(rowEvidence, rowCorrelation);
+    const receipt = resolveRcd2AuthoritativeReceipt({
+      evidence: rowEvidence, correlation: rowCorrelation, signingKey,
+    });
+    const allowedFalse = new Set([
+      `${inversion.group}.${inversion.name}`,
+      ...(inversion.coupled || []).map((entry) => `${entry.group}.${entry.name}`),
+    ]);
+    assert.equal(checks[inversion.group][inversion.name], false, inversion.name);
+    assert.notEqual(receipt.verdict, 'PASS-candidate', inversion.name);
+    assert.equal(validateRcd2AuthoritativeReceipt(receipt, signingKey).valid, true, inversion.name);
+    for (const gate of flattenGates(checks)) {
+      const key = `${gate.group}.${gate.name}`;
+      if (allowedFalse.has(key)) continue;
+      assert.equal(gate.value, true, `${inversion.name} kept ${key}`);
+    }
+  }
+});
+
+test('R-CD-2 resolution output and receipt stay public-safe', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'r-cd-2-resolution-'));
+  try {
+    const rowEvidence = evidence();
+    const rowCorrelation = correlation();
+    const evidencePath = path.join(dir, 'private-evidence.json');
+    const correlationPath = path.join(dir, 'private-correlation.json');
+    await writeFile(evidencePath, JSON.stringify(rowEvidence));
+    await writeFile(correlationPath, JSON.stringify(rowCorrelation));
+    const env = { ...process.env, OPENCLAW_GATEWAY_TOKEN: signingKey };
+    const resolved = await execFileAsync(process.execPath, [
+      resolverPath, '--run-dir', dir, '--evidence', evidencePath, '--correlation', correlationPath,
+    ], { cwd: dir, env });
+    const resolution = JSON.parse(resolved.stdout);
+    const receipt = JSON.parse(await readFile(path.join(dir, 'r-cd-2-authoritative-receipt.json'), 'utf8'));
+    assert.deepEqual(resolution, rCd2PublicResolutionOutput(receipt, rowEvidence, rowCorrelation));
+    assert.equal(flattenGates(resolution.checks).every((gate) => gate.value === true), true);
+    assert.equal(receipt.verdict, 'PASS-candidate');
+    const privatePattern = /private-chain-id|bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/;
+    assert.doesNotMatch(JSON.stringify(resolution), privatePattern);
+    assert.doesNotMatch(JSON.stringify(receipt), privatePattern);
+    const { sanitized } = sanitizeEvidenceRecords([resolution, receipt]);
+    assert.doesNotMatch(JSON.stringify(sanitized), privatePattern);
+    assert.equal(sanitized[0].checks.lifecycle.sessionCreated, true);
+    assert.equal(sanitized[1].verdict, 'PASS-candidate');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });
 
 test('R-CD-2 rejects outer-send acceptance plus an unrelated delayed message', () => {

--- a/tools/k6-proofs/scripts/__tests__/r-cd-token-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cd-token-contract.test.mjs
@@ -6,14 +6,17 @@ import {
   classifyTokenEvidence,
   createTokenLedger,
   observeTokenTaskLedger,
+  createTokenReturnObservationState,
   parseTokenReturnEvent,
   parseTokenReturnTranscriptMessage,
   rejectTokenTaskLedgerObservation,
+  rememberTokenReturnReceipt,
   summarizeTokenLedger,
   tokenDisposableOriginReady,
   tokenExpectedOriginReturnRunId,
   tokenLedgerHasTerminalTasks,
   tokenOriginCursorFromMessages,
+  tokenOriginCursorSnapshotDispatch,
 } from '../../lib/r-cd-token-contract.js';
 
 const frozenRun = JSON.parse(await readFile(
@@ -268,6 +271,17 @@ test('structured return parser binds target and source sessions', () => {
       }],
       __openclaw: { runId: originReturnRunId, seq: 3 },
     };
+    const eventData = { sessionKey: originChild, message };
+    assert.equal(parseTokenReturnEvent(eventData, {
+      expectedTargetSessionKey: originChild,
+      expectedDelegateChildSessionKey: delegateChild,
+      expectedDelegateRunId: delegateRunId,
+      expectedSentinel: returnSentinel,
+      originCursor: 2,
+      subscriptionAcceptedAtMs: 4000,
+      observedAtMs: 5000,
+      hash,
+    }), null);
     assert.deepEqual(parseTokenReturnTranscriptMessage(message, {
       expectedTargetSessionKey: originChild,
       expectedDelegateChildSessionKey: delegateChild,
@@ -297,6 +311,89 @@ test('structured return parser binds target and source sessions', () => {
       },
     ), null);
   });
+});
+
+test('first sessions.get is emitted synchronously after subscription and lineage', () => {
+  const timers = [];
+  const sent = [];
+  const dispatch = tokenOriginCursorSnapshotDispatch({
+    originSubscriptionAccepted: true,
+    originChildSessionKey: originChild,
+    originRunId,
+    recoveryPollDelayMs: 500,
+  });
+  assert.equal(dispatch.action, 'sessions.get');
+  assert.deepEqual(dispatch.params, { key: originChild, limit: 50 });
+  sent.push(dispatch);
+  assert.deepEqual(timers, []);
+  assert.equal(sent.length, 1);
+  assert.equal(tokenOriginCursorSnapshotDispatch({
+    originSubscriptionAccepted: true,
+    recoveryPollDelayMs: 0,
+  }).action, 'idle');
+  assert.deepEqual(tokenOriginCursorSnapshotDispatch({
+    originSubscriptionAccepted: true,
+    recoveryPollDelayMs: 500,
+  }), { action: 'schedule', delayMs: 500 });
+  assert.equal(tokenOriginCursorSnapshotDispatch({
+    originChildSessionKey: originChild,
+    originRunId,
+    recoveryPollDelayMs: 500,
+  }).action, 'idle');
+});
+
+test('live and transcript copies of one sequence deduplicate; a second sequence fails', () => {
+  const message = {
+    role: 'assistant',
+    timestamp: 3000,
+    content: [{
+      type: 'text',
+      text: `Continuation completed with result: ${returnSentinel}`,
+    }],
+    __openclaw: { runId: originReturnRunId, seq: 3 },
+  };
+  const live = parseTokenReturnEvent({ sessionKey: originChild, message, runId: originReturnRunId, messageSeq: 3 }, {
+    expectedTargetSessionKey: originChild,
+    expectedDelegateChildSessionKey: delegateChild,
+    expectedDelegateRunId: delegateRunId,
+    expectedSentinel: returnSentinel,
+    originCursor: 2,
+    subscriptionAcceptedAtMs: 1000,
+    observedAtMs: 3010,
+    hash,
+  });
+  const transcript = parseTokenReturnTranscriptMessage(message, {
+    expectedTargetSessionKey: originChild,
+    expectedDelegateChildSessionKey: delegateChild,
+    expectedDelegateRunId: delegateRunId,
+    expectedSentinel: returnSentinel,
+    originCursor: 2,
+    observedAtMs: 3010,
+    hash,
+  });
+  const state = createTokenReturnObservationState();
+  assert.equal(rememberTokenReturnReceipt(state, live), true);
+  assert.equal(rememberTokenReturnReceipt(state, transcript), false);
+  assert.equal(state.count, 1);
+  const second = parseTokenReturnTranscriptMessage({
+    ...message,
+    __openclaw: { runId: originReturnRunId, seq: 4 },
+  }, {
+    expectedTargetSessionKey: originChild,
+    expectedDelegateChildSessionKey: delegateChild,
+    expectedDelegateRunId: delegateRunId,
+    expectedSentinel: returnSentinel,
+    originCursor: 2,
+    observedAtMs: 4010,
+    hash,
+  });
+  assert.equal(second?.messageSeq, 4);
+  assert.equal(rememberTokenReturnReceipt(state, second), true);
+  assert.equal(state.count, 2);
+  assert.equal(classifyTokenEvidence(completeEvidence({
+    origin_return_event_count: state.count,
+    origin_return_message_seq: 4,
+  })), 'PARTIAL-candidate');
 });
 
 test('origin cursor is the last assistant message owned by the initial origin run', () => {

--- a/tools/k6-proofs/scripts/__tests__/r-cd-token-runner-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cd-token-runner-contract.test.mjs
@@ -77,7 +77,17 @@ test('scenario paginates the public task ledger and binds a structured return', 
   assert.match(source, /delegate_requester_matches_origin_child/);
   assert.match(source, /classified\.event === 'session\.message'/);
   assert.match(source, /parseTokenReturnEvent/);
+  assert.match(source, /parseTokenReturnTranscriptMessage/);
   assert.match(source, /tokenOriginCursorFromMessages/);
+  assert.match(source, /tokenOriginCursorSnapshotDispatch/);
+  assert.match(source, /rememberTokenReturnReceipt/);
+  assert.match(source, /OPENCLAW_TOKEN_CURSOR_POLL_MS \|\| 500/);
+  assert.match(source, /!\(Number\(delay\) > 0\)/);
+  assert.doesNotMatch(source, /socket\.setTimeout\([^,]+,\s*0\s*\)/);
+  const firstGet = source.indexOf('tracker.send(socket, dispatch.method, dispatch.params)');
+  const requestFn = source.indexOf('function requestOriginCursorSnapshot()');
+  const scheduleFn = source.indexOf('function scheduleOriginCursorPoll(');
+  assert.ok(requestFn > 0 && firstGet > requestFn && firstGet < scheduleFn);
   assert.match(source, /expectedDelegateRunId: identity\.delegateRunId/);
   assert.match(source, /origin_return_message_seq/);
   assert.match(source, /origin_return_event_count === 1/);

--- a/tools/k6-proofs/scripts/resolve-r-cd-2-authoritative-receipt.mjs
+++ b/tools/k6-proofs/scripts/resolve-r-cd-2-authoritative-receipt.mjs
@@ -2,7 +2,7 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import {
-  rCd2AuthorityChecks,
+  rCd2PublicResolutionOutput,
   resolveRcd2AuthoritativeReceipt,
 } from '../lib/r-cd-2-authoritative-receipt.mjs';
 
@@ -29,11 +29,9 @@ async function main() {
   const receipt = resolveRcd2AuthoritativeReceipt({ evidence, correlation, signingKey: process.env.OPENCLAW_GATEWAY_TOKEN });
   const target = path.join(runDir, 'r-cd-2-authoritative-receipt.json');
   await writeFile(target, `${JSON.stringify(receipt, null, 2)}\n`);
-  process.stdout.write(`${JSON.stringify({
-    verdict: receipt.verdict,
-    receipt: path.basename(target),
-    checks: rCd2AuthorityChecks(evidence, correlation),
-  })}\n`);
+  process.stdout.write(`${JSON.stringify(
+    rCd2PublicResolutionOutput(receipt, evidence, correlation),
+  )}\n`);
 }
 
 main().catch((error) => {

--- a/tools/k6-proofs/tests/final-authority-run-33026448492.test.mjs
+++ b/tools/k6-proofs/tests/final-authority-run-33026448492.test.mjs
@@ -3,6 +3,7 @@ import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 import {
+  rCd2AuthorityChecks,
   resolveRcd2AuthoritativeReceipt,
   validateRcd2AuthoritativeReceipt,
 } from '../lib/r-cd-2-authoritative-receipt.mjs';
@@ -31,8 +32,15 @@ test('run 33026448492 R-CD-2 shape binds through the unique nonce-reason trace',
     correlation: fixture.rCd2.correlation,
     signingKey,
   });
+  const checks = rCd2AuthorityChecks(fixture.rCd2.evidence, fixture.rCd2.correlation);
   assert.equal(receipt.verdict, 'PASS-candidate');
   assert.equal(validateRcd2AuthoritativeReceipt(receipt, signingKey).valid, true);
+  assert.equal(
+    ['lifecycle', 'topology', 'joins']
+      .flatMap((group) => Object.values(checks[group]))
+      .every(Boolean),
+    true,
+  );
 });
 
 test('run 33026448492 depth shape accepts the recovered final task ledger', () => {

--- a/tools/k6-proofs/tests/r-cd-chained-depth-2-authority.test.mjs
+++ b/tools/k6-proofs/tests/r-cd-chained-depth-2-authority.test.mjs
@@ -198,6 +198,34 @@ function consumptionReceipt({
   });
 }
 
+test('byte-identical progressSummary/result aliases count as one marker', () => {
+  const aliased = chainTasks();
+  aliased[0].result = aliased[0].progressSummary;
+  aliased[1].result = aliased[1].progressSummary;
+  assert.equal(taskReceipt(aliased)?.taskCount, 2);
+  assert.equal(taskReceipt(aliased)?.recoveryWakeScheduled, true);
+});
+
+test('a repeated marker inside one public detail field remains rejected', () => {
+  const repeatedChild = chainTasks();
+  repeatedChild[0].progressSummary = `CHILD-DONE ${nonce} CHILD-DONE ${nonce}`;
+  assert.equal(taskReceipt(repeatedChild), null);
+  const repeatedGrandchild = chainTasks();
+  repeatedGrandchild[1].progressSummary = `GRANDCHILD-DONE ${nonce} GRANDCHILD-DONE ${nonce}`;
+  assert.equal(taskReceipt(repeatedGrandchild), null);
+});
+
+test('distinct non-identical detail fields that each contain the marker remain rejected', () => {
+  const distinctChild = chainTasks();
+  distinctChild[0].progressSummary = `CHILD-DONE ${nonce}`;
+  distinctChild[0].result = `completed CHILD-DONE ${nonce} extra`;
+  assert.equal(taskReceipt(distinctChild), null);
+  const distinctGrandchild = chainTasks();
+  distinctGrandchild[1].progressSummary = `GRANDCHILD-DONE ${nonce}`;
+  distinctGrandchild[1].terminalSummary = `finished GRANDCHILD-DONE ${nonce}`;
+  assert.equal(taskReceipt(distinctGrandchild), null);
+});
+
 test('depth-2 task ledger binds exactly one delivered root-child-grandchild chain', () => {
   assert.deepEqual(taskReceipt(), {
     schema: R_CD_CHAIN_TASK_LEDGER_SCHEMA,


### PR DESCRIPTION
## Summary

Hardens the existing `08fc038d` candidate remedies for three proof-harness defects. HMAC receipts remain the sole candidate verdict authority. Fail-closed topology, nonce, and marker contracts are not relaxed.

- Closes #519 — R-CD-2 public-safe per-gate diagnostics with table-driven inversion coverage.
- Closes #520 — byte-identical `progressSummary`/`result` aliases count once; intra-field and distinct-field repeats stay non-PASS.
- Closes #521 — first `sessions.get` is synchronous after subscription + lineage; transcript recovers the pre-subscription public return; live+transcript copies of one sequence dedupe.

## Issue-by-issue remedy

### #519 / R-CD-2
Public resolver stdout now uses `rCd2PublicResolutionOutput`: boolean lifecycle, topology, and join gates only. HMAC-signed receipt stays the sole verdict. Inverting any one gate keeps the row non-PASS while unrelated gates retain their expected values. Unique nonce/reason binding when `sessions.send` omits `traceId` is preserved. Resolution JSON and receipt pass sanitizer/public-safety checks.

### #520 / R-CD-CHAINED-DEPTH-2
Existing Set-dedup of identical public detail strings is now covered: identical `progressSummary`/`result` aliases form a valid two-task ledger; a repeated marker inside one field is rejected; distinct non-identical fields that each contain the marker are rejected. Ownership, completed/delivered, timing, nonce, `continue_work`, and final-marker contracts are unchanged.

### #521 / R-CD-TOKEN
`tokenOriginCursorSnapshotDispatch` emits the first `sessions.get` immediately after subscription + exact origin lineage, without a zero-delay timer. Recovery polls require a positive delay. Live parser still rejects a pre-subscription public assistant message; transcript recovery accepts it. Live and transcript copies of one `messageSeq` count once; a second sequence is PARTIAL. Wrong session/run/nonce/cursor/root/private-log/missing-event negatives remain.

## Validation
- `node --test` over `tools/k6-proofs/scripts/__tests__` and `tools/k6-proofs/tests`: **524 pass / 0 fail**
- `node --check` on changed executable scripts/scenarios
- manifest/scenario alignment, row-manifest, telemetry contract, corpus `--current`, sanitizer, candidate-envelope, workflow/matrix, and proof-closure surfaces covered by those suites/checks
- `git diff --check` clean against `08fc038d`

## Limits
Does not refire Project-81, mutate a gateway, or fold a live PASS. Product behavior is unchanged; this is harness/authority debt only.