### PR TITLE
fix(proofs): register isolated Codex runtime before smoke

### DIFF
--- a/tools/k6-proofs/lib/isolated-runtime-plugin-contract.mjs
+++ b/tools/k6-proofs/lib/isolated-runtime-plugin-contract.mjs
@@ -1,0 +1,220 @@
+/**
+ * Isolated proof configs must register the plugin that owns the selected
+ * model's agent runtime. Observation is config-derived, never ambient host
+ * plugin state and never an expected model/plugin string substitute.
+ */
+
+function isObject(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeId(value) {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function pluginIdList(value) {
+  return Array.isArray(value)
+    ? value.map(normalizeId).filter(Boolean)
+    : [];
+}
+
+export function readPrimaryModelRef(config) {
+  const model = config?.agents?.defaults?.model;
+  if (typeof model === 'string' && model.trim()) return model.trim();
+  if (isObject(model) && typeof model.primary === 'string' && model.primary.trim()) {
+    return model.primary.trim();
+  }
+  return null;
+}
+
+function explicitAgentRuntimeId(config, modelRef) {
+  const defaults = isObject(config?.agents?.defaults) ? config.agents.defaults : {};
+  const modelRuntime = modelRef && isObject(defaults.models)
+    ? defaults.models[modelRef]?.agentRuntime?.id
+    : null;
+  const agentRuntime = defaults.agentRuntime?.id;
+  const provider = modelRef?.includes('/') ? modelRef.slice(0, modelRef.indexOf('/')) : null;
+  const providerRuntime = provider && isObject(config?.models?.providers)
+    ? config.models.providers[provider]?.agentRuntime?.id
+    : null;
+  for (const value of [modelRuntime, agentRuntime, providerRuntime]) {
+    const id = normalizeId(value);
+    if (id) return id;
+  }
+  return null;
+}
+
+/**
+ * Bundled OpenClaw semantics: canonical openai/* agent refs and explicit
+ * agentRuntime.id "codex" are owned by the codex plugin. Embedded OpenClaw
+ * traffic is opt-in via agentRuntime.id "openclaw".
+ */
+export function resolveRequiredRuntimePlugin(config) {
+  const selectedModelRef = readPrimaryModelRef(config);
+  const runtime = explicitAgentRuntimeId(config, selectedModelRef);
+  if (runtime === 'openclaw' || runtime === 'auto') {
+    return {
+      required: false,
+      runtime,
+      pluginId: null,
+      selectedModelRef,
+      reason: 'embedded-openclaw-runtime',
+    };
+  }
+  if (runtime === 'codex' || (!runtime && selectedModelRef?.startsWith('openai/'))) {
+    return {
+      required: true,
+      runtime: 'codex',
+      pluginId: 'codex',
+      selectedModelRef,
+      reason: runtime === 'codex' ? 'explicit-codex-runtime' : 'openai-codex-owned-ref',
+    };
+  }
+  if (runtime) {
+    return {
+      required: true,
+      runtime,
+      pluginId: runtime,
+      selectedModelRef,
+      reason: 'explicit-plugin-runtime',
+    };
+  }
+  return {
+    required: false,
+    runtime: null,
+    pluginId: null,
+    selectedModelRef,
+    reason: 'no-plugin-runtime-required',
+  };
+}
+
+export function observePluginRegistration(config, pluginId) {
+  const id = normalizeId(pluginId);
+  const plugins = isObject(config?.plugins) ? config.plugins : null;
+  if (!id) {
+    return {
+      present: false,
+      enabled: false,
+      allowListed: null,
+      denied: false,
+      pluginsEnabled: null,
+    };
+  }
+  if (!plugins) {
+    return {
+      present: false,
+      enabled: false,
+      allowListed: null,
+      denied: false,
+      pluginsEnabled: null,
+    };
+  }
+  const pluginsEnabled = plugins.enabled !== false;
+  const denied = !pluginsEnabled || pluginIdList(plugins.deny).includes(id);
+  const allow = pluginIdList(plugins.allow);
+  const allowListed = allow.length === 0 ? null : allow.includes(id);
+  const entry = isObject(plugins.entries) ? plugins.entries[id] : null;
+  const present = isObject(entry);
+  const enabled = pluginsEnabled && !denied && present && entry.enabled === true;
+  return {
+    present,
+    enabled,
+    allowListed,
+    denied,
+    pluginsEnabled,
+  };
+}
+
+export function evaluateIsolatedRuntimePlugin({
+  config,
+  configAvailable = true,
+  ambientRegistry = null,
+} = {}) {
+  const required = resolveRequiredRuntimePlugin(configAvailable === true ? config : null);
+  const observed = required.pluginId
+    ? observePluginRegistration(configAvailable === true ? config : null, required.pluginId)
+    : {
+      present: false,
+      enabled: false,
+      allowListed: null,
+      denied: false,
+      pluginsEnabled: null,
+    };
+  // Ambient host plugin registries must never satisfy isolated readiness.
+  void ambientRegistry;
+  let reason = required.reason;
+  let sufficient = true;
+  if (configAvailable !== true) {
+    sufficient = required.required !== true;
+    reason = required.required ? 'target-runtime-plugin-unobserved' : required.reason;
+  } else if (required.required) {
+    if (observed.denied) {
+      sufficient = false;
+      reason = 'runtime-plugin-denied';
+    } else if (observed.allowListed === false) {
+      sufficient = false;
+      reason = 'runtime-plugin-not-allowlisted';
+    } else if (observed.enabled !== true) {
+      sufficient = false;
+      reason = observed.present ? 'runtime-plugin-disabled' : 'runtime-plugin-unregistered';
+    } else if (required.runtime && required.pluginId !== required.runtime) {
+      sufficient = false;
+      reason = 'runtime-plugin-mismatch';
+    } else {
+      reason = 'runtime-plugin-observed';
+    }
+  }
+  return {
+    required: required.required,
+    runtime: required.runtime,
+    pluginId: required.pluginId,
+    selectedModelRef: required.selectedModelRef,
+    present: observed.present,
+    enabled: observed.enabled,
+    allowListed: observed.allowListed,
+    denied: observed.denied,
+    sufficient,
+    source: 'isolated-target-config',
+    reason,
+  };
+}
+
+export function applyIsolatedRuntimePlugins(config) {
+  if (!isObject(config)) {
+    throw new Error('base config must be a JSON object');
+  }
+  const required = resolveRequiredRuntimePlugin(config);
+  if (!required.required || !required.pluginId) return config;
+  const observed = observePluginRegistration(config, required.pluginId);
+  if (observed.denied) {
+    throw new Error(
+      `isolated proof profile cannot register runtime plugin '${required.pluginId}': denied`,
+    );
+  }
+
+  const plugins = isObject(config.plugins) ? { ...config.plugins } : {};
+  const entries = isObject(plugins.entries) ? { ...plugins.entries } : {};
+  const current = isObject(entries[required.pluginId]) ? entries[required.pluginId] : {};
+  entries[required.pluginId] = { ...current, enabled: true };
+  plugins.entries = entries;
+  if (Array.isArray(plugins.allow) && plugins.allow.length > 0) {
+    const allow = pluginIdList(plugins.allow);
+    if (!allow.includes(required.pluginId)) {
+      plugins.allow = [...plugins.allow, required.pluginId];
+    }
+  }
+  return { ...config, plugins };
+}
+
+export function publicRuntimePluginReceipt(evaluation) {
+  return {
+    required: evaluation.required === true,
+    runtime: evaluation.runtime,
+    pluginId: evaluation.pluginId,
+    registered: evaluation.required === true ? evaluation.enabled === true : null,
+    allowListed: evaluation.allowListed,
+    sufficient: evaluation.sufficient === true,
+    source: 'isolated-target-config',
+    reason: evaluation.reason,
+  };
+}

--- a/tools/k6-proofs/scripts/__tests__/isolated-runtime-plugin-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/isolated-runtime-plugin-contract.test.mjs
@@ -1,0 +1,208 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  applyIsolatedRuntimePlugins,
+  evaluateIsolatedRuntimePlugin,
+  observePluginRegistration,
+  publicRuntimePluginReceipt,
+  readPrimaryModelRef,
+  resolveRequiredRuntimePlugin,
+} from '../../lib/isolated-runtime-plugin-contract.mjs';
+import { sanitizeEvidenceRecords } from '../sanitize-k6-artifacts.mjs';
+
+const repoRoot = new URL('../../../..', import.meta.url).pathname;
+const provisioner = path.join(repoRoot, 'tools/k6-proofs/scripts/provision-isolated-proof-config.mjs');
+const preFix = JSON.parse(await readFile(
+  new URL('../../tests/fixtures/isolated-codex-runtime-missing.json', import.meta.url),
+  'utf8',
+));
+
+function continuationDefaults(model) {
+  return {
+    ...(model ? { model } : {}),
+    continuation: {
+      enabled: true,
+      maxChainLength: 200,
+      maxDelegatesPerTurn: 500,
+      costCapTokens: 500000,
+    },
+    subagents: { maxSpawnDepth: 5 },
+  };
+}
+
+async function withTmp(fn) {
+  const root = await mkdtemp(path.join(tmpdir(), 'p81-runtime-plugin-'));
+  try {
+    return await fn(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+test('pre-fix isolated openai model with missing Codex plugin stays non-PASS', () => {
+  assert.equal(preFix.openaiAuthProfileCount, 1);
+  assert.equal(preFix.authMigration.kind, 'auth:openai');
+  assert.equal(preFix.authMigration.planned, 1);
+  assert.equal(preFix.authMigration.applied, 1);
+  assert.equal(readPrimaryModelRef(preFix.targetConfig), 'openai/gpt-5.6-sol');
+  assert.equal(observePluginRegistration(preFix.targetConfig, 'codex').enabled, false);
+  const evaluation = evaluateIsolatedRuntimePlugin({
+    config: preFix.targetConfig,
+    ambientRegistry: { agentHarnesses: [{ harness: { id: 'codex' } }] },
+  });
+  assert.equal(evaluation.required, true);
+  assert.equal(evaluation.runtime, 'codex');
+  assert.equal(evaluation.pluginId, 'codex');
+  assert.equal(evaluation.sufficient, false);
+  assert.equal(evaluation.reason, 'runtime-plugin-unregistered');
+  assert.equal(evaluation.source, 'isolated-target-config');
+  assert.doesNotMatch(JSON.stringify(preFix), /sk-[A-Za-z0-9]|Bearer |BEGIN /);
+});
+
+test('reviewed Codex plugin registration makes the same model sufficient', () => {
+  const registered = applyIsolatedRuntimePlugins(preFix.targetConfig);
+  const evaluation = evaluateIsolatedRuntimePlugin({ config: registered });
+  assert.equal(registered.plugins.entries.codex.enabled, true);
+  assert.equal(evaluation.sufficient, true);
+  assert.equal(evaluation.enabled, true);
+  assert.equal(evaluation.reason, 'runtime-plugin-observed');
+  assert.deepEqual(publicRuntimePluginReceipt(evaluation), {
+    required: true,
+    runtime: 'codex',
+    pluginId: 'codex',
+    registered: true,
+    allowListed: null,
+    sufficient: true,
+    source: 'isolated-target-config',
+    reason: 'runtime-plugin-observed',
+  });
+});
+
+test('missing, wrong-runtime, wrong-plugin, and ambient-only controls fail closed', () => {
+  const missing = evaluateIsolatedRuntimePlugin({
+    config: { agents: { defaults: continuationDefaults('openai/gpt-5.6-sol') } },
+  });
+  assert.equal(missing.reason, 'runtime-plugin-unregistered');
+
+  const wrongRuntime = evaluateIsolatedRuntimePlugin({
+    config: {
+      agents: {
+        defaults: {
+          ...continuationDefaults('openai/gpt-5.6-sol'),
+          agentRuntime: { id: 'codex' },
+        },
+      },
+      plugins: { entries: { 'claude-cli': { enabled: true } } },
+    },
+  });
+  assert.equal(wrongRuntime.required, true);
+  assert.equal(wrongRuntime.runtime, 'codex');
+  assert.equal(wrongRuntime.enabled, false);
+  assert.equal(wrongRuntime.sufficient, false);
+
+  const wrongPlugin = evaluateIsolatedRuntimePlugin({
+    config: {
+      agents: { defaults: continuationDefaults('openai/gpt-5.6-sol') },
+      plugins: { entries: { codex: { enabled: false } } },
+    },
+  });
+  assert.equal(wrongPlugin.present, true);
+  assert.equal(wrongPlugin.reason, 'runtime-plugin-disabled');
+  assert.equal(wrongPlugin.sufficient, false);
+
+  const allowMismatch = evaluateIsolatedRuntimePlugin({
+    config: {
+      agents: { defaults: continuationDefaults('openai/gpt-5.6-sol') },
+      plugins: {
+        allow: ['openai'],
+        entries: { codex: { enabled: true } },
+      },
+    },
+  });
+  assert.equal(allowMismatch.reason, 'runtime-plugin-not-allowlisted');
+  assert.equal(allowMismatch.sufficient, false);
+
+  const ambientOnly = evaluateIsolatedRuntimePlugin({
+    config: { agents: { defaults: continuationDefaults('openai/gpt-5.6-sol') } },
+    ambientRegistry: { agentHarnesses: [{ harness: { id: 'codex' } }] },
+  });
+  assert.equal(ambientOnly.sufficient, false);
+  assert.equal(ambientOnly.source, 'isolated-target-config');
+});
+
+test('explicit openclaw runtime does not require the Codex plugin', () => {
+  const evaluation = evaluateIsolatedRuntimePlugin({
+    config: {
+      agents: {
+        defaults: {
+          ...continuationDefaults('openai/gpt-5.6-sol'),
+          agentRuntime: { id: 'openclaw' },
+        },
+      },
+    },
+  });
+  assert.equal(evaluation.required, false);
+  assert.equal(evaluation.sufficient, true);
+  assert.equal(resolveRequiredRuntimePlugin({
+    agents: { defaults: continuationDefaults() },
+  }).required, false);
+});
+
+test('isolated provisioner registers Codex for a selected openai model without leaking auth', async () => {
+  await withTmp(async (root) => {
+    const base = path.join(root, 'base.json');
+    const output = path.join(root, 'openclaw.json');
+    const receipt = path.join(root, 'receipt.json');
+    const privateToken = 'PRIVATE-GATEWAY-TOKEN-MUST-NOT-REACH-RECEIPT';
+    await writeFile(base, `${JSON.stringify({
+      gateway: { auth: { token: privateToken } },
+      agents: { defaults: continuationDefaults('openai/gpt-5.6-sol') },
+    }, null, 2)}\n`);
+    const run = spawnSync(process.execPath, [
+      provisioner,
+      '--base-config', base,
+      '--output', output,
+      '--receipt', receipt,
+      '--rows', 'R-CD-CHAINED-DEPTH-2,R-CD-TOKEN',
+    ], { cwd: repoRoot, encoding: 'utf8' });
+    assert.equal(run.status, 0, run.stderr || run.stdout);
+    const generated = JSON.parse(await readFile(output, 'utf8'));
+    const publicReceipt = JSON.parse(await readFile(receipt, 'utf8'));
+    assert.equal(generated.plugins.entries.codex.enabled, true);
+    assert.equal(generated.agents.defaults.subagents.maxSpawnDepth, 5);
+    assert.equal(generated.gateway.auth.token, privateToken);
+    assert.equal(publicReceipt.runtimePlugin.required, true);
+    assert.equal(publicReceipt.runtimePlugin.runtime, 'codex');
+    assert.equal(publicReceipt.runtimePlugin.registered, true);
+    assert.equal(publicReceipt.runtimePlugin.sufficient, true);
+    assert.doesNotMatch(await readFile(receipt, 'utf8'), new RegExp(privateToken));
+    const { sanitized } = sanitizeEvidenceRecords([publicReceipt]);
+    assert.doesNotMatch(JSON.stringify(sanitized), new RegExp(privateToken));
+    assert.equal(sanitized[0].runtimePlugin.pluginId, 'codex');
+  });
+});
+
+test('denied Codex plugin cannot be force-registered by the isolated provisioner', async () => {
+  await withTmp(async (root) => {
+    const base = path.join(root, 'base.json');
+    const output = path.join(root, 'openclaw.json');
+    const receipt = path.join(root, 'receipt.json');
+    await writeFile(base, `${JSON.stringify({
+      agents: { defaults: continuationDefaults('openai/gpt-5.6-sol') },
+      plugins: { deny: ['codex'] },
+    })}\n`);
+    const run = spawnSync(process.execPath, [
+      provisioner,
+      '--base-config', base,
+      '--output', output,
+      '--receipt', receipt,
+      '--rows', 'R-CD-2',
+    ], { cwd: repoRoot, encoding: 'utf8' });
+    assert.notEqual(run.status, 0);
+    assert.match(run.stderr, /runtime plugin 'codex': denied/);
+  });
+});

--- a/tools/k6-proofs/scripts/__tests__/proof-harness-closure-contract.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/proof-harness-closure-contract.test.mjs
@@ -77,6 +77,21 @@ test('R-CD-TOKEN closes normal-origin return authority on the public event bound
   assert.doesNotMatch(contract, /Continuation completed with result/);
 });
 
+test('isolated proof provisioning observes Codex runtime from the target config', async () => {
+  const [provisioner, readiness, contract] = await Promise.all([
+    read('scripts/provision-isolated-proof-config.mjs'),
+    read('scripts/seat-readiness-preflight.mjs'),
+    read('lib/isolated-runtime-plugin-contract.mjs'),
+  ]);
+  await access(path.join(root, 'tests/fixtures/isolated-codex-runtime-missing.json'));
+  assert.match(provisioner, /applyIsolatedRuntimePlugins/);
+  assert.match(readiness, /evaluateIsolatedRuntimePlugin/);
+  assert.match(readiness, /runtimePlugin\.sufficient/);
+  assert.match(contract, /isolated-target-config/);
+  assert.match(contract, /ambientRegistry/);
+  assert.doesNotMatch(contract, /ronan|fleet|\b129388\b/i);
+});
+
 test('backend disposition is runnable and wired through every result boundary', async () => {
   await Promise.all([
     access(path.join(root, 'lib/telemetry-backend-status.js')),

--- a/tools/k6-proofs/scripts/__tests__/seat-readiness.test.mjs
+++ b/tools/k6-proofs/scripts/__tests__/seat-readiness.test.mjs
@@ -288,6 +288,96 @@ test('target readiness A/B/C selects only authenticated target depth', async (t)
   }
 });
 
+test('isolated Codex runtime is observed from the target config, never the host', async (t) => {
+  const preFix = JSON.parse(await readFile(
+    new URL('../../tests/fixtures/isolated-codex-runtime-missing.json', import.meta.url),
+    'utf8',
+  ));
+  const depthAndContinuation = {
+    continuation: {
+      enabled: true,
+      maxChainLength: 200,
+      maxDelegatesPerTurn: 500,
+      costCapTokens: 500000,
+    },
+    subagents: { maxSpawnDepth: 5 },
+  };
+
+  await t.test('missing Codex plugin stops before model or row traffic', async () => {
+    await withTmp(async (dir) => {
+      const tools = await writeFakeSeatTools(dir, { maxSpawnDepth: 5 });
+      await withTargetGateway(dir, preFix.targetConfig, async (port) => {
+        const run = runPreflight(
+          ['--json', '--rows', 'R-CD-CHAINED-DEPTH-2,R-CD-TOKEN', '--expected-max-spawn-depth', '5'],
+          { ...readyEnv(tools), OPENCLAW_GATEWAY_WS: `ws://127.0.0.1:${port}` },
+        );
+        assert.equal(run.status, 2, run.stderr || run.stdout);
+        const report = JSON.parse(run.stdout);
+        assert.equal(report.outcome, 'PARTIAL-candidate');
+        assert.equal(report.runtimePlugin.required, true);
+        assert.equal(report.runtimePlugin.runtime, 'codex');
+        assert.equal(report.runtimePlugin.registered, false);
+        assert.equal(report.runtimePlugin.sufficient, false);
+        assert.equal(report.runtimePlugin.reason, 'runtime-plugin-unregistered');
+        assert.equal(report.continuationDepth.sufficient, true);
+        assert.deepEqual(JSON.parse(await readFile(join(dir, 'target-counts.json'), 'utf8')), {
+          configRpc: 1,
+          rowOrModelTraffic: 0,
+        });
+      });
+    });
+  });
+
+  await t.test('registered Codex plugin on the isolated target may pass readiness', async () => {
+    await withTmp(async (dir) => {
+      const tools = await writeFakeSeatTools(dir, { openclawFails: true });
+      await withTargetGateway(dir, {
+        agents: { defaults: { model: 'openai/gpt-5.6-sol', ...depthAndContinuation } },
+        plugins: { entries: { codex: { enabled: true } } },
+      }, async (port) => {
+        const run = runPreflight(
+          ['--json', '--rows', 'R-CD-CHAINED-DEPTH-2,R-CD-TOKEN', '--expected-max-spawn-depth', '5'],
+          { ...readyEnv(tools), OPENCLAW_GATEWAY_WS: `ws://127.0.0.1:${port}` },
+        );
+        assert.equal(run.status, 0, run.stderr || run.stdout);
+        const report = JSON.parse(run.stdout);
+        assert.equal(report.outcome, 'PASS-candidate');
+        assert.equal(report.runtimePlugin.registered, true);
+        assert.equal(report.runtimePlugin.sufficient, true);
+        assert.equal(report.targetObservation.source, 'authenticated-gateway-config-rpc');
+        assert.deepEqual(JSON.parse(await readFile(join(dir, 'target-counts.json'), 'utf8')), {
+          configRpc: 1,
+          rowOrModelTraffic: 0,
+        });
+      });
+    });
+  });
+
+  await t.test('wrong plugin and ambient host registration cannot satisfy the target', async () => {
+    await withTmp(async (dir) => {
+      const tools = await writeFakeSeatTools(dir, { maxSpawnDepth: 5 });
+      await withTargetGateway(dir, {
+        agents: { defaults: { model: 'openai/gpt-5.6-sol', ...depthAndContinuation } },
+        plugins: { entries: { openai: { enabled: true } } },
+      }, async (port) => {
+        const run = runPreflight(
+          ['--json', '--rows', 'R-CD-2', '--expected-max-spawn-depth', '5'],
+          { ...readyEnv(tools), OPENCLAW_GATEWAY_WS: `ws://127.0.0.1:${port}` },
+        );
+        assert.equal(run.status, 2, run.stderr || run.stdout);
+        const report = JSON.parse(run.stdout);
+        assert.equal(report.outcome, 'PARTIAL-candidate');
+        assert.equal(report.runtimePlugin.sufficient, false);
+        assert.equal(report.runtimePlugin.source, 'isolated-target-config');
+        assert.deepEqual(JSON.parse(await readFile(join(dir, 'target-counts.json'), 'utf8')), {
+          configRpc: 1,
+          rowOrModelTraffic: 0,
+        });
+      });
+    });
+  });
+});
+
 test('D: target observation rejects wrong gateway, seat, candidate, and row binding', () => {
   const source = {
     gatewayWs: 'ws://127.0.0.1:19893',
@@ -365,6 +455,9 @@ test('seat readiness schema tracks policy, continuation readiness, checked k6 ca
   assert.ok(parsed.required.includes('policy'));
   assert.ok(parsed.required.includes('continuation'));
   assert.ok(parsed.required.includes('continuationDepth'));
+  assert.ok(parsed.required.includes('runtimePlugin'));
+  assert.ok(parsed.properties.runtimePlugin.required.includes('registered'));
+  assert.ok(parsed.properties.runtimePlugin.required.includes('sufficient'));
   assert.ok(parsed.properties.continuation.required.includes('enabled'));
   assert.ok(parsed.properties.continuation.required.includes('defaultsPresent'));
   assert.ok(parsed.properties.continuationDepth.required.includes('configuredMaxSpawnDepth'));

--- a/tools/k6-proofs/scripts/provision-isolated-proof-config.mjs
+++ b/tools/k6-proofs/scripts/provision-isolated-proof-config.mjs
@@ -9,6 +9,11 @@ import {
   PROOF_PROFILE_MAX_SPAWN_DEPTH,
   resolveContinuationDepthRequirements,
 } from '../lib/continuation-depth-contract.mjs';
+import {
+  applyIsolatedRuntimePlugins,
+  evaluateIsolatedRuntimePlugin,
+  publicRuntimePluginReceipt,
+} from '../lib/isolated-runtime-plugin-contract.mjs';
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, '../../..');
@@ -75,7 +80,7 @@ async function main() {
     rows: args.rows,
     manifestsDir: path.resolve(args.manifestsDir || defaultManifestsDir),
   });
-  const generatedConfig = applyIsolatedProofProfile(baseConfig);
+  const generatedConfig = applyIsolatedRuntimePlugins(applyIsolatedProofProfile(baseConfig));
   const depth = evaluateContinuationDepth({
     config: generatedConfig,
     requirements,
@@ -83,6 +88,13 @@ async function main() {
   });
   if (!depth.sufficient) {
     throw new Error(`isolated proof profile depth validation failed: ${depth.reason}`);
+  }
+  const runtimePlugin = evaluateIsolatedRuntimePlugin({
+    config: generatedConfig,
+    configAvailable: true,
+  });
+  if (!runtimePlugin.sufficient) {
+    throw new Error(`isolated proof profile runtime plugin validation failed: ${runtimePlugin.reason}`);
   }
 
   const receipt = {
@@ -98,6 +110,7 @@ async function main() {
     requiredMaxSpawnDepth: depth.requiredMaxSpawnDepth,
     proofProfileMaxSpawnDepth: depth.proofProfileMaxSpawnDepth,
     explicitProfileApplied: depth.source === 'explicit',
+    runtimePlugin: publicRuntimePluginReceipt(runtimePlugin),
     publicSafe: true,
   };
 

--- a/tools/k6-proofs/scripts/seat-readiness-preflight.mjs
+++ b/tools/k6-proofs/scripts/seat-readiness-preflight.mjs
@@ -23,6 +23,10 @@ import {
   publicGatewayTarget,
   targetReadinessBindingErrors,
 } from '../lib/target-readiness-binding.mjs';
+import {
+  evaluateIsolatedRuntimePlugin,
+  publicRuntimePluginReceipt,
+} from '../lib/isolated-runtime-plugin-contract.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, '../../..');
@@ -164,6 +168,7 @@ function readAgentDefaultsConfig() {
   return {
     mode: out.ok && defaults ? 'checked' : 'unavailable',
     defaults,
+    config: null,
     error: out.ok && !defaults ? 'json-shape-invalid' : out.error,
   };
 }
@@ -193,7 +198,7 @@ async function readTargetAgentDefaults(gatewayWs, token) {
   try {
     socket = new WebSocket(gatewayWs);
   } catch {
-    return { mode: 'unavailable', defaults: null, error: 'target-rpc-url-invalid' };
+    return { mode: 'unavailable', defaults: null, config: null, error: 'target-rpc-url-invalid' };
   }
   return await new Promise((resolve) => {
     let settled = false;
@@ -205,36 +210,37 @@ async function readTargetAgentDefaults(gatewayWs, token) {
       resolve(result);
     };
     const timer = setTimeout(
-      () => finish({ mode: 'unavailable', defaults: null, error: 'target-rpc-timeout' }),
+      () => finish({ mode: 'unavailable', defaults: null, config: null, error: 'target-rpc-timeout' }),
       5000,
     );
     socket.onopen = () => socket.send(JSON.stringify(connectFrame(token)));
-    socket.onerror = () => finish({ mode: 'unavailable', defaults: null, error: 'target-rpc-unreachable' });
+    socket.onerror = () => finish({ mode: 'unavailable', defaults: null, config: null, error: 'target-rpc-unreachable' });
     socket.onmessage = (event) => {
       let message;
       try {
         message = JSON.parse(String(event.data));
       } catch {
-        finish({ mode: 'unavailable', defaults: null, error: 'target-rpc-json-invalid' });
+        finish({ mode: 'unavailable', defaults: null, config: null, error: 'target-rpc-json-invalid' });
         return;
       }
       if (message.type !== 'res') return;
       if (message.id === 'connect') {
         if (message.error || message.ok === false) {
-          finish({ mode: 'unavailable', defaults: null, error: 'target-auth-failed' });
+          finish({ mode: 'unavailable', defaults: null, config: null, error: 'target-auth-failed' });
           return;
         }
         socket.send(JSON.stringify({ type: 'req', id: 'config-get', method: 'config.get', params: {} }));
         return;
       }
       if (message.id !== 'config-get') return;
-      const defaults = message.payload?.config?.agents?.defaults;
+      const config = message.payload?.config;
+      const defaults = config?.agents?.defaults;
       if (message.error || message.ok === false) {
-        finish({ mode: 'unavailable', defaults: null, error: 'target-config-rpc-failed' });
+        finish({ mode: 'unavailable', defaults: null, config: null, error: 'target-config-rpc-failed' });
       } else if (!defaults || typeof defaults !== 'object' || Array.isArray(defaults)) {
-        finish({ mode: 'unavailable', defaults: null, error: 'target-config-shape-invalid' });
+        finish({ mode: 'unavailable', defaults: null, config: null, error: 'target-config-shape-invalid' });
       } else {
-        finish({ mode: 'checked', defaults, error: null });
+        finish({ mode: 'checked', defaults, config, error: null });
       }
     };
   });
@@ -261,6 +267,7 @@ function printText(report) {
   console.log(`gateway: ${report.gateway.mode}; health=${report.gateway.healthReachable}; status=${report.gateway.statusReachable}; url=${report.gateway.url}`);
   console.log(`continuation: ${report.continuation.mode}; enabled=${report.continuation.enabled}; defaults=${report.continuation.defaultsPresent}`);
   console.log(`continuation depth: configured=${report.continuationDepth.configuredMaxSpawnDepth ?? 'omitted'}; effective=${report.continuationDepth.effectiveMaxSpawnDepth ?? 'unknown'}; required=${report.continuationDepth.requiredMaxSpawnDepth ?? 'unknown'}; sufficient=${report.continuationDepth.sufficient}`);
+  console.log(`runtime plugin: required=${report.runtimePlugin.required}; runtime=${report.runtimePlugin.runtime || 'none'}; registered=${report.runtimePlugin.registered}; sufficient=${report.runtimePlugin.sufficient}`);
   console.log(`candidate sha: ${report.candidate.valid40Hex ? 'valid' : 'missing/invalid'}`);
   console.log(`seat: ${report.seat.name}; session scope: ${report.session.scope}`);
   console.log(`concurrency: ${report.concurrency.safeToRunConcurrently ? 'safe' : 'serialized'} — ${report.concurrency.reason}`);
@@ -403,11 +410,21 @@ async function main() {
   if (!valid40Hex) notes.push('OPENCLAW_CANDIDATE_SHA is missing or not a 40-char lowercase hex SHA.');
   if (bindingErrors.length) notes.push(`target readiness binding rejected: ${bindingErrors.join(', ')}.`);
 
+  const runtimePluginEvaluation = evaluateIsolatedRuntimePlugin({
+    config: agentDefaults.config || null,
+    configAvailable: agentDefaults.mode === 'checked' && Boolean(agentDefaults.config),
+  });
+  const runtimePlugin = publicRuntimePluginReceipt(runtimePluginEvaluation);
+  if (!runtimePlugin.sufficient) {
+    notes.push(`selected model runtime plugin is not observed on the isolated target: ${runtimePlugin.reason}.`);
+  }
+
   const continuationReady = continuation.mode === 'checked' &&
     continuation.enabled === true &&
     continuation.defaultsPresent &&
     continuationDepth.sufficient;
-  const pass = k6.ok && k6.matchesExpected && continuationReady && valid40Hex &&
+  const pass = k6.ok && k6.matchesExpected && continuationReady && runtimePlugin.sufficient &&
+    valid40Hex &&
     bindingErrors.length === 0 && requiredMissing.length === 0 &&
     (gateway.mode !== 'checked' || (gateway.healthReachable && gateway.statusReachable));
 
@@ -425,6 +442,7 @@ async function main() {
     gateway,
     continuation,
     continuationDepth,
+    runtimePlugin,
     targetObservation: {
       source: args.gateway ? 'authenticated-gateway-config-rpc' : 'local-cli-no-gateway',
       rpcMethod: args.gateway ? 'config.get' : null,

--- a/tools/k6-proofs/seat-readiness.schema.json
+++ b/tools/k6-proofs/seat-readiness.schema.json
@@ -14,6 +14,7 @@
     "gateway",
     "continuation",
     "continuationDepth",
+    "runtimePlugin",
     "targetObservation",
     "candidate",
     "seat",
@@ -448,6 +449,30 @@
             "type": ["string", "null"]
           }
         }
+      },
+    "runtimePlugin": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "required",
+        "runtime",
+        "pluginId",
+        "registered",
+        "allowListed",
+        "sufficient",
+        "source",
+        "reason"
+      ],
+      "properties": {
+        "required": { "type": "boolean" },
+        "runtime": { "type": ["string", "null"] },
+        "pluginId": { "type": ["string", "null"] },
+        "registered": { "type": ["boolean", "null"] },
+        "allowListed": { "type": ["boolean", "null"] },
+        "sufficient": { "type": "boolean" },
+        "source": { "const": "isolated-target-config" },
+        "reason": { "type": "string" }
       }
+    }
     }
   }

--- a/tools/k6-proofs/tests/fixtures/isolated-codex-runtime-missing.json
+++ b/tools/k6-proofs/tests/fixtures/isolated-codex-runtime-missing.json
@@ -1,0 +1,36 @@
+{
+  "schema": "openclaw.k6.isolated-codex-runtime-fixture.v1",
+  "label": "pre-fix-missing-codex-plugin",
+  "sanitization": {
+    "authMaterialOmitted": true,
+    "privateConfigOmitted": true,
+    "hostPluginRegistryOmitted": true
+  },
+  "openaiAuthProfileCount": 1,
+  "authMigration": {
+    "planned": 1,
+    "applied": 1,
+    "kind": "auth:openai"
+  },
+  "continuationDepth": {
+    "configuredMaxSpawnDepth": 5,
+    "effectiveMaxSpawnDepth": 5,
+    "requiredMaxSpawnDepth": 2
+  },
+  "targetConfig": {
+    "agents": {
+      "defaults": {
+        "model": "openai/gpt-5.6-sol",
+        "continuation": {
+          "enabled": true,
+          "maxChainLength": 200,
+          "maxDelegatesPerTurn": 500,
+          "costCapTokens": 500000
+        },
+        "subagents": {
+          "maxSpawnDepth": 5
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Isolated Project-81 proof configs now register the plugin that owns the selected model's agent runtime before model smoke. Readiness observes that registration from the authenticated target `config.get` payload only.

Closes #525

## Root cause

After #523, a fresh isolated root imported one `auth:openai` profile and passed authenticated target readiness (depth 5/5/2). Exact-model smoke then failed with:

`Agent harness runtime "codex" is unavailable because its plugin registration is missing from this prepared run.`

The isolated provisioner applied `maxSpawnDepth` only. It did not enable `plugins.entries.codex` for canonical `openai/*` / explicit Codex runtime routes, so the prepared run never loaded the Codex harness.

## Pre-fix red

Public-safe fixture `tools/k6-proofs/tests/fixtures/isolated-codex-runtime-missing.json`:
- migrated OpenAI profile count 1 (`auth:openai` planned/applied)
- selected Codex-backed model present
- Codex plugin unregistered
- readiness PARTIAL, `runtime-plugin-unregistered`
- `configRpc=1`, `rowOrModelTraffic=0`

## Generic registration fix

`applyIsolatedRuntimePlugins` follows reviewed OpenClaw semantics:
- canonical `openai/*` agent refs and `agentRuntime.id: "codex"` require plugin `codex`
- explicit `agentRuntime.id: "openclaw"` stays embedded
- sets `plugins.entries.<id>.enabled: true`
- appends the plugin to a nonempty `plugins.allow`
- refuses `plugins.deny` / plugins-disabled opt-out

No Ronan/fleet/PR/model hardcoding. Expected plugin strings are not a substitute for observed registration.

## Observed-runtime readiness

Seat readiness evaluates plugins from the isolated target `config.get` config only. Host CLI `agents.defaults` and ambient plugin registries cannot satisfy the gate.

Controls: success, missing, wrong-runtime, wrong-plugin, ambient-only, denied-plugin provisioner refusal. Depth, target binding, sanitizer, and candidate-envelope contracts are preserved.

## Validation

- `node --test` over `tools/k6-proofs/scripts/__tests__` and `tools/k6-proofs/tests`: **543 pass / 0 fail**
- `node --check` on changed scripts
- manifest/scenario alignment, row-manifest, telemetry, corpus `--current` passed
- `git diff --check` clean

## Limits

Harness provisioning/readiness only. No live proof, gateway mutation, product change, or corpus fold.