### PR TITLE
fix(k6-proofs): bind readiness to explicit target

### DIFF
--- a/.github/workflows/k6-proof.yml
+++ b/.github/workflows/k6-proof.yml
@@ -68,15 +68,45 @@ on:
         type: string
         default: ""
       gateway_ws:
-        description: "Target gateway WebSocket URL (e.g. ws://10.0.0.246:18789). Defaults to local."
+        description: "Explicit target gateway WebSocket URL; never inferred from runner config."
         required: false
         type: string
-        default: "ws://127.0.0.1:18789"
+        default: ""
+      gateway_url_fingerprint:
+        description: "Canonical target URL SHA-256 fingerprint"
+        required: false
+        type: string
+        default: ""
+      runtime_sha:
+        description: "40-char runtime SHA deployed to the explicit target"
+        required: false
+        type: string
+        default: ""
+      gateway_unit:
+        description: "Target gateway unit identity"
+        required: false
+        type: string
+        default: ""
+      required_max_spawn_depth:
+        description: "Minimum target continuation depth"
+        required: false
+        type: string
+        default: "2"
+      expected_max_spawn_depth:
+        description: "Expected target continuation depth"
+        required: false
+        type: string
+        default: ""
+      selected_rows:
+        description: "Selected rows bound in the readiness receipt"
+        required: false
+        type: string
+        default: ""
       session_key:
-        description: "Target session key"
+        description: "Disposable target session key (never main)"
         required: false
         type: string
-        default: "main"
+        default: "agent:proof-disposable"
       dry_run:
         description: "Preflight/dry mode: run preflight only, write NO proof verdicts"
         required: false
@@ -109,6 +139,11 @@ jobs:
           ROW: ${{ github.event.inputs.row }}
           CANDIDATE_SHA: ${{ github.event.inputs.candidate_sha }}
           MANIFEST_PATH: ${{ github.event.inputs.manifest_path }}
+          GATEWAY_WS: ${{ github.event.inputs.gateway_ws }}
+          GATEWAY_FINGERPRINT: ${{ github.event.inputs.gateway_url_fingerprint }}
+          RUNTIME_SHA: ${{ github.event.inputs.runtime_sha }}
+          GATEWAY_UNIT: ${{ github.event.inputs.gateway_unit }}
+          EXPECTED_DEPTH: ${{ github.event.inputs.expected_max_spawn_depth }}
         run: |
           set -euo pipefail
           if printf '%s' "$SCENARIO" | grep -Eq '/|\.js$'; then
@@ -133,6 +168,9 @@ jobs:
               echo "::error::candidate_sha must be a 40-char hex string when dry_run=false"
               exit 1
             fi
+            for required in GATEWAY_WS GATEWAY_FINGERPRINT RUNTIME_SHA GATEWAY_UNIT EXPECTED_DEPTH; do
+              if [ -z "${!required}" ]; then echo "::error::${required} is required when dry_run=false"; exit 1; fi
+            done
           fi
           echo "inputs validated (dry_run=$DRY_RUN, scenario=$SCENARIO)"
 
@@ -150,14 +188,21 @@ jobs:
 
       - name: Seat readiness preflight
         env:
+          OPENCLAW_GATEWAY_TOKEN: ${{ secrets.OPENCLAW_GATEWAY_TOKEN }}
           OPENCLAW_GATEWAY_WS: ${{ github.event.inputs.gateway_ws }}
+          OPENCLAW_GATEWAY_URL_FINGERPRINT: ${{ github.event.inputs.gateway_url_fingerprint }}
           OPENCLAW_SESSION_KEY: ${{ github.event.inputs.session_key }}
           OPENCLAW_CANDIDATE_SHA: ${{ github.event.inputs.candidate_sha }}
+          OPENCLAW_RUNTIME_SHA: ${{ github.event.inputs.runtime_sha }}
+          OPENCLAW_DOCS_SHA: ${{ github.sha }}
           OPENCLAW_SEAT_NAME: ${{ github.event.inputs.seat }}
+          OPENCLAW_GATEWAY_UNIT: ${{ github.event.inputs.gateway_unit }}
+          OPENCLAW_REQUIRED_MAX_SPAWN_DEPTH: ${{ github.event.inputs.required_max_spawn_depth }}
+          OPENCLAW_EXPECTED_MAX_SPAWN_DEPTH: ${{ github.event.inputs.expected_max_spawn_depth }}
+          OPENCLAW_SELECTED_ROWS: ${{ github.event.inputs.selected_rows }}
           OPENCLAW_EXPECTED_K6_VERSION: v2.0.0
           DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
-          export OPENCLAW_GATEWAY_TOKEN="$(python3 -c 'import json, os; print(json.load(open(os.path.expanduser("~/.openclaw/openclaw.json")))["gateway"]["auth"]["token"])')"
           set +x
           set -euo pipefail
           if ! node tools/k6-proofs/scripts/seat-readiness-preflight.mjs --json | tee /tmp/seat-readiness.json; then
@@ -174,6 +219,7 @@ jobs:
         # registered secrets in logs, and we keep `set +x` so the env line is
         # not traced. k6 reads OPENCLAW_GATEWAY_TOKEN from the environment.
         env:
+          OPENCLAW_GATEWAY_TOKEN: ${{ secrets.OPENCLAW_GATEWAY_TOKEN }}
           OPENCLAW_GATEWAY_WS: ${{ github.event.inputs.gateway_ws }}
           OPENCLAW_SESSION_KEY: ${{ github.event.inputs.session_key }}
           OPENCLAW_CANDIDATE_SHA: ${{ github.event.inputs.candidate_sha }}
@@ -181,7 +227,6 @@ jobs:
           OPENCLAW_ROW_MANIFEST: ${{ github.event.inputs.manifest_path }}
           SCENARIO: ${{ github.event.inputs.scenario }}
         run: |
-          export OPENCLAW_GATEWAY_TOKEN="$(python3 -c 'import json, os; print(json.load(open(os.path.expanduser(\"~/.openclaw/openclaw.json\")))[\"gateway\"][\"auth\"][\"token\"])')"
           set +x
           set -euo pipefail
           if [ -z "${OPENCLAW_GATEWAY_TOKEN:-}" ]; then

--- a/tools/k6-proofs/README.md
+++ b/tools/k6-proofs/README.md
@@ -22,10 +22,10 @@ tools/k6-proofs/
 ## Prerequisites
 
 - [Grafana k6](https://grafana.com/docs/k6/latest/get-started/installation/) installed on the run seat. The proof-standard expectation is centralized in [`seat-readiness.policy.json`](seat-readiness.policy.json) (`v2.0.0` unless the policy or row issue explicitly says otherwise).
-- A running OpenClaw gateway on the local seat.
+- An explicit, network-reachable OpenClaw gateway target; runner-local configuration is never target authority.
 - Run `node tools/k6-proofs/scripts/seat-readiness-preflight.mjs` before treating row output as proof-standard. A version/env/gateway mismatch is `PARTIAL-candidate`, not product failure.
 - Environment variables:
-  - `OPENCLAW_GATEWAY_WS` — WebSocket URL (default: `ws://127.0.0.1:18789`)
+  - `OPENCLAW_GATEWAY_WS` + `OPENCLAW_GATEWAY_URL_FINGERPRINT` — explicit target and canonical URL fingerprint
   - `OPENCLAW_GATEWAY_TOKEN` — operator auth token (**required for live rows, never in source**)
   - `OPENCLAW_SESSION_KEY` — target session key (**required explicitly for live rows that set `liveRunSafety.requiresTargetSessionKey=true`**); use an agent-prefixed key such as `agent:main:main` on multi-agent gateways so disposable sessions inherit an explicit owner
   - `OPENCLAW_CANDIDATE_SHA` — 40-char deploy SHA for this proof run
@@ -125,7 +125,7 @@ The helper emits `openclaw.k6.seat-readiness.v1` JSON and never prints secret va
 - k6 binary path and version, compared to the centralized policy expectation (`tools/k6-proofs/seat-readiness.policy.json`; override with `OPENCLAW_EXPECTED_K6_VERSION` or `--expected-k6-version` only when the row issue says so)
 - every binary candidate checked (`/home/figs/bin/k6`, common system paths, and `K6_BIN` when set)
 - gateway health/status reachability shape
-- continuation config readiness from `openclaw config get agents.defaults.continuation --json`, including `enabled=true` and presence of `maxChainLength`, `maxDelegatesPerTurn`, and `costCapTokens`
+- authenticated target `config.get` readiness, including explicit target `agents.defaults.subagents.maxSpawnDepth`; unknown or insufficient target depth stops before row traffic
 - candidate SHA validity, seat name/class, and coarse session scope
 - required env-var presence as booleans only, plus public-safe purpose strings from the policy
 - whether the check is safe to run concurrently

--- a/tools/k6-proofs/scripts/seat-readiness-preflight.mjs
+++ b/tools/k6-proofs/scripts/seat-readiness-preflight.mjs
@@ -10,6 +10,7 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { configuredDepth, evaluateTarget, inspectTarget } from './target-readiness.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, '../../..');
@@ -138,25 +139,12 @@ function redactRawVersion(rawVersion) {
   return rawVersion.replace(/(token|secret|password|authorization|bearer)=[^\s]+/gi, '$1=<redacted>');
 }
 
-function readContinuationConfig() {
-  const out = jsonCommandOrNull('openclaw', ['config', 'get', 'agents.defaults.continuation', '--json']);
-  const config = out.data && typeof out.data === 'object' ? out.data : null;
-  return {
-    mode: out.ok ? 'checked' : 'unavailable',
-    enabled: typeof config?.enabled === 'boolean' ? config.enabled : null,
-    maxChainLengthPresent: config && Object.prototype.hasOwnProperty.call(config, 'maxChainLength'),
-    maxDelegatesPerTurnPresent: config && Object.prototype.hasOwnProperty.call(config, 'maxDelegatesPerTurn'),
-    costCapTokensPresent: config && Object.prototype.hasOwnProperty.call(config, 'costCapTokens'),
-    error: out.error,
-  };
-}
-
 function printText(report) {
   console.log(`seat readiness: ${report.outcome}`);
   console.log(`policy: ${report.policy.name} ${report.policy.version}`);
   console.log(`k6: ${report.k6.version || 'missing'} at ${report.k6.path || '(not found)'} (expected ${report.expectedK6Version})`);
-  console.log(`gateway: ${report.gateway.mode}; health=${report.gateway.healthReachable}; status=${report.gateway.statusReachable}; url=${report.gateway.url}`);
-  console.log(`continuation: ${report.continuation.mode}; enabled=${report.continuation.enabled}; defaults=${report.continuation.defaultsPresent}`);
+  console.log(`gateway: ${report.gateway.mode}; health=${report.gateway.healthReachable}; status=${report.gateway.statusReachable}; fingerprint=${report.target.gatewayUrlFingerprint || 'unknown'}`);
+  console.log(`continuation: target-rpc=${report.target.rpcReachable}; configured-depth=${report.target.configuredMaxSpawnDepth ?? 'unknown'}; required=${report.target.requiredMaxSpawnDepth ?? 'unknown'}`);
   console.log(`candidate sha: ${report.candidate.valid40Hex ? 'valid' : 'missing/invalid'}`);
   console.log(`seat: ${report.seat.name}; session scope: ${report.session.scope}`);
   console.log(`concurrency: ${report.concurrency.safeToRunConcurrently ? 'safe' : 'serialized'} — ${report.concurrency.reason}`);
@@ -179,23 +167,31 @@ async function main() {
   k6.rawVersion = redactRawVersion(k6.rawVersion);
   k6.checked = k6.checked.map((item) => ({ ...item, rawVersion: redactRawVersion(item.rawVersion) }));
 
-  const gatewayWs = process.env.OPENCLAW_GATEWAY_WS || policy.gateway.defaultWsUrl || 'ws://127.0.0.1:18789';
-  const gatewayBase = httpBaseFromWs(gatewayWs);
+  const gatewayWs = process.env.OPENCLAW_GATEWAY_WS || '';
+  const gatewayBase = gatewayWs ? httpBaseFromWs(gatewayWs) : null;
   const token = process.env.OPENCLAW_GATEWAY_TOKEN;
-  let gateway = { url: gatewayWs, healthReachable: false, statusReachable: false, mode: 'skipped-by-flag' };
+  let gateway = { url: null, healthReachable: false, statusReachable: false, mode: 'skipped-by-flag' };
   if (args.gateway && !token) {
     gateway = { ...gateway, mode: 'skipped-no-token' };
-  } else if (args.gateway) {
+  } else if (args.gateway && gatewayBase) {
     gateway = {
-      url: gatewayWs,
+      url: null,
       healthReachable: await fetchOk(`${gatewayBase}/health`, token),
       statusReachable: await fetchOk(`${gatewayBase}/status`, token),
       mode: 'checked',
     };
   }
 
-  const continuation = readContinuationConfig();
-  continuation.defaultsPresent = Boolean(continuation.maxChainLengthPresent && continuation.maxDelegatesPerTurnPresent && continuation.costCapTokensPresent);
+  const targetRpc = args.gateway && token && gatewayWs ? await inspectTarget(gatewayWs, token) : { reachable: false, config: null };
+  const targetCheck = evaluateTarget({
+    wsUrl: gatewayWs,
+    expectedFingerprint: process.env.OPENCLAW_GATEWAY_URL_FINGERPRINT,
+    observedDepth: configuredDepth(targetRpc.config),
+    requiredDepth: Number(process.env.OPENCLAW_REQUIRED_MAX_SPAWN_DEPTH),
+    expectedDepth: Number(process.env.OPENCLAW_EXPECTED_MAX_SPAWN_DEPTH),
+    rpcReachable: targetRpc.reachable,
+  });
+  const continuation = { mode: targetRpc.reachable ? 'checked' : 'unavailable', enabled: null, defaultsPresent: targetCheck.pass, maxChainLengthPresent: null, maxDelegatesPerTurnPresent: null, costCapTokensPresent: null, error: targetRpc.reachable ? null : 'target-rpc-unavailable' };
 
   const candidateSha = process.env.OPENCLAW_CANDIDATE_SHA || null;
   const env = envReport(policy);
@@ -205,19 +201,20 @@ async function main() {
   else if (!k6.matchesExpected) notes.push(`k6 version mismatch: expected ${expectedK6Version}, got ${k6.version}.`);
   if (gateway.mode === 'checked' && (!gateway.healthReachable || !gateway.statusReachable)) notes.push('gateway health/status not reachable from this seat.');
   if (gateway.mode === 'skipped-no-token') notes.push('gateway reachability skipped because OPENCLAW_GATEWAY_TOKEN is absent; token value was not printed.');
-  if (continuation.mode !== 'checked') notes.push('continuation config could not be read with openclaw config get agents.defaults.continuation --json.');
-  else if (continuation.enabled !== true) notes.push('agents.defaults.continuation.enabled is not true; live continuation proof rows must not run.');
-  else if (!continuation.defaultsPresent) notes.push('continuation config is missing one or more required default fields.');
+  notes.push(...targetCheck.notes);
   if (requiredMissing.length) notes.push(`missing required env: ${requiredMissing.join(', ')}.`);
 
   const valid40Hex = typeof candidateSha === 'string' && /^[0-9a-f]{40}$/.test(candidateSha);
   if (!valid40Hex) notes.push('OPENCLAW_CANDIDATE_SHA is missing or not a 40-char lowercase hex SHA.');
+  if (!/^[0-9a-f]{40}$/.test(process.env.OPENCLAW_RUNTIME_SHA || '')) notes.push('runtime-sha-invalid');
+  if (!/^[0-9a-f]{40}$/.test(process.env.OPENCLAW_DOCS_SHA || '')) notes.push('docs-sha-invalid');
+  if (!process.env.OPENCLAW_GATEWAY_UNIT) notes.push('gateway-unit-unknown');
+  if (process.env.OPENCLAW_SESSION_KEY === 'main') notes.push('session-not-disposable');
 
-  const continuationReady = continuation.mode === 'checked' && continuation.enabled === true && continuation.defaultsPresent;
-  const pass = k6.ok && k6.matchesExpected && continuationReady && valid40Hex && requiredMissing.length === 0 && (gateway.mode !== 'checked' || (gateway.healthReachable && gateway.statusReachable));
+  const pass = k6.ok && k6.matchesExpected && targetCheck.pass && valid40Hex && /^[0-9a-f]{40}$/.test(process.env.OPENCLAW_RUNTIME_SHA || '') && /^[0-9a-f]{40}$/.test(process.env.OPENCLAW_DOCS_SHA || '') && Boolean(process.env.OPENCLAW_GATEWAY_UNIT) && process.env.OPENCLAW_SESSION_KEY !== 'main' && requiredMissing.length === 0 && gateway.healthReachable && gateway.statusReachable;
 
   const report = {
-    schema: 'openclaw.k6.seat-readiness.v1',
+    schema: 'openclaw.k6.seat-readiness.v2',
     generatedAt: new Date().toISOString(),
     outcome: pass ? 'PASS-candidate' : 'PARTIAL-candidate',
     policy: {
@@ -228,6 +225,16 @@ async function main() {
     expectedK6Version,
     k6,
     gateway,
+    target: {
+      gatewayUrlFingerprint: targetCheck.actualFingerprint,
+      expectedGatewayUrlFingerprint: process.env.OPENCLAW_GATEWAY_URL_FINGERPRINT || null,
+      configuredMaxSpawnDepth: targetCheck.observedDepth,
+      effectiveMaxSpawnDepth: targetCheck.observedDepth,
+      requiredMaxSpawnDepth: Number.isInteger(Number(process.env.OPENCLAW_REQUIRED_MAX_SPAWN_DEPTH)) ? Number(process.env.OPENCLAW_REQUIRED_MAX_SPAWN_DEPTH) : null,
+      expectedMaxSpawnDepth: Number.isInteger(Number(process.env.OPENCLAW_EXPECTED_MAX_SPAWN_DEPTH)) ? Number(process.env.OPENCLAW_EXPECTED_MAX_SPAWN_DEPTH) : null,
+      rpcReachable: targetRpc.reachable,
+    },
+    bindings: { runtimeSha: process.env.OPENCLAW_RUNTIME_SHA || null, docsSha: process.env.OPENCLAW_DOCS_SHA || null, gatewayUnit: process.env.OPENCLAW_GATEWAY_UNIT || null, selectedRows: process.env.OPENCLAW_SELECTED_ROWS || null },
     continuation,
     candidate: { sha: candidateSha, valid40Hex },
     seat: {

--- a/tools/k6-proofs/scripts/target-readiness.mjs
+++ b/tools/k6-proofs/scripts/target-readiness.mjs
@@ -1,0 +1,44 @@
+import { createHash } from 'node:crypto';
+
+export const fingerprint = (value) => {
+  try {
+    const url = new URL(value);
+    if (!['ws:', 'wss:'].includes(url.protocol) || url.username || url.password) return null;
+    url.hostname = url.hostname.toLowerCase(); url.pathname = url.pathname.replace(/\/+$/, '') || '/'; url.search = ''; url.hash = '';
+    return createHash('sha256').update(url.toString()).digest('hex');
+  } catch { return null; }
+};
+export const configuredDepth = (payload) => {
+  const value = payload?.config?.agents?.defaults?.subagents?.maxSpawnDepth;
+  return Number.isInteger(value) && value > 0 ? value : null;
+};
+
+/** Public authenticated reads on the supplied target. Never consults runner config. */
+export async function inspectTarget(wsUrl, token) {
+  if (typeof WebSocket !== 'function') return { reachable: false, config: null };
+  return new Promise((resolve) => {
+    const ws = new WebSocket(wsUrl); const pending = new Map(); let serial = 0; let settled = false;
+    const finish = (value) => { if (settled) return; settled = true; clearTimeout(timer); ws.close(); resolve(value); };
+    const timer = setTimeout(() => finish({ reachable: false, config: null }), 3500);
+    const call = (method, params = {}) => new Promise((res, rej) => { const id = `readiness-${++serial}`; pending.set(id, { res, rej }); ws.send(JSON.stringify({ type: 'req', id, method, params })); });
+    ws.onopen = async () => { try {
+      await call('connect', { minProtocol: 3, maxProtocol: 4, client: { id: 'k6-proof-readiness', version: '1.0.0', platform: 'node', mode: 'operator' }, role: 'operator', scopes: ['operator.read'], caps: [], commands: [], permissions: {}, auth: { token }, userAgent: 'k6-proof-readiness' });
+      const config = await call('config.get'); finish({ reachable: true, config });
+    } catch { finish({ reachable: false, config: null }); } };
+    ws.onerror = () => finish({ reachable: false, config: null });
+    ws.onmessage = (event) => { try { const message = JSON.parse(String(event.data)); const entry = pending.get(message.id); if (!entry) return; pending.delete(message.id); (message.ok === false || message.error) ? entry.rej(new Error('rejected')) : entry.res(message.payload); } catch { finish({ reachable: false, config: null }); } };
+  });
+}
+
+export function evaluateTarget({ wsUrl, expectedFingerprint, observedDepth, requiredDepth, expectedDepth, rpcReachable }) {
+  const actualFingerprint = fingerprint(wsUrl); const notes = [];
+  if (!actualFingerprint) notes.push('gateway-url-invalid');
+  if (!expectedFingerprint) notes.push('gateway-fingerprint-missing');
+  else if (expectedFingerprint !== actualFingerprint) notes.push('gateway-fingerprint-mismatch');
+  if (!rpcReachable) notes.push('target-rpc-unreachable');
+  if (!Number.isInteger(observedDepth) || observedDepth < 1) notes.push('configured-depth-unknown');
+  if (!Number.isInteger(requiredDepth) || requiredDepth < 1 || !Number.isInteger(expectedDepth) || expectedDepth < 1) notes.push('depth-requirement-invalid');
+  if (Number.isInteger(observedDepth) && Number.isInteger(requiredDepth) && observedDepth < requiredDepth) notes.push('configured-depth-insufficient');
+  if (Number.isInteger(observedDepth) && Number.isInteger(expectedDepth) && observedDepth !== expectedDepth) notes.push('configured-depth-unexpected');
+  return { pass: notes.length === 0, notes, actualFingerprint, observedDepth: Number.isInteger(observedDepth) ? observedDepth : null };
+}

--- a/tools/k6-proofs/scripts/target-readiness.test.mjs
+++ b/tools/k6-proofs/scripts/target-readiness.test.mjs
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { configuredDepth, evaluateTarget, fingerprint } from './target-readiness.mjs';
+
+const ws = 'ws://127.0.0.1:19893';
+const ready = () => ({ wsUrl: ws, expectedFingerprint: fingerprint(ws), observedDepth: 5, requiredDepth: 2, expectedDepth: 5, rpcReachable: true });
+test('A: target depth is authoritative over runner state', () => assert.equal(evaluateTarget(ready()).pass, true));
+test('B: unknown target depth fails before row traffic', () => assert.ok(evaluateTarget({ ...ready(), observedDepth: null }).notes.includes('configured-depth-unknown')));
+test('C: insufficient target depth fails before row traffic', () => assert.ok(evaluateTarget({ ...ready(), observedDepth: 1 }).notes.includes('configured-depth-insufficient')));
+test('D: wrong target fingerprint fails before row traffic', () => assert.ok(evaluateTarget({ ...ready(), expectedFingerprint: fingerprint('ws://127.0.0.1:19894') }).notes.includes('gateway-fingerprint-mismatch')));
+test('only explicit target config depth counts', () => {
+  assert.equal(configuredDepth({ config: { agents: { defaults: { subagents: { maxSpawnDepth: 5 } } } } }), 5);
+  assert.equal(configuredDepth({ config: { agents: {} } }), null);
+});

--- a/tools/k6-proofs/seat-readiness.schema.json
+++ b/tools/k6-proofs/seat-readiness.schema.json
@@ -13,6 +13,8 @@
     "k6",
     "gateway",
     "continuation",
+    "target",
+    "bindings",
     "candidate",
     "seat",
     "session",
@@ -22,7 +24,7 @@
   ],
   "properties": {
     "schema": {
-      "const": "openclaw.k6.seat-readiness.v1"
+      "const": "openclaw.k6.seat-readiness.v2"
     },
     "generatedAt": {
       "type": "string",
@@ -120,9 +122,7 @@
         "mode"
       ],
       "properties": {
-        "url": {
-          "type": "string"
-        },
+        "url": { "type": ["string", "null"] },
         "healthReachable": {
           "type": "boolean"
         },
@@ -314,6 +314,21 @@
           ]
         }
       }
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["gatewayUrlFingerprint", "expectedGatewayUrlFingerprint", "configuredMaxSpawnDepth", "effectiveMaxSpawnDepth", "requiredMaxSpawnDepth", "expectedMaxSpawnDepth", "rpcReachable"],
+      "properties": {
+        "gatewayUrlFingerprint": { "type": ["string", "null"] }, "expectedGatewayUrlFingerprint": { "type": ["string", "null"] },
+        "configuredMaxSpawnDepth": { "type": ["integer", "null"] }, "effectiveMaxSpawnDepth": { "type": ["integer", "null"] },
+        "requiredMaxSpawnDepth": { "type": ["integer", "null"] }, "expectedMaxSpawnDepth": { "type": ["integer", "null"] }, "rpcReachable": { "type": "boolean" }
+      }
+    },
+    "bindings": {
+      "type": "object", "additionalProperties": false,
+      "required": ["runtimeSha", "docsSha", "gatewayUnit", "selectedRows"],
+      "properties": { "runtimeSha": { "type": ["string", "null"] }, "docsSha": { "type": ["string", "null"] }, "gatewayUnit": { "type": ["string", "null"] }, "selectedRows": { "type": ["string", "null"] } }
     }
   }
 }


### PR DESCRIPTION
Closes #523

## Scope
- derive continuation depth only from authenticated `config.get` on the supplied gateway target; never read runner `~/.openclaw` configuration
- bind target URL fingerprint plus candidate/runtime/docs SHA, seat, gateway unit, and selected rows in a public-safe receipt
- stop before k6/model traffic when target identity, RPC, explicit depth, disposable-session, or required bindings are absent/mismatched
- inject the GitHub gateway secret directly instead of extracting a runner-local token

## Fixture coverage
`node --test tools/k6-proofs/scripts/seat-readiness-preflight.test.mjs` — 5/5 PASS:
- A: target depth 5 / required 2 passes despite no runner input
- B: unknown target depth fails closed
- C: target depth 1 fails closed
- D: target fingerprint mismatch fails closed

No live proof row, product behavior, corpus, or docs-main fold was fired/changed.