### PR TITLE
Promote two missing proof rows and classify collection partial

### DIFF
--- a/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/ARTIFACTS.md
+++ b/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/ARTIFACTS.md
@@ -4,13 +4,16 @@ The historical baseline artifacts are preserved from the reviewed
 `5035aac3a96df18f0a5d5a5c3e91a516a32daf32` corpus. They retain their original
 identity and do not claim exact-target execution.
 
-New exact-target evidence is represented by eight public corpus
+New exact-target evidence is represented by eleven public corpus
 `PUBLIC-REVIEW.json` receipts and their cited public review receipts. Synthetic
 proof identifiers and acquisition-path references disclosed by those cited
 reviews are public provenance. Credentials, provider tokens, prompts or other
 private content, and raw acquisition bytes are not published.
 
-The five newest corpus receipts use deterministic SHA-256 fingerprints for
+The newest three receipts bind the readiness digest, verified private row
+bundle digests, and both canary and independent-review URLs. `R-CW-MULTI`
+also binds the prior typed 0/60/120 row digest. Corpus receipts use
+deterministic SHA-256 fingerprints for
 compact joins over task, flow, session, run, traceparent, and span identities;
 the fingerprints do not claim every source identifier is secret. Tempo
 retrieval was unavailable; retained exact W3C identities provide the reviewed

--- a/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/CLAWSSWEEPER.md
+++ b/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/CLAWSSWEEPER.md
@@ -6,5 +6,5 @@ self-contained `7cb9d71f622250bedbf565e327bd7d7b9d90b567` subtree.
 reviewed promotions. Validate each promoted
 `PUBLIC-REVIEW.json` against `PUBLIC-REVIEW-RECEIPT.schema.json`.
 
-The rollup is 29 PASS, 2 PARTIAL, 1 FAIL, and 6 MISSING. This is a review
+The rollup is 31 PASS, 3 PARTIAL, 1 FAIL, and 3 MISSING. This is a review
 candidate, not a merged or presentation-ready corpus.

--- a/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/CLOSURE-WAVE-LEDGER.json
+++ b/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/CLOSURE-WAVE-LEDGER.json
@@ -4,15 +4,15 @@
   "canonical": {
     "pure_sha": "7cb9d71f622250bedbf565e327bd7d7b9d90b567",
     "pure_tree": "85821bfd8f4676cfac8be658122910a7eb862f55",
-    "structural_checkpoint": "08f8731490ce93879dabc973e7563c7ae0a65683",
+    "structural_checkpoint": "8f1163d757342c3ac36b8e446222b0446159211b",
     "rollup": {
       "total_rows": 38,
-      "pass": 29,
-      "partial": 2,
+      "pass": 31,
+      "partial": 3,
       "thin": 0,
       "fail": 1,
       "honest_limit": 0,
-      "missing": 6
+      "missing": 3
     },
     "baseline_sha": "5035aac3a96df18f0a5d5a5c3e91a516a32daf32",
     "baseline_tree": "5ff71a670d75022c45e0ecaf9ecddcf57d2a33a2"
@@ -90,11 +90,18 @@
       "successor integration and refire matrix"
     ],
     "reason_no_immediate_acceptance_refires": "dbf5795b is the current deployment composite, not the pending final successor product. Evidence produced before the successor and its fleet deployment cannot close changed behavior.",
-    "only_permitted_final_non_pass": "R-RC-2 HONEST-LIMIT with nonce-bound structured request_compaction receipt, finite numeric contextUsage below canonical threshold 70, matching numeric child report, and trace"
+    "current_non_pass_rows": [
+      "R-CD-2",
+      "R-CD-COLLECTION-ON-COLLAPSE",
+      "R-CD-RETURN-COVENANT-AUTHORITY",
+      "R-CD-RETURN-OVERLAP",
+      "R-CD-TOKEN",
+      "R-OBS-2",
+      "R-RC-2"
+    ]
   },
   "producer_rows": [
-    "R-CD-COLLECTION-ON-COLLAPSE",
-    "R-CW-MULTI"
+    "R-CD-COLLECTION-ON-COLLAPSE"
   ],
   "partial_control_rows": [],
   "rows": [
@@ -201,39 +208,43 @@
     },
     {
       "row": "R-CD-COLLECTION-ON-COLLAPSE",
-      "state": "missing",
+      "state": "partial",
       "attempts": [
-        "historical-baseline-review"
+        "historical-baseline-review",
+        "independent-review-5556789060"
       ],
       "owner": "proof-conductor",
       "command": "PRODUCER-R-CD-COLLECTION-ON-COLLAPSE",
-      "rejected_base": "only the static consumer ran; no A-to-B-to-delayed-C producer packet exists",
-      "successor_control": "root A receives C after B terminal collapse with no orphan and exact task/trace lineage",
-      "gate": "reviewed-producer-harness-and-final-successor-fleet"
+      "rejected_base": "B supplied recipientContext while artifact returns were forbidden; exact product rejected the malformed call before C scheduling",
+      "successor_control": "omit recipientContext while artifacts are forbidden; B terminal before C return; root A receives the C sentinel; no orphan",
+      "gate": "one-corrected-fresh-authenticated-attempt"
     },
     {
       "row": "R-CW-MULTI",
-      "state": "missing",
+      "state": "pass",
       "attempts": [
-        "historical-baseline-review"
+        "historical-baseline-review",
+        "independent-review-5555528271",
+        "independent-review-5556789060"
       ],
       "owner": "proof-conductor",
       "command": "PRODUCER-R-CW-MULTI",
-      "rejected_base": "only the static consumer ran; no three-election producer packet exists",
-      "successor_control": "one turn elects default, 60, and 120 second work; all three distinct outcomes and provenance are retained",
-      "gate": "final-successor-fleet-deployed"
+      "rejected_base": "the typed 0/60/120 packet lacked the required response-token parity phase",
+      "successor_control": "join the reviewed typed 0/60/120 packet to canonical bare CONTINUE_WORK:0 response-text parity",
+      "gate": "satisfied-by-independent-manual-review"
     },
     {
       "row": "R-CW-DELEGATE-TOKEN",
-      "state": "missing",
+      "state": "pass",
       "attempts": [
-        "historical-baseline-review"
+        "historical-baseline-review",
+        "independent-review-5556789060"
       ],
       "owner": "proof-conductor",
       "command": "PRODUCER-R-CW-DELEGATE-TOKEN",
-      "rejected_base": "the reviewed canary exercised bracket-origin continuation rather than the canonical bare-token surface",
-      "successor_control": "a fresh canonical bare-token attempt must produce the required bare-token-hop2-executed receipt",
-      "gate": "reviewed-bare-token-producer-and-final-successor-fleet"
+      "rejected_base": "prior review incorrectly treated parser origin bracket as proof of a square-bracketed work token",
+      "successor_control": "canonical bare CONTINUE_WORK:5 with response-text parser origin, zero typed substitution, and complete task/flow/successor/return/trace joins",
+      "gate": "satisfied-by-independent-manual-review"
     },
     {
       "row": "R-CD-RETURN-COVENANT-AUTHORITY",
@@ -328,13 +339,49 @@
       "to": "pass",
       "receipt": "R-CW-DELEGATE-CHILD-LIVE/PUBLIC-REVIEW.json",
       "receipt_sha256": "53a023f819745d54dd4d6491cb4034096e77b7033a5f0eabb0ef9de6ada569c6"
+    },
+    {
+      "row": "R-CW-DELEGATE-TOKEN",
+      "from": "missing",
+      "to": "pass",
+      "receipt": "R-CW-DELEGATE-TOKEN/PUBLIC-REVIEW.json",
+      "receipt_sha256": "2d48229c030e1092da26d5259221a6da009ca3f07dc01d029b8eefe68c1ebf85"
+    },
+    {
+      "row": "R-CW-MULTI",
+      "from": "missing",
+      "to": "pass",
+      "receipt": "R-CW-MULTI/PUBLIC-REVIEW.json",
+      "receipt_sha256": "09bf67fca92cd41329cad6bb4ad817133c969b9111ab838e947da4761f4bc75b"
+    },
+    {
+      "row": "R-CD-COLLECTION-ON-COLLAPSE",
+      "from": "missing",
+      "to": "partial",
+      "receipt": "R-CD-COLLECTION-ON-COLLAPSE/PUBLIC-REVIEW.json",
+      "receipt_sha256": "02b30c1da2407ec8765d47e8fa45e21bb1d2e22b04802347a5dda6159db5e525"
     }
   ],
   "manual_authority": {
     "automatic_authority": false,
-    "review_receipt_url": "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5556060622",
-    "private_artifact_manifest_sha256": "fe025f9545142d392b3a42518e4f8414ced16b50bf4efebcd9dc83fd9dc2ca82",
-    "previous_review_receipt_url": "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5555528271",
-    "previous_private_artifact_manifest_sha256": "71d96105d9d01b32d1739fe0371b7d80aa235293627d61a222918c8ef6565470"
+    "review_receipt_url": "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5556789060",
+    "canary_receipt_url": "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5556133557",
+    "readiness_binding_sha256": "cafbccd8bd71f7ba0dfe88a58f110c96df7c8759e17f91b659057c77d763db40",
+    "private_row_artifact_sha256": {
+      "R-CW-DELEGATE-TOKEN": "897e04319ca2397497bc5b79aee8adeb9fa31fc88b16d7eab257686b7820621c",
+      "R-CW-MULTI": "8768551f24255a744dfd330a0ecf06fdcafd2b0de76f8eba6ee45e51e13ee953",
+      "R-CD-COLLECTION-ON-COLLAPSE": "6e7bf50c95ee80064f8de79fa2dffc65853e158abfd9a381aa95956db87acc9a"
+    },
+    "related_private_row_artifact_sha256": {
+      "R-CW-MULTI-typed-0-60-120": "aaf199d4fcec922467f73ccd1e81109f60c01cbc3506b4fceeef918db7d38fcd"
+    },
+    "previous_review_receipt_urls": [
+      "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5556060622",
+      "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5555528271"
+    ],
+    "previous_private_artifact_manifest_sha256": [
+      "fe025f9545142d392b3a42518e4f8414ced16b50bf4efebcd9dc83fd9dc2ca82",
+      "71d96105d9d01b32d1739fe0371b7d80aa235293627d61a222918c8ef6565470"
+    ]
   }
 }

--- a/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/EXECUTION-STATUS.md
+++ b/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/EXECUTION-STATUS.md
@@ -2,16 +2,15 @@
 
 `REVIEW_CANDIDATE`
 
-An exact-product canary attempted five PARTIAL rows. Independent review found
-all five evidence packets sufficient for PASS.
+An exact-product canary attempted three MISSING rows. Independent review found
+two evidence packets sufficient for PASS and one sufficient for PARTIAL.
 
-Exactly these rows moved PARTIAL to PASS:
+Exactly these rows moved MISSING to PASS:
 
-- `R-CD-1`
-- `R-CD-4`
-- `R-CD-CHAINED-DEPTH-2`
-- `R-CD-MODEL-TOOL`
-- `R-CD-SILENT`
+- `R-CW-DELEGATE-TOKEN`
+- `R-CW-MULTI`
 
-`R-CD-TOKEN` and `R-RC-2` remain PARTIAL. The six MISSING rows and one FAIL
-row are unchanged. Final rollup: 29 PASS / 2 PARTIAL / 1 FAIL / 6 MISSING.
+`R-CD-COLLECTION-ON-COLLAPSE` moved MISSING to PARTIAL. `R-CD-TOKEN` and
+`R-RC-2` remain PARTIAL. The remaining MISSING rows are exactly
+`R-CD-RETURN-COVENANT-AUTHORITY`, `R-CD-RETURN-OVERLAP`, and `R-OBS-2`;
+`R-CD-2` remains FAIL. Final rollup: 31 PASS / 3 PARTIAL / 1 FAIL / 3 MISSING.

--- a/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/METHOD.md
+++ b/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/METHOD.md
@@ -5,11 +5,11 @@ ledger is the status baseline. Product ancestry from that SHA to
 `7cb9d71f622250bedbf565e327bd7d7b9d90b567` is verified.
 
 The current-main baseline is
-`08f8731490ce93879dabc973e7563c7ae0a65683`. Exactly five PARTIAL rows consume
-the sealed canary evidence. Their sole authority is the independent manual
-review linked by each public receipt; rejected automatic producer authority is
-excluded. Every other state is checked by row-name comparison against current
-main.
+`8f1163d757342c3ac36b8e446222b0446159211b`. Exactly three MISSING rows consume
+the sealed canary evidence: two become PASS and one becomes PARTIAL. Their sole
+authority is the independent manual review linked by each public receipt;
+rejected automatic producer authority is excluded. Every other state is
+checked by row-name comparison against current main.
 
 Synthetic proof identifiers and acquisition-path references disclosed in the
 cited public review receipts are public provenance. Credentials, provider

--- a/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/PUBLIC-REVIEW-RECEIPT.schema.json
+++ b/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/PUBLIC-REVIEW-RECEIPT.schema.json
@@ -53,6 +53,21 @@
       "pattern": "^[0-9a-f]{64}$",
       "type": "string"
     },
+    "relatedPrivateRowArtifactSha256": {
+      "items": {
+        "pattern": "^[0-9a-f]{64}$",
+        "type": "string"
+      },
+      "type": "array",
+      "uniqueItems": true
+    },
+    "readinessBindingSha256": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "canaryReceiptUrl": {
+      "const": "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5556133557"
+    },
     "identityFingerprints": {
       "additionalProperties": false,
       "required": [
@@ -111,12 +126,16 @@
       ],
       "properties": {
         "verdict": {
-          "const": "PASS-EVIDENCE-SUFFICIENT"
+          "enum": [
+            "PASS-EVIDENCE-SUFFICIENT",
+            "PARTIAL"
+          ]
         },
         "receiptUrl": {
           "enum": [
             "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5555528271",
-            "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5556060622"
+            "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5556060622",
+            "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5556789060"
           ]
         },
         "reviewedAt": {
@@ -151,12 +170,50 @@
       "type": "array"
     },
     "finalClassification": {
-      "const": "PASS"
+      "enum": [
+        "PASS",
+        "PARTIAL"
+      ]
     },
     "canonicalFoldAllowed": {
       "const": true
     }
   },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "finalClassification": {
+            "const": "PASS"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "independentReview": {
+            "type": "object",
+            "properties": {
+              "verdict": {
+                "const": "PASS-EVIDENCE-SUFFICIENT"
+              }
+            }
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "independentReview": {
+            "type": "object",
+            "properties": {
+              "verdict": {
+                "const": "PARTIAL"
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
   "$defs": {
     "fingerprintArray": {
       "items": {

--- a/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/R-CD-COLLECTION-ON-COLLAPSE/EVIDENCE.md
+++ b/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/R-CD-COLLECTION-ON-COLLAPSE/EVIDENCE.md
@@ -1,10 +1,13 @@
-# R-CD-COLLECTION-ON-COLLAPSE — inherited baseline state
+# R-CD-COLLECTION-ON-COLLAPSE — exact-product partial attempt
 
-- canonical state: `missing`
-- reviewed baseline product: `5035aac3a96df18f0a5d5a5c3e91a516a32daf32`
-- reviewed baseline docs commit: `0a893f80e55e0f93626d9a5f71bcb5dd38ca56f1`
-- exact-target execution claimed here: `false`
+- product/runtime: `7cb9d71f622250bedbf565e327bd7d7b9d90b567`
+- canary readiness docs: `08f8731490ce93879dabc973e7563c7ae0a65683`
+- canonical state: `partial`
+- authority: independent manual review
+- public receipt: [`PUBLIC-REVIEW.json`](PUBLIC-REVIEW.json)
 
-Static current-corpus validator found its required producer artifacts absent; this is missing evidence, not a product-behavior contradiction.
-
-This row's state is unchanged. Historical raw artifacts are not republished in the exact-product corpus; consult the immutable baseline commit for the original evidence.
+A reached B, but B supplied `recipientContext` while artifact returns were
+forbidden. Exact product correctly rejected that malformed call before
+scheduling C. B terminated and delivered; no C task, flow, session, run,
+trace, or sentinel existed, and no orphan remained. This attempt is not a
+product behavior failure and does not prove PASS.

--- a/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/R-CD-COLLECTION-ON-COLLAPSE/PUBLIC-REVIEW.json
+++ b/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/R-CD-COLLECTION-ON-COLLAPSE/PUBLIC-REVIEW.json
@@ -1,0 +1,47 @@
+{
+  "schema": "openclaw.proofs.public-independent-review-receipt.v1",
+  "row": "R-CD-COLLECTION-ON-COLLAPSE",
+  "scenario": "targeted-three-row-canary/collection-on-collapse",
+  "productSha": "7cb9d71f622250bedbf565e327bd7d7b9d90b567",
+  "runtimeSha": "7cb9d71f622250bedbf565e327bd7d7b9d90b567",
+  "docsSha": "08f8731490ce93879dabc973e7563c7ae0a65683",
+  "privateArtifactManifestSha256": "6e7bf50c95ee80064f8de79fa2dffc65853e158abfd9a381aa95956db87acc9a",
+  "privateRowArtifactSha256": "6e7bf50c95ee80064f8de79fa2dffc65853e158abfd9a381aa95956db87acc9a",
+  "readinessBindingSha256": "cafbccd8bd71f7ba0dfe88a58f110c96df7c8759e17f91b659057c77d763db40",
+  "canaryReceiptUrl": "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5556133557",
+  "identityFingerprints": {
+    "algorithm": "sha256-16",
+    "task": ["5b32de6cb2757a3d"],
+    "flow": ["de879c7d5c16a232"],
+    "session": ["2d8f1129d9ecfe0d"],
+    "run": ["0240249cc8ea76a0"],
+    "trace": [],
+    "notApplicableReason": "The malformed B-to-C call was rejected before C scheduling, so no C trace identity exists."
+  },
+  "observedPredicates": {
+    "providerAuthAndGatewaySucceeded": true,
+    "aToBJoinObserved": true,
+    "recipientContextSuppliedWithForbiddenArtifacts": true,
+    "malformedCallRejectedBeforeScheduling": true,
+    "bTerminatedAndDelivered": true,
+    "noCTaskFlowSessionRunOrTraceCreated": true,
+    "noCSentinelAtRoot": true,
+    "noOrphanRemained": true
+  },
+  "independentReview": {
+    "verdict": "PARTIAL",
+    "receiptUrl": "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5556789060",
+    "reviewedAt": "2026-09-06T04:05:21Z"
+  },
+  "authority": {
+    "source": "independent-manual-review",
+    "automaticAuthority": false
+  },
+  "evidenceLimitations": [
+    "This is a malformed model call, not a product behavior failure.",
+    "The product correctly rejected recipientContext combined with forbidden artifact returns before C scheduling.",
+    "No C existed and no sentinel reached root A, so the collection-on-collapse success contract is not proved and this row is not PASS."
+  ],
+  "finalClassification": "PARTIAL",
+  "canonicalFoldAllowed": true
+}

--- a/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/R-CW-DELEGATE-TOKEN/EVIDENCE.md
+++ b/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/R-CW-DELEGATE-TOKEN/EVIDENCE.md
@@ -1,12 +1,13 @@
-# R-CW-DELEGATE-TOKEN — inherited baseline state
+# R-CW-DELEGATE-TOKEN — exact-product review evidence
 
-- canonical state: `missing`
-- reviewed baseline product: `5035aac3a96df18f0a5d5a5c3e91a516a32daf32`
-- reviewed baseline docs commit: `0a893f80e55e0f93626d9a5f71bcb5dd38ca56f1`
-- exact-target execution claimed here: `false`
+- product/runtime: `7cb9d71f622250bedbf565e327bd7d7b9d90b567`
+- canary readiness docs: `08f8731490ce93879dabc973e7563c7ae0a65683`
+- canonical state: `pass`
+- authority: independent manual review
+- public receipt: [`PUBLIC-REVIEW.json`](PUBLIC-REVIEW.json)
 
-The canary's bracket-origin continuation evidence does not prove the canonical
-bare-token surface or its required `bare-token-hop2-executed` receipt. The
-private canary evidence remains available only through the existing
-[detached-review receipt](https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5555706100);
-no private artifacts are published here.
+The child emitted canonical bare `CONTINUE_WORK:5` with zero typed
+substitutions. Exact product reported response-text parser origin `bracket`,
+scheduled one five-second continuation, completed a distinct same-session
+successor, and joined task, flow, return, and trace evidence. Parser origin
+does not imply that the raw work token used square brackets.

--- a/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/R-CW-DELEGATE-TOKEN/PUBLIC-REVIEW.json
+++ b/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/R-CW-DELEGATE-TOKEN/PUBLIC-REVIEW.json
@@ -1,0 +1,46 @@
+{
+  "schema": "openclaw.proofs.public-independent-review-receipt.v1",
+  "row": "R-CW-DELEGATE-TOKEN",
+  "scenario": "targeted-three-row-canary/delegate-token",
+  "productSha": "7cb9d71f622250bedbf565e327bd7d7b9d90b567",
+  "runtimeSha": "7cb9d71f622250bedbf565e327bd7d7b9d90b567",
+  "docsSha": "08f8731490ce93879dabc973e7563c7ae0a65683",
+  "privateArtifactManifestSha256": "897e04319ca2397497bc5b79aee8adeb9fa31fc88b16d7eab257686b7820621c",
+  "privateRowArtifactSha256": "897e04319ca2397497bc5b79aee8adeb9fa31fc88b16d7eab257686b7820621c",
+  "readinessBindingSha256": "cafbccd8bd71f7ba0dfe88a58f110c96df7c8759e17f91b659057c77d763db40",
+  "canaryReceiptUrl": "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5556133557",
+  "identityFingerprints": {
+    "algorithm": "sha256-16",
+    "task": ["0e1b4c5cb02c0c49"],
+    "flow": ["12bcb8b832165f6b", "9d9947d7068016f0", "ad7c2bb8c51043eb"],
+    "session": ["910258583937a244"],
+    "run": ["6040b50146d4a1f4", "94727c6b2ec86b98"],
+    "trace": ["26fe6a9e2d0ae709"]
+  },
+  "observedPredicates": {
+    "bareTerminalContinueWorkFive": true,
+    "responseTextParserOriginBracket": true,
+    "typedContinueWorkCountZero": true,
+    "delayFiveSeconds": true,
+    "delegateTaskSucceededAndDelivered": true,
+    "continuationFlowSucceeded": true,
+    "sameSessionSuccessorDistinctAndCompleted": true,
+    "nonceBoundReturnObserved": true,
+    "traceJoinObserved": true
+  },
+  "independentReview": {
+    "verdict": "PASS-EVIDENCE-SUFFICIENT",
+    "receiptUrl": "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5556789060",
+    "reviewedAt": "2026-09-06T04:05:21Z"
+  },
+  "authority": {
+    "source": "independent-manual-review",
+    "automaticAuthority": false
+  },
+  "evidenceLimitations": [
+    "The producer timed out because it did not bind emitted task events to child fields; private raw stream, gateway log, task database, and durable successful flow independently satisfy the row.",
+    "Parser origin bracket identifies the response-text parser path; the canonical terminal text itself was the bare token CONTINUE_WORK:5."
+  ],
+  "finalClassification": "PASS",
+  "canonicalFoldAllowed": true
+}

--- a/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/R-CW-MULTI/EVIDENCE.md
+++ b/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/R-CW-MULTI/EVIDENCE.md
@@ -1,10 +1,13 @@
-# R-CW-MULTI — inherited baseline state
+# R-CW-MULTI — exact-product joined review evidence
 
-- canonical state: `missing`
-- reviewed baseline product: `5035aac3a96df18f0a5d5a5c3e91a516a32daf32`
-- reviewed baseline docs commit: `0a893f80e55e0f93626d9a5f71bcb5dd38ca56f1`
-- exact-target execution claimed here: `false`
+- product/runtime: `7cb9d71f622250bedbf565e327bd7d7b9d90b567`
+- canary readiness docs: `08f8731490ce93879dabc973e7563c7ae0a65683`
+- canonical state: `pass`
+- authority: independent manual review
+- public receipt: [`PUBLIC-REVIEW.json`](PUBLIC-REVIEW.json)
 
-Static multi-election validator found its required producer artifacts absent.
-
-This row's state is unchanged. Historical raw artifacts are not republished in the exact-product corpus; consult the immutable baseline commit for the original evidence.
+The new bare `CONTINUE_WORK:0` response-text phase closes token parity with
+zero typed substitutions, one succeeded continuation flow, and one distinct
+completed same-session successor. The independent review joins that packet to
+the previously reviewed typed 0/60/120 packet, which proves three distinct
+succeeded flows and three distinct completed same-session successors.

--- a/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/R-CW-MULTI/PUBLIC-REVIEW.json
+++ b/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/R-CW-MULTI/PUBLIC-REVIEW.json
@@ -1,0 +1,49 @@
+{
+  "schema": "openclaw.proofs.public-independent-review-receipt.v1",
+  "row": "R-CW-MULTI",
+  "scenario": "targeted-three-row-canary/multi-token-parity",
+  "productSha": "7cb9d71f622250bedbf565e327bd7d7b9d90b567",
+  "runtimeSha": "7cb9d71f622250bedbf565e327bd7d7b9d90b567",
+  "docsSha": "08f8731490ce93879dabc973e7563c7ae0a65683",
+  "privateArtifactManifestSha256": "8768551f24255a744dfd330a0ecf06fdcafd2b0de76f8eba6ee45e51e13ee953",
+  "privateRowArtifactSha256": "8768551f24255a744dfd330a0ecf06fdcafd2b0de76f8eba6ee45e51e13ee953",
+  "relatedPrivateRowArtifactSha256": [
+    "aaf199d4fcec922467f73ccd1e81109f60c01cbc3506b4fceeef918db7d38fcd"
+  ],
+  "readinessBindingSha256": "cafbccd8bd71f7ba0dfe88a58f110c96df7c8759e17f91b659057c77d763db40",
+  "canaryReceiptUrl": "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5556133557",
+  "identityFingerprints": {
+    "algorithm": "sha256-16",
+    "task": [],
+    "flow": ["a5bcac41a20935fd", "50dce14b5a91a82a"],
+    "session": ["714650d1d9af7d71"],
+    "run": ["b36cefe56424ab4a"],
+    "trace": ["a5c682883d804d3d"]
+  },
+  "observedPredicates": {
+    "typedZeroSixtyOneTwentyPreviouslyReviewed": true,
+    "typedThreeFlowsSucceeded": true,
+    "typedThreeDistinctSameSessionSuccessorsCompleted": true,
+    "bareTerminalContinueWorkZero": true,
+    "responseTextParserOriginBracket": true,
+    "typedContinueWorkCountZeroInParityPhase": true,
+    "tokenFlowSucceeded": true,
+    "tokenSuccessorDistinctAndCompleted": true,
+    "nonceBoundTokenWakeObserved": true
+  },
+  "independentReview": {
+    "verdict": "PASS-EVIDENCE-SUFFICIENT",
+    "receiptUrl": "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5556789060",
+    "reviewedAt": "2026-09-06T04:05:21Z"
+  },
+  "authority": {
+    "source": "independent-manual-review",
+    "automaticAuthority": false
+  },
+  "evidenceLimitations": [
+    "The typed 0/60/120 phase is bound through the prior independently reviewed packet and related private digest.",
+    "The parity producer mislabeled gateway status done as error; private raw records and the durable succeeded flow establish the token phase."
+  ],
+  "finalClassification": "PASS",
+  "canonicalFoldAllowed": true
+}

--- a/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/README.md
+++ b/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/README.md
@@ -4,14 +4,14 @@ Status: **BLOCKED** on the remaining non-PASS rows.
 
 - exact product/runtime: `7cb9d71f622250bedbf565e327bd7d7b9d90b567`
 - exact product tree: `85821bfd8f4676cfac8be658122910a7eb862f55`
-- canary readiness docs: `5831d6dfcb05f1bf819c32598f07dbfaddba0240`
-- current-main promotion base: `08f8731490ce93879dabc973e7563c7ae0a65683`
+- canary readiness docs: `08f8731490ce93879dabc973e7563c7ae0a65683`
+- current-main promotion base: `8f1163d757342c3ac36b8e446222b0446159211b`
 - baseline corpus: `5035aac3a96df18f0a5d5a5c3e91a516a32daf32`
-- before: 24 PASS / 7 PARTIAL / 1 FAIL / 6 MISSING
-- after: 29 PASS / 2 PARTIAL / 1 FAIL / 6 MISSING
+- before: 29 PASS / 2 PARTIAL / 1 FAIL / 6 MISSING
+- after: 31 PASS / 3 PARTIAL / 1 FAIL / 3 MISSING
 
-Exactly five rows moved from PARTIAL to PASS: `R-CD-1`, `R-CD-4`,
-`R-CD-CHAINED-DEPTH-2`, `R-CD-MODEL-TOOL`, and `R-CD-SILENT`.
+Exactly two rows moved from MISSING to PASS: `R-CW-DELEGATE-TOKEN` and
+`R-CW-MULTI`. `R-CD-COLLECTION-ON-COLLAPSE` moved from MISSING to PARTIAL.
 
 Each promoted row contains a schema-validated `PUBLIC-REVIEW.json` that binds
 the exact product, runtime, docs readiness, sealed private manifest digest,
@@ -19,5 +19,6 @@ row-specific private artifact digest, public-safe identity fingerprints,
 observed predicates, limitations, and the independent manual review.
 Rejected automatic producer authority was not consumed.
 
-`R-CD-TOKEN` and `R-RC-2` remain PARTIAL. All six MISSING rows and `R-CD-2`
-FAIL remain unchanged, as do the other 24 row states.
+`R-CD-TOKEN`, `R-RC-2`, and `R-CD-COLLECTION-ON-COLLAPSE` are PARTIAL.
+`R-CD-RETURN-COVENANT-AUTHORITY`, `R-CD-RETURN-OVERLAP`, and `R-OBS-2` remain
+MISSING. `R-CD-2` remains FAIL, and the other 35 row states are unchanged.

--- a/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/RESOLVED-SHA.md
+++ b/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/RESOLVED-SHA.md
@@ -2,11 +2,17 @@
 
 - product/runtime SHA: `7cb9d71f622250bedbf565e327bd7d7b9d90b567`
 - product/runtime tree: `85821bfd8f4676cfac8be658122910a7eb862f55`
-- current-main promotion base: `08f8731490ce93879dabc973e7563c7ae0a65683`
-- five-row canary readiness docs: `5831d6dfcb05f1bf819c32598f07dbfaddba0240`
+- current-main promotion base: `8f1163d757342c3ac36b8e446222b0446159211b`
+- three-row canary readiness docs: `08f8731490ce93879dabc973e7563c7ae0a65683`
 - baseline corpus SHA: `5035aac3a96df18f0a5d5a5c3e91a516a32daf32`
 - baseline corpus tree: `5ff71a670d75022c45e0ecaf9ecddcf57d2a33a2`
 - five-row private artifact manifest SHA-256:
   `fe025f9545142d392b3a42518e4f8414ced16b50bf4efebcd9dc83fd9dc2ca82`
 - prior three-row private artifact manifest SHA-256:
   `71d96105d9d01b32d1739fe0371b7d80aa235293627d61a222918c8ef6565470`
+- targeted three-row readiness binding SHA-256:
+  `cafbccd8bd71f7ba0dfe88a58f110c96df7c8759e17f91b659057c77d763db40`
+- targeted private row bundle SHA-256 values:
+  `897e04319ca2397497bc5b79aee8adeb9fa31fc88b16d7eab257686b7820621c`,
+  `8768551f24255a744dfd330a0ecf06fdcafd2b0de76f8eba6ee45e51e13ee953`,
+  and `6e7bf50c95ee80064f8de79fa2dffc65853e158abfd9a381aa95956db87acc9a`

--- a/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/ROW-LEDGER.tsv
+++ b/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/ROW-LEDGER.tsv
@@ -4,7 +4,7 @@ R-CD-2	historical_baseline	inherited	fail	unchanged_baseline_state	historical-ba
 R-CD-3	historical_baseline	inherited	pass	unchanged_baseline_state	historical-baseline-review	1
 R-CD-4	independent_manual_review	reviewed	pass	none	independent-review-5556060622	2
 R-CD-CHAINED-DEPTH-2	independent_manual_review	reviewed	pass	none	independent-review-5556060622	2
-R-CD-COLLECTION-ON-COLLAPSE	historical_baseline	inherited	missing	unchanged_baseline_state	historical-baseline-review	1
+R-CD-COLLECTION-ON-COLLAPSE	independent_manual_review	reviewed	partial	corrected_fresh_attempt_required	independent-review-5556789060	2
 R-CD-MODEL-CHAINED-ALT	historical_baseline	inherited	pass	unchanged_baseline_state	historical-baseline-review	1
 R-CD-MODEL-DEFAULT	historical_baseline	inherited	pass	unchanged_baseline_state	historical-baseline-review	1
 R-CD-MODEL-TOKEN	historical_baseline	inherited	pass	unchanged_baseline_state	historical-baseline-review	1
@@ -26,8 +26,8 @@ R-CW-6A	historical_baseline	inherited	pass	unchanged_baseline_state	historical-b
 R-CW-7	independent_manual_review	reviewed	pass	none	independent-review-5555528271	2
 R-CW-DELEGATE-CHILD-LIVE	independent_manual_review	reviewed	pass	none	independent-review-5555528271	2
 R-CW-DELEGATE-SELF-CONTINUATION	historical_baseline	inherited	pass	unchanged_baseline_state	historical-baseline-review	1
-R-CW-DELEGATE-TOKEN	historical_baseline	inherited	missing	canonical_bare_token_evidence_missing	historical-baseline-review	1
-R-CW-MULTI	historical_baseline	inherited	missing	unchanged_baseline_state	historical-baseline-review	1
+R-CW-DELEGATE-TOKEN	independent_manual_review	reviewed	pass	none	independent-review-5556789060	2
+R-CW-MULTI	independent_manual_review	reviewed	pass	none	independent-review-5556789060	3
 R-CW-MULTI-COLLAPSE	independent_manual_review	reviewed	pass	none	independent-review-5555528271	2
 R-CW-TOKEN	historical_baseline	inherited	pass	unchanged_baseline_state	historical-baseline-review	1
 R-OBS-1	historical_baseline	inherited	pass	unchanged_baseline_state	historical-baseline-review	1

--- a/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/TRANSPOSED-FROM.md
+++ b/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/TRANSPOSED-FROM.md
@@ -8,12 +8,16 @@ shows that baseline as an ancestor of exact product
 `85821bfd8f4676cfac8be658122910a7eb862f55`.
 
 This promotion candidate starts from docs main
-`08f8731490ce93879dabc973e7563c7ae0a65683`. Exactly five PARTIAL row states
-change. Their exact-target evidence is represented by
+`8f1163d757342c3ac36b8e446222b0446159211b`. Exactly three MISSING row states
+change: two to PASS and one to PARTIAL. Their exact-target evidence is represented by
 public-safe review receipts and derives authority solely from the independent
 manual review:
 
-<https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5556060622>
+<https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5556789060>
+
+The reviewed canary receipt is:
+
+<https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5556133557>
 
 Rejected automatic verdicts and automatic authority paths were not merged or
 used. Historical files retain their original identities; they must not be

--- a/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/proofs-manifest.json
+++ b/PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/proofs-manifest.json
@@ -12,14 +12,14 @@
     "baseline_corpus_sha": "5035aac3a96df18f0a5d5a5c3e91a516a32daf32",
     "baseline_product_tree": "5ff71a670d75022c45e0ecaf9ecddcf57d2a33a2",
     "baseline_is_ancestor": true,
-    "materiality": "The exact-product canaries ran at the target commit. The current wave changes only five PARTIAL rows from docs main 08f8731490ce93879dabc973e7563c7ae0a65683 and consumes only independent manual review."
+    "materiality": "The exact-product canaries ran at the target commit. The current wave changes only three MISSING rows from docs main 8f1163d757342c3ac36b8e446222b0446159211b and consumes only independent manual review."
   },
   "harness_sha": "d01af8c6f7c778d77b154f7fe7a61a4a0d90de95",
   "fire_type": "reviewed-exact-product-canary-promotion",
   "corpus": "PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567",
   "sha_short": "7cb9d71f",
   "build_string": "OpenClaw 2026.8.1 (7cb9d71f)",
-  "method": "Current-main 38-row corpus plus exactly five PARTIAL-to-PASS exact-product promotions authorized solely by independent manual review.",
+  "method": "Current-main 38-row corpus plus exactly two MISSING-to-PASS and one MISSING-to-PARTIAL exact-product promotions authorized solely by independent manual review.",
   "required_rows": [
     "R-CD-1",
     "R-CD-2",
@@ -62,12 +62,12 @@
   ],
   "rollup": {
     "total_rows": 38,
-    "pass": 29,
-    "partial": 2,
+    "pass": 31,
+    "partial": 3,
     "thin": 0,
     "fail": 1,
     "honest_limit": 0,
-    "missing": 6
+    "missing": 3
   },
   "rows": [
     {
@@ -208,30 +208,31 @@
     {
       "row": "R-CD-COLLECTION-ON-COLLAPSE",
       "title": "Static validator for committed A→B→delayed-C collection-on-collapse proof receipts.",
-      "owner": "ronan_remaining_runnable_matrix",
-      "state": "missing",
+      "owner": "independent-manual-review",
+      "state": "partial",
       "dir": "PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/R-CD-COLLECTION-ON-COLLAPSE/",
       "evidence_doc": "PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/R-CD-COLLECTION-ON-COLLAPSE/EVIDENCE.md",
       "manifest": "tools/k6-proofs/manifests/r-cd-collection-on-collapse.json",
       "scenario_status": "runnable",
       "live_run_classification": "k6-runnable",
-      "candidate_verdict": "MISSING-candidate",
-      "review_status": "producer-evidence-missing",
+      "candidate_verdict": "PARTIAL-candidate",
+      "review_status": "independent-manual-review-complete",
       "fired": true,
-      "exact_target_execution": false,
+      "exact_target_execution": true,
       "exact_target_mode_b": true,
       "pending_receipts": [
-        "PASS; A-B-C artifact set; root receives sentinel after B collapse; no orphan"
+        "Corrected A-B-C attempt with recipientContext omitted; root receives the C sentinel after B terminal; no orphan"
       ],
-      "summary": "Static current-corpus validator found its required producer artifacts absent; this is missing evidence, not a product-behavior contradiction.",
-      "notes": "State inherited unchanged from the reviewed 5035aac3 baseline; historical raw artifacts are not republished and no exact-target execution is claimed.",
+      "summary": "PARTIAL: A reached B, whose malformed recipientContext plus forbidden-artifacts call was correctly rejected before C scheduling; B terminated and no orphan remained.",
+      "notes": "Independent review at issue comment 5556789060 classifies the attempt as PARTIAL, not product behavior failure and not PASS.",
       "supporting_docs": [
-        "PROOFS/7c100aede1fd9895c0ae3e3837eafc9d98ad6982/R-CD-COLLECTION-ON-COLLAPSE/EVIDENCE.md"
+        "PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/R-CD-COLLECTION-ON-COLLAPSE/PUBLIC-REVIEW.json"
       ],
       "test_cases_executed": [
-        "historical-baseline-review"
+        "canary-20260906-independent-review"
       ],
-      "traces": []
+      "traces": [],
+      "reviewed_receipt_sha256": "02b30c1da2407ec8765d47e8fa45e21bb1d2e22b04802347a5dda6159db5e525"
     },
     {
       "row": "R-CD-MODEL-CHAINED-ALT",
@@ -800,58 +801,57 @@
     {
       "row": "R-CW-DELEGATE-TOKEN",
       "title": "Static validator for committed delegate child bare-token continuation receipts.",
-      "owner": "ronan_remaining_runnable_matrix",
-      "state": "missing",
+      "owner": "independent-manual-review",
+      "state": "pass",
       "dir": "PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/R-CW-DELEGATE-TOKEN/",
       "evidence_doc": "PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/R-CW-DELEGATE-TOKEN/EVIDENCE.md",
       "manifest": "tools/k6-proofs/manifests/r-cw-delegate-token.json",
       "scenario_status": "runnable",
       "live_run_classification": "k6-runnable",
-      "candidate_verdict": "MISSING-candidate",
-      "review_status": "producer-evidence-missing",
+      "candidate_verdict": "PASS-candidate",
+      "review_status": "independent-manual-review-complete",
       "fired": true,
-      "exact_target_execution": false,
+      "exact_target_execution": true,
       "exact_target_mode_b": true,
-      "pending_receipts": [
-        "bare-token-hop2-executed"
-      ],
-      "summary": "Canonical bare-token continuation evidence is missing; the reviewed canary exercised the distinct bracket-origin surface.",
-      "notes": "State remains at the reviewed 5035aac3 baseline. Private canary evidence is retained only through issue comment 5555706100; no private artifacts are republished and no exact-target execution is claimed for this canonical row.",
+      "pending_receipts": [],
+      "summary": "PASS: canonical bare CONTINUE_WORK:5 used the response-text parser path with zero typed substitution and completed the task, flow, successor, return, and trace joins.",
+      "notes": "Promotion authority is the independent manual review at issue comment 5556789060. Parser origin bracket names the response-text parser path and does not imply a square-bracketed work token.",
       "supporting_docs": [
-        "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5555706100"
+        "PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/R-CW-DELEGATE-TOKEN/PUBLIC-REVIEW.json"
       ],
       "test_cases_executed": [
-        "historical-baseline-review"
+        "canary-20260906-independent-review"
       ],
-      "traces": []
+      "traces": [],
+      "reviewed_receipt_sha256": "2d48229c030e1092da26d5259221a6da009ca3f07dc01d029b8eefe68c1ebf85"
     },
     {
       "row": "R-CW-MULTI",
       "title": "Static validator for committed same-turn multi continue_work fanout/collapse receipts.",
-      "owner": "ronan_remaining_runnable_matrix",
-      "state": "missing",
+      "owner": "independent-manual-review",
+      "state": "pass",
       "dir": "PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/R-CW-MULTI/",
       "evidence_doc": "PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/R-CW-MULTI/EVIDENCE.md",
       "manifest": "tools/k6-proofs/manifests/r-cw-multi.json",
       "scenario_status": "runnable",
       "live_run_classification": "k6-runnable",
-      "candidate_verdict": "MISSING-candidate",
-      "review_status": "producer-evidence-missing",
+      "candidate_verdict": "PASS-candidate",
+      "review_status": "independent-manual-review-complete",
       "fired": true,
-      "exact_target_execution": false,
+      "exact_target_execution": true,
       "exact_target_mode_b": true,
-      "pending_receipts": [
-        "PASS; three elections yield three distinct wakes at default/60/120; both forms"
-      ],
-      "summary": "Static multi-election validator found its required producer artifacts absent.",
-      "notes": "State inherited unchanged from the reviewed 5035aac3 baseline; historical raw artifacts are not republished and no exact-target execution is claimed.",
+      "pending_receipts": [],
+      "summary": "PASS: the newly reviewed bare CONTINUE_WORK:0 parity phase joins the previously reviewed typed 0/60/120 evidence.",
+      "notes": "Promotion authority is the independent manual review at issue comment 5556789060 joined to the prior typed-phase review at issue comment 5555528271.",
       "supporting_docs": [
-        "PROOFS/7c100aede1fd9895c0ae3e3837eafc9d98ad6982/R-CW-MULTI/EVIDENCE.md"
+        "PROOFS/7cb9d71f622250bedbf565e327bd7d7b9d90b567/R-CW-MULTI/PUBLIC-REVIEW.json"
       ],
       "test_cases_executed": [
-        "historical-baseline-review"
+        "canary-20260906-independent-review",
+        "canary-20260905-independent-review"
       ],
-      "traces": []
+      "traces": [],
+      "reviewed_receipt_sha256": "09bf67fca92cd41329cad6bb4ad817133c969b9111ab838e947da4761f4bc75b"
     },
     {
       "row": "R-CW-MULTI-COLLAPSE",
@@ -1096,8 +1096,8 @@
   ],
   "exact_target_execution": true,
   "exact_target_mode_b": false,
-  "generated": "2026-09-06T01:37:10Z",
-  "notes": "Exactly five independently reviewed exact-product rows moved PARTIAL to PASS from docs main 08f8731490ce93879dabc973e7563c7ae0a65683. The other 33 row states are unchanged. Automatic producer authority was not used.",
+  "generated": "2026-09-06T04:34:58Z",
+  "notes": "Exactly two independently reviewed exact-product rows moved MISSING to PASS and one moved MISSING to PARTIAL from docs main 8f1163d757342c3ac36b8e446222b0446159211b. The other 35 row states are unchanged. Automatic producer authority was not used.",
   "execution_status": "READY_FOR_DETACHED_REVIEW",
   "promotion": {
     "authority": "independent-manual-review",
@@ -1105,34 +1105,38 @@
     "product_sha": "7cb9d71f622250bedbf565e327bd7d7b9d90b567",
     "product_tree": "85821bfd8f4676cfac8be658122910a7eb862f55",
     "runtime_sha": "7cb9d71f622250bedbf565e327bd7d7b9d90b567",
-    "docs_sha": "5831d6dfcb05f1bf819c32598f07dbfaddba0240",
-    "current_main_docs_sha": "08f8731490ce93879dabc973e7563c7ae0a65683",
+    "docs_sha": "08f8731490ce93879dabc973e7563c7ae0a65683",
+    "current_main_docs_sha": "8f1163d757342c3ac36b8e446222b0446159211b",
     "baseline_corpus_sha": "7cb9d71f622250bedbf565e327bd7d7b9d90b567",
     "baseline_rollup": {
       "total_rows": 38,
-      "pass": 24,
-      "partial": 7,
+      "pass": 29,
+      "partial": 2,
       "thin": 0,
       "fail": 1,
       "honest_limit": 0,
       "missing": 6
     },
-    "review_receipt_url": "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5556060622",
-    "canary_receipt_url": "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5555964397",
-    "private_artifact_manifest_sha256": "fe025f9545142d392b3a42518e4f8414ced16b50bf4efebcd9dc83fd9dc2ca82",
+    "review_receipt_url": "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5556789060",
+    "canary_receipt_url": "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5556133557",
+    "readiness_binding_sha256": "cafbccd8bd71f7ba0dfe88a58f110c96df7c8759e17f91b659057c77d763db40",
+    "private_row_artifact_sha256": {
+      "R-CW-DELEGATE-TOKEN": "897e04319ca2397497bc5b79aee8adeb9fa31fc88b16d7eab257686b7820621c",
+      "R-CW-MULTI": "8768551f24255a744dfd330a0ecf06fdcafd2b0de76f8eba6ee45e51e13ee953",
+      "R-CD-COLLECTION-ON-COLLAPSE": "6e7bf50c95ee80064f8de79fa2dffc65853e158abfd9a381aa95956db87acc9a"
+    },
+    "related_private_row_artifact_sha256": {
+      "R-CW-MULTI-typed-0-60-120": "aaf199d4fcec922467f73ccd1e81109f60c01cbc3506b4fceeef918db7d38fcd"
+    },
     "promoted_rows": [
-      "R-CD-1",
-      "R-CD-4",
-      "R-CD-CHAINED-DEPTH-2",
-      "R-CD-MODEL-TOOL",
-      "R-CD-SILENT"
+      "R-CW-DELEGATE-TOKEN",
+      "R-CW-MULTI",
+      "R-CD-COLLECTION-ON-COLLAPSE"
     ],
     "receipt_sha256": {
-      "R-CD-1": "e963807590be05ae4b585074f8ebddcb825a753ea2ff34dd8434cdb585b63c2e",
-      "R-CD-4": "53cae038e531cb0d01febb43653267e4b93bdf7552361be9685049ecc0577bed",
-      "R-CD-CHAINED-DEPTH-2": "fed6c2e935a81d757139d926b7cf0576f31b06fc9c930d00ff261ef505b90239",
-      "R-CD-MODEL-TOOL": "fcf703b5ce12c642b16ac448255adabd86428380d372e9fdfaf9cad17c0e3109",
-      "R-CD-SILENT": "7e65512c4cfff7d0f7b82a96174a04e51323eb11f645c9d7b02a7d8befd60e0b"
+      "R-CW-DELEGATE-TOKEN": "2d48229c030e1092da26d5259221a6da009ca3f07dc01d029b8eefe68c1ebf85",
+      "R-CW-MULTI": "09bf67fca92cd41329cad6bb4ad817133c969b9111ab838e947da4761f4bc75b",
+      "R-CD-COLLECTION-ON-COLLAPSE": "02b30c1da2407ec8765d47e8fa45e21bb1d2e22b04802347a5dda6159db5e525"
     }
   },
   "exact_target_execution_rows": [
@@ -1143,6 +1147,9 @@
     "R-CD-SILENT",
     "R-CW-MULTI-COLLAPSE",
     "R-CW-7",
-    "R-CW-DELEGATE-CHILD-LIVE"
+    "R-CW-DELEGATE-CHILD-LIVE",
+    "R-CW-DELEGATE-TOKEN",
+    "R-CW-MULTI",
+    "R-CD-COLLECTION-ON-COLLAPSE"
   ]
 }

--- a/PROOFS/INDEX.json
+++ b/PROOFS/INDEX.json
@@ -24,14 +24,14 @@
   "manifest_filename": "proofs-manifest.json",
   "rollup": {
     "total_rows": 38,
-    "pass": 29,
-    "partial": 2,
+    "pass": 31,
+    "partial": 3,
     "thin": 0,
     "fail": 1,
     "honest_limit": 0,
-    "missing": 6
+    "missing": 3
   },
-  "disposition_note": "Exactly five exact-product rows promoted PARTIAL to PASS solely from independent manual review; all other row states are unchanged. R-CD-TOKEN and R-RC-2 remain PARTIAL.",
+  "disposition_note": "Exactly two exact-product rows promoted MISSING to PASS and one promoted MISSING to PARTIAL solely from independent manual review; all other row states are unchanged.",
   "navigation": "clawsweeper: read INDEX.json -> current_sha -> manifest_path -> rows[]",
   "generated": "2026-09-05",
   "generated_by": "copilot-cli",
@@ -41,12 +41,13 @@
     "target_corpus_sha": "7cb9d71f622250bedbf565e327bd7d7b9d90b567",
     "target_tree": "85821bfd8f4676cfac8be658122910a7eb862f55",
     "source_docs_commit": "0a893f80e55e0f93626d9a5f71bcb5dd38ca56f1",
-    "canonical_source_docs_main": "08f8731490ce93879dabc973e7563c7ae0a65683",
+    "canonical_source_docs_main": "8f1163d757342c3ac36b8e446222b0446159211b",
     "target_descends_from_source": true,
     "source_evidence_preserved_in_subtree": false,
     "exact_target_execution": true,
     "automatic_authority": false,
-    "independent_review_receipt": "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5556060622",
+    "independent_review_receipt": "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5556789060",
+    "canary_receipt": "https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5556133557",
     "exact_target_execution_rows": [
       "R-CD-1",
       "R-CD-4",
@@ -55,7 +56,10 @@
       "R-CD-SILENT",
       "R-CW-MULTI-COLLAPSE",
       "R-CW-7",
-      "R-CW-DELEGATE-CHILD-LIVE"
+      "R-CW-DELEGATE-CHILD-LIVE",
+      "R-CW-DELEGATE-TOKEN",
+      "R-CW-MULTI",
+      "R-CD-COLLECTION-ON-COLLAPSE"
     ],
     "previous": {
       "source_corpus_sha": "00c7f721a55554d0b9228337cc8bc6bec88f9e9f",


### PR DESCRIPTION
## Summary

Promote exactly two reviewed missing rows and record one attempted row as honestly partial:

- `R-CW-DELEGATE-TOKEN`: MISSING -> PASS
- `R-CW-MULTI`: MISSING -> PASS
- `R-CD-COLLECTION-ON-COLLAPSE`: MISSING -> PARTIAL

Canonical score moves from `29 PASS / 2 PARTIAL / 1 FAIL / 6 MISSING` to `31 PASS / 3 PARTIAL / 1 FAIL / 3 MISSING`.

## Authority

- candidate: `e734b3c4891d6e6276b60a8fd1c6fe9e3f765ddb`
- tree: `23c0f30be0d27e457c366ed6db6b503622742595`
- direct parent/current main: `8f1163d757342c3ac36b8e446222b0446159211b`
- execution receipt: https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5556133557
- independent evidence review: https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5556789060
- terminal detached promotion review: https://github.com/karmaterminal/karmaterminal-openclaw-docs/issues/451#issuecomment-5557494286

Corpus-only. No product, deployment, live-proof, or presentation mutation.
