### PR TITLE
Fix Project-81 target-bound seat readiness

### DIFF
--- a/.github/workflows/project81-k6-proof.yml
+++ b/.github/workflows/project81-k6-proof.yml
@@ -213,8 +213,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # The runner executes ON the prince's own host, so the authoritative
-          # token for THIS seat's gateway is the one in that seat's own config.
+          # Host config is an authentication source only. Target readiness and
+          # continuation depth are always read from inputs.gateway_ws by RPC.
           # A single shared secret cannot authenticate against six gateways that
           # each hold a different token -- it only ever matched one seat, and
           # every other seat failed at `connect`, surfacing later and confusingly

--- a/tools/k6-proofs/docs/PROOF-RUN-METHOD.md
+++ b/tools/k6-proofs/docs/PROOF-RUN-METHOD.md
@@ -109,6 +109,12 @@ The live helper obtains continuation config through authenticated `config.get`
 on `OPENCLAW_GATEWAY_WS`; host config can provide authentication but never the
 target depth. Its public observation binds only a credential-free gateway
 fingerprint plus seat, unit, docs, candidate/runtime, rows, and depth contract.
+Candidate and runtime are separate 40-character identities and may differ at
+this readiness layer. The runner records that state as
+`candidateMatchesRuntime:false`; readiness does not promote it to exact-target
+evidence. Rows that require exact execution, including R-CD-TOKEN and
+R-CD-CHAINED-DEPTH-2, retain their row-specific equal-build gates, and the
+candidate-envelope validator withholds exact PASS authority on mismatch.
 
 ### 4. Dry-run the selected set
 

--- a/tools/k6-proofs/docs/PROOF-RUN-METHOD.md
+++ b/tools/k6-proofs/docs/PROOF-RUN-METHOD.md
@@ -89,6 +89,7 @@ OPENCLAW_CANDIDATE_SHA=<40-char-sha> \
 OPENCLAW_SEAT_NAME=<seat> \
 OPENCLAW_SESSION_KEY=<scratch-or-disposable-session> \
 OPENCLAW_GATEWAY_TOKEN=*** \
+OPENCLAW_GATEWAY_WS=<target-gateway-ws-url> \
 node tools/k6-proofs/scripts/seat-readiness-preflight.mjs --json \
   --rows <comma-separated-selected-rows>
 ```
@@ -104,6 +105,10 @@ before k6 or model traffic. Isolated Project-81 profiles use
 and a public-safe configured/effective/required-depth receipt. Pass
 `--expected-max-spawn-depth 5` (or workflow input
 `expected_max_spawn_depth=5`) when that exact isolated profile is required.
+The live helper obtains continuation config through authenticated `config.get`
+on `OPENCLAW_GATEWAY_WS`; host config can provide authentication but never the
+target depth. Its public observation binds only a credential-free gateway
+fingerprint plus seat, unit, docs, candidate/runtime, rows, and depth contract.
 
 ### 4. Dry-run the selected set
 

--- a/tools/k6-proofs/lib/target-readiness-binding.mjs
+++ b/tools/k6-proofs/lib/target-readiness-binding.mjs
@@ -77,7 +77,6 @@ export function targetReadinessBindingErrors(actual, expected, { requireComplete
     if (!SHA.test(actual.docsHead || '')) errors.push('docs-head-invalid');
     if (!SHA.test(actual.candidateSha || '')) errors.push('candidate-sha-invalid');
     if (!SHA.test(actual.runtimeBuildSha || '')) errors.push('runtime-build-sha-invalid');
-    if (actual.candidateSha !== actual.runtimeBuildSha) errors.push('candidate-runtime-mismatch');
   }
   return [...new Set(errors)];
 }

--- a/tools/k6-proofs/lib/target-readiness-binding.mjs
+++ b/tools/k6-proofs/lib/target-readiness-binding.mjs
@@ -1,0 +1,83 @@
+import { createHash } from 'node:crypto';
+
+const SHA = /^[0-9a-f]{40}$/u;
+const ROW = /^[A-Z0-9][A-Z0-9._-]*$/u;
+const UNIT = /^[A-Za-z0-9][A-Za-z0-9_.@:-]*$/u;
+
+export function publicGatewayTarget(value) {
+  const url = new URL(value);
+  if (url.protocol !== 'ws:' && url.protocol !== 'wss:') {
+    throw new Error('gateway URL must use ws or wss');
+  }
+  url.username = '';
+  url.password = '';
+  url.search = '';
+  url.hash = '';
+  const publicUrl = url.toString().replace(/\/$/, '');
+  return {
+    url: publicUrl,
+    fingerprint: createHash('sha256').update(publicUrl).digest('hex'),
+  };
+}
+
+export function buildTargetReadinessBinding({
+  gatewayWs,
+  seat,
+  gatewayUnit,
+  docsHead,
+  candidateSha,
+  runtimeBuildSha,
+  selectedRows,
+  requiredMaxSpawnDepth,
+  expectedMaxSpawnDepth,
+}) {
+  const gateway = publicGatewayTarget(gatewayWs);
+  return {
+    gatewayUrlFingerprint: gateway.fingerprint,
+    seat,
+    gatewayUnit,
+    docsHead: docsHead || null,
+    candidateSha: candidateSha || null,
+    runtimeBuildSha: runtimeBuildSha || null,
+    selectedRows: [...selectedRows],
+    requiredMaxSpawnDepth,
+    expectedMaxSpawnDepth,
+  };
+}
+
+export function targetReadinessBindingErrors(actual, expected, { requireComplete = false } = {}) {
+  const errors = [];
+  if (!actual || typeof actual !== 'object' || Array.isArray(actual)) return ['binding-missing'];
+  for (const key of [
+    'gatewayUrlFingerprint',
+    'seat',
+    'gatewayUnit',
+    'docsHead',
+    'candidateSha',
+    'runtimeBuildSha',
+    'requiredMaxSpawnDepth',
+    'expectedMaxSpawnDepth',
+  ]) {
+    if (actual[key] !== expected[key]) errors.push(`${key}-mismatch`);
+  }
+  if (
+    !Array.isArray(actual.selectedRows) ||
+    actual.selectedRows.length !== expected.selectedRows.length ||
+    actual.selectedRows.some((row, index) => row !== expected.selectedRows[index])
+  ) {
+    errors.push('selectedRows-mismatch');
+  }
+  if (!/^[0-9a-f]{64}$/u.test(actual.gatewayUrlFingerprint || '')) errors.push('gateway-fingerprint-invalid');
+  if (typeof actual.seat !== 'string' || actual.seat.length === 0) errors.push('seat-invalid');
+  if (!UNIT.test(actual.gatewayUnit || '')) errors.push('gateway-unit-invalid');
+  if (!Array.isArray(actual.selectedRows) || actual.selectedRows.some((row) => !ROW.test(row))) {
+    errors.push('selected-rows-invalid');
+  }
+  if (requireComplete) {
+    if (!SHA.test(actual.docsHead || '')) errors.push('docs-head-invalid');
+    if (!SHA.test(actual.candidateSha || '')) errors.push('candidate-sha-invalid');
+    if (!SHA.test(actual.runtimeBuildSha || '')) errors.push('runtime-build-sha-invalid');
+    if (actual.candidateSha !== actual.runtimeBuildSha) errors.push('candidate-runtime-mismatch');
+  }
+  return [...new Set(errors)];
+}

--- a/tools/k6-proofs/scripts/__tests__/continuation-row-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/continuation-row-contract.test.mjs
@@ -45,8 +45,69 @@ function rcd2Trace({ reasonHash, reasonLength }) {
   };
 }
 
+function websocketFrame(payload) {
+  const body = Buffer.from(JSON.stringify(payload));
+  return body.length < 126
+    ? Buffer.concat([Buffer.from([0x81, body.length]), body])
+    : Buffer.concat([Buffer.from([0x81, 126, body.length >> 8, body.length & 0xff]), body]);
+}
+
+function decodeWebsocketFrame(buffer) {
+  if ((buffer[0] & 0x0f) !== 1) return null;
+  const masked = (buffer[1] & 0x80) !== 0;
+  let length = buffer[1] & 0x7f;
+  let offset = 2;
+  if (length === 126) {
+    length = buffer.readUInt16BE(offset);
+    offset += 2;
+  }
+  const mask = masked ? buffer.subarray(offset, offset + 4) : null;
+  if (masked) offset += 4;
+  const body = Buffer.from(buffer.subarray(offset, offset + length));
+  if (mask) for (let i = 0; i < body.length; i += 1) body[i] ^= mask[i % 4];
+  return JSON.parse(body.toString('utf8'));
+}
+
 async function listen(handler) {
   const server = createServer(handler);
+  server.on('upgrade', (req, socket) => {
+    const accept = createHash('sha1')
+      .update(`${req.headers['sec-websocket-key']}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+      .digest('base64');
+    socket.write(`HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: ${accept}\r\n\r\n`);
+    socket.on('data', (data) => {
+      if ((data[0] & 0x0f) === 8) {
+        socket.end();
+        return;
+      }
+      const request = decodeWebsocketFrame(data);
+      if (!request) return;
+      if (request.method === 'connect') {
+        socket.write(websocketFrame({ type: 'res', id: request.id, ok: true, payload: { type: 'hello-ok' } }));
+      } else if (request.method === 'config.get') {
+        socket.write(websocketFrame({
+          type: 'res',
+          id: request.id,
+          ok: true,
+          payload: {
+            config: {
+              agents: {
+                defaults: {
+                  continuation: {
+                    enabled: true,
+                    maxChainLength: 3,
+                    maxDelegatesPerTurn: 3,
+                    costCapTokens: 3,
+                  },
+                  subagents: { maxSpawnDepth: 5 },
+                },
+              },
+            },
+          },
+        }));
+      }
+    });
+  });
   await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
   const address = server.address();
   return { server, baseUrl: `http://127.0.0.1:${address.port}` };

--- a/tools/k6-proofs/scripts/__tests__/harness-provenance-runner.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/harness-provenance-runner.test.mjs
@@ -30,6 +30,29 @@ const run = promisify(execFile);
 const candidateSha = 'a'.repeat(40);
 const HARNESS_INFRA_EXIT = 78;
 
+function websocketFrame(payload) {
+  const body = Buffer.from(JSON.stringify(payload));
+  return body.length < 126
+    ? Buffer.concat([Buffer.from([0x81, body.length]), body])
+    : Buffer.concat([Buffer.from([0x81, 126, body.length >> 8, body.length & 0xff]), body]);
+}
+
+function decodeWebsocketFrame(buffer) {
+  if ((buffer[0] & 0x0f) !== 1) return null;
+  const masked = (buffer[1] & 0x80) !== 0;
+  let length = buffer[1] & 0x7f;
+  let offset = 2;
+  if (length === 126) {
+    length = buffer.readUInt16BE(offset);
+    offset += 2;
+  }
+  const mask = masked ? buffer.subarray(offset, offset + 4) : null;
+  if (masked) offset += 4;
+  const body = Buffer.from(buffer.subarray(offset, offset + length));
+  if (mask) for (let i = 0; i < body.length; i += 1) body[i] ^= mask[i % 4];
+  return JSON.parse(body.toString('utf8'));
+}
+
 async function withRunner(fn, { mutate = null, beforeCommit = null } = {}) {
   const root = await mkdtemp(path.join(tmpdir(), 'p86-harness-provenance-'));
   const out = path.join(root, 'out');
@@ -426,6 +449,19 @@ async function withApprovedMatrix(fn, {
   k6ShimFor = null,
   openclawShimFor = null,
   envFor = null,
+  targetConfig = {
+    agents: {
+      defaults: {
+        continuation: {
+          enabled: true,
+          maxChainLength: 3,
+          maxDelegatesPerTurn: 3,
+          costCapTokens: 3,
+        },
+        subagents: { maxSpawnDepth: 5 },
+      },
+    },
+  },
 } = {}) {
   const root = await mkdtemp(path.join(tmpdir(), 'p86-harness-provenance-ok-'));
   const bin = path.join(root, 'bin');
@@ -436,6 +472,30 @@ async function withApprovedMatrix(fn, {
   if (afterCommit) await afterCommit(harness);
 
   const gateway = createServer((req, res) => res.writeHead(req.url.startsWith('/health') || req.url.startsWith('/status') ? 200 : 404).end('{}'));
+  gateway.on('upgrade', (req, socket) => {
+    const accept = createHash('sha1')
+      .update(`${req.headers['sec-websocket-key']}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+      .digest('base64');
+    socket.write(`HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: ${accept}\r\n\r\n`);
+    socket.on('data', (data) => {
+      if ((data[0] & 0x0f) === 8) {
+        socket.end();
+        return;
+      }
+      const request = decodeWebsocketFrame(data);
+      if (!request) return;
+      if (request.method === 'connect') {
+        socket.write(websocketFrame({ type: 'res', id: request.id, ok: true, payload: { type: 'hello-ok' } }));
+      } else if (request.method === 'config.get') {
+        socket.write(websocketFrame({
+          type: 'res',
+          id: request.id,
+          ok: true,
+          payload: { config: targetConfig },
+        }));
+      }
+    });
+  });
   await new Promise((resolve) => gateway.listen(0, '127.0.0.1', resolve));
   const gatewayPort = gateway.address().port;
 
@@ -494,48 +554,61 @@ async function withApprovedMatrix(fn, {
   }
 }
 
-test('insufficient nested-row depth fails before scenario dispatch', async () => {
-  await withApprovedMatrix(
-    async (harness) => {
-      const result = await harness.invoke();
-      assert.equal(result.code, HARNESS_INFRA_EXIT, result.stderr);
-      const readiness = JSON.parse(
-        await readFile(path.join(harness.out, 'seat-readiness.json'), 'utf8'),
-      );
-      assert.equal(readiness.outcome, 'PARTIAL-candidate');
-      assert.equal(readiness.continuationDepth.configuredMaxSpawnDepth, null);
-      assert.equal(readiness.continuationDepth.effectiveMaxSpawnDepth, 1);
-      assert.equal(readiness.continuationDepth.requiredMaxSpawnDepth, 2);
-      assert.equal(readiness.continuationDepth.reason, 'effective-depth-insufficient');
-
-      const receipt = JSON.parse(
-        await readFile(path.join(harness.out, 'harness-control-receipt.json'), 'utf8'),
-      );
-      assert.equal(receipt.stage, 'seat-readiness');
-      assert.equal(receipt.rowsExecuted, 0);
-      assert.equal(receipt.rowVerdictsSynthesized, false);
-      assert.equal(receipt.detail.check, 'selected-row-continuation-depth');
-      assert.deepEqual(receipt.detail.selectedRows, [
-        'R-CD-CHAINED-DEPTH-2',
-        'R-CD-TOKEN',
-      ]);
-      await assert.rejects(
-        readFile(path.join(harness.root, 'k6-dispatched'), 'utf8'),
-        /ENOENT/,
-      );
-    },
+test('unknown or insufficient target depth fails before scenario dispatch despite host depth 5', async (t) => {
+  const continuation = {
+    enabled: true,
+    maxChainLength: 3,
+    maxDelegatesPerTurn: 3,
+    costCapTokens: 3,
+  };
+  for (const fixture of [
+    { name: 'target depth unknown', config: {}, effective: null, reason: 'configured-depth-unknown' },
     {
-      rows: 'R-CD-CHAINED-DEPTH-2,R-CD-TOKEN',
-      openclawShimFor: () => '#!/bin/sh\nprintf \'%s\\n\' \'{"continuation":{"enabled":true,"maxChainLength":3,"maxDelegatesPerTurn":3,"costCapTokens":3}}\'\n',
-      k6ShimFor: (harness) => [
-        '#!/bin/sh',
-        'if [ "${1:-}" = version ]; then printf \'%s\\n\' \'k6 v2.0.0\'; exit 0; fi',
-        `printf '%s\\n' dispatched > ${path.join(harness.root, 'k6-dispatched')}`,
-        'exit 0',
-        '',
-      ].join('\n'),
+      name: 'target depth 1',
+      config: { agents: { defaults: { continuation, subagents: { maxSpawnDepth: 1 } } } },
+      effective: 1,
+      reason: 'effective-depth-insufficient',
     },
-  );
+  ]) {
+    await t.test(fixture.name, async () => {
+      await withApprovedMatrix(
+        async (harness) => {
+          const result = await harness.invoke();
+          assert.equal(result.code, HARNESS_INFRA_EXIT, result.stderr);
+          const readiness = JSON.parse(
+            await readFile(path.join(harness.out, 'seat-readiness.json'), 'utf8'),
+          );
+          assert.equal(readiness.outcome, 'PARTIAL-candidate');
+          assert.equal(readiness.continuationDepth.effectiveMaxSpawnDepth, fixture.effective);
+          assert.equal(readiness.continuationDepth.requiredMaxSpawnDepth, 2);
+          assert.equal(readiness.continuationDepth.reason, fixture.reason);
+
+          const receipt = JSON.parse(
+            await readFile(path.join(harness.out, 'harness-control-receipt.json'), 'utf8'),
+          );
+          assert.equal(receipt.stage, 'seat-readiness');
+          assert.equal(receipt.rowsExecuted, 0);
+          assert.equal(receipt.rowVerdictsSynthesized, false);
+          assert.equal(receipt.detail.check, 'selected-row-continuation-depth');
+          await assert.rejects(
+            readFile(path.join(harness.root, 'k6-dispatched'), 'utf8'),
+            /ENOENT/,
+          );
+        },
+        {
+          rows: 'R-CD-CHAINED-DEPTH-2,R-CD-TOKEN',
+          targetConfig: fixture.config,
+          k6ShimFor: (harness) => [
+            '#!/bin/sh',
+            'if [ "${1:-}" = version ]; then printf \'%s\\n\' \'k6 v2.0.0\'; exit 0; fi',
+            `printf '%s\\n' dispatched > ${path.join(harness.root, 'k6-dispatched')}`,
+            'exit 0',
+            '',
+          ].join('\n'),
+        },
+      );
+    });
+  }
 });
 
 test('the catalog preflight log is public-safe: no credentials, no local paths', async () => {
@@ -745,6 +818,11 @@ test('an approved live run freezes the docs ref and records the exact harness di
       assert.equal(provenance.runtimeIdentity.continuationDepth.effectiveMaxSpawnDepth, 5);
       assert.equal(provenance.runtimeIdentity.continuationDepth.requiredMaxSpawnDepth, 1);
       assert.equal(provenance.runtimeIdentity.continuationDepth.sufficient, true);
+      assert.equal(provenance.runtimeIdentity.targetObservation.source, 'authenticated-gateway-config-rpc');
+      assert.equal(provenance.runtimeIdentity.targetObservation.binding.docsHead, harness.docsRef);
+      assert.equal(provenance.runtimeIdentity.targetObservation.binding.candidateSha, candidateSha);
+      assert.equal(provenance.runtimeIdentity.targetObservation.binding.runtimeBuildSha, candidateSha);
+      assert.deepEqual(provenance.runtimeIdentity.targetObservation.binding.selectedRows, ['R-CW-5A']);
       assert.equal(provenance.runnerScript, 'tools/k6-proofs/scripts/run-proofs.sh');
       assert.match(provenance.runnerScriptSha256, /^[a-f0-9]{64}$/);
       assert.equal(provenance.candidateOnly, true);

--- a/tools/k6-proofs/scripts/__tests__/r-cd-token-runner-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/r-cd-token-runner-contract.test.mjs
@@ -56,6 +56,9 @@ test('workflow forwards exact isolated runtime, seat, telemetry, and service ide
   assert.match(workflow, /OPENCLAW_SEAT_CLASS: \$\{\{ inputs\.seat_class \}\}/);
   assert.match(workflow, /OPENCLAW_PROOFS_OTEL_SERVICE_NAME: \$\{\{ inputs\.otel_service_name \}\}/);
   assert.match(workflow, /OPENCLAW_PROOFS_GATEWAY_UNIT: \$\{\{ inputs\.gateway_unit \}\}/);
+  assert.match(workflow, /Host config is an authentication source only/);
+  assert.match(runner, /seat-readiness-preflight\.mjs --json --require-target-binding/);
+  assert.match(runner, /export OPENCLAW_PROOFS_DOCS_REF="\$DOCS_REF"/);
   assert.match(runner, /OPENCLAW_SEAT_NAME="\$\{OPENCLAW_SEAT_NAME:-\$\(hostname\)\}"/);
 });
 

--- a/tools/k6-proofs/scripts/__tests__/seat-readiness.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/seat-readiness.test.mjs
@@ -4,7 +4,13 @@ import { readFile, mkdtemp, rm, writeFile, chmod } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { mkdir } from 'node:fs/promises';
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
+import { once } from 'node:events';
+import {
+  buildTargetReadinessBinding,
+  publicGatewayTarget,
+  targetReadinessBindingErrors,
+} from '../../lib/target-readiness-binding.mjs';
 
 const repoRoot = new URL('../../../..', import.meta.url).pathname;
 const script = join(repoRoot, 'tools/k6-proofs/scripts/seat-readiness-preflight.mjs');
@@ -72,6 +78,82 @@ function readyEnv({ bin, fakeK6, token = 'CANARY-TOKEN-VALUE-DO-NOT-PRINT' }) {
   };
 }
 
+async function withTargetGateway(dir, config, fn) {
+  const fixture = join(dir, 'target-gateway.mjs');
+  await writeFile(fixture, `
+import { createHash } from 'node:crypto';
+import { writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+
+function frame(payload) {
+  const body = Buffer.from(JSON.stringify(payload));
+  return body.length < 126
+    ? Buffer.concat([Buffer.from([0x81, body.length]), body])
+    : Buffer.concat([Buffer.from([0x81, 126, body.length >> 8, body.length & 0xff]), body]);
+}
+
+function decode(buffer) {
+  const masked = (buffer[1] & 0x80) !== 0;
+  let length = buffer[1] & 0x7f;
+  let offset = 2;
+  if (length === 126) {
+    length = buffer.readUInt16BE(offset);
+    offset += 2;
+  }
+  const mask = masked ? buffer.subarray(offset, offset + 4) : null;
+  if (masked) offset += 4;
+  const body = Buffer.from(buffer.subarray(offset, offset + length));
+  if (mask) for (let i = 0; i < body.length; i += 1) body[i] ^= mask[i % 4];
+  return JSON.parse(body.toString('utf8'));
+}
+
+const config = ${JSON.stringify(config)};
+const counts = { configRpc: 0, rowOrModelTraffic: 0 };
+const countsPath = ${JSON.stringify(join(dir, 'target-counts.json'))};
+const saveCounts = () => writeFileSync(countsPath, JSON.stringify(counts));
+saveCounts();
+const server = createServer((req, res) => {
+  if (req.url === '/counts') {
+    res.writeHead(200);
+    res.end(JSON.stringify(counts));
+  } else {
+    res.writeHead(req.url === '/health' || req.url === '/status' ? 200 : 404);
+    res.end('{}');
+  }
+});
+server.on('upgrade', (req, socket) => {
+  const accept = createHash('sha1')
+    .update(req.headers['sec-websocket-key'] + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11')
+    .digest('base64');
+  socket.write('HTTP/1.1 101 Switching Protocols\\r\\nUpgrade: websocket\\r\\nConnection: Upgrade\\r\\nSec-WebSocket-Accept: ' + accept + '\\r\\n\\r\\n');
+  socket.on('data', (data) => {
+    const request = decode(data);
+    if (request.method === 'connect') {
+      socket.write(frame({ type: 'res', id: request.id, ok: true, payload: { type: 'hello-ok' } }));
+    } else if (request.method === 'config.get') {
+      counts.configRpc += 1;
+      saveCounts();
+      socket.write(frame({ type: 'res', id: request.id, ok: true, payload: { config } }));
+    } else {
+      counts.rowOrModelTraffic += 1;
+      saveCounts();
+    }
+  });
+});
+server.listen(0, '127.0.0.1', () => console.log(server.address().port));
+`);
+  const child = spawn(process.execPath, [fixture], { stdio: ['ignore', 'pipe', 'pipe'] });
+  const [chunk] = await once(child.stdout, 'data');
+  try {
+    return await fn(Number(String(chunk).trim()));
+  } finally {
+    if (child.exitCode === null) {
+      child.kill('SIGTERM');
+      await once(child, 'exit');
+    }
+  }
+}
+
 test('seat readiness policy keeps the k6 proof-standard version in one place', async () => {
   const parsed = JSON.parse(await readFile(policy, 'utf8'));
   assert.equal(parsed.schema, 'openclaw.k6.seat-readiness-policy.v1');
@@ -128,6 +210,107 @@ test('seat readiness JSON contains no env secret values and reports booleans onl
     );
     assert.equal(report.session.scope, 'main-agent-session');
   });
+});
+
+test('target readiness A/B/C selects only authenticated target depth', async (t) => {
+  const targetDefaults = (maxSpawnDepth) => ({
+    agents: {
+      defaults: {
+        continuation: {
+          enabled: true,
+          maxChainLength: 200,
+          maxDelegatesPerTurn: 500,
+          costCapTokens: 500000,
+        },
+        ...(maxSpawnDepth === undefined ? {} : { subagents: { maxSpawnDepth } }),
+      },
+    },
+  });
+
+  await t.test('A: host unknown and target depth 5 passes required 2 expected 5', async () => {
+    await withTmp(async (dir) => {
+      const tools = await writeFakeSeatTools(dir, { openclawFails: true });
+      await withTargetGateway(dir, targetDefaults(5), async (port) => {
+        const run = runPreflight(
+          ['--json', '--rows', 'R-CD-CHAINED-DEPTH-2,R-CD-TOKEN', '--expected-max-spawn-depth', '5'],
+          {
+            ...readyEnv(tools),
+            OPENCLAW_GATEWAY_WS: `ws://127.0.0.1:${port}`,
+          },
+        );
+        assert.equal(run.status, 0, run.stderr || run.stdout);
+        const report = JSON.parse(run.stdout);
+        assert.equal(report.outcome, 'PASS-candidate');
+        assert.equal(report.continuationDepth.configuredMaxSpawnDepth, 5);
+        assert.equal(report.continuationDepth.effectiveMaxSpawnDepth, 5);
+        assert.equal(report.continuationDepth.requiredMaxSpawnDepth, 2);
+        assert.equal(report.continuationDepth.expectedMaxSpawnDepth, 5);
+        assert.equal(report.targetObservation.source, 'authenticated-gateway-config-rpc');
+        assert.equal(report.targetObservation.bindingValid, true);
+        assert.deepEqual(JSON.parse(await readFile(join(dir, 'target-counts.json'), 'utf8')), {
+          configRpc: 1,
+          rowOrModelTraffic: 0,
+        });
+      });
+    });
+  });
+
+  for (const fixture of [
+    { label: 'B: host depth 5 and target depth unknown stops', targetDepth: null, reason: 'configured-depth-unknown' },
+    { label: 'C: host depth 5 and target depth 1 stops', targetDepth: 1, reason: 'effective-depth-insufficient' },
+  ]) {
+    await t.test(fixture.label, async () => {
+      await withTmp(async (dir) => {
+        const tools = await writeFakeSeatTools(dir, { maxSpawnDepth: 5 });
+        const targetConfig = fixture.targetDepth === null ? {} : targetDefaults(fixture.targetDepth);
+        await withTargetGateway(dir, targetConfig, async (port) => {
+          const run = runPreflight(
+            ['--json', '--rows', 'R-CD-CHAINED-DEPTH-2,R-CD-TOKEN', '--expected-max-spawn-depth', '5'],
+            { ...readyEnv(tools), OPENCLAW_GATEWAY_WS: `ws://127.0.0.1:${port}` },
+          );
+          assert.equal(run.status, 2, run.stderr || run.stdout);
+          const report = JSON.parse(run.stdout);
+          assert.equal(report.outcome, 'PARTIAL-candidate');
+          assert.equal(report.continuationDepth.reason, fixture.reason);
+          assert.deepEqual(JSON.parse(await readFile(join(dir, 'target-counts.json'), 'utf8')), {
+            configRpc: 1,
+            rowOrModelTraffic: 0,
+          });
+        });
+      });
+    });
+  }
+});
+
+test('D: target observation rejects wrong gateway, seat, candidate, and row binding', () => {
+  const source = {
+    gatewayWs: 'ws://127.0.0.1:19893',
+    seat: 'target-seat',
+    gatewayUnit: 'openclaw-gateway-isolated',
+    docsHead: 'a'.repeat(40),
+    candidateSha: 'b'.repeat(40),
+    runtimeBuildSha: 'b'.repeat(40),
+    selectedRows: ['R-CD-2', 'R-CD-TOKEN'],
+    requiredMaxSpawnDepth: 2,
+    expectedMaxSpawnDepth: 5,
+  };
+  const expected = buildTargetReadinessBinding(source);
+  for (const mutation of [
+    { gatewayUrlFingerprint: '0'.repeat(64) },
+    { seat: 'wrong-seat' },
+    { candidateSha: 'c'.repeat(40) },
+    { selectedRows: ['R-CD-2'] },
+  ]) {
+    assert.notDeepEqual(
+      targetReadinessBindingErrors({ ...expected, ...mutation }, expected, { requireComplete: true }),
+      [],
+    );
+  }
+  const secret = 'URL-CREDENTIAL-CANARY';
+  const publicTarget = publicGatewayTarget(`ws://user:${secret}@127.0.0.1:19893/?token=${secret}`);
+  assert.equal(publicTarget.url, 'ws://127.0.0.1:19893');
+  assert.doesNotMatch(JSON.stringify(publicTarget), new RegExp(secret));
+  assert.deepEqual(publicTarget, publicGatewayTarget('ws://127.0.0.1:19893'));
 });
 
 test('seat readiness schema tracks policy, continuation readiness, checked k6 candidates, and env purposes', async () => {

--- a/tools/k6-proofs/scripts/__tests__/seat-readiness.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/seat-readiness.test.mjs
@@ -170,16 +170,21 @@ test('seat readiness JSON contains no env secret values and reports booleans onl
   await withTmp(async (dir) => {
     const tools = await writeFakeSeatTools(dir, { maxSpawnDepth: 5 });
     const token = 'CANARY-TOKEN-VALUE-DO-NOT-PRINT';
+    const urlSecret = 'URL-CREDENTIAL-VALUE-DO-NOT-PRINT';
     const run = runPreflight([
       '--json',
       '--no-gateway',
       '--expected-k6-version', 'v2.0.0',
       '--expected-max-spawn-depth', '5',
       '--rows', 'R-CD-CHAINED-DEPTH-2,R-CD-TOKEN',
-    ], readyEnv({ ...tools, token }));
+    ], {
+      ...readyEnv({ ...tools, token }),
+      OPENCLAW_GATEWAY_WS: `ws://user:${urlSecret}@127.0.0.1:18789/?token=${urlSecret}`,
+    });
 
     assert.equal(run.status, 0, run.stderr || run.stdout);
     assert.doesNotMatch(run.stdout, new RegExp(token));
+    assert.doesNotMatch(run.stdout, new RegExp(urlSecret));
     const report = JSON.parse(run.stdout);
     assert.equal(report.schema, 'openclaw.k6.seat-readiness.v1');
     assert.equal(report.outcome, 'PASS-candidate');
@@ -187,6 +192,7 @@ test('seat readiness JSON contains no env secret values and reports booleans onl
     assert.equal(report.k6.path, tools.fakeK6);
     assert.equal(report.k6.version, 'v2.0.0');
     assert.equal(report.gateway.mode, 'skipped-by-flag');
+    assert.equal(report.gateway.url, 'ws://127.0.0.1:18789');
     assert.equal(report.continuation.mode, 'checked');
     assert.equal(report.continuation.enabled, true);
     assert.equal(report.continuation.defaultsPresent, true);

--- a/tools/k6-proofs/scripts/__tests__/seat-readiness.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/seat-readiness.test.mjs
@@ -319,6 +319,47 @@ test('D: target observation rejects wrong gateway, seat, candidate, and row bind
   assert.deepEqual(publicTarget, publicGatewayTarget('ws://127.0.0.1:19893'));
 });
 
+test('complete target binding preserves distinct valid candidate and runtime identities', async () => {
+  const candidateSha = 'b'.repeat(40);
+  const runtimeBuildSha = 'c'.repeat(40);
+  const source = {
+    gatewayWs: 'ws://127.0.0.1:19893',
+    seat: 'target-seat',
+    gatewayUnit: 'openclaw-gateway-isolated',
+    docsHead: 'a'.repeat(40),
+    candidateSha,
+    runtimeBuildSha,
+    selectedRows: ['R-CD-2'],
+    requiredMaxSpawnDepth: 1,
+    expectedMaxSpawnDepth: null,
+  };
+  const binding = buildTargetReadinessBinding(source);
+  assert.deepEqual(
+    targetReadinessBindingErrors(binding, binding, { requireComplete: true }),
+    [],
+  );
+
+  await withTmp(async (dir) => {
+    const tools = await writeFakeSeatTools(dir);
+    const run = runPreflight(
+      ['--json', '--no-gateway', '--require-target-binding', '--rows', 'R-CD-2'],
+      {
+        ...readyEnv(tools),
+        OPENCLAW_CANDIDATE_SHA: candidateSha,
+        OPENCLAW_RUNTIME_BUILD_SHA: runtimeBuildSha,
+        OPENCLAW_PROOFS_DOCS_REF: source.docsHead,
+      },
+    );
+    assert.equal(run.status, 0, run.stderr || run.stdout);
+    const report = JSON.parse(run.stdout);
+    assert.equal(report.outcome, 'PASS-candidate');
+    assert.equal(report.targetObservation.bindingValid, true);
+    assert.deepEqual(report.targetObservation.bindingErrors, []);
+    assert.equal(report.targetObservation.binding.candidateSha, candidateSha);
+    assert.equal(report.targetObservation.binding.runtimeBuildSha, runtimeBuildSha);
+  });
+});
+
 test('seat readiness schema tracks policy, continuation readiness, checked k6 candidates, and env purposes', async () => {
   const parsed = JSON.parse(await readFile(schema, 'utf8'));
   assert.ok(parsed.required.includes('policy'));

--- a/tools/k6-proofs/scripts/run-proofs.sh
+++ b/tools/k6-proofs/scripts/run-proofs.sh
@@ -664,6 +664,7 @@ fi
 ROW_SELECTION_JSON="$(printf '%s' "$ROWS" | jq -R 'split(",") | map(ascii_upcase)')"
 IFS=',' read -ra ROW_ARRAY <<< "$ROWS"
 export OPENCLAW_SELECTED_ROWS="$ROWS"
+export OPENCLAW_PROOFS_DOCS_REF="$DOCS_REF"
 echo "Rows: $ROWS"
 
 if [[ "$DRY_RUN" == "false" ]]; then
@@ -789,7 +790,7 @@ SEAT_READINESS_JSON="$OUT_ROOT/seat-readiness.json"
 SEAT_READINESS_SHA256=""
 if [[ "$DRY_RUN" == "false" ]]; then
   echo "Running seat-readiness preflight (k6/tooling/gateway/continuation config)..."
-  if ! node scripts/seat-readiness-preflight.mjs --json --rows "$ROWS" > "$SEAT_READINESS_JSON"; then
+  if ! node scripts/seat-readiness-preflight.mjs --json --require-target-binding --rows "$ROWS" > "$SEAT_READINESS_JSON"; then
     echo "SEAT READINESS FAILED: $SEAT_READINESS_JSON" >&2
     jq -r '.outcome as $out | "outcome=\($out) continuation=\(.continuation.enabled) defaults=\(.continuation.defaultsPresent) configuredDepth=\(.continuationDepth.configuredMaxSpawnDepth) effectiveDepth=\(.continuationDepth.effectiveMaxSpawnDepth) requiredDepth=\(.continuationDepth.requiredMaxSpawnDepth) notes=\(.notes|join("; "))"' "$SEAT_READINESS_JSON" >&2 || true
     SEAT_READINESS_DETAIL="$(
@@ -801,6 +802,8 @@ if [[ "$DRY_RUN" == "false" ]]; then
         configuredMaxSpawnDepth:(.continuationDepth.configuredMaxSpawnDepth // null),
         effectiveMaxSpawnDepth:(.continuationDepth.effectiveMaxSpawnDepth // null),
         requiredMaxSpawnDepth:(.continuationDepth.requiredMaxSpawnDepth // null),
+        expectedMaxSpawnDepth:(.continuationDepth.expectedMaxSpawnDepth // null),
+        targetObservation:(.targetObservation // null),
         reason:(.continuationDepth.reason // null),
         receipt:"seat-readiness.json"
       }' "$SEAT_READINESS_JSON" 2>/dev/null ||
@@ -822,8 +825,10 @@ HARNESS_PROVENANCE_JSON="$OUT_ROOT/harness-provenance.json"
 RUNNER_SCRIPT_SHA256="$(sha256sum "$RUNNER_SCRIPT_PATH" | cut -d' ' -f1)"
 RUN_MATRIX_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 SEAT_READINESS_DEPTH_JSON="null"
+SEAT_READINESS_TARGET_JSON="null"
 if [[ -f "$SEAT_READINESS_JSON" ]]; then
   SEAT_READINESS_DEPTH_JSON="$(jq -c '.continuationDepth // null' "$SEAT_READINESS_JSON")"
+  SEAT_READINESS_TARGET_JSON="$(jq -c '.targetObservation // null' "$SEAT_READINESS_JSON")"
 fi
 # A reused artifact root must not let a later matrix overwrite the provenance of
 # rows an earlier one already wrote, so each matrix also keeps an immutable copy
@@ -872,6 +877,7 @@ jq -n \
   --arg startedAt "$RUN_MATRIX_STARTED_AT" \
   --argjson identityVerified "$HARNESS_IDENTITY_VERIFIED" \
   --argjson continuationDepth "$SEAT_READINESS_DEPTH_JSON" \
+  --argjson targetObservation "$SEAT_READINESS_TARGET_JSON" \
   --argjson rowSelection "$(safe_row_selection_json)" \
   --argjson rows "$PROVENANCE_ROWS_JSON" \
   '{
@@ -890,7 +896,8 @@ jq -n \
       candidateMatchesRuntime: ($candidate != "" and $candidate == $runtimeBuildSha),
       seatReadinessReceipt: (if $seatReadinessSha256 == "" then null else "seat-readiness.json" end),
       seatReadinessSha256: (if $seatReadinessSha256 == "" then null else $seatReadinessSha256 end),
-      continuationDepth: $continuationDepth
+      continuationDepth: $continuationDepth,
+      targetObservation: $targetObservation
     },
     runnerScript: $runnerScript,
     runnerScriptSha256: $runnerScriptSha256,

--- a/tools/k6-proofs/scripts/seat-readiness-preflight.mjs
+++ b/tools/k6-proofs/scripts/seat-readiness-preflight.mjs
@@ -18,6 +18,11 @@ import {
   PROOF_PROFILE_MAX_SPAWN_DEPTH,
   resolveContinuationDepthRequirements,
 } from '../lib/continuation-depth-contract.mjs';
+import {
+  buildTargetReadinessBinding,
+  publicGatewayTarget,
+  targetReadinessBindingErrors,
+} from '../lib/target-readiness-binding.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, '../../..');
@@ -41,6 +46,7 @@ function parseArgs(argv) {
     else if (arg === '--rows') out.rows = argv[++i];
     else if (arg === '--manifests-dir') out.manifestsDir = argv[++i];
     else if (arg === '--policy') out.policyPath = argv[++i];
+    else if (arg === '--require-target-binding') out.requireTargetBinding = true;
     else if (arg === '--help' || arg === '-h') out.help = true;
     else throw new Error(`unknown arg: ${arg}`);
   }
@@ -162,6 +168,78 @@ function readAgentDefaultsConfig() {
   };
 }
 
+function connectFrame(token) {
+  return {
+    type: 'req',
+    id: 'connect',
+    method: 'connect',
+    params: {
+      minProtocol: 3,
+      maxProtocol: 4,
+      client: { id: 'gateway-client', version: '0.2.0', platform: 'linux', mode: 'backend' },
+      role: 'operator',
+      scopes: ['operator.read'],
+      caps: [],
+      commands: [],
+      permissions: {},
+      auth: { token },
+      userAgent: 'k6-proof-seat-readiness/0.1.0',
+    },
+  };
+}
+
+async function readTargetAgentDefaults(gatewayWs, token) {
+  let socket;
+  try {
+    socket = new WebSocket(gatewayWs);
+  } catch {
+    return { mode: 'unavailable', defaults: null, error: 'target-rpc-url-invalid' };
+  }
+  return await new Promise((resolve) => {
+    let settled = false;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      socket.close();
+      resolve(result);
+    };
+    const timer = setTimeout(
+      () => finish({ mode: 'unavailable', defaults: null, error: 'target-rpc-timeout' }),
+      5000,
+    );
+    socket.onopen = () => socket.send(JSON.stringify(connectFrame(token)));
+    socket.onerror = () => finish({ mode: 'unavailable', defaults: null, error: 'target-rpc-unreachable' });
+    socket.onmessage = (event) => {
+      let message;
+      try {
+        message = JSON.parse(String(event.data));
+      } catch {
+        finish({ mode: 'unavailable', defaults: null, error: 'target-rpc-json-invalid' });
+        return;
+      }
+      if (message.type !== 'res') return;
+      if (message.id === 'connect') {
+        if (message.error || message.ok === false) {
+          finish({ mode: 'unavailable', defaults: null, error: 'target-auth-failed' });
+          return;
+        }
+        socket.send(JSON.stringify({ type: 'req', id: 'config-get', method: 'config.get', params: {} }));
+        return;
+      }
+      if (message.id !== 'config-get') return;
+      const defaults = message.payload?.config?.agents?.defaults;
+      if (message.error || message.ok === false) {
+        finish({ mode: 'unavailable', defaults: null, error: 'target-config-rpc-failed' });
+      } else if (!defaults || typeof defaults !== 'object' || Array.isArray(defaults)) {
+        finish({ mode: 'unavailable', defaults: null, error: 'target-config-shape-invalid' });
+      } else {
+        finish({ mode: 'checked', defaults, error: null });
+      }
+    };
+  });
+}
+
 function readContinuationConfig(agentDefaults) {
   const config = agentDefaults.defaults?.continuation;
   const available = agentDefaults.mode === 'checked' &&
@@ -206,16 +284,26 @@ async function main() {
   k6.checked = k6.checked.map((item) => ({ ...item, rawVersion: redactRawVersion(item.rawVersion) }));
 
   const gatewayWs = process.env.OPENCLAW_GATEWAY_WS || policy.gateway.defaultWsUrl || 'ws://127.0.0.1:18789';
+  const publicGateway = publicGatewayTarget(gatewayWs);
   const gatewayBase = httpBaseFromWs(gatewayWs);
   const token = process.env.OPENCLAW_GATEWAY_TOKEN;
-  let gateway = { url: gatewayWs, healthReachable: false, statusReachable: false, mode: 'skipped-by-flag' };
+  let gateway = {
+    url: publicGateway.url,
+    urlFingerprint: publicGateway.fingerprint,
+    healthReachable: false,
+    statusReachable: false,
+    configRpc: 'skipped',
+    mode: 'skipped-by-flag',
+  };
   if (args.gateway && !token) {
     gateway = { ...gateway, mode: 'skipped-no-token' };
   } else if (args.gateway) {
     gateway = {
-      url: gatewayWs,
+      url: publicGateway.url,
+      urlFingerprint: publicGateway.fingerprint,
       healthReachable: await fetchOk(`${gatewayBase}/health`, token),
       statusReachable: await fetchOk(`${gatewayBase}/status`, token),
+      configRpc: 'pending',
       mode: 'checked',
     };
   }
@@ -243,7 +331,10 @@ async function main() {
     depthContractError = error?.code || 'expected-depth-invalid';
   }
 
-  const agentDefaults = readAgentDefaultsConfig();
+  const agentDefaults = args.gateway && token
+    ? await readTargetAgentDefaults(gatewayWs, token)
+    : readAgentDefaultsConfig();
+  if (args.gateway && token) gateway.configRpc = agentDefaults.mode;
   const continuation = readContinuationConfig(agentDefaults);
   continuation.defaultsPresent = Boolean(continuation.maxChainLengthPresent && continuation.maxDelegatesPerTurnPresent && continuation.costCapTokensPresent);
   let continuationDepth = evaluateContinuationDepth({
@@ -271,6 +362,20 @@ async function main() {
   }
 
   const candidateSha = process.env.OPENCLAW_CANDIDATE_SHA || null;
+  const binding = buildTargetReadinessBinding({
+    gatewayWs,
+    seat: process.env.OPENCLAW_SEAT_NAME || policy.seat?.defaultName || 'unknown-seat',
+    gatewayUnit: process.env.OPENCLAW_PROOFS_GATEWAY_UNIT || 'openclaw-gateway',
+    docsHead: process.env.OPENCLAW_PROOFS_DOCS_REF || process.env.DOCS_REF || null,
+    candidateSha,
+    runtimeBuildSha: process.env.OPENCLAW_RUNTIME_BUILD_SHA || null,
+    selectedRows,
+    requiredMaxSpawnDepth: continuationDepth.requiredMaxSpawnDepth,
+    expectedMaxSpawnDepth,
+  });
+  const bindingErrors = targetReadinessBindingErrors(binding, binding, {
+    requireComplete: args.requireTargetBinding === true,
+  });
   const env = envReport(policy);
   const requiredMissing = env.filter((e) => e.required && !e.present).map((e) => e.name);
   const notes = [];
@@ -278,7 +383,9 @@ async function main() {
   else if (!k6.matchesExpected) notes.push(`k6 version mismatch: expected ${expectedK6Version}, got ${k6.version}.`);
   if (gateway.mode === 'checked' && (!gateway.healthReachable || !gateway.statusReachable)) notes.push('gateway health/status not reachable from this seat.');
   if (gateway.mode === 'skipped-no-token') notes.push('gateway reachability skipped because OPENCLAW_GATEWAY_TOKEN is absent; token value was not printed.');
-  if (continuation.mode !== 'checked') notes.push('continuation config could not be read from openclaw config get agents.defaults --json.');
+  if (continuation.mode !== 'checked') notes.push(args.gateway
+    ? 'continuation config could not be read from the authenticated target gateway config.get RPC.'
+    : 'continuation config could not be read from openclaw config get agents.defaults --json.');
   else if (continuation.enabled !== true) notes.push('agents.defaults.continuation.enabled is not true; live continuation proof rows must not run.');
   else if (!continuation.defaultsPresent) notes.push('continuation config is missing one or more required default fields.');
   if (!continuationDepth.sufficient) {
@@ -294,12 +401,15 @@ async function main() {
 
   const valid40Hex = typeof candidateSha === 'string' && /^[0-9a-f]{40}$/.test(candidateSha);
   if (!valid40Hex) notes.push('OPENCLAW_CANDIDATE_SHA is missing or not a 40-char lowercase hex SHA.');
+  if (bindingErrors.length) notes.push(`target readiness binding rejected: ${bindingErrors.join(', ')}.`);
 
   const continuationReady = continuation.mode === 'checked' &&
     continuation.enabled === true &&
     continuation.defaultsPresent &&
     continuationDepth.sufficient;
-  const pass = k6.ok && k6.matchesExpected && continuationReady && valid40Hex && requiredMissing.length === 0 && (gateway.mode !== 'checked' || (gateway.healthReachable && gateway.statusReachable));
+  const pass = k6.ok && k6.matchesExpected && continuationReady && valid40Hex &&
+    bindingErrors.length === 0 && requiredMissing.length === 0 &&
+    (gateway.mode !== 'checked' || (gateway.healthReachable && gateway.statusReachable));
 
   const report = {
     schema: 'openclaw.k6.seat-readiness.v1',
@@ -315,6 +425,13 @@ async function main() {
     gateway,
     continuation,
     continuationDepth,
+    targetObservation: {
+      source: args.gateway ? 'authenticated-gateway-config-rpc' : 'local-cli-no-gateway',
+      rpcMethod: args.gateway ? 'config.get' : null,
+      binding,
+      bindingValid: bindingErrors.length === 0,
+      bindingErrors,
+    },
     candidate: { sha: candidateSha, valid40Hex },
     seat: {
       name: process.env.OPENCLAW_SEAT_NAME || policy.seat?.defaultName || 'unknown-seat',

--- a/tools/k6-proofs/scripts/seat-readiness-preflight.mjs
+++ b/tools/k6-proofs/scripts/seat-readiness-preflight.mjs
@@ -54,7 +54,7 @@ function parseArgs(argv) {
 }
 
 function usage() {
-  console.log(`Usage: node tools/k6-proofs/scripts/seat-readiness-preflight.mjs [--json] [--no-gateway] [--policy path] [--expected-k6-version v2.0.0] [--expected-max-spawn-depth 5] [--rows R-CD-CHAINED-DEPTH-2,R-CD-TOKEN]\n\nEmits no secret values. Exit 0 only for PASS-candidate. Version/env defaults come from tools/k6-proofs/seat-readiness.policy.json; selected-row depth comes from the row manifests.`);
+  console.log(`Usage: node tools/k6-proofs/scripts/seat-readiness-preflight.mjs [--json] [--no-gateway] [--require-target-binding] [--policy path] [--expected-k6-version v2.0.0] [--expected-max-spawn-depth 5] [--rows R-CD-CHAINED-DEPTH-2,R-CD-TOKEN]\n\nEmits no secret values. Exit 0 only for PASS-candidate. Version/env defaults come from tools/k6-proofs/seat-readiness.policy.json; selected-row depth comes from the row manifests.`);
 }
 
 function commandOrNull(cmd, args) {
@@ -178,7 +178,7 @@ function connectFrame(token) {
       maxProtocol: 4,
       client: { id: 'gateway-client', version: '0.2.0', platform: 'linux', mode: 'backend' },
       role: 'operator',
-      scopes: ['operator.read'],
+      scopes: ['operator.read', 'operator.write', 'session.control'],
       caps: [],
       commands: [],
       permissions: {},

--- a/tools/k6-proofs/seat-readiness.policy.json
+++ b/tools/k6-proofs/seat-readiness.policy.json
@@ -1,7 +1,7 @@
 {
   "schema": "openclaw.k6.seat-readiness-policy.v1",
   "name": "k6 PROOFS seat readiness policy",
-  "version": "2026-08-26",
+  "version": "2026-08-27",
   "k6": {
     "expectedVersion": "v2.0.0",
     "binaryCandidates": [

--- a/tools/k6-proofs/seat-readiness.schema.json
+++ b/tools/k6-proofs/seat-readiness.schema.json
@@ -14,6 +14,7 @@
     "gateway",
     "continuation",
     "continuationDepth",
+    "targetObservation",
     "candidate",
     "seat",
     "session",
@@ -116,13 +117,19 @@
       "additionalProperties": false,
       "required": [
         "url",
+        "urlFingerprint",
         "healthReachable",
         "statusReachable",
+        "configRpc",
         "mode"
       ],
       "properties": {
         "url": {
           "type": "string"
+        },
+        "urlFingerprint": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
         },
         "healthReachable": {
           "type": "boolean"
@@ -130,12 +137,66 @@
         "statusReachable": {
           "type": "boolean"
         },
+        "configRpc": {
+          "enum": ["checked", "unavailable", "skipped", "pending"]
+        },
         "mode": {
           "enum": [
             "checked",
             "skipped-no-token",
             "skipped-by-flag"
           ]
+        }
+      }
+    },
+    "targetObservation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source", "rpcMethod", "binding", "bindingValid", "bindingErrors"],
+      "properties": {
+        "source": {
+          "enum": ["authenticated-gateway-config-rpc", "local-cli-no-gateway"]
+        },
+        "rpcMethod": {
+          "type": ["string", "null"]
+        },
+        "bindingValid": {
+          "type": "boolean"
+        },
+        "bindingErrors": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true
+        },
+        "binding": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "gatewayUrlFingerprint",
+            "seat",
+            "gatewayUnit",
+            "docsHead",
+            "candidateSha",
+            "runtimeBuildSha",
+            "selectedRows",
+            "requiredMaxSpawnDepth",
+            "expectedMaxSpawnDepth"
+          ],
+          "properties": {
+            "gatewayUrlFingerprint": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+            "seat": { "type": "string", "minLength": 1 },
+            "gatewayUnit": { "type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9_.@:-]*$" },
+            "docsHead": { "type": ["string", "null"], "pattern": "^[0-9a-f]{40}$" },
+            "candidateSha": { "type": ["string", "null"], "pattern": "^[0-9a-f]{40}$" },
+            "runtimeBuildSha": { "type": ["string", "null"], "pattern": "^[0-9a-f]{40}$" },
+            "selectedRows": {
+              "type": "array",
+              "items": { "type": "string", "pattern": "^[A-Z0-9][A-Z0-9._-]*$" },
+              "uniqueItems": true
+            },
+            "requiredMaxSpawnDepth": { "type": ["integer", "null"], "minimum": 1, "maximum": 5 },
+            "expectedMaxSpawnDepth": { "type": ["integer", "null"], "minimum": 1, "maximum": 5 }
+          }
         }
       }
     },

--- a/tools/k6-proofs/skill/SKILL.md
+++ b/tools/k6-proofs/skill/SKILL.md
@@ -188,8 +188,10 @@ row manifest. Build a fresh isolated config with
 template, explicitly sets the reviewed proof profile depth to `5`, and emits a
 public-safe configured/effective/required-depth receipt. Then require
 `seat-readiness-preflight.mjs --rows ... --expected-max-spawn-depth 5` before
-smoke or row traffic. Omitted depth resolves to product default `1`; malformed,
-unknown, or insufficient depth fails closed.
+smoke or row traffic. Live readiness reads config from the authenticated
+`OPENCLAW_GATEWAY_WS` target, never from ambient host config. Omitted depth
+resolves to product default `1`; malformed, unknown, or insufficient depth
+fails closed.
 
 ### Custom Metrics Naming
 Prefix all custom metrics with the row name (underscores, lowercase):


### PR DESCRIPTION
Fixes #523

## Summary
- read continuation config and effective spawn depth from authenticated `config.get` on the explicit `gateway_ws` target
- bind the public target observation to the credential-free gateway fingerprint, seat, unit, docs head, candidate/runtime SHA, selected rows, and required/expected depth
- preserve fail-closed zero-row infrastructure stops and existing live-run safety gates
- add deterministic A/B/C/D target-vs-host and binding controls

## Validation
- complete proof-harness Node suite: 478/478
- manifest/scenario/row/telemetry/corpus validators pass
- all 155 harness JavaScript files pass `node --check`

No live proof was run and no proof corpus content changed.